### PR TITLE
Update documentation anchors

### DIFF
--- a/docs/hugo/content/reference/alertsmanagement/v1api20210401.md
+++ b/docs/hugo/content/reference/alertsmanagement/v1api20210401.md
@@ -5,15 +5,15 @@ title: alertsmanagement.azure.com/v1api20210401
 linktitle: v1api20210401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-04-01" |             |
 
-<a id="SmartDetectorAlertRule"></a>SmartDetectorAlertRule
----------------------------------------------------------
+SmartDetectorAlertRule{#SmartDetectorAlertRule}
+-----------------------------------------------
 
 Generator information: - Generated from: /alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2021-04-01/SmartDetectorAlertRulesApi.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;microsoft.alertsManagement/smartDetectorAlertRules/{alertRuleName}
 
@@ -26,7 +26,7 @@ Used by: [SmartDetectorAlertRuleList](#SmartDetectorAlertRuleList).
 | spec                                                                                    |             | [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="SmartDetectorAlertRule_Spec"></a>SmartDetectorAlertRule_Spec
+### SmartDetectorAlertRule_Spec {#SmartDetectorAlertRule_Spec}
 
 | Property        | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -44,7 +44,7 @@ Used by: [SmartDetectorAlertRuleList](#SmartDetectorAlertRuleList).
 | tags            | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | throttling      | The alert rule throttling information.                                                                                                                                                                                                                                                       | [ThrottlingInformation](#ThrottlingInformation)<br/><small>Optional</small>                                                                                          |
 
-### <a id="SmartDetectorAlertRule_STATUS"></a>SmartDetectorAlertRule_STATUS
+### SmartDetectorAlertRule_STATUS{#SmartDetectorAlertRule_STATUS}
 
 | Property     | Description                                                                                                                                   | Type                                                                                                                                                    |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,8 +63,8 @@ Used by: [SmartDetectorAlertRuleList](#SmartDetectorAlertRuleList).
 | throttling   | The alert rule throttling information.                                                                                                        | [ThrottlingInformation_STATUS](#ThrottlingInformation_STATUS)<br/><small>Optional</small>                                                               |
 | type         | The resource type.                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SmartDetectorAlertRuleList"></a>SmartDetectorAlertRuleList
------------------------------------------------------------------
+SmartDetectorAlertRuleList{#SmartDetectorAlertRuleList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2021-04-01/SmartDetectorAlertRulesApi.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;microsoft.alertsManagement/smartDetectorAlertRules/{alertRuleName}
 
@@ -74,8 +74,8 @@ Generator information: - Generated from: /alertsmanagement/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [SmartDetectorAlertRule[]](#SmartDetectorAlertRule)<br/><small>Optional</small> |
 
-<a id="SmartDetectorAlertRule_Spec"></a>SmartDetectorAlertRule_Spec
--------------------------------------------------------------------
+SmartDetectorAlertRule_Spec{#SmartDetectorAlertRule_Spec}
+---------------------------------------------------------
 
 Used by: [SmartDetectorAlertRule](#SmartDetectorAlertRule).
 
@@ -95,8 +95,8 @@ Used by: [SmartDetectorAlertRule](#SmartDetectorAlertRule).
 | tags            | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | throttling      | The alert rule throttling information.                                                                                                                                                                                                                                                       | [ThrottlingInformation](#ThrottlingInformation)<br/><small>Optional</small>                                                                                          |
 
-<a id="SmartDetectorAlertRule_STATUS"></a>SmartDetectorAlertRule_STATUS
------------------------------------------------------------------------
+SmartDetectorAlertRule_STATUS{#SmartDetectorAlertRule_STATUS}
+-------------------------------------------------------------
 
 Used by: [SmartDetectorAlertRule](#SmartDetectorAlertRule).
 
@@ -117,8 +117,8 @@ Used by: [SmartDetectorAlertRule](#SmartDetectorAlertRule).
 | throttling   | The alert rule throttling information.                                                                                                        | [ThrottlingInformation_STATUS](#ThrottlingInformation_STATUS)<br/><small>Optional</small>                                                               |
 | type         | The resource type.                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ActionGroupsInformation"></a>ActionGroupsInformation
------------------------------------------------------------
+ActionGroupsInformation{#ActionGroupsInformation}
+-------------------------------------------------
 
 The Action Groups information, used by the alert rule.
 
@@ -130,8 +130,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 | customWebhookPayload | An optional custom web-hook payload to use in web-hook notifications. | string<br/><small>Optional</small>                                                                                                                           |
 | groupReferences      | The Action Group resource IDs.                                        | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="ActionGroupsInformation_STATUS"></a>ActionGroupsInformation_STATUS
--------------------------------------------------------------------------
+ActionGroupsInformation_STATUS{#ActionGroupsInformation_STATUS}
+---------------------------------------------------------------
 
 The Action Groups information, used by the alert rule.
 
@@ -143,8 +143,8 @@ Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 | customWebhookPayload | An optional custom web-hook payload to use in web-hook notifications. | string<br/><small>Optional</small>   |
 | groupIds             | The Action Group resource IDs.                                        | string[]<br/><small>Optional</small> |
 
-<a id="AlertRuleProperties_Severity"></a>AlertRuleProperties_Severity
----------------------------------------------------------------------
+AlertRuleProperties_Severity{#AlertRuleProperties_Severity}
+-----------------------------------------------------------
 
 Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 
@@ -156,8 +156,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 | "Sev3" |             |
 | "Sev4" |             |
 
-<a id="AlertRuleProperties_Severity_STATUS"></a>AlertRuleProperties_Severity_STATUS
------------------------------------------------------------------------------------
+AlertRuleProperties_Severity_STATUS{#AlertRuleProperties_Severity_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 
@@ -169,8 +169,8 @@ Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 | "Sev3" |             |
 | "Sev4" |             |
 
-<a id="AlertRuleProperties_State"></a>AlertRuleProperties_State
----------------------------------------------------------------
+AlertRuleProperties_State{#AlertRuleProperties_State}
+-----------------------------------------------------
 
 Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 
@@ -179,8 +179,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AlertRuleProperties_State_STATUS"></a>AlertRuleProperties_State_STATUS
------------------------------------------------------------------------------
+AlertRuleProperties_State_STATUS{#AlertRuleProperties_State_STATUS}
+-------------------------------------------------------------------
 
 Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 
@@ -189,8 +189,8 @@ Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Detector"></a>Detector
------------------------------
+Detector{#Detector}
+-------------------
 
 The detector information. By default this is not populated, unless it's specified in expandDetector
 
@@ -201,8 +201,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 | id         | The detector id.            | string<br/><small>Required</small>             |
 | parameters | The detector's parameters.' | map[string]v1.JSON<br/><small>Optional</small> |
 
-<a id="Detector_STATUS"></a>Detector_STATUS
--------------------------------------------
+Detector_STATUS{#Detector_STATUS}
+---------------------------------
 
 The detector information. By default this is not populated, unless it's specified in expandDetector
 
@@ -219,8 +219,8 @@ Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 | supportedCadences      | The Smart Detector supported cadences.                                                                   | int[]<br/><small>Optional</small>                                                                       |
 | supportedResourceTypes | The Smart Detector supported resource types.                                                             | string[]<br/><small>Optional</small>                                                                    |
 
-<a id="SmartDetectorAlertRuleOperatorSpec"></a>SmartDetectorAlertRuleOperatorSpec
----------------------------------------------------------------------------------
+SmartDetectorAlertRuleOperatorSpec{#SmartDetectorAlertRuleOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -231,8 +231,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ThrottlingInformation"></a>ThrottlingInformation
--------------------------------------------------------
+ThrottlingInformation{#ThrottlingInformation}
+---------------------------------------------
 
 Optional throttling information for the alert rule.
 
@@ -242,8 +242,8 @@ Used by: [SmartDetectorAlertRule_Spec](#SmartDetectorAlertRule_Spec).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | duration | The required duration (in ISO8601 format) to wait before notifying on the alert rule again. The time granularity must be in minutes and minimum value is 0 minutes | string<br/><small>Optional</small> |
 
-<a id="ThrottlingInformation_STATUS"></a>ThrottlingInformation_STATUS
----------------------------------------------------------------------
+ThrottlingInformation_STATUS{#ThrottlingInformation_STATUS}
+-----------------------------------------------------------
 
 Optional throttling information for the alert rule.
 
@@ -253,8 +253,8 @@ Used by: [SmartDetectorAlertRule_STATUS](#SmartDetectorAlertRule_STATUS).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | duration | The required duration (in ISO8601 format) to wait before notifying on the alert rule again. The time granularity must be in minutes and minimum value is 0 minutes | string<br/><small>Optional</small> |
 
-<a id="DetectorParameterDefinition_STATUS"></a>DetectorParameterDefinition_STATUS
----------------------------------------------------------------------------------
+DetectorParameterDefinition_STATUS{#DetectorParameterDefinition_STATUS}
+-----------------------------------------------------------------------
 
 The detector parameter definition.
 
@@ -268,8 +268,8 @@ Used by: [Detector_STATUS](#Detector_STATUS).
 | name        | The detector parameter name.                                     | string<br/><small>Optional</small>                                                                              |
 | type        | The detector parameter type.                                     | [DetectorParameterDefinition_Type_STATUS](#DetectorParameterDefinition_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="DetectorParameterDefinition_Type_STATUS"></a>DetectorParameterDefinition_Type_STATUS
--------------------------------------------------------------------------------------------
+DetectorParameterDefinition_Type_STATUS{#DetectorParameterDefinition_Type_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DetectorParameterDefinition_STATUS](#DetectorParameterDefinition_STATUS).
 

--- a/docs/hugo/content/reference/alertsmanagement/v1api20230301.md
+++ b/docs/hugo/content/reference/alertsmanagement/v1api20230301.md
@@ -5,15 +5,15 @@ title: alertsmanagement.azure.com/v1api20230301
 linktitle: v1api20230301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-03-01" |             |
 
-<a id="PrometheusRuleGroup"></a>PrometheusRuleGroup
----------------------------------------------------
+PrometheusRuleGroup{#PrometheusRuleGroup}
+-----------------------------------------
 
 Generator information: - Generated from: /alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2023-03-01/PrometheusRuleGroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.AlertsManagement/prometheusRuleGroups/{ruleGroupName}
 
@@ -26,7 +26,7 @@ Used by: [PrometheusRuleGroupList](#PrometheusRuleGroupList).
 | spec                                                                                    |             | [PrometheusRuleGroup_Spec](#PrometheusRuleGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrometheusRuleGroup_STATUS](#PrometheusRuleGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrometheusRuleGroup_Spec"></a>PrometheusRuleGroup_Spec
+### PrometheusRuleGroup_Spec {#PrometheusRuleGroup_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [PrometheusRuleGroupList](#PrometheusRuleGroupList).
 | scopesReferences | Target Azure Monitor workspaces resource ids. This api-version is currently limited to creating with one scope. This may change in future.                                                                                                                                                   | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>         |
 | tags             | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="PrometheusRuleGroup_STATUS"></a>PrometheusRuleGroup_STATUS
+### PrometheusRuleGroup_STATUS{#PrometheusRuleGroup_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -60,8 +60,8 @@ Used by: [PrometheusRuleGroupList](#PrometheusRuleGroupList).
 | tags        | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrometheusRuleGroupList"></a>PrometheusRuleGroupList
------------------------------------------------------------
+PrometheusRuleGroupList{#PrometheusRuleGroupList}
+-------------------------------------------------
 
 Generator information: - Generated from: /alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2023-03-01/PrometheusRuleGroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.AlertsManagement/prometheusRuleGroups/{ruleGroupName}
 
@@ -71,8 +71,8 @@ Generator information: - Generated from: /alertsmanagement/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                           |
 | items                                                                               |             | [PrometheusRuleGroup[]](#PrometheusRuleGroup)<br/><small>Optional</small> |
 
-<a id="PrometheusRuleGroup_Spec"></a>PrometheusRuleGroup_Spec
--------------------------------------------------------------
+PrometheusRuleGroup_Spec{#PrometheusRuleGroup_Spec}
+---------------------------------------------------
 
 Used by: [PrometheusRuleGroup](#PrometheusRuleGroup).
 
@@ -90,8 +90,8 @@ Used by: [PrometheusRuleGroup](#PrometheusRuleGroup).
 | scopesReferences | Target Azure Monitor workspaces resource ids. This api-version is currently limited to creating with one scope. This may change in future.                                                                                                                                                   | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>         |
 | tags             | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="PrometheusRuleGroup_STATUS"></a>PrometheusRuleGroup_STATUS
------------------------------------------------------------------
+PrometheusRuleGroup_STATUS{#PrometheusRuleGroup_STATUS}
+-------------------------------------------------------
 
 Used by: [PrometheusRuleGroup](#PrometheusRuleGroup).
 
@@ -111,8 +111,8 @@ Used by: [PrometheusRuleGroup](#PrometheusRuleGroup).
 | tags        | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrometheusRule"></a>PrometheusRule
------------------------------------------
+PrometheusRule{#PrometheusRule}
+-------------------------------
 
 An Azure Prometheus alerting or recording rule.
 
@@ -131,8 +131,8 @@ Used by: [PrometheusRuleGroup_Spec](#PrometheusRuleGroup_Spec).
 | resolveConfiguration | Defines the configuration for resolving fired alerts. Only relevant for alerts.                                                                                                                                                                 | [PrometheusRuleResolveConfiguration](#PrometheusRuleResolveConfiguration)<br/><small>Optional</small> |
 | severity             | The severity of the alerts fired by the rule. Must be between 0 and 4.                                                                                                                                                                          | int<br/><small>Optional</small>                                                                       |
 
-<a id="PrometheusRule_STATUS"></a>PrometheusRule_STATUS
--------------------------------------------------------
+PrometheusRule_STATUS{#PrometheusRule_STATUS}
+---------------------------------------------
 
 An Azure Prometheus alerting or recording rule.
 
@@ -151,8 +151,8 @@ Used by: [PrometheusRuleGroup_STATUS](#PrometheusRuleGroup_STATUS).
 | resolveConfiguration | Defines the configuration for resolving fired alerts. Only relevant for alerts.                                                                                                                                                                 | [PrometheusRuleResolveConfiguration_STATUS](#PrometheusRuleResolveConfiguration_STATUS)<br/><small>Optional</small> |
 | severity             | The severity of the alerts fired by the rule. Must be between 0 and 4.                                                                                                                                                                          | int<br/><small>Optional</small>                                                                                     |
 
-<a id="PrometheusRuleGroupOperatorSpec"></a>PrometheusRuleGroupOperatorSpec
----------------------------------------------------------------------------
+PrometheusRuleGroupOperatorSpec{#PrometheusRuleGroupOperatorSpec}
+-----------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -163,8 +163,8 @@ Used by: [PrometheusRuleGroup_Spec](#PrometheusRuleGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -179,8 +179,8 @@ Used by: [PrometheusRuleGroup_STATUS](#PrometheusRuleGroup_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="PrometheusRuleGroupAction"></a>PrometheusRuleGroupAction
----------------------------------------------------------------
+PrometheusRuleGroupAction{#PrometheusRuleGroupAction}
+-----------------------------------------------------
 
 An alert action. Only relevant for alerts.
 
@@ -191,8 +191,8 @@ Used by: [PrometheusRule](#PrometheusRule).
 | actionGroupReference | The resource id of the action group to use. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | actionProperties     | The properties of an action group object.   | map[string]string<br/><small>Optional</small>                                                                                                              |
 
-<a id="PrometheusRuleGroupAction_STATUS"></a>PrometheusRuleGroupAction_STATUS
------------------------------------------------------------------------------
+PrometheusRuleGroupAction_STATUS{#PrometheusRuleGroupAction_STATUS}
+-------------------------------------------------------------------
 
 An alert action. Only relevant for alerts.
 
@@ -203,8 +203,8 @@ Used by: [PrometheusRule_STATUS](#PrometheusRule_STATUS).
 | actionGroupId    | The resource id of the action group to use. | string<br/><small>Optional</small>            |
 | actionProperties | The properties of an action group object.   | map[string]string<br/><small>Optional</small> |
 
-<a id="PrometheusRuleResolveConfiguration"></a>PrometheusRuleResolveConfiguration
----------------------------------------------------------------------------------
+PrometheusRuleResolveConfiguration{#PrometheusRuleResolveConfiguration}
+-----------------------------------------------------------------------
 
 Specifies the Prometheus alert rule configuration.
 
@@ -215,8 +215,8 @@ Used by: [PrometheusRule](#PrometheusRule).
 | autoResolved  | Enable alert auto-resolution.  | bool<br/><small>Optional</small>   |
 | timeToResolve | Alert auto-resolution timeout. | string<br/><small>Optional</small> |
 
-<a id="PrometheusRuleResolveConfiguration_STATUS"></a>PrometheusRuleResolveConfiguration_STATUS
------------------------------------------------------------------------------------------------
+PrometheusRuleResolveConfiguration_STATUS{#PrometheusRuleResolveConfiguration_STATUS}
+-------------------------------------------------------------------------------------
 
 Specifies the Prometheus alert rule configuration.
 
@@ -227,8 +227,8 @@ Used by: [PrometheusRule_STATUS](#PrometheusRule_STATUS).
 | autoResolved  | Enable alert auto-resolution.  | bool<br/><small>Optional</small>   |
 | timeToResolve | Alert auto-resolution timeout. | string<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -239,8 +239,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/apimanagement/v1api20220801.md
+++ b/docs/hugo/content/reference/apimanagement/v1api20220801.md
@@ -5,8 +5,8 @@ title: apimanagement.azure.com/v1api20220801
 linktitle: v1api20220801
 ------------------------
 
-<a id="Api"></a>Api
--------------------
+Api{#Api}
+---------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimapis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}
 
@@ -19,7 +19,7 @@ Used by: [ApiList](#ApiList).
 | spec                                                                                    |             | [Api_Spec](#Api_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Api_STATUS](#Api_STATUS)<br/><small>Optional</small> |
 
-### <a id="Api_Spec"></a>Api_Spec
+### Api_Spec {#Api_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ Used by: [ApiList](#ApiList).
 | value                            | Content value when Importing an API.                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | wsdlSelector                     | Criteria to limit import of WSDL to a subset of the document.                                                                                                                                                                                                                              | [ApiCreateOrUpdateProperties_WsdlSelector](#ApiCreateOrUpdateProperties_WsdlSelector)<br/><small>Optional</small>                                                    |
 
-### <a id="Api_STATUS"></a>Api_STATUS
+### Api_STATUS{#Api_STATUS}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -82,8 +82,8 @@ Used by: [ApiList](#ApiList).
 | termsOfServiceUrl             | A URL to the Terms of Service for the API. MUST be in the format of a URL.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiList"></a>ApiList
----------------------------
+ApiList{#ApiList}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimapis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}
 
@@ -93,15 +93,15 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                           |
 | items                                                                               |             | [Api[]](#Api)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-08-01" |             |
 
-<a id="ApiVersionSet"></a>ApiVersionSet
----------------------------------------
+ApiVersionSet{#ApiVersionSet}
+-----------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimapiversionsets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apiVersionSets/{versionSetId}
 
@@ -114,7 +114,7 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | spec                                                                                    |             | [ApiVersionSet_Spec](#ApiVersionSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ApiVersionSet_STATUS](#ApiVersionSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="ApiVersionSet_Spec"></a>ApiVersionSet_Spec
+### ApiVersionSet_Spec {#ApiVersionSet_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -127,7 +127,7 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                               | [ApiVersionSetContractProperties_VersioningScheme](#ApiVersionSetContractProperties_VersioningScheme)<br/><small>Required</small>                                    |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ApiVersionSet_STATUS"></a>ApiVersionSet_STATUS
+### ApiVersionSet_STATUS{#ApiVersionSet_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -141,8 +141,8 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                                                              | [ApiVersionSetContractProperties_VersioningScheme_STATUS](#ApiVersionSetContractProperties_VersioningScheme_STATUS)<br/><small>Optional</small>         |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiVersionSetList"></a>ApiVersionSetList
------------------------------------------------
+ApiVersionSetList{#ApiVersionSetList}
+-------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimapiversionsets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apiVersionSets/{versionSetId}
 
@@ -152,8 +152,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [ApiVersionSet[]](#ApiVersionSet)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvider"></a>AuthorizationProvider
--------------------------------------------------------
+AuthorizationProvider{#AuthorizationProvider}
+---------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}
 
@@ -166,7 +166,7 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | spec                                                                                    |             | [AuthorizationProvider_Spec](#AuthorizationProvider_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvider_STATUS](#AuthorizationProvider_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvider_Spec"></a>AuthorizationProvider_Spec
+### AuthorizationProvider_Spec {#AuthorizationProvider_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -177,7 +177,7 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [AuthorizationProviderOperatorSpec](#AuthorizationProviderOperatorSpec)<br/><small>Optional</small>                                                                  |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="AuthorizationProvider_STATUS"></a>AuthorizationProvider_STATUS
+### AuthorizationProvider_STATUS{#AuthorizationProvider_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -189,8 +189,8 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | oauth2           | OAuth2 settings                                                                                                                                                                                                                                                                                                           | [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAuth2Settings_STATUS)<br/><small>Optional</small>                                   |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProviderList"></a>AuthorizationProviderList
----------------------------------------------------------------
+AuthorizationProviderList{#AuthorizationProviderList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}
 
@@ -200,8 +200,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [AuthorizationProvider[]](#AuthorizationProvider)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorization"></a>AuthorizationProvidersAuthorization
------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization{#AuthorizationProvidersAuthorization}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}
 
@@ -214,7 +214,7 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | spec                                                                                    |             | [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvidersAuthorization_Spec"></a>AuthorizationProvidersAuthorization_Spec
+### AuthorizationProvidersAuthorization_Spec {#AuthorizationProvidersAuthorization_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -225,7 +225,7 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/AuthorizationProvider resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters        | Authorization parameters                                                                                                                                                                                                                                                                                 | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small>         |
 
-### <a id="AuthorizationProvidersAuthorization_STATUS"></a>AuthorizationProvidersAuthorization_STATUS
+### AuthorizationProvidersAuthorization_STATUS{#AuthorizationProvidersAuthorization_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -239,8 +239,8 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | status            | Status of the Authorization                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationList"></a>AuthorizationProvidersAuthorizationList
--------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationList{#AuthorizationProvidersAuthorizationList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}
 
@@ -250,8 +250,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [AuthorizationProvidersAuthorization[]](#AuthorizationProvidersAuthorization)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy"></a>AuthorizationProvidersAuthorizationsAccessPolicy
--------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy{#AuthorizationProvidersAuthorizationsAccessPolicy}
+---------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}/accessPolicies/{authorizationAccessPolicyId}
 
@@ -264,7 +264,7 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | spec                                                                                    |             | [AuthorizationProvidersAuthorizationsAccessPolicy_Spec](#AuthorizationProvidersAuthorizationsAccessPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvidersAuthorizationsAccessPolicy_STATUS](#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvidersAuthorizationsAccessPolicy_Spec"></a>AuthorizationProvidersAuthorizationsAccessPolicy_Spec
+### AuthorizationProvidersAuthorizationsAccessPolicy_Spec {#AuthorizationProvidersAuthorizationsAccessPolicy_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -276,7 +276,7 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | tenantId           | The Tenant Id                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | The Tenant Id                                                                                                                                                                                                                                                                                                          | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="AuthorizationProvidersAuthorizationsAccessPolicy_STATUS"></a>AuthorizationProvidersAuthorizationsAccessPolicy_STATUS
+### AuthorizationProvidersAuthorizationsAccessPolicy_STATUS{#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -287,8 +287,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | tenantId   | The Tenant Id                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicyList"></a>AuthorizationProvidersAuthorizationsAccessPolicyList
----------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicyList{#AuthorizationProvidersAuthorizationsAccessPolicyList}
+-----------------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}/accessPolicies/{authorizationAccessPolicyId}
 
@@ -298,8 +298,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                                     |
 | items                                                                               |             | [AuthorizationProvidersAuthorizationsAccessPolicy[]](#AuthorizationProvidersAuthorizationsAccessPolicy)<br/><small>Optional</small> |
 
-<a id="Backend"></a>Backend
----------------------------
+Backend{#Backend}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimbackends.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/backends/{backendId}
 
@@ -312,7 +312,7 @@ Used by: [BackendList](#BackendList).
 | spec                                                                                    |             | [Backend_Spec](#Backend_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Backend_STATUS](#Backend_STATUS)<br/><small>Optional</small> |
 
-### <a id="Backend_Spec"></a>Backend_Spec
+### Backend_Spec {#Backend_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -329,7 +329,7 @@ Used by: [BackendList](#BackendList).
 | tls               | Backend TLS Properties                                                                                                                                                                                                                                                                     | [BackendTlsProperties](#BackendTlsProperties)<br/><small>Optional</small>                                                                                            |
 | url               | Runtime Url of the Backend.                                                                                                                                                                                                                                                                | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="Backend_STATUS"></a>Backend_STATUS
+### Backend_STATUS{#Backend_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -347,8 +347,8 @@ Used by: [BackendList](#BackendList).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | url         | Runtime Url of the Backend.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackendList"></a>BackendList
------------------------------------
+BackendList{#BackendList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimbackends.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/backends/{backendId}
 
@@ -358,8 +358,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Backend[]](#Backend)<br/><small>Optional</small> |
 
-<a id="NamedValue"></a>NamedValue
----------------------------------
+NamedValue{#NamedValue}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimnamedvalues.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}
 
@@ -372,7 +372,7 @@ Used by: [NamedValueList](#NamedValueList).
 | spec                                                                                    |             | [NamedValue_Spec](#NamedValue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamedValue_STATUS](#NamedValue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamedValue_Spec"></a>NamedValue_Spec
+### NamedValue_Spec {#NamedValue_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -385,7 +385,7 @@ Used by: [NamedValueList](#NamedValueList).
 | tags         | Optional tags that when provided can be used to filter the NamedValue list.                                                                                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 | value        | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="NamedValue_STATUS"></a>NamedValue_STATUS
+### NamedValue_STATUS{#NamedValue_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -399,8 +399,8 @@ Used by: [NamedValueList](#NamedValueList).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value       | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamedValueList"></a>NamedValueList
------------------------------------------
+NamedValueList{#NamedValueList}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimnamedvalues.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}
 
@@ -410,8 +410,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [NamedValue[]](#NamedValue)<br/><small>Optional</small> |
 
-<a id="Policy"></a>Policy
--------------------------
+Policy{#Policy}
+---------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimpolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policies/{policyId}
 
@@ -424,7 +424,7 @@ Used by: [PolicyList](#PolicyList).
 | spec                                                                                    |             | [Policy_Spec](#Policy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Policy_STATUS](#Policy_STATUS)<br/><small>Optional</small> |
 
-### <a id="Policy_Spec"></a>Policy_Spec
+### Policy_Spec {#Policy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -433,7 +433,7 @@ Used by: [PolicyList](#PolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="Policy_STATUS"></a>Policy_STATUS
+### Policy_STATUS{#Policy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -444,8 +444,8 @@ Used by: [PolicyList](#PolicyList).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragment"></a>PolicyFragment
------------------------------------------
+PolicyFragment{#PolicyFragment}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimpolicyfragments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policyFragments/{id}
 
@@ -458,7 +458,7 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | spec                                                                                    |             | [PolicyFragment_Spec](#PolicyFragment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PolicyFragment_STATUS](#PolicyFragment_STATUS)<br/><small>Optional</small> |
 
-### <a id="PolicyFragment_Spec"></a>PolicyFragment_Spec
+### PolicyFragment_Spec {#PolicyFragment_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -469,7 +469,7 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the policy fragment.                                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="PolicyFragment_STATUS"></a>PolicyFragment_STATUS
+### PolicyFragment_STATUS{#PolicyFragment_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -481,8 +481,8 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value       | Contents of the policy fragment.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragmentList"></a>PolicyFragmentList
--------------------------------------------------
+PolicyFragmentList{#PolicyFragmentList}
+---------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimpolicyfragments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policyFragments/{id}
 
@@ -492,8 +492,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PolicyFragment[]](#PolicyFragment)<br/><small>Optional</small> |
 
-<a id="PolicyList"></a>PolicyList
----------------------------------
+PolicyList{#PolicyList}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimpolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policies/{policyId}
 
@@ -503,8 +503,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Policy[]](#Policy)<br/><small>Optional</small> |
 
-<a id="Product"></a>Product
----------------------------
+Product{#Product}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}
 
@@ -517,7 +517,7 @@ Used by: [ProductList](#ProductList).
 | spec                                                                                    |             | [Product_Spec](#Product_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Product_STATUS](#Product_STATUS)<br/><small>Optional</small> |
 
-### <a id="Product_Spec"></a>Product_Spec
+### Product_Spec {#Product_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -532,7 +532,7 @@ Used by: [ProductList](#ProductList).
 | subscriptionsLimit   | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="Product_STATUS"></a>Product_STATUS
+### Product_STATUS{#Product_STATUS}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -548,8 +548,8 @@ Used by: [ProductList](#ProductList).
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductApi"></a>ProductApi
----------------------------------
+ProductApi{#ProductApi}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis/{apiId}
 
@@ -562,7 +562,7 @@ Used by: [ProductApiList](#ProductApiList).
 | spec                                                                                    |             | [ProductApi_Spec](#ProductApi_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ProductApi_STATUS](#ProductApi_STATUS)<br/><small>Optional</small> |
 
-### <a id="ProductApi_Spec"></a>ProductApi_Spec
+### ProductApi_Spec {#ProductApi_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -570,14 +570,14 @@ Used by: [ProductApiList](#ProductApiList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [ProductApiOperatorSpec](#ProductApiOperatorSpec)<br/><small>Optional</small>                                                                                        |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="ProductApi_STATUS"></a>ProductApi_STATUS
+### ProductApi_STATUS{#ProductApi_STATUS}
 
 | Property   | Description                        | Type                                                                                                                                                    |
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="ProductApiList"></a>ProductApiList
------------------------------------------
+ProductApiList{#ProductApiList}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis/{apiId}
 
@@ -587,8 +587,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [ProductApi[]](#ProductApi)<br/><small>Optional</small> |
 
-<a id="ProductList"></a>ProductList
------------------------------------
+ProductList{#ProductList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}
 
@@ -598,8 +598,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Product[]](#Product)<br/><small>Optional</small> |
 
-<a id="ProductPolicy"></a>ProductPolicy
----------------------------------------
+ProductPolicy{#ProductPolicy}
+-----------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/policies/{policyId}
 
@@ -612,7 +612,7 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | spec                                                                                    |             | [ProductPolicy_Spec](#ProductPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ProductPolicy_STATUS](#ProductPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ProductPolicy_Spec"></a>ProductPolicy_Spec
+### ProductPolicy_Spec {#ProductPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -621,7 +621,7 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="ProductPolicy_STATUS"></a>ProductPolicy_STATUS
+### ProductPolicy_STATUS{#ProductPolicy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -632,8 +632,8 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductPolicyList"></a>ProductPolicyList
------------------------------------------------
+ProductPolicyList{#ProductPolicyList}
+-------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/policies/{policyId}
 
@@ -643,8 +643,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [ProductPolicy[]](#ProductPolicy)<br/><small>Optional</small> |
 
-<a id="Service"></a>Service
----------------------------
+Service{#Service}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimdeployment.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}
 
@@ -657,7 +657,7 @@ Used by: [ServiceList](#ServiceList).
 | spec                                                                                    |             | [Service_Spec](#Service_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Service_STATUS](#Service_STATUS)<br/><small>Optional</small> |
 
-### <a id="Service_Spec"></a>Service_Spec
+### Service_Spec {#Service_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -686,7 +686,7 @@ Used by: [ServiceList](#ServiceList).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType](#ApiManagementServiceProperties_VirtualNetworkType)<br/><small>Optional</small>                                  |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Service_STATUS"></a>Service_STATUS
+### Service_STATUS{#Service_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                    |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -732,8 +732,8 @@ Used by: [ServiceList](#ServiceList).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType_STATUS](#ApiManagementServiceProperties_VirtualNetworkType_STATUS)<br/><small>Optional</small>       |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ServiceList"></a>ServiceList
------------------------------------
+ServiceList{#ServiceList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimdeployment.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}
 
@@ -743,8 +743,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Service[]](#Service)<br/><small>Optional</small> |
 
-<a id="Subscription"></a>Subscription
--------------------------------------
+Subscription{#Subscription}
+---------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimsubscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{sid}
 
@@ -757,7 +757,7 @@ Used by: [SubscriptionList](#SubscriptionList).
 | spec                                                                                    |             | [Subscription_Spec](#Subscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Subscription_STATUS](#Subscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="Subscription_Spec"></a>Subscription_Spec
+### Subscription_Spec {#Subscription_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -772,7 +772,7 @@ Used by: [SubscriptionList](#SubscriptionList).
 | secondaryKey   | Secondary subscription key. If not specified during request key will be generated automatically.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | state          | Initial subscription state. If no value is specified, subscription is created with Submitted state. Possible states are * active – the subscription is active, * suspended – the subscription is blocked, and the subscriber cannot call any APIs of the product, * submitted – the subscription request has been made by the developer, but has not yet been approved or rejected, * rejected – the subscription request has been denied by an administrator, * cancelled – the subscription has been cancelled by the developer or administrator, * expired – the subscription reached its expiration date and was deactivated. | [SubscriptionCreateParameterProperties_State](#SubscriptionCreateParameterProperties_State)<br/><small>Optional</small>                                              |
 
-### <a id="Subscription_STATUS"></a>Subscription_STATUS
+### Subscription_STATUS{#Subscription_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -792,8 +792,8 @@ Used by: [SubscriptionList](#SubscriptionList).
 | stateComment     | Optional subscription comment added by an administrator when the state is changed to the 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SubscriptionList"></a>SubscriptionList
----------------------------------------------
+SubscriptionList{#SubscriptionList}
+-----------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/stable/2022-08-01/apimsubscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{sid}
 
@@ -803,8 +803,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [Subscription[]](#Subscription)<br/><small>Optional</small> |
 
-<a id="Api_Spec"></a>Api_Spec
------------------------------
+Api_Spec{#Api_Spec}
+-------------------
 
 Used by: [Api](#Api).
 
@@ -839,8 +839,8 @@ Used by: [Api](#Api).
 | value                            | Content value when Importing an API.                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | wsdlSelector                     | Criteria to limit import of WSDL to a subset of the document.                                                                                                                                                                                                                              | [ApiCreateOrUpdateProperties_WsdlSelector](#ApiCreateOrUpdateProperties_WsdlSelector)<br/><small>Optional</small>                                                    |
 
-<a id="Api_STATUS"></a>Api_STATUS
----------------------------------
+Api_STATUS{#Api_STATUS}
+-----------------------
 
 Used by: [Api](#Api).
 
@@ -872,8 +872,8 @@ Used by: [Api](#Api).
 | termsOfServiceUrl             | A URL to the Terms of Service for the API. MUST be in the format of a URL.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiVersionSet_Spec"></a>ApiVersionSet_Spec
--------------------------------------------------
+ApiVersionSet_Spec{#ApiVersionSet_Spec}
+---------------------------------------
 
 Used by: [ApiVersionSet](#ApiVersionSet).
 
@@ -888,8 +888,8 @@ Used by: [ApiVersionSet](#ApiVersionSet).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                               | [ApiVersionSetContractProperties_VersioningScheme](#ApiVersionSetContractProperties_VersioningScheme)<br/><small>Required</small>                                    |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ApiVersionSet_STATUS"></a>ApiVersionSet_STATUS
------------------------------------------------------
+ApiVersionSet_STATUS{#ApiVersionSet_STATUS}
+-------------------------------------------
 
 Used by: [ApiVersionSet](#ApiVersionSet).
 
@@ -905,8 +905,8 @@ Used by: [ApiVersionSet](#ApiVersionSet).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                                                              | [ApiVersionSetContractProperties_VersioningScheme_STATUS](#ApiVersionSetContractProperties_VersioningScheme_STATUS)<br/><small>Optional</small>         |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvider_Spec"></a>AuthorizationProvider_Spec
------------------------------------------------------------------
+AuthorizationProvider_Spec{#AuthorizationProvider_Spec}
+-------------------------------------------------------
 
 Used by: [AuthorizationProvider](#AuthorizationProvider).
 
@@ -919,8 +919,8 @@ Used by: [AuthorizationProvider](#AuthorizationProvider).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [AuthorizationProviderOperatorSpec](#AuthorizationProviderOperatorSpec)<br/><small>Optional</small>                                                                  |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="AuthorizationProvider_STATUS"></a>AuthorizationProvider_STATUS
----------------------------------------------------------------------
+AuthorizationProvider_STATUS{#AuthorizationProvider_STATUS}
+-----------------------------------------------------------
 
 Used by: [AuthorizationProvider](#AuthorizationProvider).
 
@@ -934,8 +934,8 @@ Used by: [AuthorizationProvider](#AuthorizationProvider).
 | oauth2           | OAuth2 settings                                                                                                                                                                                                                                                                                                           | [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAuth2Settings_STATUS)<br/><small>Optional</small>                                   |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorization_Spec"></a>AuthorizationProvidersAuthorization_Spec
----------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization_Spec{#AuthorizationProvidersAuthorization_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorization).
 
@@ -948,8 +948,8 @@ Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorizat
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/AuthorizationProvider resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters        | Authorization parameters                                                                                                                                                                                                                                                                                 | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small>         |
 
-<a id="AuthorizationProvidersAuthorization_STATUS"></a>AuthorizationProvidersAuthorization_STATUS
--------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization_STATUS{#AuthorizationProvidersAuthorization_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorization).
 
@@ -965,8 +965,8 @@ Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorizat
 | status            | Status of the Authorization                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy_Spec"></a>AuthorizationProvidersAuthorizationsAccessPolicy_Spec
------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy_Spec{#AuthorizationProvidersAuthorizationsAccessPolicy_Spec}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvidersAuthorizationsAccessPolicy).
 
@@ -980,8 +980,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvid
 | tenantId           | The Tenant Id                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | The Tenant Id                                                                                                                                                                                                                                                                                                          | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy_STATUS"></a>AuthorizationProvidersAuthorizationsAccessPolicy_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy_STATUS{#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvidersAuthorizationsAccessPolicy).
 
@@ -994,8 +994,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvid
 | tenantId   | The Tenant Id                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Backend_Spec"></a>Backend_Spec
--------------------------------------
+Backend_Spec{#Backend_Spec}
+---------------------------
 
 Used by: [Backend](#Backend).
 
@@ -1014,8 +1014,8 @@ Used by: [Backend](#Backend).
 | tls               | Backend TLS Properties                                                                                                                                                                                                                                                                     | [BackendTlsProperties](#BackendTlsProperties)<br/><small>Optional</small>                                                                                            |
 | url               | Runtime Url of the Backend.                                                                                                                                                                                                                                                                | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="Backend_STATUS"></a>Backend_STATUS
------------------------------------------
+Backend_STATUS{#Backend_STATUS}
+-------------------------------
 
 Used by: [Backend](#Backend).
 
@@ -1035,8 +1035,8 @@ Used by: [Backend](#Backend).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | url         | Runtime Url of the Backend.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamedValue_Spec"></a>NamedValue_Spec
--------------------------------------------
+NamedValue_Spec{#NamedValue_Spec}
+---------------------------------
 
 Used by: [NamedValue](#NamedValue).
 
@@ -1051,8 +1051,8 @@ Used by: [NamedValue](#NamedValue).
 | tags         | Optional tags that when provided can be used to filter the NamedValue list.                                                                                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 | value        | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="NamedValue_STATUS"></a>NamedValue_STATUS
------------------------------------------------
+NamedValue_STATUS{#NamedValue_STATUS}
+-------------------------------------
 
 Used by: [NamedValue](#NamedValue).
 
@@ -1068,8 +1068,8 @@ Used by: [NamedValue](#NamedValue).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value       | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Policy_Spec"></a>Policy_Spec
------------------------------------
+Policy_Spec{#Policy_Spec}
+-------------------------
 
 Used by: [Policy](#Policy).
 
@@ -1080,8 +1080,8 @@ Used by: [Policy](#Policy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="Policy_STATUS"></a>Policy_STATUS
----------------------------------------
+Policy_STATUS{#Policy_STATUS}
+-----------------------------
 
 Used by: [Policy](#Policy).
 
@@ -1094,8 +1094,8 @@ Used by: [Policy](#Policy).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragment_Spec"></a>PolicyFragment_Spec
----------------------------------------------------
+PolicyFragment_Spec{#PolicyFragment_Spec}
+-----------------------------------------
 
 Used by: [PolicyFragment](#PolicyFragment).
 
@@ -1108,8 +1108,8 @@ Used by: [PolicyFragment](#PolicyFragment).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the policy fragment.                                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="PolicyFragment_STATUS"></a>PolicyFragment_STATUS
--------------------------------------------------------
+PolicyFragment_STATUS{#PolicyFragment_STATUS}
+---------------------------------------------
 
 Used by: [PolicyFragment](#PolicyFragment).
 
@@ -1123,8 +1123,8 @@ Used by: [PolicyFragment](#PolicyFragment).
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value       | Contents of the policy fragment.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Product_Spec"></a>Product_Spec
--------------------------------------
+Product_Spec{#Product_Spec}
+---------------------------
 
 Used by: [Product](#Product).
 
@@ -1141,8 +1141,8 @@ Used by: [Product](#Product).
 | subscriptionsLimit   | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="Product_STATUS"></a>Product_STATUS
------------------------------------------
+Product_STATUS{#Product_STATUS}
+-------------------------------
 
 Used by: [Product](#Product).
 
@@ -1160,8 +1160,8 @@ Used by: [Product](#Product).
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductApi_Spec"></a>ProductApi_Spec
--------------------------------------------
+ProductApi_Spec{#ProductApi_Spec}
+---------------------------------
 
 Used by: [ProductApi](#ProductApi).
 
@@ -1171,8 +1171,8 @@ Used by: [ProductApi](#ProductApi).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [ProductApiOperatorSpec](#ProductApiOperatorSpec)<br/><small>Optional</small>                                                                                        |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="ProductApi_STATUS"></a>ProductApi_STATUS
------------------------------------------------
+ProductApi_STATUS{#ProductApi_STATUS}
+-------------------------------------
 
 Used by: [ProductApi](#ProductApi).
 
@@ -1180,8 +1180,8 @@ Used by: [ProductApi](#ProductApi).
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="ProductPolicy_Spec"></a>ProductPolicy_Spec
--------------------------------------------------
+ProductPolicy_Spec{#ProductPolicy_Spec}
+---------------------------------------
 
 Used by: [ProductPolicy](#ProductPolicy).
 
@@ -1192,8 +1192,8 @@ Used by: [ProductPolicy](#ProductPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="ProductPolicy_STATUS"></a>ProductPolicy_STATUS
------------------------------------------------------
+ProductPolicy_STATUS{#ProductPolicy_STATUS}
+-------------------------------------------
 
 Used by: [ProductPolicy](#ProductPolicy).
 
@@ -1206,8 +1206,8 @@ Used by: [ProductPolicy](#ProductPolicy).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Service_Spec"></a>Service_Spec
--------------------------------------
+Service_Spec{#Service_Spec}
+---------------------------
 
 Used by: [Service](#Service).
 
@@ -1238,8 +1238,8 @@ Used by: [Service](#Service).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType](#ApiManagementServiceProperties_VirtualNetworkType)<br/><small>Optional</small>                                  |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Service_STATUS"></a>Service_STATUS
------------------------------------------
+Service_STATUS{#Service_STATUS}
+-------------------------------
 
 Used by: [Service](#Service).
 
@@ -1287,8 +1287,8 @@ Used by: [Service](#Service).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType_STATUS](#ApiManagementServiceProperties_VirtualNetworkType_STATUS)<br/><small>Optional</small>       |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="Subscription_Spec"></a>Subscription_Spec
------------------------------------------------
+Subscription_Spec{#Subscription_Spec}
+-------------------------------------
 
 Used by: [Subscription](#Subscription).
 
@@ -1305,8 +1305,8 @@ Used by: [Subscription](#Subscription).
 | secondaryKey   | Secondary subscription key. If not specified during request key will be generated automatically.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | state          | Initial subscription state. If no value is specified, subscription is created with Submitted state. Possible states are * active – the subscription is active, * suspended – the subscription is blocked, and the subscriber cannot call any APIs of the product, * submitted – the subscription request has been made by the developer, but has not yet been approved or rejected, * rejected – the subscription request has been denied by an administrator, * cancelled – the subscription has been cancelled by the developer or administrator, * expired – the subscription reached its expiration date and was deactivated. | [SubscriptionCreateParameterProperties_State](#SubscriptionCreateParameterProperties_State)<br/><small>Optional</small>                                              |
 
-<a id="Subscription_STATUS"></a>Subscription_STATUS
----------------------------------------------------
+Subscription_STATUS{#Subscription_STATUS}
+-----------------------------------------
 
 Used by: [Subscription](#Subscription).
 
@@ -1328,8 +1328,8 @@ Used by: [Subscription](#Subscription).
 | stateComment     | Optional subscription comment added by an administrator when the state is changed to the 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdditionalLocation"></a>AdditionalLocation
--------------------------------------------------
+AdditionalLocation{#AdditionalLocation}
+---------------------------------------
 
 Description of an additional API Management resource location.
 
@@ -1345,8 +1345,8 @@ Used by: [Service_Spec](#Service_Spec).
 | virtualNetworkConfiguration | Virtual network configuration for the location.                                                                                                                                      | [VirtualNetworkConfiguration](#VirtualNetworkConfiguration)<br/><small>Optional</small>                                                                    |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                         | string[]<br/><small>Optional</small>                                                                                                                       |
 
-<a id="AdditionalLocation_STATUS"></a>AdditionalLocation_STATUS
----------------------------------------------------------------
+AdditionalLocation_STATUS{#AdditionalLocation_STATUS}
+-----------------------------------------------------
 
 Description of an additional API Management resource location.
 
@@ -1367,8 +1367,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | virtualNetworkConfiguration | Virtual network configuration for the location.                                                                                                                                                                             | [VirtualNetworkConfiguration_STATUS](#VirtualNetworkConfiguration_STATUS)<br/><small>Optional</small>               |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                |
 
-<a id="ApiContactInformation"></a>ApiContactInformation
--------------------------------------------------------
+ApiContactInformation{#ApiContactInformation}
+---------------------------------------------
 
 API contact information
 
@@ -1380,8 +1380,8 @@ Used by: [Api_Spec](#Api_Spec).
 | name     | The identifying name of the contact person/organization                                         | string<br/><small>Optional</small> |
 | url      | The URL pointing to the contact information. MUST be in the format of a URL                     | string<br/><small>Optional</small> |
 
-<a id="ApiContactInformation_STATUS"></a>ApiContactInformation_STATUS
----------------------------------------------------------------------
+ApiContactInformation_STATUS{#ApiContactInformation_STATUS}
+-----------------------------------------------------------
 
 API contact information
 
@@ -1393,8 +1393,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | name     | The identifying name of the contact person/organization                                         | string<br/><small>Optional</small> |
 | url      | The URL pointing to the contact information. MUST be in the format of a URL                     | string<br/><small>Optional</small> |
 
-<a id="ApiContractProperties_Protocols_STATUS"></a>ApiContractProperties_Protocols_STATUS
------------------------------------------------------------------------------------------
+ApiContractProperties_Protocols_STATUS{#ApiContractProperties_Protocols_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Api_STATUS](#Api_STATUS).
 
@@ -1405,8 +1405,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | "ws"    |             |
 | "wss"   |             |
 
-<a id="ApiContractProperties_Type_STATUS"></a>ApiContractProperties_Type_STATUS
--------------------------------------------------------------------------------
+ApiContractProperties_Type_STATUS{#ApiContractProperties_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [Api_STATUS](#Api_STATUS).
 
@@ -1417,8 +1417,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_ApiType"></a>ApiCreateOrUpdateProperties_ApiType
------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_ApiType{#ApiCreateOrUpdateProperties_ApiType}
+-------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1429,8 +1429,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_Format"></a>ApiCreateOrUpdateProperties_Format
----------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Format{#ApiCreateOrUpdateProperties_Format}
+-----------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1448,8 +1448,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "wsdl"              |             |
 | "wsdl-link"         |             |
 
-<a id="ApiCreateOrUpdateProperties_Protocols"></a>ApiCreateOrUpdateProperties_Protocols
----------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Protocols{#ApiCreateOrUpdateProperties_Protocols}
+-----------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1460,8 +1460,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "ws"    |             |
 | "wss"   |             |
 
-<a id="ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters"></a>ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters
--------------------------------------------------------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters{#ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1470,8 +1470,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "query"    |             |
 | "template" |             |
 
-<a id="ApiCreateOrUpdateProperties_Type"></a>ApiCreateOrUpdateProperties_Type
------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Type{#ApiCreateOrUpdateProperties_Type}
+-------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1482,8 +1482,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_WsdlSelector"></a>ApiCreateOrUpdateProperties_WsdlSelector
----------------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_WsdlSelector{#ApiCreateOrUpdateProperties_WsdlSelector}
+-----------------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1492,8 +1492,8 @@ Used by: [Api_Spec](#Api_Spec).
 | wsdlEndpointName | Name of endpoint(port) to import from WSDL | string<br/><small>Optional</small> |
 | wsdlServiceName  | Name of service to import from WSDL        | string<br/><small>Optional</small> |
 
-<a id="ApiLicenseInformation"></a>ApiLicenseInformation
--------------------------------------------------------
+ApiLicenseInformation{#ApiLicenseInformation}
+---------------------------------------------
 
 API license information
 
@@ -1504,8 +1504,8 @@ Used by: [Api_Spec](#Api_Spec).
 | name     | The license name used for the API                                     | string<br/><small>Optional</small> |
 | url      | A URL to the license used for the API. MUST be in the format of a URL | string<br/><small>Optional</small> |
 
-<a id="ApiLicenseInformation_STATUS"></a>ApiLicenseInformation_STATUS
----------------------------------------------------------------------
+ApiLicenseInformation_STATUS{#ApiLicenseInformation_STATUS}
+-----------------------------------------------------------
 
 API license information
 
@@ -1516,8 +1516,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | name     | The license name used for the API                                     | string<br/><small>Optional</small> |
 | url      | A URL to the license used for the API. MUST be in the format of a URL | string<br/><small>Optional</small> |
 
-<a id="ApiManagementServiceIdentity"></a>ApiManagementServiceIdentity
----------------------------------------------------------------------
+ApiManagementServiceIdentity{#ApiManagementServiceIdentity}
+-----------------------------------------------------------
 
 Identity properties of the Api Management service resource.
 
@@ -1528,8 +1528,8 @@ Used by: [Service_Spec](#Service_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                         | [ApiManagementServiceIdentity_Type](#ApiManagementServiceIdentity_Type)<br/><small>Required</small> |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small>           |
 
-<a id="ApiManagementServiceIdentity_STATUS"></a>ApiManagementServiceIdentity_STATUS
------------------------------------------------------------------------------------
+ApiManagementServiceIdentity_STATUS{#ApiManagementServiceIdentity_STATUS}
+-------------------------------------------------------------------------
 
 Identity properties of the Api Management service resource.
 
@@ -1542,8 +1542,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                         | [ApiManagementServiceIdentity_Type_STATUS](#ApiManagementServiceIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentityProperties_STATUS](#UserIdentityProperties_STATUS)<br/><small>Optional</small>            |
 
-<a id="ApiManagementServiceProperties_NatGatewayState"></a>ApiManagementServiceProperties_NatGatewayState
----------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_NatGatewayState{#ApiManagementServiceProperties_NatGatewayState}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1552,8 +1552,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_NatGatewayState_STATUS"></a>ApiManagementServiceProperties_NatGatewayState_STATUS
------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_NatGatewayState_STATUS{#ApiManagementServiceProperties_NatGatewayState_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1562,8 +1562,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_PlatformVersion_STATUS"></a>ApiManagementServiceProperties_PlatformVersion_STATUS
------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PlatformVersion_STATUS{#ApiManagementServiceProperties_PlatformVersion_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1574,8 +1574,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "stv2"         |             |
 | "undetermined" |             |
 
-<a id="ApiManagementServiceProperties_PublicNetworkAccess"></a>ApiManagementServiceProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PublicNetworkAccess{#ApiManagementServiceProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1584,8 +1584,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_PublicNetworkAccess_STATUS"></a>ApiManagementServiceProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PublicNetworkAccess_STATUS{#ApiManagementServiceProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1594,8 +1594,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_VirtualNetworkType"></a>ApiManagementServiceProperties_VirtualNetworkType
----------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_VirtualNetworkType{#ApiManagementServiceProperties_VirtualNetworkType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1605,8 +1605,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Internal" |             |
 | "None"     |             |
 
-<a id="ApiManagementServiceProperties_VirtualNetworkType_STATUS"></a>ApiManagementServiceProperties_VirtualNetworkType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_VirtualNetworkType_STATUS{#ApiManagementServiceProperties_VirtualNetworkType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1616,8 +1616,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Internal" |             |
 | "None"     |             |
 
-<a id="ApiManagementServiceSkuProperties"></a>ApiManagementServiceSkuProperties
--------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties{#ApiManagementServiceSkuProperties}
+---------------------------------------------------------------------
 
 API Management service resource SKU properties.
 
@@ -1628,8 +1628,8 @@ Used by: [AdditionalLocation](#AdditionalLocation), and [Service_Spec](#Service_
 | capacity | Capacity of the SKU (number of deployed units of the SKU). For Consumption SKU capacity must be specified as 0. | int<br/><small>Required</small>                                                                               |
 | name     | Name of the Sku.                                                                                                | [ApiManagementServiceSkuProperties_Name](#ApiManagementServiceSkuProperties_Name)<br/><small>Required</small> |
 
-<a id="ApiManagementServiceSkuProperties_STATUS"></a>ApiManagementServiceSkuProperties_STATUS
----------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_STATUS{#ApiManagementServiceSkuProperties_STATUS}
+-----------------------------------------------------------------------------------
 
 API Management service resource SKU properties.
 
@@ -1640,8 +1640,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS), and [Service_S
 | capacity | Capacity of the SKU (number of deployed units of the SKU). For Consumption SKU capacity must be specified as 0. | int<br/><small>Optional</small>                                                                                             |
 | name     | Name of the Sku.                                                                                                | [ApiManagementServiceSkuProperties_Name_STATUS](#ApiManagementServiceSkuProperties_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiOperatorSpec"></a>ApiOperatorSpec
--------------------------------------------
+ApiOperatorSpec{#ApiOperatorSpec}
+---------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1652,8 +1652,8 @@ Used by: [Api_Spec](#Api_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ApiVersionConstraint"></a>ApiVersionConstraint
------------------------------------------------------
+ApiVersionConstraint{#ApiVersionConstraint}
+-------------------------------------------
 
 Control Plane Apis version constraint for the API Management service.
 
@@ -1663,8 +1663,8 @@ Used by: [Service_Spec](#Service_Spec).
 |---------------|---------------------------------------------------------------------------------------------------------|------------------------------------|
 | minApiVersion | Limit control plane API calls to API Management service with version equal to or newer than this value. | string<br/><small>Optional</small> |
 
-<a id="ApiVersionConstraint_STATUS"></a>ApiVersionConstraint_STATUS
--------------------------------------------------------------------
+ApiVersionConstraint_STATUS{#ApiVersionConstraint_STATUS}
+---------------------------------------------------------
 
 Control Plane Apis version constraint for the API Management service.
 
@@ -1674,8 +1674,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 |---------------|---------------------------------------------------------------------------------------------------------|------------------------------------|
 | minApiVersion | Limit control plane API calls to API Management service with version equal to or newer than this value. | string<br/><small>Optional</small> |
 
-<a id="ApiVersionSetContractDetails"></a>ApiVersionSetContractDetails
----------------------------------------------------------------------
+ApiVersionSetContractDetails{#ApiVersionSetContractDetails}
+-----------------------------------------------------------
 
 An API Version Set contains the common configuration for a set of API Versions relating
 
@@ -1690,8 +1690,8 @@ Used by: [Api_Spec](#Api_Spec).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.         | [ApiVersionSetContractDetails_VersioningScheme](#ApiVersionSetContractDetails_VersioningScheme)<br/><small>Optional</small>                                |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.        | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ApiVersionSetContractDetails_STATUS"></a>ApiVersionSetContractDetails_STATUS
------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_STATUS{#ApiVersionSetContractDetails_STATUS}
+-------------------------------------------------------------------------
 
 An API Version Set contains the common configuration for a set of API Versions relating
 
@@ -1706,8 +1706,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.         | [ApiVersionSetContractDetails_VersioningScheme_STATUS](#ApiVersionSetContractDetails_VersioningScheme_STATUS)<br/><small>Optional</small> |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.        | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="ApiVersionSetContractProperties_VersioningScheme"></a>ApiVersionSetContractProperties_VersioningScheme
--------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractProperties_VersioningScheme{#ApiVersionSetContractProperties_VersioningScheme}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 
@@ -1717,8 +1717,8 @@ Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetContractProperties_VersioningScheme_STATUS"></a>ApiVersionSetContractProperties_VersioningScheme_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractProperties_VersioningScheme_STATUS{#ApiVersionSetContractProperties_VersioningScheme_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSet_STATUS](#ApiVersionSet_STATUS).
 
@@ -1728,8 +1728,8 @@ Used by: [ApiVersionSet_STATUS](#ApiVersionSet_STATUS).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetOperatorSpec"></a>ApiVersionSetOperatorSpec
----------------------------------------------------------------
+ApiVersionSetOperatorSpec{#ApiVersionSetOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1740,8 +1740,8 @@ Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthenticationSettingsContract"></a>AuthenticationSettingsContract
--------------------------------------------------------------------------
+AuthenticationSettingsContract{#AuthenticationSettingsContract}
+---------------------------------------------------------------
 
 API Authentication Settings.
 
@@ -1754,8 +1754,8 @@ Used by: [Api_Spec](#Api_Spec).
 | openid                       | OpenID Connect Authentication Settings                                        | [OpenIdAuthenticationSettingsContract](#OpenIdAuthenticationSettingsContract)<br/><small>Optional</small>   |
 | openidAuthenticationSettings | Collection of Open ID Connect authentication settings included into this API. | [OpenIdAuthenticationSettingsContract[]](#OpenIdAuthenticationSettingsContract)<br/><small>Optional</small> |
 
-<a id="AuthenticationSettingsContract_STATUS"></a>AuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------
+AuthenticationSettingsContract_STATUS{#AuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------
 
 API Authentication Settings.
 
@@ -1768,37 +1768,37 @@ Used by: [Api_STATUS](#Api_STATUS).
 | openid                       | OpenID Connect Authentication Settings                                        | [OpenIdAuthenticationSettingsContract_STATUS](#OpenIdAuthenticationSettingsContract_STATUS)<br/><small>Optional</small>   |
 | openidAuthenticationSettings | Collection of Open ID Connect authentication settings included into this API. | [OpenIdAuthenticationSettingsContract_STATUS[]](#OpenIdAuthenticationSettingsContract_STATUS)<br/><small>Optional</small> |
 
-<a id="AuthorizationContractProperties_AuthorizationType"></a>AuthorizationContractProperties_AuthorizationType
+AuthorizationContractProperties_AuthorizationType{#AuthorizationContractProperties_AuthorizationType}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+AuthorizationContractProperties_AuthorizationType_STATUS{#AuthorizationContractProperties_AuthorizationType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+AuthorizationContractProperties_Oauth2GrantType{#AuthorizationContractProperties_Oauth2GrantType}
+-------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
+
+| Value               | Description |
+|---------------------|-------------|
+| "AuthorizationCode" |             |
+| "ClientCredentials" |             |
+
+AuthorizationContractProperties_Oauth2GrantType_STATUS{#AuthorizationContractProperties_Oauth2GrantType_STATUS}
 ---------------------------------------------------------------------------------------------------------------
 
-Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
-
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
-
-<a id="AuthorizationContractProperties_AuthorizationType_STATUS"></a>AuthorizationContractProperties_AuthorizationType_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
-
-<a id="AuthorizationContractProperties_Oauth2GrantType"></a>AuthorizationContractProperties_Oauth2GrantType
------------------------------------------------------------------------------------------------------------
-
-Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
-
-| Value               | Description |
-|---------------------|-------------|
-| "AuthorizationCode" |             |
-| "ClientCredentials" |             |
-
-<a id="AuthorizationContractProperties_Oauth2GrantType_STATUS"></a>AuthorizationContractProperties_Oauth2GrantType_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
 Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
 
 | Value               | Description |
@@ -1806,8 +1806,8 @@ Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAut
 | "AuthorizationCode" |             |
 | "ClientCredentials" |             |
 
-<a id="AuthorizationError_STATUS"></a>AuthorizationError_STATUS
----------------------------------------------------------------
+AuthorizationError_STATUS{#AuthorizationError_STATUS}
+-----------------------------------------------------
 
 Authorization error details.
 
@@ -1818,8 +1818,8 @@ Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAut
 | code     | Error code    | string<br/><small>Optional</small> |
 | message  | Error message | string<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2Settings"></a>AuthorizationProviderOAuth2Settings
------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2Settings{#AuthorizationProviderOAuth2Settings}
+-------------------------------------------------------------------------
 
 OAuth2 settings details
 
@@ -1830,8 +1830,8 @@ Used by: [AuthorizationProvider_Spec](#AuthorizationProvider_Spec).
 | grantTypes  | OAuth2 settings                                  | [AuthorizationProviderOAuth2GrantTypes](#AuthorizationProviderOAuth2GrantTypes)<br/><small>Optional</small> |
 | redirectUrl | Redirect URL to be set in the OAuth application. | string<br/><small>Optional</small>                                                                          |
 
-<a id="AuthorizationProviderOAuth2Settings_STATUS"></a>AuthorizationProviderOAuth2Settings_STATUS
--------------------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2Settings_STATUS{#AuthorizationProviderOAuth2Settings_STATUS}
+---------------------------------------------------------------------------------------
 
 OAuth2 settings details
 
@@ -1842,8 +1842,8 @@ Used by: [AuthorizationProvider_STATUS](#AuthorizationProvider_STATUS).
 | grantTypes  | OAuth2 settings                                  | [AuthorizationProviderOAuth2GrantTypes_STATUS](#AuthorizationProviderOAuth2GrantTypes_STATUS)<br/><small>Optional</small> |
 | redirectUrl | Redirect URL to be set in the OAuth application. | string<br/><small>Optional</small>                                                                                        |
 
-<a id="AuthorizationProviderOperatorSpec"></a>AuthorizationProviderOperatorSpec
--------------------------------------------------------------------------------
+AuthorizationProviderOperatorSpec{#AuthorizationProviderOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1854,8 +1854,8 @@ Used by: [AuthorizationProvider_Spec](#AuthorizationProvider_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationOperatorSpec"></a>AuthorizationProvidersAuthorizationOperatorSpec
------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationOperatorSpec{#AuthorizationProvidersAuthorizationOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1866,8 +1866,8 @@ Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAutho
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec"></a>AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec
--------------------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec{#AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec}
+---------------------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1878,8 +1878,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy_Spec](#AuthorizationP
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackendContractProperties_Protocol"></a>BackendContractProperties_Protocol
----------------------------------------------------------------------------------
+BackendContractProperties_Protocol{#BackendContractProperties_Protocol}
+-----------------------------------------------------------------------
 
 Used by: [Backend_Spec](#Backend_Spec).
 
@@ -1888,8 +1888,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | "http" |             |
 | "soap" |             |
 
-<a id="BackendContractProperties_Protocol_STATUS"></a>BackendContractProperties_Protocol_STATUS
------------------------------------------------------------------------------------------------
+BackendContractProperties_Protocol_STATUS{#BackendContractProperties_Protocol_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Backend_STATUS](#Backend_STATUS).
 
@@ -1898,8 +1898,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | "http" |             |
 | "soap" |             |
 
-<a id="BackendCredentialsContract"></a>BackendCredentialsContract
------------------------------------------------------------------
+BackendCredentialsContract{#BackendCredentialsContract}
+-------------------------------------------------------
 
 Details of the Credentials used to connect to Backend.
 
@@ -1913,8 +1913,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | header         | Header Parameter description.                                                            | map[string]string[]<br/><small>Optional</small>                                                             |
 | query          | Query Parameter description.                                                             | map[string]string[]<br/><small>Optional</small>                                                             |
 
-<a id="BackendCredentialsContract_STATUS"></a>BackendCredentialsContract_STATUS
--------------------------------------------------------------------------------
+BackendCredentialsContract_STATUS{#BackendCredentialsContract_STATUS}
+---------------------------------------------------------------------
 
 Details of the Credentials used to connect to Backend.
 
@@ -1928,8 +1928,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | header         | Header Parameter description.                                                            | map[string]string[]<br/><small>Optional</small>                                                                           |
 | query          | Query Parameter description.                                                             | map[string]string[]<br/><small>Optional</small>                                                                           |
 
-<a id="BackendOperatorSpec"></a>BackendOperatorSpec
----------------------------------------------------
+BackendOperatorSpec{#BackendOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1940,8 +1940,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackendProperties"></a>BackendProperties
------------------------------------------------
+BackendProperties{#BackendProperties}
+-------------------------------------
 
 Properties specific to the Backend Type.
 
@@ -1951,8 +1951,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 |----------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | serviceFabricCluster | Backend Service Fabric Cluster Properties | [BackendServiceFabricClusterProperties](#BackendServiceFabricClusterProperties)<br/><small>Optional</small> |
 
-<a id="BackendProperties_STATUS"></a>BackendProperties_STATUS
--------------------------------------------------------------
+BackendProperties_STATUS{#BackendProperties_STATUS}
+---------------------------------------------------
 
 Properties specific to the Backend Type.
 
@@ -1962,8 +1962,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 |----------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | serviceFabricCluster | Backend Service Fabric Cluster Properties | [BackendServiceFabricClusterProperties_STATUS](#BackendServiceFabricClusterProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="BackendProxyContract"></a>BackendProxyContract
------------------------------------------------------
+BackendProxyContract{#BackendProxyContract}
+-------------------------------------------
 
 Details of the Backend WebProxy Server to use in the Request to Backend.
 
@@ -1975,8 +1975,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | url      | WebProxy Server AbsoluteUri property which includes the entire URI stored in the Uri instance, including all fragments and query strings. | string<br/><small>Required</small>                                                                                                                     |
 | username | Username to connect to the WebProxy server                                                                                                | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="BackendProxyContract_STATUS"></a>BackendProxyContract_STATUS
--------------------------------------------------------------------
+BackendProxyContract_STATUS{#BackendProxyContract_STATUS}
+---------------------------------------------------------
 
 Details of the Backend WebProxy Server to use in the Request to Backend.
 
@@ -1987,8 +1987,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | url      | WebProxy Server AbsoluteUri property which includes the entire URI stored in the Uri instance, including all fragments and query strings. | string<br/><small>Optional</small> |
 | username | Username to connect to the WebProxy server                                                                                                | string<br/><small>Optional</small> |
 
-<a id="BackendTlsProperties"></a>BackendTlsProperties
------------------------------------------------------
+BackendTlsProperties{#BackendTlsProperties}
+-------------------------------------------
 
 Properties controlling TLS Certificate Validation.
 
@@ -1999,8 +1999,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | validateCertificateChain | Flag indicating whether SSL certificate chain validation should be done when using self-signed certificates for this backend host. | bool<br/><small>Optional</small> |
 | validateCertificateName  | Flag indicating whether SSL certificate name validation should be done when using self-signed certificates for this backend host.  | bool<br/><small>Optional</small> |
 
-<a id="BackendTlsProperties_STATUS"></a>BackendTlsProperties_STATUS
--------------------------------------------------------------------
+BackendTlsProperties_STATUS{#BackendTlsProperties_STATUS}
+---------------------------------------------------------
 
 Properties controlling TLS Certificate Validation.
 
@@ -2011,8 +2011,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | validateCertificateChain | Flag indicating whether SSL certificate chain validation should be done when using self-signed certificates for this backend host. | bool<br/><small>Optional</small> |
 | validateCertificateName  | Flag indicating whether SSL certificate name validation should be done when using self-signed certificates for this backend host.  | bool<br/><small>Optional</small> |
 
-<a id="CertificateConfiguration"></a>CertificateConfiguration
--------------------------------------------------------------
+CertificateConfiguration{#CertificateConfiguration}
+---------------------------------------------------
 
 Certificate configuration which consist of non-trusted intermediates and root certificates.
 
@@ -2025,8 +2025,8 @@ Used by: [Service_Spec](#Service_Spec).
 | encodedCertificate  | Base64 Encoded certificate.                                                                                                                     | string<br/><small>Optional</small>                                                                                                                     |
 | storeName           | The System.Security.Cryptography.x509certificates.StoreName certificate store location. Only Root and CertificateAuthority are valid locations. | [CertificateConfiguration_StoreName](#CertificateConfiguration_StoreName)<br/><small>Required</small>                                                  |
 
-<a id="CertificateConfiguration_STATUS"></a>CertificateConfiguration_STATUS
----------------------------------------------------------------------------
+CertificateConfiguration_STATUS{#CertificateConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Certificate configuration which consist of non-trusted intermediates and root certificates.
 
@@ -2038,8 +2038,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | encodedCertificate | Base64 Encoded certificate.                                                                                                                     | string<br/><small>Optional</small>                                                                                  |
 | storeName          | The System.Security.Cryptography.x509certificates.StoreName certificate store location. Only Root and CertificateAuthority are valid locations. | [CertificateConfiguration_StoreName_STATUS](#CertificateConfiguration_StoreName_STATUS)<br/><small>Optional</small> |
 
-<a id="HostnameConfiguration"></a>HostnameConfiguration
--------------------------------------------------------
+HostnameConfiguration{#HostnameConfiguration}
+---------------------------------------------
 
 Custom hostname configuration.
 
@@ -2060,8 +2060,8 @@ Used by: [Service_Spec](#Service_Spec).
 | negotiateClientCertificate | Specify true to always negotiate client certificate on the hostname. Default Value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                             |
 | type                       | Hostname type.                                                                                                                                                                                                                                                                                                                                                                              | [HostnameConfiguration_Type](#HostnameConfiguration_Type)<br/><small>Required</small>                                                                        |
 
-<a id="HostnameConfiguration_STATUS"></a>HostnameConfiguration_STATUS
----------------------------------------------------------------------
+HostnameConfiguration_STATUS{#HostnameConfiguration_STATUS}
+-----------------------------------------------------------
 
 Custom hostname configuration.
 
@@ -2080,8 +2080,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | negotiateClientCertificate | Specify true to always negotiate client certificate on the hostname. Default Value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                              |
 | type                       | Hostname type.                                                                                                                                                                                                                                                                                                                                                                              | [HostnameConfiguration_Type_STATUS](#HostnameConfiguration_Type_STATUS)<br/><small>Optional</small>                           |
 
-<a id="KeyVaultContractCreateProperties"></a>KeyVaultContractCreateProperties
------------------------------------------------------------------------------
+KeyVaultContractCreateProperties{#KeyVaultContractCreateProperties}
+-------------------------------------------------------------------
 
 Create keyVault contract details.
 
@@ -2093,8 +2093,8 @@ Used by: [NamedValue_Spec](#NamedValue_Spec).
 | identityClientIdFromConfig | Null for SystemAssignedIdentity or Client Id for UserAssignedIdentity , which will be used to access key vault secret.                                                             | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | secretIdentifier           | Key vault secret identifier for fetching secret. Providing a versioned secret will prevent auto-refresh. This requires API Management service to be configured with aka.ms/apimmsi | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="KeyVaultContractProperties_STATUS"></a>KeyVaultContractProperties_STATUS
--------------------------------------------------------------------------------
+KeyVaultContractProperties_STATUS{#KeyVaultContractProperties_STATUS}
+---------------------------------------------------------------------
 
 KeyVault contract details.
 
@@ -2106,8 +2106,8 @@ Used by: [NamedValue_STATUS](#NamedValue_STATUS).
 | lastStatus       | Last time sync and refresh status of secret from key vault.                                                                                                                        | [KeyVaultLastAccessStatusContractProperties_STATUS](#KeyVaultLastAccessStatusContractProperties_STATUS)<br/><small>Optional</small> |
 | secretIdentifier | Key vault secret identifier for fetching secret. Providing a versioned secret will prevent auto-refresh. This requires API Management service to be configured with aka.ms/apimmsi | string<br/><small>Optional</small>                                                                                                  |
 
-<a id="NamedValueOperatorSpec"></a>NamedValueOperatorSpec
----------------------------------------------------------
+NamedValueOperatorSpec{#NamedValueOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2118,8 +2118,8 @@ Used by: [NamedValue_Spec](#NamedValue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PolicyContractProperties_Format"></a>PolicyContractProperties_Format
----------------------------------------------------------------------------
+PolicyContractProperties_Format{#PolicyContractProperties_Format}
+-----------------------------------------------------------------
 
 Used by: [Policy_Spec](#Policy_Spec), and [ProductPolicy_Spec](#ProductPolicy_Spec).
 
@@ -2130,8 +2130,8 @@ Used by: [Policy_Spec](#Policy_Spec), and [ProductPolicy_Spec](#ProductPolicy_Sp
 | "xml"         |             |
 | "xml-link"    |             |
 
-<a id="PolicyContractProperties_Format_STATUS"></a>PolicyContractProperties_Format_STATUS
------------------------------------------------------------------------------------------
+PolicyContractProperties_Format_STATUS{#PolicyContractProperties_Format_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Policy_STATUS](#Policy_STATUS), and [ProductPolicy_STATUS](#ProductPolicy_STATUS).
 
@@ -2142,8 +2142,8 @@ Used by: [Policy_STATUS](#Policy_STATUS), and [ProductPolicy_STATUS](#ProductPol
 | "xml"         |             |
 | "xml-link"    |             |
 
-<a id="PolicyFragmentContractProperties_Format"></a>PolicyFragmentContractProperties_Format
--------------------------------------------------------------------------------------------
+PolicyFragmentContractProperties_Format{#PolicyFragmentContractProperties_Format}
+---------------------------------------------------------------------------------
 
 Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 
@@ -2152,8 +2152,8 @@ Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 | "rawxml" |             |
 | "xml"    |             |
 
-<a id="PolicyFragmentContractProperties_Format_STATUS"></a>PolicyFragmentContractProperties_Format_STATUS
----------------------------------------------------------------------------------------------------------
+PolicyFragmentContractProperties_Format_STATUS{#PolicyFragmentContractProperties_Format_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [PolicyFragment_STATUS](#PolicyFragment_STATUS).
 
@@ -2162,8 +2162,8 @@ Used by: [PolicyFragment_STATUS](#PolicyFragment_STATUS).
 | "rawxml" |             |
 | "xml"    |             |
 
-<a id="PolicyFragmentOperatorSpec"></a>PolicyFragmentOperatorSpec
------------------------------------------------------------------
+PolicyFragmentOperatorSpec{#PolicyFragmentOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2174,8 +2174,8 @@ Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PolicyOperatorSpec"></a>PolicyOperatorSpec
--------------------------------------------------
+PolicyOperatorSpec{#PolicyOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2186,8 +2186,8 @@ Used by: [Policy_Spec](#Policy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductApiOperatorSpec"></a>ProductApiOperatorSpec
----------------------------------------------------------
+ProductApiOperatorSpec{#ProductApiOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2198,8 +2198,8 @@ Used by: [ProductApi_Spec](#ProductApi_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductContractProperties_State"></a>ProductContractProperties_State
----------------------------------------------------------------------------
+ProductContractProperties_State{#ProductContractProperties_State}
+-----------------------------------------------------------------
 
 Used by: [Product_Spec](#Product_Spec).
 
@@ -2208,8 +2208,8 @@ Used by: [Product_Spec](#Product_Spec).
 | "notPublished" |             |
 | "published"    |             |
 
-<a id="ProductContractProperties_State_STATUS"></a>ProductContractProperties_State_STATUS
------------------------------------------------------------------------------------------
+ProductContractProperties_State_STATUS{#ProductContractProperties_State_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Product_STATUS](#Product_STATUS).
 
@@ -2218,8 +2218,8 @@ Used by: [Product_STATUS](#Product_STATUS).
 | "notPublished" |             |
 | "published"    |             |
 
-<a id="ProductOperatorSpec"></a>ProductOperatorSpec
----------------------------------------------------
+ProductOperatorSpec{#ProductOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2230,8 +2230,8 @@ Used by: [Product_Spec](#Product_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductPolicyOperatorSpec"></a>ProductPolicyOperatorSpec
----------------------------------------------------------------
+ProductPolicyOperatorSpec{#ProductPolicyOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2242,8 +2242,8 @@ Used by: [ProductPolicy_Spec](#ProductPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RemotePrivateEndpointConnectionWrapper_STATUS"></a>RemotePrivateEndpointConnectionWrapper_STATUS
--------------------------------------------------------------------------------------------------------
+RemotePrivateEndpointConnectionWrapper_STATUS{#RemotePrivateEndpointConnectionWrapper_STATUS}
+---------------------------------------------------------------------------------------------
 
 Remote Private Endpoint Connection resource.
 
@@ -2259,8 +2259,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | provisioningState                 | The provisioning state of the private endpoint connection resource.                                  | string<br/><small>Optional</small>                                                                                |
 | type                              | Private Endpoint Connection Resource Type                                                            | string<br/><small>Optional</small>                                                                                |
 
-<a id="ServiceOperatorSpec"></a>ServiceOperatorSpec
----------------------------------------------------
+ServiceOperatorSpec{#ServiceOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2271,8 +2271,8 @@ Used by: [Service_Spec](#Service_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SubscriptionContractProperties_State_STATUS"></a>SubscriptionContractProperties_State_STATUS
----------------------------------------------------------------------------------------------------
+SubscriptionContractProperties_State_STATUS{#SubscriptionContractProperties_State_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Subscription_STATUS](#Subscription_STATUS).
 
@@ -2285,8 +2285,8 @@ Used by: [Subscription_STATUS](#Subscription_STATUS).
 | "submitted" |             |
 | "suspended" |             |
 
-<a id="SubscriptionCreateParameterProperties_State"></a>SubscriptionCreateParameterProperties_State
----------------------------------------------------------------------------------------------------
+SubscriptionCreateParameterProperties_State{#SubscriptionCreateParameterProperties_State}
+-----------------------------------------------------------------------------------------
 
 Used by: [Subscription_Spec](#Subscription_Spec).
 
@@ -2299,8 +2299,8 @@ Used by: [Subscription_Spec](#Subscription_Spec).
 | "submitted" |             |
 | "suspended" |             |
 
-<a id="SubscriptionKeyParameterNamesContract"></a>SubscriptionKeyParameterNamesContract
----------------------------------------------------------------------------------------
+SubscriptionKeyParameterNamesContract{#SubscriptionKeyParameterNamesContract}
+-----------------------------------------------------------------------------
 
 Subscription key parameter names details.
 
@@ -2311,8 +2311,8 @@ Used by: [Api_Spec](#Api_Spec).
 | header   | Subscription key header name.                 | string<br/><small>Optional</small> |
 | query    | Subscription key query string parameter name. | string<br/><small>Optional</small> |
 
-<a id="SubscriptionKeyParameterNamesContract_STATUS"></a>SubscriptionKeyParameterNamesContract_STATUS
------------------------------------------------------------------------------------------------------
+SubscriptionKeyParameterNamesContract_STATUS{#SubscriptionKeyParameterNamesContract_STATUS}
+-------------------------------------------------------------------------------------------
 
 Subscription key parameter names details.
 
@@ -2323,8 +2323,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | header   | Subscription key header name.                 | string<br/><small>Optional</small> |
 | query    | Subscription key query string parameter name. | string<br/><small>Optional</small> |
 
-<a id="SubscriptionOperatorSpec"></a>SubscriptionOperatorSpec
--------------------------------------------------------------
+SubscriptionOperatorSpec{#SubscriptionOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2336,8 +2336,8 @@ Used by: [Subscription_Spec](#Subscription_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [SubscriptionOperatorSecrets](#SubscriptionOperatorSecrets)<br/><small>Optional</small>                                                                             |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2352,8 +2352,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkConfiguration"></a>VirtualNetworkConfiguration
--------------------------------------------------------------------
+VirtualNetworkConfiguration{#VirtualNetworkConfiguration}
+---------------------------------------------------------
 
 Configuration of a virtual network to which API Management service is deployed.
 
@@ -2363,8 +2363,8 @@ Used by: [AdditionalLocation](#AdditionalLocation), and [Service_Spec](#Service_
 |-------------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | subnetResourceReference | The full resource ID of a subnet in a virtual network to deploy the API Management service in. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkConfiguration_STATUS"></a>VirtualNetworkConfiguration_STATUS
----------------------------------------------------------------------------------
+VirtualNetworkConfiguration_STATUS{#VirtualNetworkConfiguration_STATUS}
+-----------------------------------------------------------------------
 
 Configuration of a virtual network to which API Management service is deployed.
 
@@ -2376,8 +2376,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS), and [Service_S
 | subnetResourceId | The full resource ID of a subnet in a virtual network to deploy the API Management service in. | string<br/><small>Optional</small> |
 | vnetid           | The virtual network ID. This is typically a GUID. Expect a null GUID by default.               | string<br/><small>Optional</small> |
 
-<a id="AdditionalLocation_NatGatewayState"></a>AdditionalLocation_NatGatewayState
----------------------------------------------------------------------------------
+AdditionalLocation_NatGatewayState{#AdditionalLocation_NatGatewayState}
+-----------------------------------------------------------------------
 
 Used by: [AdditionalLocation](#AdditionalLocation).
 
@@ -2386,8 +2386,8 @@ Used by: [AdditionalLocation](#AdditionalLocation).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdditionalLocation_NatGatewayState_STATUS"></a>AdditionalLocation_NatGatewayState_STATUS
------------------------------------------------------------------------------------------------
+AdditionalLocation_NatGatewayState_STATUS{#AdditionalLocation_NatGatewayState_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 
@@ -2396,8 +2396,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdditionalLocation_PlatformVersion_STATUS"></a>AdditionalLocation_PlatformVersion_STATUS
------------------------------------------------------------------------------------------------
+AdditionalLocation_PlatformVersion_STATUS{#AdditionalLocation_PlatformVersion_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 
@@ -2408,8 +2408,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 | "stv2"         |             |
 | "undetermined" |             |
 
-<a id="ApiManagementServiceIdentity_Type"></a>ApiManagementServiceIdentity_Type
--------------------------------------------------------------------------------
+ApiManagementServiceIdentity_Type{#ApiManagementServiceIdentity_Type}
+---------------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 
@@ -2420,8 +2420,8 @@ Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ApiManagementServiceIdentity_Type_STATUS"></a>ApiManagementServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------------------
+ApiManagementServiceIdentity_Type_STATUS{#ApiManagementServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STATUS).
 
@@ -2432,8 +2432,8 @@ Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STA
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ApiManagementServiceSkuProperties_Name"></a>ApiManagementServiceSkuProperties_Name
------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_Name{#ApiManagementServiceSkuProperties_Name}
+-------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceSkuProperties](#ApiManagementServiceSkuProperties).
 
@@ -2446,8 +2446,8 @@ Used by: [ApiManagementServiceSkuProperties](#ApiManagementServiceSkuProperties)
 | "Premium"     |             |
 | "Standard"    |             |
 
-<a id="ApiManagementServiceSkuProperties_Name_STATUS"></a>ApiManagementServiceSkuProperties_Name_STATUS
--------------------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_Name_STATUS{#ApiManagementServiceSkuProperties_Name_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceSkuProperties_STATUS](#ApiManagementServiceSkuProperties_STATUS).
 
@@ -2460,8 +2460,8 @@ Used by: [ApiManagementServiceSkuProperties_STATUS](#ApiManagementServiceSkuProp
 | "Premium"     |             |
 | "Standard"    |             |
 
-<a id="ApiVersionSetContractDetails_VersioningScheme"></a>ApiVersionSetContractDetails_VersioningScheme
--------------------------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_VersioningScheme{#ApiVersionSetContractDetails_VersioningScheme}
+---------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSetContractDetails](#ApiVersionSetContractDetails).
 
@@ -2471,8 +2471,8 @@ Used by: [ApiVersionSetContractDetails](#ApiVersionSetContractDetails).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetContractDetails_VersioningScheme_STATUS"></a>ApiVersionSetContractDetails_VersioningScheme_STATUS
----------------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_VersioningScheme_STATUS{#ApiVersionSetContractDetails_VersioningScheme_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSetContractDetails_STATUS](#ApiVersionSetContractDetails_STATUS).
 
@@ -2482,8 +2482,8 @@ Used by: [ApiVersionSetContractDetails_STATUS](#ApiVersionSetContractDetails_STA
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ArmIdWrapper_STATUS"></a>ArmIdWrapper_STATUS
----------------------------------------------------
+ArmIdWrapper_STATUS{#ArmIdWrapper_STATUS}
+-----------------------------------------
 
 A wrapper for an ARM resource id
 
@@ -2493,8 +2493,8 @@ Used by: [RemotePrivateEndpointConnectionWrapper_STATUS](#RemotePrivateEndpointC
 |----------|-------------|------------------------------------|
 | id       |             | string<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2GrantTypes"></a>AuthorizationProviderOAuth2GrantTypes
----------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2GrantTypes{#AuthorizationProviderOAuth2GrantTypes}
+-----------------------------------------------------------------------------
 
 Authorization Provider oauth2 grant types settings
 
@@ -2505,8 +2505,8 @@ Used by: [AuthorizationProviderOAuth2Settings](#AuthorizationProviderOAuth2Setti
 | authorizationCode | OAuth2 authorization code grant parameters | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small> |
 | clientCredentials | OAuth2 client credential grant parameters  | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2GrantTypes_STATUS"></a>AuthorizationProviderOAuth2GrantTypes_STATUS
------------------------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2GrantTypes_STATUS{#AuthorizationProviderOAuth2GrantTypes_STATUS}
+-------------------------------------------------------------------------------------------
 
 Authorization Provider oauth2 grant types settings
 
@@ -2517,8 +2517,8 @@ Used by: [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAut
 | authorizationCode | OAuth2 authorization code grant parameters | map[string]string<br/><small>Optional</small> |
 | clientCredentials | OAuth2 client credential grant parameters  | map[string]string<br/><small>Optional</small> |
 
-<a id="BackendAuthorizationHeaderCredentials"></a>BackendAuthorizationHeaderCredentials
----------------------------------------------------------------------------------------
+BackendAuthorizationHeaderCredentials{#BackendAuthorizationHeaderCredentials}
+-----------------------------------------------------------------------------
 
 Authorization header information.
 
@@ -2529,8 +2529,8 @@ Used by: [BackendCredentialsContract](#BackendCredentialsContract).
 | parameter | Authentication Parameter value. | string<br/><small>Required</small> |
 | scheme    | Authentication Scheme name.     | string<br/><small>Required</small> |
 
-<a id="BackendAuthorizationHeaderCredentials_STATUS"></a>BackendAuthorizationHeaderCredentials_STATUS
------------------------------------------------------------------------------------------------------
+BackendAuthorizationHeaderCredentials_STATUS{#BackendAuthorizationHeaderCredentials_STATUS}
+-------------------------------------------------------------------------------------------
 
 Authorization header information.
 
@@ -2541,8 +2541,8 @@ Used by: [BackendCredentialsContract_STATUS](#BackendCredentialsContract_STATUS)
 | parameter | Authentication Parameter value. | string<br/><small>Optional</small> |
 | scheme    | Authentication Scheme name.     | string<br/><small>Optional</small> |
 
-<a id="BackendServiceFabricClusterProperties"></a>BackendServiceFabricClusterProperties
----------------------------------------------------------------------------------------
+BackendServiceFabricClusterProperties{#BackendServiceFabricClusterProperties}
+-----------------------------------------------------------------------------
 
 Properties of the Service Fabric Type Backend.
 
@@ -2557,8 +2557,8 @@ Used by: [BackendProperties](#BackendProperties).
 | serverCertificateThumbprints  | Thumbprints of certificates cluster management service uses for tls communication                              | string[]<br/><small>Optional</small>                                      |
 | serverX509Names               | Server X509 Certificate Names Collection                                                                       | [X509CertificateName[]](#X509CertificateName)<br/><small>Optional</small> |
 
-<a id="BackendServiceFabricClusterProperties_STATUS"></a>BackendServiceFabricClusterProperties_STATUS
------------------------------------------------------------------------------------------------------
+BackendServiceFabricClusterProperties_STATUS{#BackendServiceFabricClusterProperties_STATUS}
+-------------------------------------------------------------------------------------------
 
 Properties of the Service Fabric Type Backend.
 
@@ -2573,8 +2573,8 @@ Used by: [BackendProperties_STATUS](#BackendProperties_STATUS).
 | serverCertificateThumbprints  | Thumbprints of certificates cluster management service uses for tls communication                              | string[]<br/><small>Optional</small>                                                    |
 | serverX509Names               | Server X509 Certificate Names Collection                                                                       | [X509CertificateName_STATUS[]](#X509CertificateName_STATUS)<br/><small>Optional</small> |
 
-<a id="CertificateConfiguration_StoreName"></a>CertificateConfiguration_StoreName
----------------------------------------------------------------------------------
+CertificateConfiguration_StoreName{#CertificateConfiguration_StoreName}
+-----------------------------------------------------------------------
 
 Used by: [CertificateConfiguration](#CertificateConfiguration).
 
@@ -2583,8 +2583,8 @@ Used by: [CertificateConfiguration](#CertificateConfiguration).
 | "CertificateAuthority" |             |
 | "Root"                 |             |
 
-<a id="CertificateConfiguration_StoreName_STATUS"></a>CertificateConfiguration_StoreName_STATUS
------------------------------------------------------------------------------------------------
+CertificateConfiguration_StoreName_STATUS{#CertificateConfiguration_StoreName_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS).
 
@@ -2593,8 +2593,8 @@ Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS).
 | "CertificateAuthority" |             |
 | "Root"                 |             |
 
-<a id="CertificateInformation"></a>CertificateInformation
----------------------------------------------------------
+CertificateInformation{#CertificateInformation}
+-----------------------------------------------
 
 SSL certificate information.
 
@@ -2609,8 +2609,8 @@ Used by: [CertificateConfiguration](#CertificateConfiguration), and [HostnameCon
 | thumbprint           | Thumbprint of the certificate.                                                                                                               | string<br/><small>Optional</small>                                                                                                                           |
 | thumbprintFromConfig | Thumbprint of the certificate.                                                                                                               | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="CertificateInformation_STATUS"></a>CertificateInformation_STATUS
------------------------------------------------------------------------
+CertificateInformation_STATUS{#CertificateInformation_STATUS}
+-------------------------------------------------------------
 
 SSL certificate information.
 
@@ -2622,8 +2622,8 @@ Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS), an
 | subject    | Subject of the certificate.                                                                                                                  | string<br/><small>Optional</small> |
 | thumbprint | Thumbprint of the certificate.                                                                                                               | string<br/><small>Optional</small> |
 
-<a id="HostnameConfiguration_CertificateSource"></a>HostnameConfiguration_CertificateSource
--------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateSource{#HostnameConfiguration_CertificateSource}
+---------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2634,8 +2634,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "KeyVault" |             |
 | "Managed"  |             |
 
-<a id="HostnameConfiguration_CertificateSource_STATUS"></a>HostnameConfiguration_CertificateSource_STATUS
----------------------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateSource_STATUS{#HostnameConfiguration_CertificateSource_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2646,8 +2646,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "KeyVault" |             |
 | "Managed"  |             |
 
-<a id="HostnameConfiguration_CertificateStatus"></a>HostnameConfiguration_CertificateStatus
--------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateStatus{#HostnameConfiguration_CertificateStatus}
+---------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2657,8 +2657,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="HostnameConfiguration_CertificateStatus_STATUS"></a>HostnameConfiguration_CertificateStatus_STATUS
----------------------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateStatus_STATUS{#HostnameConfiguration_CertificateStatus_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2668,8 +2668,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="HostnameConfiguration_Type"></a>HostnameConfiguration_Type
------------------------------------------------------------------
+HostnameConfiguration_Type{#HostnameConfiguration_Type}
+-------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2681,8 +2681,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "Proxy"           |             |
 | "Scm"             |             |
 
-<a id="HostnameConfiguration_Type_STATUS"></a>HostnameConfiguration_Type_STATUS
--------------------------------------------------------------------------------
+HostnameConfiguration_Type_STATUS{#HostnameConfiguration_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2694,8 +2694,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "Proxy"           |             |
 | "Scm"             |             |
 
-<a id="KeyVaultLastAccessStatusContractProperties_STATUS"></a>KeyVaultLastAccessStatusContractProperties_STATUS
----------------------------------------------------------------------------------------------------------------
+KeyVaultLastAccessStatusContractProperties_STATUS{#KeyVaultLastAccessStatusContractProperties_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Issue contract Update Properties.
 
@@ -2707,8 +2707,8 @@ Used by: [KeyVaultContractProperties_STATUS](#KeyVaultContractProperties_STATUS)
 | message      | Details of the error else empty.                                                                                                        | string<br/><small>Optional</small> |
 | timeStampUtc | Last time secret was accessed. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard. | string<br/><small>Optional</small> |
 
-<a id="OAuth2AuthenticationSettingsContract"></a>OAuth2AuthenticationSettingsContract
--------------------------------------------------------------------------------------
+OAuth2AuthenticationSettingsContract{#OAuth2AuthenticationSettingsContract}
+---------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2719,8 +2719,8 @@ Used by: [AuthenticationSettingsContract](#AuthenticationSettingsContract), and 
 | authorizationServerId | OAuth authorization server identifier. | string<br/><small>Optional</small> |
 | scope                 | operations scope.                      | string<br/><small>Optional</small> |
 
-<a id="OAuth2AuthenticationSettingsContract_STATUS"></a>OAuth2AuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------------------
+OAuth2AuthenticationSettingsContract_STATUS{#OAuth2AuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2731,8 +2731,8 @@ Used by: [AuthenticationSettingsContract_STATUS](#AuthenticationSettingsContract
 | authorizationServerId | OAuth authorization server identifier. | string<br/><small>Optional</small> |
 | scope                 | operations scope.                      | string<br/><small>Optional</small> |
 
-<a id="OpenIdAuthenticationSettingsContract"></a>OpenIdAuthenticationSettingsContract
--------------------------------------------------------------------------------------
+OpenIdAuthenticationSettingsContract{#OpenIdAuthenticationSettingsContract}
+---------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2743,8 +2743,8 @@ Used by: [AuthenticationSettingsContract](#AuthenticationSettingsContract), and 
 | bearerTokenSendingMethods | How to send token to the server.       | [BearerTokenSendingMethodsContract[]](#BearerTokenSendingMethodsContract)<br/><small>Optional</small> |
 | openidProviderId          | OAuth authorization server identifier. | string<br/><small>Optional</small>                                                                    |
 
-<a id="OpenIdAuthenticationSettingsContract_STATUS"></a>OpenIdAuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------------------
+OpenIdAuthenticationSettingsContract_STATUS{#OpenIdAuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2755,8 +2755,8 @@ Used by: [AuthenticationSettingsContract_STATUS](#AuthenticationSettingsContract
 | bearerTokenSendingMethods | How to send token to the server.       | [BearerTokenSendingMethodsContract_STATUS[]](#BearerTokenSendingMethodsContract_STATUS)<br/><small>Optional</small> |
 | openidProviderId          | OAuth authorization server identifier. | string<br/><small>Optional</small>                                                                                  |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -2768,8 +2768,8 @@ Used by: [RemotePrivateEndpointConnectionWrapper_STATUS](#RemotePrivateEndpointC
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small>                                                                                          |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="SubscriptionOperatorSecrets"></a>SubscriptionOperatorSecrets
--------------------------------------------------------------------
+SubscriptionOperatorSecrets{#SubscriptionOperatorSecrets}
+---------------------------------------------------------
 
 Used by: [SubscriptionOperatorSpec](#SubscriptionOperatorSpec).
 
@@ -2778,7 +2778,19 @@ Used by: [SubscriptionOperatorSpec](#SubscriptionOperatorSpec).
 | primaryKey   | indicates where the PrimaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.   | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2790,20 +2802,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2813,8 +2813,8 @@ Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentityProperties_STATUS"></a>UserIdentityProperties_STATUS
------------------------------------------------------------------------
+UserIdentityProperties_STATUS{#UserIdentityProperties_STATUS}
+-------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STATUS).
 
@@ -2823,8 +2823,8 @@ Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STA
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="BearerTokenSendingMethodsContract"></a>BearerTokenSendingMethodsContract
--------------------------------------------------------------------------------
+BearerTokenSendingMethodsContract{#BearerTokenSendingMethodsContract}
+---------------------------------------------------------------------
 
 Form of an authorization grant, which the client uses to request the access token.
 
@@ -2835,8 +2835,8 @@ Used by: [OpenIdAuthenticationSettingsContract](#OpenIdAuthenticationSettingsCon
 | "authorizationHeader" |             |
 | "query"               |             |
 
-<a id="BearerTokenSendingMethodsContract_STATUS"></a>BearerTokenSendingMethodsContract_STATUS
----------------------------------------------------------------------------------------------
+BearerTokenSendingMethodsContract_STATUS{#BearerTokenSendingMethodsContract_STATUS}
+-----------------------------------------------------------------------------------
 
 Form of an authorization grant, which the client uses to request the access token.
 
@@ -2847,8 +2847,8 @@ Used by: [OpenIdAuthenticationSettingsContract_STATUS](#OpenIdAuthenticationSett
 | "authorizationHeader" |             |
 | "query"               |             |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -2860,8 +2860,8 @@ Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectio
 | "Pending"  |             |
 | "Rejected" |             |
 
-<a id="X509CertificateName"></a>X509CertificateName
----------------------------------------------------
+X509CertificateName{#X509CertificateName}
+-----------------------------------------
 
 Properties of server X509Names.
 
@@ -2872,8 +2872,8 @@ Used by: [BackendServiceFabricClusterProperties](#BackendServiceFabricClusterPro
 | issuerCertificateThumbprint | Thumbprint for the Issuer of the Certificate. | string<br/><small>Optional</small> |
 | name                        | Common Name of the Certificate.               | string<br/><small>Optional</small> |
 
-<a id="X509CertificateName_STATUS"></a>X509CertificateName_STATUS
------------------------------------------------------------------
+X509CertificateName_STATUS{#X509CertificateName_STATUS}
+-------------------------------------------------------
 
 Properties of server X509Names.
 

--- a/docs/hugo/content/reference/apimanagement/v1api20230501preview.md
+++ b/docs/hugo/content/reference/apimanagement/v1api20230501preview.md
@@ -5,8 +5,8 @@ title: apimanagement.azure.com/v1api20230501preview
 linktitle: v1api20230501preview
 -------------------------------
 
-<a id="Api"></a>Api
--------------------
+Api{#Api}
+---------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimapis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}
 
@@ -19,7 +19,7 @@ Used by: [ApiList](#ApiList).
 | spec                                                                                    |             | [Api_Spec](#Api_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Api_STATUS](#Api_STATUS)<br/><small>Optional</small> |
 
-### <a id="Api_Spec"></a>Api_Spec
+### Api_Spec {#Api_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ Used by: [ApiList](#ApiList).
 | value                            | Content value when Importing an API.                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | wsdlSelector                     | Criteria to limit import of WSDL to a subset of the document.                                                                                                                                                                                                                              | [ApiCreateOrUpdateProperties_WsdlSelector](#ApiCreateOrUpdateProperties_WsdlSelector)<br/><small>Optional</small>                                                    |
 
-### <a id="Api_STATUS"></a>Api_STATUS
+### Api_STATUS{#Api_STATUS}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -83,8 +83,8 @@ Used by: [ApiList](#ApiList).
 | termsOfServiceUrl             | A URL to the Terms of Service for the API. MUST be in the format of a URL.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiList"></a>ApiList
----------------------------
+ApiList{#ApiList}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimapis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}
 
@@ -94,15 +94,15 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                           |
 | items                                                                               |             | [Api[]](#Api)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2023-05-01-preview" |             |
 
-<a id="ApiVersionSet"></a>ApiVersionSet
----------------------------------------
+ApiVersionSet{#ApiVersionSet}
+-----------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimapiversionsets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apiVersionSets/{versionSetId}
 
@@ -115,7 +115,7 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | spec                                                                                    |             | [ApiVersionSet_Spec](#ApiVersionSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ApiVersionSet_STATUS](#ApiVersionSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="ApiVersionSet_Spec"></a>ApiVersionSet_Spec
+### ApiVersionSet_Spec {#ApiVersionSet_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -128,7 +128,7 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                               | [ApiVersionSetContractProperties_VersioningScheme](#ApiVersionSetContractProperties_VersioningScheme)<br/><small>Required</small>                                    |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ApiVersionSet_STATUS"></a>ApiVersionSet_STATUS
+### ApiVersionSet_STATUS{#ApiVersionSet_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -142,8 +142,8 @@ Used by: [ApiVersionSetList](#ApiVersionSetList).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                                                              | [ApiVersionSetContractProperties_VersioningScheme_STATUS](#ApiVersionSetContractProperties_VersioningScheme_STATUS)<br/><small>Optional</small>         |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiVersionSetList"></a>ApiVersionSetList
------------------------------------------------
+ApiVersionSetList{#ApiVersionSetList}
+-------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimapiversionsets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/apiVersionSets/{versionSetId}
 
@@ -153,8 +153,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [ApiVersionSet[]](#ApiVersionSet)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvider"></a>AuthorizationProvider
--------------------------------------------------------
+AuthorizationProvider{#AuthorizationProvider}
+---------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}
 
@@ -167,7 +167,7 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | spec                                                                                    |             | [AuthorizationProvider_Spec](#AuthorizationProvider_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvider_STATUS](#AuthorizationProvider_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvider_Spec"></a>AuthorizationProvider_Spec
+### AuthorizationProvider_Spec {#AuthorizationProvider_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -178,7 +178,7 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [AuthorizationProviderOperatorSpec](#AuthorizationProviderOperatorSpec)<br/><small>Optional</small>                                                                  |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="AuthorizationProvider_STATUS"></a>AuthorizationProvider_STATUS
+### AuthorizationProvider_STATUS{#AuthorizationProvider_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -190,8 +190,8 @@ Used by: [AuthorizationProviderList](#AuthorizationProviderList).
 | oauth2           | OAuth2 settings                                                                                                                                                                                                                                                                                                           | [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAuth2Settings_STATUS)<br/><small>Optional</small>                                   |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProviderList"></a>AuthorizationProviderList
----------------------------------------------------------------
+AuthorizationProviderList{#AuthorizationProviderList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}
 
@@ -201,8 +201,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [AuthorizationProvider[]](#AuthorizationProvider)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorization"></a>AuthorizationProvidersAuthorization
------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization{#AuthorizationProvidersAuthorization}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}
 
@@ -215,7 +215,7 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | spec                                                                                    |             | [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvidersAuthorization_Spec"></a>AuthorizationProvidersAuthorization_Spec
+### AuthorizationProvidersAuthorization_Spec {#AuthorizationProvidersAuthorization_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -226,7 +226,7 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/AuthorizationProvider resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters        | Authorization parameters                                                                                                                                                                                                                                                                                 | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small>         |
 
-### <a id="AuthorizationProvidersAuthorization_STATUS"></a>AuthorizationProvidersAuthorization_STATUS
+### AuthorizationProvidersAuthorization_STATUS{#AuthorizationProvidersAuthorization_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -240,8 +240,8 @@ Used by: [AuthorizationProvidersAuthorizationList](#AuthorizationProvidersAuthor
 | status            | Status of the Authorization                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationList"></a>AuthorizationProvidersAuthorizationList
--------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationList{#AuthorizationProvidersAuthorizationList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}
 
@@ -251,8 +251,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [AuthorizationProvidersAuthorization[]](#AuthorizationProvidersAuthorization)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy"></a>AuthorizationProvidersAuthorizationsAccessPolicy
--------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy{#AuthorizationProvidersAuthorizationsAccessPolicy}
+---------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}/accessPolicies/{authorizationAccessPolicyId}
 
@@ -265,7 +265,7 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | spec                                                                                    |             | [AuthorizationProvidersAuthorizationsAccessPolicy_Spec](#AuthorizationProvidersAuthorizationsAccessPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthorizationProvidersAuthorizationsAccessPolicy_STATUS](#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthorizationProvidersAuthorizationsAccessPolicy_Spec"></a>AuthorizationProvidersAuthorizationsAccessPolicy_Spec
+### AuthorizationProvidersAuthorizationsAccessPolicy_Spec {#AuthorizationProvidersAuthorizationsAccessPolicy_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -278,7 +278,7 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | tenantId           | The Tenant Id                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | The Tenant Id                                                                                                                                                                                                                                                                                                          | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="AuthorizationProvidersAuthorizationsAccessPolicy_STATUS"></a>AuthorizationProvidersAuthorizationsAccessPolicy_STATUS
+### AuthorizationProvidersAuthorizationsAccessPolicy_STATUS{#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -290,8 +290,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicyList](#AuthorizationPr
 | tenantId   | The Tenant Id                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicyList"></a>AuthorizationProvidersAuthorizationsAccessPolicyList
----------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicyList{#AuthorizationProvidersAuthorizationsAccessPolicyList}
+-----------------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimauthorizationproviders.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/authorizationProviders/{authorizationProviderId}/authorizations/{authorizationId}/accessPolicies/{authorizationAccessPolicyId}
 
@@ -301,8 +301,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                                     |
 | items                                                                               |             | [AuthorizationProvidersAuthorizationsAccessPolicy[]](#AuthorizationProvidersAuthorizationsAccessPolicy)<br/><small>Optional</small> |
 
-<a id="Backend"></a>Backend
----------------------------
+Backend{#Backend}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimbackends.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/backends/{backendId}
 
@@ -315,7 +315,7 @@ Used by: [BackendList](#BackendList).
 | spec                                                                                    |             | [Backend_Spec](#Backend_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Backend_STATUS](#Backend_STATUS)<br/><small>Optional</small> |
 
-### <a id="Backend_Spec"></a>Backend_Spec
+### Backend_Spec {#Backend_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -335,7 +335,7 @@ Used by: [BackendList](#BackendList).
 | type              | Type of the backend. A backend can be either Single or Pool.                                                                                                                                                                                                                               | [BackendContractProperties_Type](#BackendContractProperties_Type)<br/><small>Optional</small>                                                                        |
 | url               | Runtime Url of the Backend.                                                                                                                                                                                                                                                                | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="Backend_STATUS"></a>Backend_STATUS
+### Backend_STATUS{#Backend_STATUS}
 
 | Property        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -356,8 +356,8 @@ Used by: [BackendList](#BackendList).
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | url             | Runtime Url of the Backend.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackendList"></a>BackendList
------------------------------------
+BackendList{#BackendList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimbackends.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/backends/{backendId}
 
@@ -367,8 +367,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Backend[]](#Backend)<br/><small>Optional</small> |
 
-<a id="NamedValue"></a>NamedValue
----------------------------------
+NamedValue{#NamedValue}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimnamedvalues.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}
 
@@ -381,7 +381,7 @@ Used by: [NamedValueList](#NamedValueList).
 | spec                                                                                    |             | [NamedValue_Spec](#NamedValue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamedValue_STATUS](#NamedValue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamedValue_Spec"></a>NamedValue_Spec
+### NamedValue_Spec {#NamedValue_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -394,7 +394,7 @@ Used by: [NamedValueList](#NamedValueList).
 | tags         | Optional tags that when provided can be used to filter the NamedValue list.                                                                                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 | value        | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="NamedValue_STATUS"></a>NamedValue_STATUS
+### NamedValue_STATUS{#NamedValue_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -409,8 +409,8 @@ Used by: [NamedValueList](#NamedValueList).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value             | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamedValueList"></a>NamedValueList
------------------------------------------
+NamedValueList{#NamedValueList}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimnamedvalues.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}
 
@@ -420,8 +420,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [NamedValue[]](#NamedValue)<br/><small>Optional</small> |
 
-<a id="Policy"></a>Policy
--------------------------
+Policy{#Policy}
+---------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimpolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policies/{policyId}
 
@@ -434,7 +434,7 @@ Used by: [PolicyList](#PolicyList).
 | spec                                                                                    |             | [Policy_Spec](#Policy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Policy_STATUS](#Policy_STATUS)<br/><small>Optional</small> |
 
-### <a id="Policy_Spec"></a>Policy_Spec
+### Policy_Spec {#Policy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -443,7 +443,7 @@ Used by: [PolicyList](#PolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="Policy_STATUS"></a>Policy_STATUS
+### Policy_STATUS{#Policy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -454,8 +454,8 @@ Used by: [PolicyList](#PolicyList).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragment"></a>PolicyFragment
------------------------------------------
+PolicyFragment{#PolicyFragment}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimpolicyfragments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policyFragments/{id}
 
@@ -468,7 +468,7 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | spec                                                                                    |             | [PolicyFragment_Spec](#PolicyFragment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PolicyFragment_STATUS](#PolicyFragment_STATUS)<br/><small>Optional</small> |
 
-### <a id="PolicyFragment_Spec"></a>PolicyFragment_Spec
+### PolicyFragment_Spec {#PolicyFragment_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -479,7 +479,7 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the policy fragment.                                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="PolicyFragment_STATUS"></a>PolicyFragment_STATUS
+### PolicyFragment_STATUS{#PolicyFragment_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -492,8 +492,8 @@ Used by: [PolicyFragmentList](#PolicyFragmentList).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value             | Contents of the policy fragment.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragmentList"></a>PolicyFragmentList
--------------------------------------------------
+PolicyFragmentList{#PolicyFragmentList}
+---------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimpolicyfragments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policyFragments/{id}
 
@@ -503,8 +503,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PolicyFragment[]](#PolicyFragment)<br/><small>Optional</small> |
 
-<a id="PolicyList"></a>PolicyList
----------------------------------
+PolicyList{#PolicyList}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimpolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/policies/{policyId}
 
@@ -514,8 +514,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Policy[]](#Policy)<br/><small>Optional</small> |
 
-<a id="Product"></a>Product
----------------------------
+Product{#Product}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}
 
@@ -528,7 +528,7 @@ Used by: [ProductList](#ProductList).
 | spec                                                                                    |             | [Product_Spec](#Product_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Product_STATUS](#Product_STATUS)<br/><small>Optional</small> |
 
-### <a id="Product_Spec"></a>Product_Spec
+### Product_Spec {#Product_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -543,7 +543,7 @@ Used by: [ProductList](#ProductList).
 | subscriptionsLimit   | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="Product_STATUS"></a>Product_STATUS
+### Product_STATUS{#Product_STATUS}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -559,8 +559,8 @@ Used by: [ProductList](#ProductList).
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductApi"></a>ProductApi
----------------------------------
+ProductApi{#ProductApi}
+-----------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis/{apiId}
 
@@ -573,7 +573,7 @@ Used by: [ProductApiList](#ProductApiList).
 | spec                                                                                    |             | [ProductApi_Spec](#ProductApi_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ProductApi_STATUS](#ProductApi_STATUS)<br/><small>Optional</small> |
 
-### <a id="ProductApi_Spec"></a>ProductApi_Spec
+### ProductApi_Spec {#ProductApi_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -581,14 +581,14 @@ Used by: [ProductApiList](#ProductApiList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [ProductApiOperatorSpec](#ProductApiOperatorSpec)<br/><small>Optional</small>                                                                                        |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="ProductApi_STATUS"></a>ProductApi_STATUS
+### ProductApi_STATUS{#ProductApi_STATUS}
 
 | Property   | Description                        | Type                                                                                                                                                    |
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="ProductApiList"></a>ProductApiList
------------------------------------------
+ProductApiList{#ProductApiList}
+-------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis/{apiId}
 
@@ -598,8 +598,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [ProductApi[]](#ProductApi)<br/><small>Optional</small> |
 
-<a id="ProductList"></a>ProductList
------------------------------------
+ProductList{#ProductList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}
 
@@ -609,8 +609,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Product[]](#Product)<br/><small>Optional</small> |
 
-<a id="ProductPolicy"></a>ProductPolicy
----------------------------------------
+ProductPolicy{#ProductPolicy}
+-----------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/policies/{policyId}
 
@@ -623,7 +623,7 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | spec                                                                                    |             | [ProductPolicy_Spec](#ProductPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ProductPolicy_STATUS](#ProductPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ProductPolicy_Spec"></a>ProductPolicy_Spec
+### ProductPolicy_Spec {#ProductPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -632,7 +632,7 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="ProductPolicy_STATUS"></a>ProductPolicy_STATUS
+### ProductPolicy_STATUS{#ProductPolicy_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -643,8 +643,8 @@ Used by: [ProductPolicyList](#ProductPolicyList).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductPolicyList"></a>ProductPolicyList
------------------------------------------------
+ProductPolicyList{#ProductPolicyList}
+-------------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimproducts.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/products/{productId}/policies/{policyId}
 
@@ -654,8 +654,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [ProductPolicy[]](#ProductPolicy)<br/><small>Optional</small> |
 
-<a id="Service"></a>Service
----------------------------
+Service{#Service}
+-----------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimdeployment.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}
 
@@ -668,7 +668,7 @@ Used by: [ServiceList](#ServiceList).
 | spec                                                                                    |             | [Service_Spec](#Service_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Service_STATUS](#Service_STATUS)<br/><small>Optional</small> |
 
-### <a id="Service_Spec"></a>Service_Spec
+### Service_Spec {#Service_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -700,7 +700,7 @@ Used by: [ServiceList](#ServiceList).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType](#ApiManagementServiceProperties_VirtualNetworkType)<br/><small>Optional</small>                                  |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Service_STATUS"></a>Service_STATUS
+### Service_STATUS{#Service_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                    |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -749,8 +749,8 @@ Used by: [ServiceList](#ServiceList).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType_STATUS](#ApiManagementServiceProperties_VirtualNetworkType_STATUS)<br/><small>Optional</small>       |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ServiceList"></a>ServiceList
------------------------------------
+ServiceList{#ServiceList}
+-------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimdeployment.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}
 
@@ -760,8 +760,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Service[]](#Service)<br/><small>Optional</small> |
 
-<a id="Subscription"></a>Subscription
--------------------------------------
+Subscription{#Subscription}
+---------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimsubscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{sid}
 
@@ -774,7 +774,7 @@ Used by: [SubscriptionList](#SubscriptionList).
 | spec                                                                                    |             | [Subscription_Spec](#Subscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Subscription_STATUS](#Subscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="Subscription_Spec"></a>Subscription_Spec
+### Subscription_Spec {#Subscription_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -789,7 +789,7 @@ Used by: [SubscriptionList](#SubscriptionList).
 | secondaryKey   | Secondary subscription key. If not specified during request key will be generated automatically.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | state          | Initial subscription state. If no value is specified, subscription is created with Submitted state. Possible states are * active – the subscription is active, * suspended – the subscription is blocked, and the subscriber cannot call any APIs of the product, * submitted – the subscription request has been made by the developer, but has not yet been approved or rejected, * rejected – the subscription request has been denied by an administrator, * cancelled – the subscription has been cancelled by the developer or administrator, * expired – the subscription reached its expiration date and was deactivated. | [SubscriptionCreateParameterProperties_State](#SubscriptionCreateParameterProperties_State)<br/><small>Optional</small>                                              |
 
-### <a id="Subscription_STATUS"></a>Subscription_STATUS
+### Subscription_STATUS{#Subscription_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -809,8 +809,8 @@ Used by: [SubscriptionList](#SubscriptionList).
 | stateComment     | Optional subscription comment added by an administrator when the state is changed to the 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SubscriptionList"></a>SubscriptionList
----------------------------------------------
+SubscriptionList{#SubscriptionList}
+-----------------------------------
 
 Generator information: - Generated from: /apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimsubscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ApiManagement/service/{serviceName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{sid}
 
@@ -820,8 +820,8 @@ Generator information: - Generated from: /apimanagement/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [Subscription[]](#Subscription)<br/><small>Optional</small> |
 
-<a id="Api_Spec"></a>Api_Spec
------------------------------
+Api_Spec{#Api_Spec}
+-------------------
 
 Used by: [Api](#Api).
 
@@ -856,8 +856,8 @@ Used by: [Api](#Api).
 | value                            | Content value when Importing an API.                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | wsdlSelector                     | Criteria to limit import of WSDL to a subset of the document.                                                                                                                                                                                                                              | [ApiCreateOrUpdateProperties_WsdlSelector](#ApiCreateOrUpdateProperties_WsdlSelector)<br/><small>Optional</small>                                                    |
 
-<a id="Api_STATUS"></a>Api_STATUS
----------------------------------
+Api_STATUS{#Api_STATUS}
+-----------------------
 
 Used by: [Api](#Api).
 
@@ -890,8 +890,8 @@ Used by: [Api](#Api).
 | termsOfServiceUrl             | A URL to the Terms of Service for the API. MUST be in the format of a URL.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiVersionSet_Spec"></a>ApiVersionSet_Spec
--------------------------------------------------
+ApiVersionSet_Spec{#ApiVersionSet_Spec}
+---------------------------------------
 
 Used by: [ApiVersionSet](#ApiVersionSet).
 
@@ -906,8 +906,8 @@ Used by: [ApiVersionSet](#ApiVersionSet).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                               | [ApiVersionSetContractProperties_VersioningScheme](#ApiVersionSetContractProperties_VersioningScheme)<br/><small>Required</small>                                    |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ApiVersionSet_STATUS"></a>ApiVersionSet_STATUS
------------------------------------------------------
+ApiVersionSet_STATUS{#ApiVersionSet_STATUS}
+-------------------------------------------
 
 Used by: [ApiVersionSet](#ApiVersionSet).
 
@@ -923,8 +923,8 @@ Used by: [ApiVersionSet](#ApiVersionSet).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.                                                                                                                                                                                                                              | [ApiVersionSetContractProperties_VersioningScheme_STATUS](#ApiVersionSetContractProperties_VersioningScheme_STATUS)<br/><small>Optional</small>         |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvider_Spec"></a>AuthorizationProvider_Spec
------------------------------------------------------------------
+AuthorizationProvider_Spec{#AuthorizationProvider_Spec}
+-------------------------------------------------------
 
 Used by: [AuthorizationProvider](#AuthorizationProvider).
 
@@ -937,8 +937,8 @@ Used by: [AuthorizationProvider](#AuthorizationProvider).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [AuthorizationProviderOperatorSpec](#AuthorizationProviderOperatorSpec)<br/><small>Optional</small>                                                                  |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="AuthorizationProvider_STATUS"></a>AuthorizationProvider_STATUS
----------------------------------------------------------------------
+AuthorizationProvider_STATUS{#AuthorizationProvider_STATUS}
+-----------------------------------------------------------
 
 Used by: [AuthorizationProvider](#AuthorizationProvider).
 
@@ -952,8 +952,8 @@ Used by: [AuthorizationProvider](#AuthorizationProvider).
 | oauth2           | OAuth2 settings                                                                                                                                                                                                                                                                                                           | [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAuth2Settings_STATUS)<br/><small>Optional</small>                                   |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorization_Spec"></a>AuthorizationProvidersAuthorization_Spec
----------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization_Spec{#AuthorizationProvidersAuthorization_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorization).
 
@@ -966,8 +966,8 @@ Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorizat
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/AuthorizationProvider resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters        | Authorization parameters                                                                                                                                                                                                                                                                                 | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small>         |
 
-<a id="AuthorizationProvidersAuthorization_STATUS"></a>AuthorizationProvidersAuthorization_STATUS
--------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorization_STATUS{#AuthorizationProvidersAuthorization_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorization).
 
@@ -983,8 +983,8 @@ Used by: [AuthorizationProvidersAuthorization](#AuthorizationProvidersAuthorizat
 | status            | Status of the Authorization                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy_Spec"></a>AuthorizationProvidersAuthorizationsAccessPolicy_Spec
------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy_Spec{#AuthorizationProvidersAuthorizationsAccessPolicy_Spec}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvidersAuthorizationsAccessPolicy).
 
@@ -999,8 +999,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvid
 | tenantId           | The Tenant Id                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | The Tenant Id                                                                                                                                                                                                                                                                                                          | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicy_STATUS"></a>AuthorizationProvidersAuthorizationsAccessPolicy_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicy_STATUS{#AuthorizationProvidersAuthorizationsAccessPolicy_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvidersAuthorizationsAccessPolicy).
 
@@ -1014,8 +1014,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy](#AuthorizationProvid
 | tenantId   | The Tenant Id                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Backend_Spec"></a>Backend_Spec
--------------------------------------
+Backend_Spec{#Backend_Spec}
+---------------------------
 
 Used by: [Backend](#Backend).
 
@@ -1037,8 +1037,8 @@ Used by: [Backend](#Backend).
 | type              | Type of the backend. A backend can be either Single or Pool.                                                                                                                                                                                                                               | [BackendContractProperties_Type](#BackendContractProperties_Type)<br/><small>Optional</small>                                                                        |
 | url               | Runtime Url of the Backend.                                                                                                                                                                                                                                                                | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="Backend_STATUS"></a>Backend_STATUS
------------------------------------------
+Backend_STATUS{#Backend_STATUS}
+-------------------------------
 
 Used by: [Backend](#Backend).
 
@@ -1061,8 +1061,8 @@ Used by: [Backend](#Backend).
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | url             | Runtime Url of the Backend.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamedValue_Spec"></a>NamedValue_Spec
--------------------------------------------
+NamedValue_Spec{#NamedValue_Spec}
+---------------------------------
 
 Used by: [NamedValue](#NamedValue).
 
@@ -1077,8 +1077,8 @@ Used by: [NamedValue](#NamedValue).
 | tags         | Optional tags that when provided can be used to filter the NamedValue list.                                                                                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 | value        | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="NamedValue_STATUS"></a>NamedValue_STATUS
------------------------------------------------
+NamedValue_STATUS{#NamedValue_STATUS}
+-------------------------------------
 
 Used by: [NamedValue](#NamedValue).
 
@@ -1095,8 +1095,8 @@ Used by: [NamedValue](#NamedValue).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value             | Value of the NamedValue. Can contain policy expressions. It may not be empty or consist only of whitespace. This property will not be filled on 'GET' operations! Use '/listSecrets' POST request to get the value.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Policy_Spec"></a>Policy_Spec
------------------------------------
+Policy_Spec{#Policy_Spec}
+-------------------------
 
 Used by: [Policy](#Policy).
 
@@ -1107,8 +1107,8 @@ Used by: [Policy](#Policy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="Policy_STATUS"></a>Policy_STATUS
----------------------------------------
+Policy_STATUS{#Policy_STATUS}
+-----------------------------
 
 Used by: [Policy](#Policy).
 
@@ -1121,8 +1121,8 @@ Used by: [Policy](#Policy).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PolicyFragment_Spec"></a>PolicyFragment_Spec
----------------------------------------------------
+PolicyFragment_Spec{#PolicyFragment_Spec}
+-----------------------------------------
 
 Used by: [PolicyFragment](#PolicyFragment).
 
@@ -1135,8 +1135,8 @@ Used by: [PolicyFragment](#PolicyFragment).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Service resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the policy fragment.                                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="PolicyFragment_STATUS"></a>PolicyFragment_STATUS
--------------------------------------------------------
+PolicyFragment_STATUS{#PolicyFragment_STATUS}
+---------------------------------------------
 
 Used by: [PolicyFragment](#PolicyFragment).
 
@@ -1151,8 +1151,8 @@ Used by: [PolicyFragment](#PolicyFragment).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value             | Contents of the policy fragment.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Product_Spec"></a>Product_Spec
--------------------------------------
+Product_Spec{#Product_Spec}
+---------------------------
 
 Used by: [Product](#Product).
 
@@ -1169,8 +1169,8 @@ Used by: [Product](#Product).
 | subscriptionsLimit   | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="Product_STATUS"></a>Product_STATUS
------------------------------------------
+Product_STATUS{#Product_STATUS}
+-------------------------------
 
 Used by: [Product](#Product).
 
@@ -1188,8 +1188,8 @@ Used by: [Product](#Product).
 | terms                | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProductApi_Spec"></a>ProductApi_Spec
--------------------------------------------
+ProductApi_Spec{#ProductApi_Spec}
+---------------------------------
 
 Used by: [ProductApi](#ProductApi).
 
@@ -1199,8 +1199,8 @@ Used by: [ProductApi](#ProductApi).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                            | [ProductApiOperatorSpec](#ProductApiOperatorSpec)<br/><small>Optional</small>                                                                                        |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="ProductApi_STATUS"></a>ProductApi_STATUS
------------------------------------------------
+ProductApi_STATUS{#ProductApi_STATUS}
+-------------------------------------
 
 Used by: [ProductApi](#ProductApi).
 
@@ -1208,8 +1208,8 @@ Used by: [ProductApi](#ProductApi).
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="ProductPolicy_Spec"></a>ProductPolicy_Spec
--------------------------------------------------
+ProductPolicy_Spec{#ProductPolicy_Spec}
+---------------------------------------
 
 Used by: [ProductPolicy](#ProductPolicy).
 
@@ -1220,8 +1220,8 @@ Used by: [ProductPolicy](#ProductPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a apimanagement.azure.com/Product resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | value        | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                           | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="ProductPolicy_STATUS"></a>ProductPolicy_STATUS
------------------------------------------------------
+ProductPolicy_STATUS{#ProductPolicy_STATUS}
+-------------------------------------------
 
 Used by: [ProductPolicy](#ProductPolicy).
 
@@ -1234,8 +1234,8 @@ Used by: [ProductPolicy](#ProductPolicy).
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value      | Contents of the Policy as defined by the format.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Service_Spec"></a>Service_Spec
--------------------------------------
+Service_Spec{#Service_Spec}
+---------------------------
 
 Used by: [Service](#Service).
 
@@ -1269,8 +1269,8 @@ Used by: [Service](#Service).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType](#ApiManagementServiceProperties_VirtualNetworkType)<br/><small>Optional</small>                                  |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Service_STATUS"></a>Service_STATUS
------------------------------------------
+Service_STATUS{#Service_STATUS}
+-------------------------------
 
 Used by: [Service](#Service).
 
@@ -1321,8 +1321,8 @@ Used by: [Service](#Service).
 | virtualNetworkType          | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an Internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [ApiManagementServiceProperties_VirtualNetworkType_STATUS](#ApiManagementServiceProperties_VirtualNetworkType_STATUS)<br/><small>Optional</small>       |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="Subscription_Spec"></a>Subscription_Spec
------------------------------------------------
+Subscription_Spec{#Subscription_Spec}
+-------------------------------------
 
 Used by: [Subscription](#Subscription).
 
@@ -1339,8 +1339,8 @@ Used by: [Subscription](#Subscription).
 | secondaryKey   | Secondary subscription key. If not specified during request key will be generated automatically.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | state          | Initial subscription state. If no value is specified, subscription is created with Submitted state. Possible states are * active – the subscription is active, * suspended – the subscription is blocked, and the subscriber cannot call any APIs of the product, * submitted – the subscription request has been made by the developer, but has not yet been approved or rejected, * rejected – the subscription request has been denied by an administrator, * cancelled – the subscription has been cancelled by the developer or administrator, * expired – the subscription reached its expiration date and was deactivated. | [SubscriptionCreateParameterProperties_State](#SubscriptionCreateParameterProperties_State)<br/><small>Optional</small>                                              |
 
-<a id="Subscription_STATUS"></a>Subscription_STATUS
----------------------------------------------------
+Subscription_STATUS{#Subscription_STATUS}
+-----------------------------------------
 
 Used by: [Subscription](#Subscription).
 
@@ -1362,8 +1362,8 @@ Used by: [Subscription](#Subscription).
 | stateComment     | Optional subscription comment added by an administrator when the state is changed to the 'rejected'.                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdditionalLocation"></a>AdditionalLocation
--------------------------------------------------
+AdditionalLocation{#AdditionalLocation}
+---------------------------------------
 
 Description of an additional API Management resource location.
 
@@ -1379,8 +1379,8 @@ Used by: [Service_Spec](#Service_Spec).
 | virtualNetworkConfiguration | Virtual network configuration for the location.                                                                                                                                      | [VirtualNetworkConfiguration](#VirtualNetworkConfiguration)<br/><small>Optional</small>                                                                    |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                         | string[]<br/><small>Optional</small>                                                                                                                       |
 
-<a id="AdditionalLocation_STATUS"></a>AdditionalLocation_STATUS
----------------------------------------------------------------
+AdditionalLocation_STATUS{#AdditionalLocation_STATUS}
+-----------------------------------------------------
 
 Description of an additional API Management resource location.
 
@@ -1401,8 +1401,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | virtualNetworkConfiguration | Virtual network configuration for the location.                                                                                                                                                                             | [VirtualNetworkConfiguration_STATUS](#VirtualNetworkConfiguration_STATUS)<br/><small>Optional</small>               |
 | zones                       | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                | string[]<br/><small>Optional</small>                                                                                |
 
-<a id="ApiContactInformation"></a>ApiContactInformation
--------------------------------------------------------
+ApiContactInformation{#ApiContactInformation}
+---------------------------------------------
 
 API contact information
 
@@ -1414,8 +1414,8 @@ Used by: [Api_Spec](#Api_Spec).
 | name     | The identifying name of the contact person/organization                                         | string<br/><small>Optional</small> |
 | url      | The URL pointing to the contact information. MUST be in the format of a URL                     | string<br/><small>Optional</small> |
 
-<a id="ApiContactInformation_STATUS"></a>ApiContactInformation_STATUS
----------------------------------------------------------------------
+ApiContactInformation_STATUS{#ApiContactInformation_STATUS}
+-----------------------------------------------------------
 
 API contact information
 
@@ -1427,8 +1427,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | name     | The identifying name of the contact person/organization                                         | string<br/><small>Optional</small> |
 | url      | The URL pointing to the contact information. MUST be in the format of a URL                     | string<br/><small>Optional</small> |
 
-<a id="ApiContractProperties_Protocols_STATUS"></a>ApiContractProperties_Protocols_STATUS
------------------------------------------------------------------------------------------
+ApiContractProperties_Protocols_STATUS{#ApiContractProperties_Protocols_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Api_STATUS](#Api_STATUS).
 
@@ -1439,8 +1439,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | "ws"    |             |
 | "wss"   |             |
 
-<a id="ApiContractProperties_Type_STATUS"></a>ApiContractProperties_Type_STATUS
--------------------------------------------------------------------------------
+ApiContractProperties_Type_STATUS{#ApiContractProperties_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [Api_STATUS](#Api_STATUS).
 
@@ -1453,8 +1453,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_ApiType"></a>ApiCreateOrUpdateProperties_ApiType
------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_ApiType{#ApiCreateOrUpdateProperties_ApiType}
+-------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1467,8 +1467,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_Format"></a>ApiCreateOrUpdateProperties_Format
----------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Format{#ApiCreateOrUpdateProperties_Format}
+-----------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1490,8 +1490,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "wsdl"              |             |
 | "wsdl-link"         |             |
 
-<a id="ApiCreateOrUpdateProperties_Protocols"></a>ApiCreateOrUpdateProperties_Protocols
----------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Protocols{#ApiCreateOrUpdateProperties_Protocols}
+-----------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1502,8 +1502,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "ws"    |             |
 | "wss"   |             |
 
-<a id="ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters"></a>ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters
--------------------------------------------------------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters{#ApiCreateOrUpdateProperties_TranslateRequiredQueryParameters}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1512,8 +1512,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "query"    |             |
 | "template" |             |
 
-<a id="ApiCreateOrUpdateProperties_Type"></a>ApiCreateOrUpdateProperties_Type
------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_Type{#ApiCreateOrUpdateProperties_Type}
+-------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1526,8 +1526,8 @@ Used by: [Api_Spec](#Api_Spec).
 | "soap"      |             |
 | "websocket" |             |
 
-<a id="ApiCreateOrUpdateProperties_WsdlSelector"></a>ApiCreateOrUpdateProperties_WsdlSelector
----------------------------------------------------------------------------------------------
+ApiCreateOrUpdateProperties_WsdlSelector{#ApiCreateOrUpdateProperties_WsdlSelector}
+-----------------------------------------------------------------------------------
 
 Used by: [Api_Spec](#Api_Spec).
 
@@ -1536,8 +1536,8 @@ Used by: [Api_Spec](#Api_Spec).
 | wsdlEndpointName | Name of endpoint(port) to import from WSDL | string<br/><small>Optional</small> |
 | wsdlServiceName  | Name of service to import from WSDL        | string<br/><small>Optional</small> |
 
-<a id="ApiLicenseInformation"></a>ApiLicenseInformation
--------------------------------------------------------
+ApiLicenseInformation{#ApiLicenseInformation}
+---------------------------------------------
 
 API license information
 
@@ -1548,8 +1548,8 @@ Used by: [Api_Spec](#Api_Spec).
 | name     | The license name used for the API                                     | string<br/><small>Optional</small> |
 | url      | A URL to the license used for the API. MUST be in the format of a URL | string<br/><small>Optional</small> |
 
-<a id="ApiLicenseInformation_STATUS"></a>ApiLicenseInformation_STATUS
----------------------------------------------------------------------
+ApiLicenseInformation_STATUS{#ApiLicenseInformation_STATUS}
+-----------------------------------------------------------
 
 API license information
 
@@ -1560,8 +1560,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | name     | The license name used for the API                                     | string<br/><small>Optional</small> |
 | url      | A URL to the license used for the API. MUST be in the format of a URL | string<br/><small>Optional</small> |
 
-<a id="ApiManagementServiceIdentity"></a>ApiManagementServiceIdentity
----------------------------------------------------------------------
+ApiManagementServiceIdentity{#ApiManagementServiceIdentity}
+-----------------------------------------------------------
 
 Identity properties of the Api Management service resource.
 
@@ -1572,8 +1572,8 @@ Used by: [Service_Spec](#Service_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                         | [ApiManagementServiceIdentity_Type](#ApiManagementServiceIdentity_Type)<br/><small>Required</small> |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small>           |
 
-<a id="ApiManagementServiceIdentity_STATUS"></a>ApiManagementServiceIdentity_STATUS
------------------------------------------------------------------------------------
+ApiManagementServiceIdentity_STATUS{#ApiManagementServiceIdentity_STATUS}
+-------------------------------------------------------------------------
 
 Identity properties of the Api Management service resource.
 
@@ -1586,8 +1586,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                         | [ApiManagementServiceIdentity_Type_STATUS](#ApiManagementServiceIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentityProperties_STATUS](#UserIdentityProperties_STATUS)<br/><small>Optional</small>            |
 
-<a id="ApiManagementServiceProperties_DeveloperPortalStatus"></a>ApiManagementServiceProperties_DeveloperPortalStatus
----------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_DeveloperPortalStatus{#ApiManagementServiceProperties_DeveloperPortalStatus}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1596,8 +1596,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_DeveloperPortalStatus_STATUS"></a>ApiManagementServiceProperties_DeveloperPortalStatus_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_DeveloperPortalStatus_STATUS{#ApiManagementServiceProperties_DeveloperPortalStatus_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1606,8 +1606,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_LegacyPortalStatus"></a>ApiManagementServiceProperties_LegacyPortalStatus
----------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_LegacyPortalStatus{#ApiManagementServiceProperties_LegacyPortalStatus}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1616,8 +1616,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_LegacyPortalStatus_STATUS"></a>ApiManagementServiceProperties_LegacyPortalStatus_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_LegacyPortalStatus_STATUS{#ApiManagementServiceProperties_LegacyPortalStatus_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1626,8 +1626,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_NatGatewayState"></a>ApiManagementServiceProperties_NatGatewayState
----------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_NatGatewayState{#ApiManagementServiceProperties_NatGatewayState}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1636,8 +1636,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_NatGatewayState_STATUS"></a>ApiManagementServiceProperties_NatGatewayState_STATUS
------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_NatGatewayState_STATUS{#ApiManagementServiceProperties_NatGatewayState_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1646,8 +1646,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_PlatformVersion_STATUS"></a>ApiManagementServiceProperties_PlatformVersion_STATUS
------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PlatformVersion_STATUS{#ApiManagementServiceProperties_PlatformVersion_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1659,8 +1659,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "stv2.1"       |             |
 | "undetermined" |             |
 
-<a id="ApiManagementServiceProperties_PublicNetworkAccess"></a>ApiManagementServiceProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PublicNetworkAccess{#ApiManagementServiceProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1669,8 +1669,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_PublicNetworkAccess_STATUS"></a>ApiManagementServiceProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_PublicNetworkAccess_STATUS{#ApiManagementServiceProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1679,8 +1679,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApiManagementServiceProperties_VirtualNetworkType"></a>ApiManagementServiceProperties_VirtualNetworkType
----------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_VirtualNetworkType{#ApiManagementServiceProperties_VirtualNetworkType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [Service_Spec](#Service_Spec).
 
@@ -1690,8 +1690,8 @@ Used by: [Service_Spec](#Service_Spec).
 | "Internal" |             |
 | "None"     |             |
 
-<a id="ApiManagementServiceProperties_VirtualNetworkType_STATUS"></a>ApiManagementServiceProperties_VirtualNetworkType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ApiManagementServiceProperties_VirtualNetworkType_STATUS{#ApiManagementServiceProperties_VirtualNetworkType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [Service_STATUS](#Service_STATUS).
 
@@ -1701,8 +1701,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | "Internal" |             |
 | "None"     |             |
 
-<a id="ApiManagementServiceSkuProperties"></a>ApiManagementServiceSkuProperties
--------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties{#ApiManagementServiceSkuProperties}
+---------------------------------------------------------------------
 
 API Management service resource SKU properties.
 
@@ -1713,8 +1713,8 @@ Used by: [AdditionalLocation](#AdditionalLocation), and [Service_Spec](#Service_
 | capacity | Capacity of the SKU (number of deployed units of the SKU). For Consumption SKU capacity must be specified as 0. | int<br/><small>Required</small>                                                                               |
 | name     | Name of the Sku.                                                                                                | [ApiManagementServiceSkuProperties_Name](#ApiManagementServiceSkuProperties_Name)<br/><small>Required</small> |
 
-<a id="ApiManagementServiceSkuProperties_STATUS"></a>ApiManagementServiceSkuProperties_STATUS
----------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_STATUS{#ApiManagementServiceSkuProperties_STATUS}
+-----------------------------------------------------------------------------------
 
 API Management service resource SKU properties.
 
@@ -1725,8 +1725,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS), and [Service_S
 | capacity | Capacity of the SKU (number of deployed units of the SKU). For Consumption SKU capacity must be specified as 0. | int<br/><small>Optional</small>                                                                                             |
 | name     | Name of the Sku.                                                                                                | [ApiManagementServiceSkuProperties_Name_STATUS](#ApiManagementServiceSkuProperties_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiOperatorSpec"></a>ApiOperatorSpec
--------------------------------------------
+ApiOperatorSpec{#ApiOperatorSpec}
+---------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1737,8 +1737,8 @@ Used by: [Api_Spec](#Api_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ApiVersionConstraint"></a>ApiVersionConstraint
------------------------------------------------------
+ApiVersionConstraint{#ApiVersionConstraint}
+-------------------------------------------
 
 Control Plane Apis version constraint for the API Management service.
 
@@ -1748,8 +1748,8 @@ Used by: [Service_Spec](#Service_Spec).
 |---------------|---------------------------------------------------------------------------------------------------------|------------------------------------|
 | minApiVersion | Limit control plane API calls to API Management service with version equal to or newer than this value. | string<br/><small>Optional</small> |
 
-<a id="ApiVersionConstraint_STATUS"></a>ApiVersionConstraint_STATUS
--------------------------------------------------------------------
+ApiVersionConstraint_STATUS{#ApiVersionConstraint_STATUS}
+---------------------------------------------------------
 
 Control Plane Apis version constraint for the API Management service.
 
@@ -1759,8 +1759,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 |---------------|---------------------------------------------------------------------------------------------------------|------------------------------------|
 | minApiVersion | Limit control plane API calls to API Management service with version equal to or newer than this value. | string<br/><small>Optional</small> |
 
-<a id="ApiVersionSetContractDetails"></a>ApiVersionSetContractDetails
----------------------------------------------------------------------
+ApiVersionSetContractDetails{#ApiVersionSetContractDetails}
+-----------------------------------------------------------
 
 An API Version Set contains the common configuration for a set of API Versions relating
 
@@ -1775,8 +1775,8 @@ Used by: [Api_Spec](#Api_Spec).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.         | [ApiVersionSetContractDetails_VersioningScheme](#ApiVersionSetContractDetails_VersioningScheme)<br/><small>Optional</small>                                |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.        | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ApiVersionSetContractDetails_STATUS"></a>ApiVersionSetContractDetails_STATUS
------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_STATUS{#ApiVersionSetContractDetails_STATUS}
+-------------------------------------------------------------------------
 
 An API Version Set contains the common configuration for a set of API Versions relating
 
@@ -1791,8 +1791,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | versioningScheme  | An value that determines where the API Version identifier will be located in a HTTP request.         | [ApiVersionSetContractDetails_VersioningScheme_STATUS](#ApiVersionSetContractDetails_VersioningScheme_STATUS)<br/><small>Optional</small> |
 | versionQueryName  | Name of query parameter that indicates the API Version if versioningScheme is set to `query`.        | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="ApiVersionSetContractProperties_VersioningScheme"></a>ApiVersionSetContractProperties_VersioningScheme
--------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractProperties_VersioningScheme{#ApiVersionSetContractProperties_VersioningScheme}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 
@@ -1802,8 +1802,8 @@ Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetContractProperties_VersioningScheme_STATUS"></a>ApiVersionSetContractProperties_VersioningScheme_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractProperties_VersioningScheme_STATUS{#ApiVersionSetContractProperties_VersioningScheme_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSet_STATUS](#ApiVersionSet_STATUS).
 
@@ -1813,8 +1813,8 @@ Used by: [ApiVersionSet_STATUS](#ApiVersionSet_STATUS).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetOperatorSpec"></a>ApiVersionSetOperatorSpec
----------------------------------------------------------------
+ApiVersionSetOperatorSpec{#ApiVersionSetOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1825,8 +1825,8 @@ Used by: [ApiVersionSet_Spec](#ApiVersionSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthenticationSettingsContract"></a>AuthenticationSettingsContract
--------------------------------------------------------------------------
+AuthenticationSettingsContract{#AuthenticationSettingsContract}
+---------------------------------------------------------------
 
 API Authentication Settings.
 
@@ -1839,8 +1839,8 @@ Used by: [Api_Spec](#Api_Spec).
 | openid                       | OpenID Connect Authentication Settings                                        | [OpenIdAuthenticationSettingsContract](#OpenIdAuthenticationSettingsContract)<br/><small>Optional</small>   |
 | openidAuthenticationSettings | Collection of Open ID Connect authentication settings included into this API. | [OpenIdAuthenticationSettingsContract[]](#OpenIdAuthenticationSettingsContract)<br/><small>Optional</small> |
 
-<a id="AuthenticationSettingsContract_STATUS"></a>AuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------
+AuthenticationSettingsContract_STATUS{#AuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------
 
 API Authentication Settings.
 
@@ -1853,37 +1853,37 @@ Used by: [Api_STATUS](#Api_STATUS).
 | openid                       | OpenID Connect Authentication Settings                                        | [OpenIdAuthenticationSettingsContract_STATUS](#OpenIdAuthenticationSettingsContract_STATUS)<br/><small>Optional</small>   |
 | openidAuthenticationSettings | Collection of Open ID Connect authentication settings included into this API. | [OpenIdAuthenticationSettingsContract_STATUS[]](#OpenIdAuthenticationSettingsContract_STATUS)<br/><small>Optional</small> |
 
-<a id="AuthorizationContractProperties_AuthorizationType"></a>AuthorizationContractProperties_AuthorizationType
+AuthorizationContractProperties_AuthorizationType{#AuthorizationContractProperties_AuthorizationType}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+AuthorizationContractProperties_AuthorizationType_STATUS{#AuthorizationContractProperties_AuthorizationType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+AuthorizationContractProperties_Oauth2GrantType{#AuthorizationContractProperties_Oauth2GrantType}
+-------------------------------------------------------------------------------------------------
+
+Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
+
+| Value               | Description |
+|---------------------|-------------|
+| "AuthorizationCode" |             |
+| "ClientCredentials" |             |
+
+AuthorizationContractProperties_Oauth2GrantType_STATUS{#AuthorizationContractProperties_Oauth2GrantType_STATUS}
 ---------------------------------------------------------------------------------------------------------------
 
-Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
-
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
-
-<a id="AuthorizationContractProperties_AuthorizationType_STATUS"></a>AuthorizationContractProperties_AuthorizationType_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
-
-<a id="AuthorizationContractProperties_Oauth2GrantType"></a>AuthorizationContractProperties_Oauth2GrantType
------------------------------------------------------------------------------------------------------------
-
-Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAuthorization_Spec).
-
-| Value               | Description |
-|---------------------|-------------|
-| "AuthorizationCode" |             |
-| "ClientCredentials" |             |
-
-<a id="AuthorizationContractProperties_Oauth2GrantType_STATUS"></a>AuthorizationContractProperties_Oauth2GrantType_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
 Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAuthorization_STATUS).
 
 | Value               | Description |
@@ -1891,8 +1891,8 @@ Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAut
 | "AuthorizationCode" |             |
 | "ClientCredentials" |             |
 
-<a id="AuthorizationError_STATUS"></a>AuthorizationError_STATUS
----------------------------------------------------------------
+AuthorizationError_STATUS{#AuthorizationError_STATUS}
+-----------------------------------------------------
 
 Authorization error details.
 
@@ -1903,8 +1903,8 @@ Used by: [AuthorizationProvidersAuthorization_STATUS](#AuthorizationProvidersAut
 | code     | Error code    | string<br/><small>Optional</small> |
 | message  | Error message | string<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2Settings"></a>AuthorizationProviderOAuth2Settings
------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2Settings{#AuthorizationProviderOAuth2Settings}
+-------------------------------------------------------------------------
 
 OAuth2 settings details
 
@@ -1915,8 +1915,8 @@ Used by: [AuthorizationProvider_Spec](#AuthorizationProvider_Spec).
 | grantTypes  | OAuth2 settings                                  | [AuthorizationProviderOAuth2GrantTypes](#AuthorizationProviderOAuth2GrantTypes)<br/><small>Optional</small> |
 | redirectUrl | Redirect URL to be set in the OAuth application. | string<br/><small>Optional</small>                                                                          |
 
-<a id="AuthorizationProviderOAuth2Settings_STATUS"></a>AuthorizationProviderOAuth2Settings_STATUS
--------------------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2Settings_STATUS{#AuthorizationProviderOAuth2Settings_STATUS}
+---------------------------------------------------------------------------------------
 
 OAuth2 settings details
 
@@ -1927,8 +1927,8 @@ Used by: [AuthorizationProvider_STATUS](#AuthorizationProvider_STATUS).
 | grantTypes  | OAuth2 settings                                  | [AuthorizationProviderOAuth2GrantTypes_STATUS](#AuthorizationProviderOAuth2GrantTypes_STATUS)<br/><small>Optional</small> |
 | redirectUrl | Redirect URL to be set in the OAuth application. | string<br/><small>Optional</small>                                                                                        |
 
-<a id="AuthorizationProviderOperatorSpec"></a>AuthorizationProviderOperatorSpec
--------------------------------------------------------------------------------
+AuthorizationProviderOperatorSpec{#AuthorizationProviderOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1939,8 +1939,8 @@ Used by: [AuthorizationProvider_Spec](#AuthorizationProvider_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationOperatorSpec"></a>AuthorizationProvidersAuthorizationOperatorSpec
------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationOperatorSpec{#AuthorizationProvidersAuthorizationOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1951,8 +1951,8 @@ Used by: [AuthorizationProvidersAuthorization_Spec](#AuthorizationProvidersAutho
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec"></a>AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec
--------------------------------------------------------------------------------------------------------------------------------------
+AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec{#AuthorizationProvidersAuthorizationsAccessPolicyOperatorSpec}
+---------------------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1963,8 +1963,8 @@ Used by: [AuthorizationProvidersAuthorizationsAccessPolicy_Spec](#AuthorizationP
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackendCircuitBreaker"></a>BackendCircuitBreaker
--------------------------------------------------------
+BackendCircuitBreaker{#BackendCircuitBreaker}
+---------------------------------------------
 
 The configuration of the backend circuit breaker
 
@@ -1974,8 +1974,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 |----------|-------------------------------------|-------------------------------------------------------------------------|
 | rules    | The rules for tripping the backend. | [CircuitBreakerRule[]](#CircuitBreakerRule)<br/><small>Optional</small> |
 
-<a id="BackendCircuitBreaker_STATUS"></a>BackendCircuitBreaker_STATUS
----------------------------------------------------------------------
+BackendCircuitBreaker_STATUS{#BackendCircuitBreaker_STATUS}
+-----------------------------------------------------------
 
 The configuration of the backend circuit breaker
 
@@ -1985,8 +1985,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 |----------|-------------------------------------|---------------------------------------------------------------------------------------|
 | rules    | The rules for tripping the backend. | [CircuitBreakerRule_STATUS[]](#CircuitBreakerRule_STATUS)<br/><small>Optional</small> |
 
-<a id="BackendContractProperties_Protocol"></a>BackendContractProperties_Protocol
----------------------------------------------------------------------------------
+BackendContractProperties_Protocol{#BackendContractProperties_Protocol}
+-----------------------------------------------------------------------
 
 Used by: [Backend_Spec](#Backend_Spec).
 
@@ -1995,8 +1995,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | "http" |             |
 | "soap" |             |
 
-<a id="BackendContractProperties_Protocol_STATUS"></a>BackendContractProperties_Protocol_STATUS
------------------------------------------------------------------------------------------------
+BackendContractProperties_Protocol_STATUS{#BackendContractProperties_Protocol_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Backend_STATUS](#Backend_STATUS).
 
@@ -2005,8 +2005,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | "http" |             |
 | "soap" |             |
 
-<a id="BackendContractProperties_Type"></a>BackendContractProperties_Type
--------------------------------------------------------------------------
+BackendContractProperties_Type{#BackendContractProperties_Type}
+---------------------------------------------------------------
 
 Used by: [Backend_Spec](#Backend_Spec).
 
@@ -2015,8 +2015,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | "Pool"   |             |
 | "Single" |             |
 
-<a id="BackendContractProperties_Type_STATUS"></a>BackendContractProperties_Type_STATUS
----------------------------------------------------------------------------------------
+BackendContractProperties_Type_STATUS{#BackendContractProperties_Type_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [Backend_STATUS](#Backend_STATUS).
 
@@ -2025,8 +2025,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | "Pool"   |             |
 | "Single" |             |
 
-<a id="BackendCredentialsContract"></a>BackendCredentialsContract
------------------------------------------------------------------
+BackendCredentialsContract{#BackendCredentialsContract}
+-------------------------------------------------------
 
 Details of the Credentials used to connect to Backend.
 
@@ -2040,8 +2040,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | header         | Header Parameter description.                                                            | map[string]string[]<br/><small>Optional</small>                                                             |
 | query          | Query Parameter description.                                                             | map[string]string[]<br/><small>Optional</small>                                                             |
 
-<a id="BackendCredentialsContract_STATUS"></a>BackendCredentialsContract_STATUS
--------------------------------------------------------------------------------
+BackendCredentialsContract_STATUS{#BackendCredentialsContract_STATUS}
+---------------------------------------------------------------------
 
 Details of the Credentials used to connect to Backend.
 
@@ -2055,8 +2055,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | header         | Header Parameter description.                                                            | map[string]string[]<br/><small>Optional</small>                                                                           |
 | query          | Query Parameter description.                                                             | map[string]string[]<br/><small>Optional</small>                                                                           |
 
-<a id="BackendOperatorSpec"></a>BackendOperatorSpec
----------------------------------------------------
+BackendOperatorSpec{#BackendOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2067,8 +2067,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackendPool"></a>BackendPool
------------------------------------
+BackendPool{#BackendPool}
+-------------------------
 
 Backend pool information
 
@@ -2078,8 +2078,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 |----------|---------------------------------------------------|-------------------------------------------------------------------|
 | services | The list of backend entities belonging to a pool. | [BackendPoolItem[]](#BackendPoolItem)<br/><small>Optional</small> |
 
-<a id="BackendPool_STATUS"></a>BackendPool_STATUS
--------------------------------------------------
+BackendPool_STATUS{#BackendPool_STATUS}
+---------------------------------------
 
 Backend pool information
 
@@ -2089,8 +2089,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 |----------|---------------------------------------------------|---------------------------------------------------------------------------------|
 | services | The list of backend entities belonging to a pool. | [BackendPoolItem_STATUS[]](#BackendPoolItem_STATUS)<br/><small>Optional</small> |
 
-<a id="BackendProperties"></a>BackendProperties
------------------------------------------------
+BackendProperties{#BackendProperties}
+-------------------------------------
 
 Properties specific to the Backend Type.
 
@@ -2100,8 +2100,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 |----------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | serviceFabricCluster | Backend Service Fabric Cluster Properties | [BackendServiceFabricClusterProperties](#BackendServiceFabricClusterProperties)<br/><small>Optional</small> |
 
-<a id="BackendProperties_STATUS"></a>BackendProperties_STATUS
--------------------------------------------------------------
+BackendProperties_STATUS{#BackendProperties_STATUS}
+---------------------------------------------------
 
 Properties specific to the Backend Type.
 
@@ -2111,8 +2111,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 |----------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | serviceFabricCluster | Backend Service Fabric Cluster Properties | [BackendServiceFabricClusterProperties_STATUS](#BackendServiceFabricClusterProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="BackendProxyContract"></a>BackendProxyContract
------------------------------------------------------
+BackendProxyContract{#BackendProxyContract}
+-------------------------------------------
 
 Details of the Backend WebProxy Server to use in the Request to Backend.
 
@@ -2124,8 +2124,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | url      | WebProxy Server AbsoluteUri property which includes the entire URI stored in the Uri instance, including all fragments and query strings. | string<br/><small>Required</small>                                                                                                                     |
 | username | Username to connect to the WebProxy server                                                                                                | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="BackendProxyContract_STATUS"></a>BackendProxyContract_STATUS
--------------------------------------------------------------------
+BackendProxyContract_STATUS{#BackendProxyContract_STATUS}
+---------------------------------------------------------
 
 Details of the Backend WebProxy Server to use in the Request to Backend.
 
@@ -2136,8 +2136,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | url      | WebProxy Server AbsoluteUri property which includes the entire URI stored in the Uri instance, including all fragments and query strings. | string<br/><small>Optional</small> |
 | username | Username to connect to the WebProxy server                                                                                                | string<br/><small>Optional</small> |
 
-<a id="BackendTlsProperties"></a>BackendTlsProperties
------------------------------------------------------
+BackendTlsProperties{#BackendTlsProperties}
+-------------------------------------------
 
 Properties controlling TLS Certificate Validation.
 
@@ -2148,8 +2148,8 @@ Used by: [Backend_Spec](#Backend_Spec).
 | validateCertificateChain | Flag indicating whether SSL certificate chain validation should be done when using self-signed certificates for this backend host. | bool<br/><small>Optional</small> |
 | validateCertificateName  | Flag indicating whether SSL certificate name validation should be done when using self-signed certificates for this backend host.  | bool<br/><small>Optional</small> |
 
-<a id="BackendTlsProperties_STATUS"></a>BackendTlsProperties_STATUS
--------------------------------------------------------------------
+BackendTlsProperties_STATUS{#BackendTlsProperties_STATUS}
+---------------------------------------------------------
 
 Properties controlling TLS Certificate Validation.
 
@@ -2160,8 +2160,8 @@ Used by: [Backend_STATUS](#Backend_STATUS).
 | validateCertificateChain | Flag indicating whether SSL certificate chain validation should be done when using self-signed certificates for this backend host. | bool<br/><small>Optional</small> |
 | validateCertificateName  | Flag indicating whether SSL certificate name validation should be done when using self-signed certificates for this backend host.  | bool<br/><small>Optional</small> |
 
-<a id="CertificateConfiguration"></a>CertificateConfiguration
--------------------------------------------------------------
+CertificateConfiguration{#CertificateConfiguration}
+---------------------------------------------------
 
 Certificate configuration which consist of non-trusted intermediates and root certificates.
 
@@ -2174,8 +2174,8 @@ Used by: [Service_Spec](#Service_Spec).
 | encodedCertificate  | Base64 Encoded certificate.                                                                                                                     | string<br/><small>Optional</small>                                                                                                                     |
 | storeName           | The System.Security.Cryptography.x509certificates.StoreName certificate store location. Only Root and CertificateAuthority are valid locations. | [CertificateConfiguration_StoreName](#CertificateConfiguration_StoreName)<br/><small>Required</small>                                                  |
 
-<a id="CertificateConfiguration_STATUS"></a>CertificateConfiguration_STATUS
----------------------------------------------------------------------------
+CertificateConfiguration_STATUS{#CertificateConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Certificate configuration which consist of non-trusted intermediates and root certificates.
 
@@ -2187,8 +2187,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | encodedCertificate | Base64 Encoded certificate.                                                                                                                     | string<br/><small>Optional</small>                                                                                  |
 | storeName          | The System.Security.Cryptography.x509certificates.StoreName certificate store location. Only Root and CertificateAuthority are valid locations. | [CertificateConfiguration_StoreName_STATUS](#CertificateConfiguration_StoreName_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationApi"></a>ConfigurationApi
----------------------------------------------
+ConfigurationApi{#ConfigurationApi}
+-----------------------------------
 
 Information regarding the Configuration API of the API Management service.
 
@@ -2198,8 +2198,8 @@ Used by: [Service_Spec](#Service_Spec).
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | legacyApi | Indication whether or not the legacy Configuration API (v1) should be exposed on the API Management service. Value is optional but must be 'Enabled' or 'Disabled'. If 'Disabled', legacy Configuration API (v1) will not be available for self-hosted gateways. Default value is 'Enabled' | [ConfigurationApi_LegacyApi](#ConfigurationApi_LegacyApi)<br/><small>Optional</small> |
 
-<a id="ConfigurationApi_STATUS"></a>ConfigurationApi_STATUS
------------------------------------------------------------
+ConfigurationApi_STATUS{#ConfigurationApi_STATUS}
+-------------------------------------------------
 
 Information regarding the Configuration API of the API Management service.
 
@@ -2209,8 +2209,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | legacyApi | Indication whether or not the legacy Configuration API (v1) should be exposed on the API Management service. Value is optional but must be 'Enabled' or 'Disabled'. If 'Disabled', legacy Configuration API (v1) will not be available for self-hosted gateways. Default value is 'Enabled' | [ConfigurationApi_LegacyApi_STATUS](#ConfigurationApi_LegacyApi_STATUS)<br/><small>Optional</small> |
 
-<a id="HostnameConfiguration"></a>HostnameConfiguration
--------------------------------------------------------
+HostnameConfiguration{#HostnameConfiguration}
+---------------------------------------------
 
 Custom hostname configuration.
 
@@ -2231,8 +2231,8 @@ Used by: [Service_Spec](#Service_Spec).
 | negotiateClientCertificate | Specify true to always negotiate client certificate on the hostname. Default Value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                             |
 | type                       | Hostname type.                                                                                                                                                                                                                                                                                                                                                                              | [HostnameConfiguration_Type](#HostnameConfiguration_Type)<br/><small>Required</small>                                                                        |
 
-<a id="HostnameConfiguration_STATUS"></a>HostnameConfiguration_STATUS
----------------------------------------------------------------------
+HostnameConfiguration_STATUS{#HostnameConfiguration_STATUS}
+-----------------------------------------------------------
 
 Custom hostname configuration.
 
@@ -2251,8 +2251,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | negotiateClientCertificate | Specify true to always negotiate client certificate on the hostname. Default Value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                              |
 | type                       | Hostname type.                                                                                                                                                                                                                                                                                                                                                                              | [HostnameConfiguration_Type_STATUS](#HostnameConfiguration_Type_STATUS)<br/><small>Optional</small>                           |
 
-<a id="KeyVaultContractCreateProperties"></a>KeyVaultContractCreateProperties
------------------------------------------------------------------------------
+KeyVaultContractCreateProperties{#KeyVaultContractCreateProperties}
+-------------------------------------------------------------------
 
 Create keyVault contract details.
 
@@ -2264,8 +2264,8 @@ Used by: [NamedValue_Spec](#NamedValue_Spec).
 | identityClientIdFromConfig | Null for SystemAssignedIdentity or Client Id for UserAssignedIdentity , which will be used to access key vault secret.                                                             | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | secretIdentifier           | Key vault secret identifier for fetching secret. Providing a versioned secret will prevent auto-refresh. This requires API Management service to be configured with aka.ms/apimmsi | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="KeyVaultContractProperties_STATUS"></a>KeyVaultContractProperties_STATUS
--------------------------------------------------------------------------------
+KeyVaultContractProperties_STATUS{#KeyVaultContractProperties_STATUS}
+---------------------------------------------------------------------
 
 KeyVault contract details.
 
@@ -2277,8 +2277,8 @@ Used by: [NamedValue_STATUS](#NamedValue_STATUS).
 | lastStatus       | Last time sync and refresh status of secret from key vault.                                                                                                                        | [KeyVaultLastAccessStatusContractProperties_STATUS](#KeyVaultLastAccessStatusContractProperties_STATUS)<br/><small>Optional</small> |
 | secretIdentifier | Key vault secret identifier for fetching secret. Providing a versioned secret will prevent auto-refresh. This requires API Management service to be configured with aka.ms/apimmsi | string<br/><small>Optional</small>                                                                                                  |
 
-<a id="NamedValueOperatorSpec"></a>NamedValueOperatorSpec
----------------------------------------------------------
+NamedValueOperatorSpec{#NamedValueOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2289,8 +2289,8 @@ Used by: [NamedValue_Spec](#NamedValue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PolicyContractProperties_Format"></a>PolicyContractProperties_Format
----------------------------------------------------------------------------
+PolicyContractProperties_Format{#PolicyContractProperties_Format}
+-----------------------------------------------------------------
 
 Used by: [Policy_Spec](#Policy_Spec), and [ProductPolicy_Spec](#ProductPolicy_Spec).
 
@@ -2301,8 +2301,8 @@ Used by: [Policy_Spec](#Policy_Spec), and [ProductPolicy_Spec](#ProductPolicy_Sp
 | "xml"         |             |
 | "xml-link"    |             |
 
-<a id="PolicyContractProperties_Format_STATUS"></a>PolicyContractProperties_Format_STATUS
------------------------------------------------------------------------------------------
+PolicyContractProperties_Format_STATUS{#PolicyContractProperties_Format_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Policy_STATUS](#Policy_STATUS), and [ProductPolicy_STATUS](#ProductPolicy_STATUS).
 
@@ -2313,8 +2313,8 @@ Used by: [Policy_STATUS](#Policy_STATUS), and [ProductPolicy_STATUS](#ProductPol
 | "xml"         |             |
 | "xml-link"    |             |
 
-<a id="PolicyFragmentContractProperties_Format"></a>PolicyFragmentContractProperties_Format
--------------------------------------------------------------------------------------------
+PolicyFragmentContractProperties_Format{#PolicyFragmentContractProperties_Format}
+---------------------------------------------------------------------------------
 
 Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 
@@ -2323,8 +2323,8 @@ Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 | "rawxml" |             |
 | "xml"    |             |
 
-<a id="PolicyFragmentContractProperties_Format_STATUS"></a>PolicyFragmentContractProperties_Format_STATUS
----------------------------------------------------------------------------------------------------------
+PolicyFragmentContractProperties_Format_STATUS{#PolicyFragmentContractProperties_Format_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [PolicyFragment_STATUS](#PolicyFragment_STATUS).
 
@@ -2333,8 +2333,8 @@ Used by: [PolicyFragment_STATUS](#PolicyFragment_STATUS).
 | "rawxml" |             |
 | "xml"    |             |
 
-<a id="PolicyFragmentOperatorSpec"></a>PolicyFragmentOperatorSpec
------------------------------------------------------------------
+PolicyFragmentOperatorSpec{#PolicyFragmentOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2345,8 +2345,8 @@ Used by: [PolicyFragment_Spec](#PolicyFragment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PolicyOperatorSpec"></a>PolicyOperatorSpec
--------------------------------------------------
+PolicyOperatorSpec{#PolicyOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2357,8 +2357,8 @@ Used by: [Policy_Spec](#Policy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductApiOperatorSpec"></a>ProductApiOperatorSpec
----------------------------------------------------------
+ProductApiOperatorSpec{#ProductApiOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2369,8 +2369,8 @@ Used by: [ProductApi_Spec](#ProductApi_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductContractProperties_State"></a>ProductContractProperties_State
----------------------------------------------------------------------------
+ProductContractProperties_State{#ProductContractProperties_State}
+-----------------------------------------------------------------
 
 Used by: [Product_Spec](#Product_Spec).
 
@@ -2379,8 +2379,8 @@ Used by: [Product_Spec](#Product_Spec).
 | "notPublished" |             |
 | "published"    |             |
 
-<a id="ProductContractProperties_State_STATUS"></a>ProductContractProperties_State_STATUS
------------------------------------------------------------------------------------------
+ProductContractProperties_State_STATUS{#ProductContractProperties_State_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Product_STATUS](#Product_STATUS).
 
@@ -2389,8 +2389,8 @@ Used by: [Product_STATUS](#Product_STATUS).
 | "notPublished" |             |
 | "published"    |             |
 
-<a id="ProductOperatorSpec"></a>ProductOperatorSpec
----------------------------------------------------
+ProductOperatorSpec{#ProductOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2401,8 +2401,8 @@ Used by: [Product_Spec](#Product_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProductPolicyOperatorSpec"></a>ProductPolicyOperatorSpec
----------------------------------------------------------------
+ProductPolicyOperatorSpec{#ProductPolicyOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2413,8 +2413,8 @@ Used by: [ProductPolicy_Spec](#ProductPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RemotePrivateEndpointConnectionWrapper_STATUS"></a>RemotePrivateEndpointConnectionWrapper_STATUS
--------------------------------------------------------------------------------------------------------
+RemotePrivateEndpointConnectionWrapper_STATUS{#RemotePrivateEndpointConnectionWrapper_STATUS}
+---------------------------------------------------------------------------------------------
 
 Remote Private Endpoint Connection resource.
 
@@ -2430,8 +2430,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | provisioningState                 | The provisioning state of the private endpoint connection resource.                                  | string<br/><small>Optional</small>                                                                                |
 | type                              | Private Endpoint Connection Resource Type                                                            | string<br/><small>Optional</small>                                                                                |
 
-<a id="ServiceOperatorSpec"></a>ServiceOperatorSpec
----------------------------------------------------
+ServiceOperatorSpec{#ServiceOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2442,8 +2442,8 @@ Used by: [Service_Spec](#Service_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SubscriptionContractProperties_State_STATUS"></a>SubscriptionContractProperties_State_STATUS
----------------------------------------------------------------------------------------------------
+SubscriptionContractProperties_State_STATUS{#SubscriptionContractProperties_State_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Subscription_STATUS](#Subscription_STATUS).
 
@@ -2456,8 +2456,8 @@ Used by: [Subscription_STATUS](#Subscription_STATUS).
 | "submitted" |             |
 | "suspended" |             |
 
-<a id="SubscriptionCreateParameterProperties_State"></a>SubscriptionCreateParameterProperties_State
----------------------------------------------------------------------------------------------------
+SubscriptionCreateParameterProperties_State{#SubscriptionCreateParameterProperties_State}
+-----------------------------------------------------------------------------------------
 
 Used by: [Subscription_Spec](#Subscription_Spec).
 
@@ -2470,8 +2470,8 @@ Used by: [Subscription_Spec](#Subscription_Spec).
 | "submitted" |             |
 | "suspended" |             |
 
-<a id="SubscriptionKeyParameterNamesContract"></a>SubscriptionKeyParameterNamesContract
----------------------------------------------------------------------------------------
+SubscriptionKeyParameterNamesContract{#SubscriptionKeyParameterNamesContract}
+-----------------------------------------------------------------------------
 
 Subscription key parameter names details.
 
@@ -2482,8 +2482,8 @@ Used by: [Api_Spec](#Api_Spec).
 | header   | Subscription key header name.                 | string<br/><small>Optional</small> |
 | query    | Subscription key query string parameter name. | string<br/><small>Optional</small> |
 
-<a id="SubscriptionKeyParameterNamesContract_STATUS"></a>SubscriptionKeyParameterNamesContract_STATUS
------------------------------------------------------------------------------------------------------
+SubscriptionKeyParameterNamesContract_STATUS{#SubscriptionKeyParameterNamesContract_STATUS}
+-------------------------------------------------------------------------------------------
 
 Subscription key parameter names details.
 
@@ -2494,8 +2494,8 @@ Used by: [Api_STATUS](#Api_STATUS).
 | header   | Subscription key header name.                 | string<br/><small>Optional</small> |
 | query    | Subscription key query string parameter name. | string<br/><small>Optional</small> |
 
-<a id="SubscriptionOperatorSpec"></a>SubscriptionOperatorSpec
--------------------------------------------------------------
+SubscriptionOperatorSpec{#SubscriptionOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2507,8 +2507,8 @@ Used by: [Subscription_Spec](#Subscription_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [SubscriptionOperatorSecrets](#SubscriptionOperatorSecrets)<br/><small>Optional</small>                                                                             |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2523,8 +2523,8 @@ Used by: [Service_STATUS](#Service_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkConfiguration"></a>VirtualNetworkConfiguration
--------------------------------------------------------------------
+VirtualNetworkConfiguration{#VirtualNetworkConfiguration}
+---------------------------------------------------------
 
 Configuration of a virtual network to which API Management service is deployed.
 
@@ -2534,8 +2534,8 @@ Used by: [AdditionalLocation](#AdditionalLocation), and [Service_Spec](#Service_
 |-------------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | subnetResourceReference | The full resource ID of a subnet in a virtual network to deploy the API Management service in. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkConfiguration_STATUS"></a>VirtualNetworkConfiguration_STATUS
----------------------------------------------------------------------------------
+VirtualNetworkConfiguration_STATUS{#VirtualNetworkConfiguration_STATUS}
+-----------------------------------------------------------------------
 
 Configuration of a virtual network to which API Management service is deployed.
 
@@ -2547,8 +2547,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS), and [Service_S
 | subnetResourceId | The full resource ID of a subnet in a virtual network to deploy the API Management service in. | string<br/><small>Optional</small> |
 | vnetid           | The virtual network ID. This is typically a GUID. Expect a null GUID by default.               | string<br/><small>Optional</small> |
 
-<a id="AdditionalLocation_NatGatewayState"></a>AdditionalLocation_NatGatewayState
----------------------------------------------------------------------------------
+AdditionalLocation_NatGatewayState{#AdditionalLocation_NatGatewayState}
+-----------------------------------------------------------------------
 
 Used by: [AdditionalLocation](#AdditionalLocation).
 
@@ -2557,8 +2557,8 @@ Used by: [AdditionalLocation](#AdditionalLocation).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdditionalLocation_NatGatewayState_STATUS"></a>AdditionalLocation_NatGatewayState_STATUS
------------------------------------------------------------------------------------------------
+AdditionalLocation_NatGatewayState_STATUS{#AdditionalLocation_NatGatewayState_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 
@@ -2567,8 +2567,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdditionalLocation_PlatformVersion_STATUS"></a>AdditionalLocation_PlatformVersion_STATUS
------------------------------------------------------------------------------------------------
+AdditionalLocation_PlatformVersion_STATUS{#AdditionalLocation_PlatformVersion_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 
@@ -2580,8 +2580,8 @@ Used by: [AdditionalLocation_STATUS](#AdditionalLocation_STATUS).
 | "stv2.1"       |             |
 | "undetermined" |             |
 
-<a id="ApiManagementServiceIdentity_Type"></a>ApiManagementServiceIdentity_Type
--------------------------------------------------------------------------------
+ApiManagementServiceIdentity_Type{#ApiManagementServiceIdentity_Type}
+---------------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 
@@ -2592,8 +2592,8 @@ Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ApiManagementServiceIdentity_Type_STATUS"></a>ApiManagementServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------------------
+ApiManagementServiceIdentity_Type_STATUS{#ApiManagementServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STATUS).
 
@@ -2604,8 +2604,8 @@ Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STA
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ApiManagementServiceSkuProperties_Name"></a>ApiManagementServiceSkuProperties_Name
------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_Name{#ApiManagementServiceSkuProperties_Name}
+-------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceSkuProperties](#ApiManagementServiceSkuProperties).
 
@@ -2620,8 +2620,8 @@ Used by: [ApiManagementServiceSkuProperties](#ApiManagementServiceSkuProperties)
 | "Standard"    |             |
 | "StandardV2"  |             |
 
-<a id="ApiManagementServiceSkuProperties_Name_STATUS"></a>ApiManagementServiceSkuProperties_Name_STATUS
--------------------------------------------------------------------------------------------------------
+ApiManagementServiceSkuProperties_Name_STATUS{#ApiManagementServiceSkuProperties_Name_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ApiManagementServiceSkuProperties_STATUS](#ApiManagementServiceSkuProperties_STATUS).
 
@@ -2636,8 +2636,8 @@ Used by: [ApiManagementServiceSkuProperties_STATUS](#ApiManagementServiceSkuProp
 | "Standard"    |             |
 | "StandardV2"  |             |
 
-<a id="ApiVersionSetContractDetails_VersioningScheme"></a>ApiVersionSetContractDetails_VersioningScheme
--------------------------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_VersioningScheme{#ApiVersionSetContractDetails_VersioningScheme}
+---------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSetContractDetails](#ApiVersionSetContractDetails).
 
@@ -2647,8 +2647,8 @@ Used by: [ApiVersionSetContractDetails](#ApiVersionSetContractDetails).
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ApiVersionSetContractDetails_VersioningScheme_STATUS"></a>ApiVersionSetContractDetails_VersioningScheme_STATUS
----------------------------------------------------------------------------------------------------------------------
+ApiVersionSetContractDetails_VersioningScheme_STATUS{#ApiVersionSetContractDetails_VersioningScheme_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ApiVersionSetContractDetails_STATUS](#ApiVersionSetContractDetails_STATUS).
 
@@ -2658,8 +2658,8 @@ Used by: [ApiVersionSetContractDetails_STATUS](#ApiVersionSetContractDetails_STA
 | "Query"   |             |
 | "Segment" |             |
 
-<a id="ArmIdWrapper_STATUS"></a>ArmIdWrapper_STATUS
----------------------------------------------------
+ArmIdWrapper_STATUS{#ArmIdWrapper_STATUS}
+-----------------------------------------
 
 A wrapper for an ARM resource id
 
@@ -2669,8 +2669,8 @@ Used by: [RemotePrivateEndpointConnectionWrapper_STATUS](#RemotePrivateEndpointC
 |----------|-------------|------------------------------------|
 | id       |             | string<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2GrantTypes"></a>AuthorizationProviderOAuth2GrantTypes
----------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2GrantTypes{#AuthorizationProviderOAuth2GrantTypes}
+-----------------------------------------------------------------------------
 
 Authorization Provider oauth2 grant types settings
 
@@ -2681,8 +2681,8 @@ Used by: [AuthorizationProviderOAuth2Settings](#AuthorizationProviderOAuth2Setti
 | authorizationCode | OAuth2 authorization code grant parameters | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small> |
 | clientCredentials | OAuth2 client credential grant parameters  | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small> |
 
-<a id="AuthorizationProviderOAuth2GrantTypes_STATUS"></a>AuthorizationProviderOAuth2GrantTypes_STATUS
------------------------------------------------------------------------------------------------------
+AuthorizationProviderOAuth2GrantTypes_STATUS{#AuthorizationProviderOAuth2GrantTypes_STATUS}
+-------------------------------------------------------------------------------------------
 
 Authorization Provider oauth2 grant types settings
 
@@ -2693,8 +2693,8 @@ Used by: [AuthorizationProviderOAuth2Settings_STATUS](#AuthorizationProviderOAut
 | authorizationCode | OAuth2 authorization code grant parameters | map[string]string<br/><small>Optional</small> |
 | clientCredentials | OAuth2 client credential grant parameters  | map[string]string<br/><small>Optional</small> |
 
-<a id="BackendAuthorizationHeaderCredentials"></a>BackendAuthorizationHeaderCredentials
----------------------------------------------------------------------------------------
+BackendAuthorizationHeaderCredentials{#BackendAuthorizationHeaderCredentials}
+-----------------------------------------------------------------------------
 
 Authorization header information.
 
@@ -2705,8 +2705,8 @@ Used by: [BackendCredentialsContract](#BackendCredentialsContract).
 | parameter | Authentication Parameter value. | string<br/><small>Required</small> |
 | scheme    | Authentication Scheme name.     | string<br/><small>Required</small> |
 
-<a id="BackendAuthorizationHeaderCredentials_STATUS"></a>BackendAuthorizationHeaderCredentials_STATUS
------------------------------------------------------------------------------------------------------
+BackendAuthorizationHeaderCredentials_STATUS{#BackendAuthorizationHeaderCredentials_STATUS}
+-------------------------------------------------------------------------------------------
 
 Authorization header information.
 
@@ -2717,8 +2717,8 @@ Used by: [BackendCredentialsContract_STATUS](#BackendCredentialsContract_STATUS)
 | parameter | Authentication Parameter value. | string<br/><small>Optional</small> |
 | scheme    | Authentication Scheme name.     | string<br/><small>Optional</small> |
 
-<a id="BackendPoolItem"></a>BackendPoolItem
--------------------------------------------
+BackendPoolItem{#BackendPoolItem}
+---------------------------------
 
 Backend pool service information
 
@@ -2728,8 +2728,8 @@ Used by: [BackendPool](#BackendPool).
 |-----------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The unique ARM id of the backend entity. The ARM id should refer to an already existing backend entity. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="BackendPoolItem_STATUS"></a>BackendPoolItem_STATUS
----------------------------------------------------------
+BackendPoolItem_STATUS{#BackendPoolItem_STATUS}
+-----------------------------------------------
 
 Backend pool service information
 
@@ -2739,8 +2739,8 @@ Used by: [BackendPool_STATUS](#BackendPool_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | The unique ARM id of the backend entity. The ARM id should refer to an already existing backend entity. | string<br/><small>Required</small> |
 
-<a id="BackendServiceFabricClusterProperties"></a>BackendServiceFabricClusterProperties
----------------------------------------------------------------------------------------
+BackendServiceFabricClusterProperties{#BackendServiceFabricClusterProperties}
+-----------------------------------------------------------------------------
 
 Properties of the Service Fabric Type Backend.
 
@@ -2755,8 +2755,8 @@ Used by: [BackendProperties](#BackendProperties).
 | serverCertificateThumbprints  | Thumbprints of certificates cluster management service uses for tls communication                              | string[]<br/><small>Optional</small>                                      |
 | serverX509Names               | Server X509 Certificate Names Collection                                                                       | [X509CertificateName[]](#X509CertificateName)<br/><small>Optional</small> |
 
-<a id="BackendServiceFabricClusterProperties_STATUS"></a>BackendServiceFabricClusterProperties_STATUS
------------------------------------------------------------------------------------------------------
+BackendServiceFabricClusterProperties_STATUS{#BackendServiceFabricClusterProperties_STATUS}
+-------------------------------------------------------------------------------------------
 
 Properties of the Service Fabric Type Backend.
 
@@ -2771,8 +2771,8 @@ Used by: [BackendProperties_STATUS](#BackendProperties_STATUS).
 | serverCertificateThumbprints  | Thumbprints of certificates cluster management service uses for tls communication                              | string[]<br/><small>Optional</small>                                                    |
 | serverX509Names               | Server X509 Certificate Names Collection                                                                       | [X509CertificateName_STATUS[]](#X509CertificateName_STATUS)<br/><small>Optional</small> |
 
-<a id="CertificateConfiguration_StoreName"></a>CertificateConfiguration_StoreName
----------------------------------------------------------------------------------
+CertificateConfiguration_StoreName{#CertificateConfiguration_StoreName}
+-----------------------------------------------------------------------
 
 Used by: [CertificateConfiguration](#CertificateConfiguration).
 
@@ -2781,8 +2781,8 @@ Used by: [CertificateConfiguration](#CertificateConfiguration).
 | "CertificateAuthority" |             |
 | "Root"                 |             |
 
-<a id="CertificateConfiguration_StoreName_STATUS"></a>CertificateConfiguration_StoreName_STATUS
------------------------------------------------------------------------------------------------
+CertificateConfiguration_StoreName_STATUS{#CertificateConfiguration_StoreName_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS).
 
@@ -2791,8 +2791,8 @@ Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS).
 | "CertificateAuthority" |             |
 | "Root"                 |             |
 
-<a id="CertificateInformation"></a>CertificateInformation
----------------------------------------------------------
+CertificateInformation{#CertificateInformation}
+-----------------------------------------------
 
 SSL certificate information.
 
@@ -2807,8 +2807,8 @@ Used by: [CertificateConfiguration](#CertificateConfiguration), and [HostnameCon
 | thumbprint           | Thumbprint of the certificate.                                                                                                               | string<br/><small>Optional</small>                                                                                                                           |
 | thumbprintFromConfig | Thumbprint of the certificate.                                                                                                               | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="CertificateInformation_STATUS"></a>CertificateInformation_STATUS
------------------------------------------------------------------------
+CertificateInformation_STATUS{#CertificateInformation_STATUS}
+-------------------------------------------------------------
 
 SSL certificate information.
 
@@ -2820,8 +2820,8 @@ Used by: [CertificateConfiguration_STATUS](#CertificateConfiguration_STATUS), an
 | subject    | Subject of the certificate.                                                                                                                  | string<br/><small>Optional</small> |
 | thumbprint | Thumbprint of the certificate.                                                                                                               | string<br/><small>Optional</small> |
 
-<a id="CircuitBreakerRule"></a>CircuitBreakerRule
--------------------------------------------------
+CircuitBreakerRule{#CircuitBreakerRule}
+---------------------------------------
 
 Rule configuration to trip the backend.
 
@@ -2833,8 +2833,8 @@ Used by: [BackendCircuitBreaker](#BackendCircuitBreaker).
 | name             | The rule name.                                      | string<br/><small>Optional</small>                                                            |
 | tripDuration     | The duration for which the circuit will be tripped. | string<br/><small>Optional</small>                                                            |
 
-<a id="CircuitBreakerRule_STATUS"></a>CircuitBreakerRule_STATUS
----------------------------------------------------------------
+CircuitBreakerRule_STATUS{#CircuitBreakerRule_STATUS}
+-----------------------------------------------------
 
 Rule configuration to trip the backend.
 
@@ -2846,8 +2846,8 @@ Used by: [BackendCircuitBreaker_STATUS](#BackendCircuitBreaker_STATUS).
 | name             | The rule name.                                      | string<br/><small>Optional</small>                                                                          |
 | tripDuration     | The duration for which the circuit will be tripped. | string<br/><small>Optional</small>                                                                          |
 
-<a id="ConfigurationApi_LegacyApi"></a>ConfigurationApi_LegacyApi
------------------------------------------------------------------
+ConfigurationApi_LegacyApi{#ConfigurationApi_LegacyApi}
+-------------------------------------------------------
 
 Used by: [ConfigurationApi](#ConfigurationApi).
 
@@ -2856,8 +2856,8 @@ Used by: [ConfigurationApi](#ConfigurationApi).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ConfigurationApi_LegacyApi_STATUS"></a>ConfigurationApi_LegacyApi_STATUS
--------------------------------------------------------------------------------
+ConfigurationApi_LegacyApi_STATUS{#ConfigurationApi_LegacyApi_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ConfigurationApi_STATUS](#ConfigurationApi_STATUS).
 
@@ -2866,8 +2866,8 @@ Used by: [ConfigurationApi_STATUS](#ConfigurationApi_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="HostnameConfiguration_CertificateSource"></a>HostnameConfiguration_CertificateSource
--------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateSource{#HostnameConfiguration_CertificateSource}
+---------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2878,8 +2878,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "KeyVault" |             |
 | "Managed"  |             |
 
-<a id="HostnameConfiguration_CertificateSource_STATUS"></a>HostnameConfiguration_CertificateSource_STATUS
----------------------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateSource_STATUS{#HostnameConfiguration_CertificateSource_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2890,8 +2890,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "KeyVault" |             |
 | "Managed"  |             |
 
-<a id="HostnameConfiguration_CertificateStatus"></a>HostnameConfiguration_CertificateStatus
--------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateStatus{#HostnameConfiguration_CertificateStatus}
+---------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2901,8 +2901,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="HostnameConfiguration_CertificateStatus_STATUS"></a>HostnameConfiguration_CertificateStatus_STATUS
----------------------------------------------------------------------------------------------------------
+HostnameConfiguration_CertificateStatus_STATUS{#HostnameConfiguration_CertificateStatus_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2912,8 +2912,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="HostnameConfiguration_Type"></a>HostnameConfiguration_Type
------------------------------------------------------------------
+HostnameConfiguration_Type{#HostnameConfiguration_Type}
+-------------------------------------------------------
 
 Used by: [HostnameConfiguration](#HostnameConfiguration).
 
@@ -2926,8 +2926,8 @@ Used by: [HostnameConfiguration](#HostnameConfiguration).
 | "Proxy"            |             |
 | "Scm"              |             |
 
-<a id="HostnameConfiguration_Type_STATUS"></a>HostnameConfiguration_Type_STATUS
--------------------------------------------------------------------------------
+HostnameConfiguration_Type_STATUS{#HostnameConfiguration_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 
@@ -2940,8 +2940,8 @@ Used by: [HostnameConfiguration_STATUS](#HostnameConfiguration_STATUS).
 | "Proxy"            |             |
 | "Scm"              |             |
 
-<a id="KeyVaultLastAccessStatusContractProperties_STATUS"></a>KeyVaultLastAccessStatusContractProperties_STATUS
----------------------------------------------------------------------------------------------------------------
+KeyVaultLastAccessStatusContractProperties_STATUS{#KeyVaultLastAccessStatusContractProperties_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Issue contract Update Properties.
 
@@ -2953,8 +2953,8 @@ Used by: [KeyVaultContractProperties_STATUS](#KeyVaultContractProperties_STATUS)
 | message      | Details of the error else empty.                                                                                                        | string<br/><small>Optional</small> |
 | timeStampUtc | Last time secret was accessed. The date conforms to the following format: `yyyy-MM-ddTHH:mm:ssZ` as specified by the ISO 8601 standard. | string<br/><small>Optional</small> |
 
-<a id="OAuth2AuthenticationSettingsContract"></a>OAuth2AuthenticationSettingsContract
--------------------------------------------------------------------------------------
+OAuth2AuthenticationSettingsContract{#OAuth2AuthenticationSettingsContract}
+---------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2965,8 +2965,8 @@ Used by: [AuthenticationSettingsContract](#AuthenticationSettingsContract), and 
 | authorizationServerId | OAuth authorization server identifier. | string<br/><small>Optional</small> |
 | scope                 | operations scope.                      | string<br/><small>Optional</small> |
 
-<a id="OAuth2AuthenticationSettingsContract_STATUS"></a>OAuth2AuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------------------
+OAuth2AuthenticationSettingsContract_STATUS{#OAuth2AuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2977,8 +2977,8 @@ Used by: [AuthenticationSettingsContract_STATUS](#AuthenticationSettingsContract
 | authorizationServerId | OAuth authorization server identifier. | string<br/><small>Optional</small> |
 | scope                 | operations scope.                      | string<br/><small>Optional</small> |
 
-<a id="OpenIdAuthenticationSettingsContract"></a>OpenIdAuthenticationSettingsContract
--------------------------------------------------------------------------------------
+OpenIdAuthenticationSettingsContract{#OpenIdAuthenticationSettingsContract}
+---------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -2989,8 +2989,8 @@ Used by: [AuthenticationSettingsContract](#AuthenticationSettingsContract), and 
 | bearerTokenSendingMethods | How to send token to the server.       | [BearerTokenSendingMethodsContract[]](#BearerTokenSendingMethodsContract)<br/><small>Optional</small> |
 | openidProviderId          | OAuth authorization server identifier. | string<br/><small>Optional</small>                                                                    |
 
-<a id="OpenIdAuthenticationSettingsContract_STATUS"></a>OpenIdAuthenticationSettingsContract_STATUS
----------------------------------------------------------------------------------------------------
+OpenIdAuthenticationSettingsContract_STATUS{#OpenIdAuthenticationSettingsContract_STATUS}
+-----------------------------------------------------------------------------------------
 
 API OAuth2 Authentication settings details.
 
@@ -3001,8 +3001,8 @@ Used by: [AuthenticationSettingsContract_STATUS](#AuthenticationSettingsContract
 | bearerTokenSendingMethods | How to send token to the server.       | [BearerTokenSendingMethodsContract_STATUS[]](#BearerTokenSendingMethodsContract_STATUS)<br/><small>Optional</small> |
 | openidProviderId          | OAuth authorization server identifier. | string<br/><small>Optional</small>                                                                                  |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -3014,8 +3014,8 @@ Used by: [RemotePrivateEndpointConnectionWrapper_STATUS](#RemotePrivateEndpointC
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small>                                                                                          |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="SubscriptionOperatorSecrets"></a>SubscriptionOperatorSecrets
--------------------------------------------------------------------
+SubscriptionOperatorSecrets{#SubscriptionOperatorSecrets}
+---------------------------------------------------------
 
 Used by: [SubscriptionOperatorSpec](#SubscriptionOperatorSpec).
 
@@ -3024,7 +3024,19 @@ Used by: [SubscriptionOperatorSpec](#SubscriptionOperatorSpec).
 | primaryKey   | indicates where the PrimaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.   | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3036,20 +3048,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -3059,8 +3059,8 @@ Used by: [ApiManagementServiceIdentity](#ApiManagementServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentityProperties_STATUS"></a>UserIdentityProperties_STATUS
------------------------------------------------------------------------
+UserIdentityProperties_STATUS{#UserIdentityProperties_STATUS}
+-------------------------------------------------------------
 
 Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STATUS).
 
@@ -3069,8 +3069,8 @@ Used by: [ApiManagementServiceIdentity_STATUS](#ApiManagementServiceIdentity_STA
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="BearerTokenSendingMethodsContract"></a>BearerTokenSendingMethodsContract
--------------------------------------------------------------------------------
+BearerTokenSendingMethodsContract{#BearerTokenSendingMethodsContract}
+---------------------------------------------------------------------
 
 Form of an authorization grant, which the client uses to request the access token.
 
@@ -3081,8 +3081,8 @@ Used by: [OpenIdAuthenticationSettingsContract](#OpenIdAuthenticationSettingsCon
 | "authorizationHeader" |             |
 | "query"               |             |
 
-<a id="BearerTokenSendingMethodsContract_STATUS"></a>BearerTokenSendingMethodsContract_STATUS
----------------------------------------------------------------------------------------------
+BearerTokenSendingMethodsContract_STATUS{#BearerTokenSendingMethodsContract_STATUS}
+-----------------------------------------------------------------------------------
 
 Form of an authorization grant, which the client uses to request the access token.
 
@@ -3093,8 +3093,8 @@ Used by: [OpenIdAuthenticationSettingsContract_STATUS](#OpenIdAuthenticationSett
 | "authorizationHeader" |             |
 | "query"               |             |
 
-<a id="CircuitBreakerFailureCondition"></a>CircuitBreakerFailureCondition
--------------------------------------------------------------------------
+CircuitBreakerFailureCondition{#CircuitBreakerFailureCondition}
+---------------------------------------------------------------
 
 The trip conditions of the circuit breaker
 
@@ -3108,8 +3108,8 @@ Used by: [CircuitBreakerRule](#CircuitBreakerRule).
 | percentage       | The threshold for opening the circuit.                  | int<br/><small>Optional</small>                                                                                           |
 | statusCodeRanges | The status code ranges which are considered as failure. | [FailureStatusCodeRange[]](#FailureStatusCodeRange)<br/><small>Optional</small>                                           |
 
-<a id="CircuitBreakerFailureCondition_STATUS"></a>CircuitBreakerFailureCondition_STATUS
----------------------------------------------------------------------------------------
+CircuitBreakerFailureCondition_STATUS{#CircuitBreakerFailureCondition_STATUS}
+-----------------------------------------------------------------------------
 
 The trip conditions of the circuit breaker
 
@@ -3123,8 +3123,8 @@ Used by: [CircuitBreakerRule_STATUS](#CircuitBreakerRule_STATUS).
 | percentage       | The threshold for opening the circuit.                  | int<br/><small>Optional</small>                                                                                                         |
 | statusCodeRanges | The status code ranges which are considered as failure. | [FailureStatusCodeRange_STATUS[]](#FailureStatusCodeRange_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -3136,8 +3136,8 @@ Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectio
 | "Pending"  |             |
 | "Rejected" |             |
 
-<a id="X509CertificateName"></a>X509CertificateName
----------------------------------------------------
+X509CertificateName{#X509CertificateName}
+-----------------------------------------
 
 Properties of server X509Names.
 
@@ -3148,8 +3148,8 @@ Used by: [BackendServiceFabricClusterProperties](#BackendServiceFabricClusterPro
 | issuerCertificateThumbprint | Thumbprint for the Issuer of the Certificate. | string<br/><small>Optional</small> |
 | name                        | Common Name of the Certificate.               | string<br/><small>Optional</small> |
 
-<a id="X509CertificateName_STATUS"></a>X509CertificateName_STATUS
------------------------------------------------------------------
+X509CertificateName_STATUS{#X509CertificateName_STATUS}
+-------------------------------------------------------
 
 Properties of server X509Names.
 
@@ -3160,18 +3160,18 @@ Used by: [BackendServiceFabricClusterProperties_STATUS](#BackendServiceFabricClu
 | issuerCertificateThumbprint | Thumbprint for the Issuer of the Certificate. | string<br/><small>Optional</small> |
 | name                        | Common Name of the Certificate.               | string<br/><small>Optional</small> |
 
-<a id="CircuitBreakerFailureCondition_ErrorReasons"></a>CircuitBreakerFailureCondition_ErrorReasons
----------------------------------------------------------------------------------------------------
+CircuitBreakerFailureCondition_ErrorReasons{#CircuitBreakerFailureCondition_ErrorReasons}
+-----------------------------------------------------------------------------------------
 
 Used by: [CircuitBreakerFailureCondition](#CircuitBreakerFailureCondition).
 
-<a id="CircuitBreakerFailureCondition_ErrorReasons_STATUS"></a>CircuitBreakerFailureCondition_ErrorReasons_STATUS
------------------------------------------------------------------------------------------------------------------
+CircuitBreakerFailureCondition_ErrorReasons_STATUS{#CircuitBreakerFailureCondition_ErrorReasons_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [CircuitBreakerFailureCondition_STATUS](#CircuitBreakerFailureCondition_STATUS).
 
-<a id="FailureStatusCodeRange"></a>FailureStatusCodeRange
----------------------------------------------------------
+FailureStatusCodeRange{#FailureStatusCodeRange}
+-----------------------------------------------
 
 The failure http status code range
 
@@ -3182,8 +3182,8 @@ Used by: [CircuitBreakerFailureCondition](#CircuitBreakerFailureCondition).
 | max      | The maximum http status code. | int<br/><small>Optional</small> |
 | min      | The minimum http status code. | int<br/><small>Optional</small> |
 
-<a id="FailureStatusCodeRange_STATUS"></a>FailureStatusCodeRange_STATUS
------------------------------------------------------------------------
+FailureStatusCodeRange_STATUS{#FailureStatusCodeRange_STATUS}
+-------------------------------------------------------------
 
 The failure http status code range
 

--- a/docs/hugo/content/reference/app/v1api20240301.md
+++ b/docs/hugo/content/reference/app/v1api20240301.md
@@ -5,15 +5,15 @@ title: app.azure.com/v1api20240301
 linktitle: v1api20240301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-03-01" |             |
 
-<a id="AuthConfig"></a>AuthConfig
----------------------------------
+AuthConfig{#AuthConfig}
+-----------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/AuthConfigs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/containerApps/{containerAppName}/authConfigs/{authConfigName}
 
@@ -26,7 +26,7 @@ Used by: [AuthConfigList](#AuthConfigList).
 | spec                                                                                    |             | [AuthConfig_Spec](#AuthConfig_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AuthConfig_STATUS](#AuthConfig_STATUS)<br/><small>Optional</small> |
 
-### <a id="AuthConfig_Spec"></a>AuthConfig_Spec
+### AuthConfig_Spec {#AuthConfig_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                 |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [AuthConfigList](#AuthConfigList).
 | owner              | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a app.azure.com/ContainerApp resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | platform           | The configuration settings of the platform of ContainerApp Service Authentication/Authorization.                                                                                                                                                                                      | [AuthPlatform](#AuthPlatform)<br/><small>Optional</small>                                                                                                            |
 
-### <a id="AuthConfig_STATUS"></a>AuthConfig_STATUS
+### AuthConfig_STATUS{#AuthConfig_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,8 +56,8 @@ Used by: [AuthConfigList](#AuthConfigList).
 | systemData         | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthConfigList"></a>AuthConfigList
------------------------------------------
+AuthConfigList{#AuthConfigList}
+-------------------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/AuthConfigs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/containerApps/{containerAppName}/authConfigs/{authConfigName}
 
@@ -67,8 +67,8 @@ Generator information: - Generated from: /app/resource-manager/Microsoft.App/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [AuthConfig[]](#AuthConfig)<br/><small>Optional</small> |
 
-<a id="ContainerApp"></a>ContainerApp
--------------------------------------
+ContainerApp{#ContainerApp}
+---------------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/ContainerApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/containerApps/{containerAppName}
 
@@ -81,7 +81,7 @@ Used by: [ContainerAppList](#ContainerAppList).
 | spec                                                                                    |             | [ContainerApp_Spec](#ContainerApp_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ContainerApp_STATUS](#ContainerApp_STATUS)<br/><small>Optional</small> |
 
-### <a id="ContainerApp_Spec"></a>ContainerApp_Spec
+### ContainerApp_Spec {#ContainerApp_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                        | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -99,7 +99,7 @@ Used by: [ContainerAppList](#ContainerAppList).
 | template                    | Container App versioned application definition.                                                                                                                                                                                                                                                    | [Template](#Template)<br/><small>Optional</small>                                                                                                                    |
 | workloadProfileName         | Workload profile name to pin for container app execution.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ContainerApp_STATUS"></a>ContainerApp_STATUS
+### ContainerApp_STATUS{#ContainerApp_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -126,8 +126,8 @@ Used by: [ContainerAppList](#ContainerAppList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workloadProfileName        | Workload profile name to pin for container app execution.                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ContainerAppList"></a>ContainerAppList
----------------------------------------------
+ContainerAppList{#ContainerAppList}
+-----------------------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/ContainerApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/containerApps/{containerAppName}
 
@@ -137,8 +137,8 @@ Generator information: - Generated from: /app/resource-manager/Microsoft.App/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [ContainerApp[]](#ContainerApp)<br/><small>Optional</small> |
 
-<a id="Job"></a>Job
--------------------
+Job{#Job}
+---------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/Jobs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/jobs/{jobName}
 
@@ -151,7 +151,7 @@ Used by: [JobList](#JobList).
 | spec                                                                                    |             | [Job_Spec](#Job_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Job_STATUS](#Job_STATUS)<br/><small>Optional</small> |
 
-### <a id="Job_Spec"></a>Job_Spec
+### Job_Spec {#Job_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -166,7 +166,7 @@ Used by: [JobList](#JobList).
 | template             | Container Apps job definition.                                                                                                                                                                                                                                                               | [JobTemplate](#JobTemplate)<br/><small>Optional</small>                                                                                                              |
 | workloadProfileName  | Workload profile name to pin for container apps job execution.                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="Job_STATUS"></a>Job_STATUS
+### Job_STATUS{#Job_STATUS}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -186,8 +186,8 @@ Used by: [JobList](#JobList).
 | type                | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workloadProfileName | Workload profile name to pin for container apps job execution.                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="JobList"></a>JobList
----------------------------
+JobList{#JobList}
+-----------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/Jobs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/jobs/{jobName}
 
@@ -197,8 +197,8 @@ Generator information: - Generated from: /app/resource-manager/Microsoft.App/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                           |
 | items                                                                               |             | [Job[]](#Job)<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment"></a>ManagedEnvironment
--------------------------------------------------
+ManagedEnvironment{#ManagedEnvironment}
+---------------------------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/ManagedEnvironments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/managedEnvironments/{environmentName}
 
@@ -211,7 +211,7 @@ Used by: [ManagedEnvironmentList](#ManagedEnvironmentList).
 | spec                                                                                    |             | [ManagedEnvironment_Spec](#ManagedEnvironment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedEnvironment_Spec"></a>ManagedEnvironment_Spec
+### ManagedEnvironment_Spec {#ManagedEnvironment_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -232,7 +232,7 @@ Used by: [ManagedEnvironmentList](#ManagedEnvironmentList).
 | workloadProfiles            | Workload profiles configured for the Managed Environment.                                                                                                                                                                                                                                    | [WorkloadProfile[]](#WorkloadProfile)<br/><small>Optional</small>                                                                                                    |
 | zoneRedundant               | Whether or not this Managed Environment is zone-redundant.                                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="ManagedEnvironment_STATUS"></a>ManagedEnvironment_STATUS
+### ManagedEnvironment_STATUS{#ManagedEnvironment_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                        |
 |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -260,8 +260,8 @@ Used by: [ManagedEnvironmentList](#ManagedEnvironmentList).
 | workloadProfiles            | Workload profiles configured for the Managed Environment.                                                                                                                                                                                                                                                                 | [WorkloadProfile_STATUS[]](#WorkloadProfile_STATUS)<br/><small>Optional</small>                                                                             |
 | zoneRedundant               | Whether or not this Managed Environment is zone-redundant.                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                            |
 
-<a id="ManagedEnvironmentList"></a>ManagedEnvironmentList
----------------------------------------------------------
+ManagedEnvironmentList{#ManagedEnvironmentList}
+-----------------------------------------------
 
 Generator information: - Generated from: /app/resource-manager/Microsoft.App/stable/2024-03-01/ManagedEnvironments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.App/managedEnvironments/{environmentName}
 
@@ -271,8 +271,8 @@ Generator information: - Generated from: /app/resource-manager/Microsoft.App/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ManagedEnvironment[]](#ManagedEnvironment)<br/><small>Optional</small> |
 
-<a id="AuthConfig_Spec"></a>AuthConfig_Spec
--------------------------------------------
+AuthConfig_Spec{#AuthConfig_Spec}
+---------------------------------
 
 Used by: [AuthConfig](#AuthConfig).
 
@@ -288,8 +288,8 @@ Used by: [AuthConfig](#AuthConfig).
 | owner              | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a app.azure.com/ContainerApp resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | platform           | The configuration settings of the platform of ContainerApp Service Authentication/Authorization.                                                                                                                                                                                      | [AuthPlatform](#AuthPlatform)<br/><small>Optional</small>                                                                                                            |
 
-<a id="AuthConfig_STATUS"></a>AuthConfig_STATUS
------------------------------------------------
+AuthConfig_STATUS{#AuthConfig_STATUS}
+-------------------------------------
 
 Used by: [AuthConfig](#AuthConfig).
 
@@ -307,8 +307,8 @@ Used by: [AuthConfig](#AuthConfig).
 | systemData         | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ContainerApp_Spec"></a>ContainerApp_Spec
------------------------------------------------
+ContainerApp_Spec{#ContainerApp_Spec}
+-------------------------------------
 
 Used by: [ContainerApp](#ContainerApp).
 
@@ -328,8 +328,8 @@ Used by: [ContainerApp](#ContainerApp).
 | template                    | Container App versioned application definition.                                                                                                                                                                                                                                                    | [Template](#Template)<br/><small>Optional</small>                                                                                                                    |
 | workloadProfileName         | Workload profile name to pin for container app execution.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ContainerApp_STATUS"></a>ContainerApp_STATUS
----------------------------------------------------
+ContainerApp_STATUS{#ContainerApp_STATUS}
+-----------------------------------------
 
 Container App.
 
@@ -360,8 +360,8 @@ Used by: [ContainerApp](#ContainerApp).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workloadProfileName        | Workload profile name to pin for container app execution.                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Job_Spec"></a>Job_Spec
------------------------------
+Job_Spec{#Job_Spec}
+-------------------
 
 Used by: [Job](#Job).
 
@@ -378,8 +378,8 @@ Used by: [Job](#Job).
 | template             | Container Apps job definition.                                                                                                                                                                                                                                                               | [JobTemplate](#JobTemplate)<br/><small>Optional</small>                                                                                                              |
 | workloadProfileName  | Workload profile name to pin for container apps job execution.                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="Job_STATUS"></a>Job_STATUS
----------------------------------
+Job_STATUS{#Job_STATUS}
+-----------------------
 
 Container App Job
 
@@ -403,8 +403,8 @@ Used by: [Job](#Job).
 | type                | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workloadProfileName | Workload profile name to pin for container apps job execution.                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ManagedEnvironment_Spec"></a>ManagedEnvironment_Spec
------------------------------------------------------------
+ManagedEnvironment_Spec{#ManagedEnvironment_Spec}
+-------------------------------------------------
 
 Used by: [ManagedEnvironment](#ManagedEnvironment).
 
@@ -427,8 +427,8 @@ Used by: [ManagedEnvironment](#ManagedEnvironment).
 | workloadProfiles            | Workload profiles configured for the Managed Environment.                                                                                                                                                                                                                                    | [WorkloadProfile[]](#WorkloadProfile)<br/><small>Optional</small>                                                                                                    |
 | zoneRedundant               | Whether or not this Managed Environment is zone-redundant.                                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="ManagedEnvironment_STATUS"></a>ManagedEnvironment_STATUS
----------------------------------------------------------------
+ManagedEnvironment_STATUS{#ManagedEnvironment_STATUS}
+-----------------------------------------------------
 
 An environment for hosting container apps
 
@@ -460,8 +460,8 @@ Used by: [ManagedEnvironment](#ManagedEnvironment).
 | workloadProfiles            | Workload profiles configured for the Managed Environment.                                                                                                                                                                                                                                                                 | [WorkloadProfile_STATUS[]](#WorkloadProfile_STATUS)<br/><small>Optional</small>                                                                             |
 | zoneRedundant               | Whether or not this Managed Environment is zone-redundant.                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                            |
 
-<a id="AppLogsConfiguration"></a>AppLogsConfiguration
------------------------------------------------------
+AppLogsConfiguration{#AppLogsConfiguration}
+-------------------------------------------
 
 Configuration of application logs
 
@@ -472,8 +472,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 | destination               | Logs destination, can be 'log-analytics', 'azure-monitor' or 'none'                                  | string<br/><small>Optional</small>                                                  |
 | logAnalyticsConfiguration | Log Analytics configuration, must only be provided when destination is configured as 'log-analytics' | [LogAnalyticsConfiguration](#LogAnalyticsConfiguration)<br/><small>Optional</small> |
 
-<a id="AppLogsConfiguration_STATUS"></a>AppLogsConfiguration_STATUS
--------------------------------------------------------------------
+AppLogsConfiguration_STATUS{#AppLogsConfiguration_STATUS}
+---------------------------------------------------------
 
 Configuration of application logs
 
@@ -484,8 +484,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 | destination               | Logs destination, can be 'log-analytics', 'azure-monitor' or 'none'                                  | string<br/><small>Optional</small>                                                                |
 | logAnalyticsConfiguration | Log Analytics configuration, must only be provided when destination is configured as 'log-analytics' | [LogAnalyticsConfiguration_STATUS](#LogAnalyticsConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="AuthConfigOperatorSpec"></a>AuthConfigOperatorSpec
----------------------------------------------------------
+AuthConfigOperatorSpec{#AuthConfigOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -496,8 +496,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AuthPlatform"></a>AuthPlatform
--------------------------------------
+AuthPlatform{#AuthPlatform}
+---------------------------
 
 The configuration settings of the platform of ContainerApp Service Authentication/Authorization.
 
@@ -508,8 +508,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | enabled        | <code>true</code> if the Authentication / Authorization feature is enabled for the current app; otherwise, <code>false</code>.                                                                                    | bool<br/><small>Optional</small>   |
 | runtimeVersion | The RuntimeVersion of the Authentication / Authorization feature in use for the current app. The setting in this value can control the behavior of certain features in the Authentication / Authorization module. | string<br/><small>Optional</small> |
 
-<a id="AuthPlatform_STATUS"></a>AuthPlatform_STATUS
----------------------------------------------------
+AuthPlatform_STATUS{#AuthPlatform_STATUS}
+-----------------------------------------
 
 The configuration settings of the platform of ContainerApp Service Authentication/Authorization.
 
@@ -520,8 +520,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | enabled        | <code>true</code> if the Authentication / Authorization feature is enabled for the current app; otherwise, <code>false</code>.                                                                                    | bool<br/><small>Optional</small>   |
 | runtimeVersion | The RuntimeVersion of the Authentication / Authorization feature in use for the current app. The setting in this value can control the behavior of certain features in the Authentication / Authorization module. | string<br/><small>Optional</small> |
 
-<a id="Configuration"></a>Configuration
----------------------------------------
+Configuration{#Configuration}
+-----------------------------
 
 Non versioned Container App configuration properties that define the mutable settings of a Container app
 
@@ -537,8 +537,8 @@ Used by: [ContainerApp_Spec](#ContainerApp_Spec).
 | secrets              | Collection of secrets used by a Container app                                                                                                                                                                                                                                                                          | [Secret[]](#Secret)<br/><small>Optional</small>                                                     |
 | service              | Container App to be a dev Container App Service                                                                                                                                                                                                                                                                        | [Service](#Service)<br/><small>Optional</small>                                                     |
 
-<a id="Configuration_STATUS"></a>Configuration_STATUS
------------------------------------------------------
+Configuration_STATUS{#Configuration_STATUS}
+-------------------------------------------
 
 Non versioned Container App configuration properties that define the mutable settings of a Container app
 
@@ -554,8 +554,8 @@ Used by: [ContainerApp_STATUS](#ContainerApp_STATUS).
 | secrets              | Collection of secrets used by a Container app                                                                                                                                                                                                                                                                          | [Secret_STATUS[]](#Secret_STATUS)<br/><small>Optional</small>                                                     |
 | service              | Container App to be a dev Container App Service                                                                                                                                                                                                                                                                        | [Service_STATUS](#Service_STATUS)<br/><small>Optional</small>                                                     |
 
-<a id="ContainerApp_Properties_ProvisioningState_STATUS"></a>ContainerApp_Properties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------
+ContainerApp_Properties_ProvisioningState_STATUS{#ContainerApp_Properties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ContainerApp_STATUS](#ContainerApp_STATUS).
 
@@ -567,8 +567,8 @@ Used by: [ContainerApp_STATUS](#ContainerApp_STATUS).
 | "InProgress" |             |
 | "Succeeded"  |             |
 
-<a id="ContainerAppOperatorSpec"></a>ContainerAppOperatorSpec
--------------------------------------------------------------
+ContainerAppOperatorSpec{#ContainerAppOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -580,8 +580,8 @@ Used by: [ContainerApp_Spec](#ContainerApp_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [ContainerAppOperatorConfigMaps](#ContainerAppOperatorConfigMaps)<br/><small>Optional</small>                                                                       |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="CustomDomainConfiguration"></a>CustomDomainConfiguration
----------------------------------------------------------------
+CustomDomainConfiguration{#CustomDomainConfiguration}
+-----------------------------------------------------
 
 Configuration properties for apps environment custom domain
 
@@ -593,8 +593,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 | certificateValue    | PFX or PEM blob                       | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | dnsSuffix           | Dns suffix for the environment domain | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="CustomDomainConfiguration_STATUS"></a>CustomDomainConfiguration_STATUS
------------------------------------------------------------------------------
+CustomDomainConfiguration_STATUS{#CustomDomainConfiguration_STATUS}
+-------------------------------------------------------------------
 
 Configuration properties for apps environment custom domain
 
@@ -608,8 +608,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 | subjectName                | Subject name of the certificate.        | string<br/><small>Optional</small> |
 | thumbprint                 | Certificate thumbprint.                 | string<br/><small>Optional</small> |
 
-<a id="DaprConfiguration_STATUS"></a>DaprConfiguration_STATUS
--------------------------------------------------------------
+DaprConfiguration_STATUS{#DaprConfiguration_STATUS}
+---------------------------------------------------
 
 Configuration properties Dapr component
 
@@ -619,8 +619,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 |----------|---------------------|------------------------------------|
 | version  | The version of Dapr | string<br/><small>Optional</small> |
 
-<a id="EncryptionSettings"></a>EncryptionSettings
--------------------------------------------------
+EncryptionSettings{#EncryptionSettings}
+---------------------------------------
 
 The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization.
 
@@ -631,8 +631,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | containerAppAuthEncryptionSecretName | The secret name which is referenced for EncryptionKey. | string<br/><small>Optional</small> |
 | containerAppAuthSigningSecretName    | The secret name which is referenced for SigningKey.    | string<br/><small>Optional</small> |
 
-<a id="EncryptionSettings_STATUS"></a>EncryptionSettings_STATUS
----------------------------------------------------------------
+EncryptionSettings_STATUS{#EncryptionSettings_STATUS}
+-----------------------------------------------------
 
 The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization.
 
@@ -643,8 +643,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | containerAppAuthEncryptionSecretName | The secret name which is referenced for EncryptionKey. | string<br/><small>Optional</small> |
 | containerAppAuthSigningSecretName    | The secret name which is referenced for SigningKey.    | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -655,8 +655,8 @@ Used by: [ContainerApp_Spec](#ContainerApp_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -667,8 +667,8 @@ Used by: [ContainerApp_STATUS](#ContainerApp_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GlobalValidation"></a>GlobalValidation
----------------------------------------------
+GlobalValidation{#GlobalValidation}
+-----------------------------------
 
 The configuration settings that determines the validation flow of users using ContainerApp Service Authentication/Authorization.
 
@@ -680,8 +680,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | redirectToProvider          | The default authentication provider to use when multiple providers are configured. This setting is only needed if multiple providers are configured and the unauthenticated client action is set to "RedirectToLoginPage". | string<br/><small>Optional</small>                                                                                        |
 | unauthenticatedClientAction | The action to take when an unauthenticated client attempts to access the app.                                                                                                                                              | [GlobalValidation_UnauthenticatedClientAction](#GlobalValidation_UnauthenticatedClientAction)<br/><small>Optional</small> |
 
-<a id="GlobalValidation_STATUS"></a>GlobalValidation_STATUS
------------------------------------------------------------
+GlobalValidation_STATUS{#GlobalValidation_STATUS}
+-------------------------------------------------
 
 The configuration settings that determines the validation flow of users using ContainerApp Service Authentication/Authorization.
 
@@ -693,8 +693,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | redirectToProvider          | The default authentication provider to use when multiple providers are configured. This setting is only needed if multiple providers are configured and the unauthenticated client action is set to "RedirectToLoginPage". | string<br/><small>Optional</small>                                                                                                      |
 | unauthenticatedClientAction | The action to take when an unauthenticated client attempts to access the app.                                                                                                                                              | [GlobalValidation_UnauthenticatedClientAction_STATUS](#GlobalValidation_UnauthenticatedClientAction_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpSettings"></a>HttpSettings
--------------------------------------
+HttpSettings{#HttpSettings}
+---------------------------
 
 The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization.
 
@@ -706,8 +706,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | requireHttps | <code>false</code> if the authentication/authorization responses not having the HTTPS scheme are permissible; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                      |
 | routes       | The configuration settings of the paths HTTP requests.                                                                                      | [HttpSettingsRoutes](#HttpSettingsRoutes)<br/><small>Optional</small> |
 
-<a id="HttpSettings_STATUS"></a>HttpSettings_STATUS
----------------------------------------------------
+HttpSettings_STATUS{#HttpSettings_STATUS}
+-----------------------------------------
 
 The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization.
 
@@ -719,8 +719,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | requireHttps | <code>false</code> if the authentication/authorization responses not having the HTTPS scheme are permissible; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                                    |
 | routes       | The configuration settings of the paths HTTP requests.                                                                                      | [HttpSettingsRoutes_STATUS](#HttpSettingsRoutes_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityProviders"></a>IdentityProviders
------------------------------------------------
+IdentityProviders{#IdentityProviders}
+-------------------------------------
 
 The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization.
 
@@ -737,8 +737,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | google                       | The configuration settings of the Google provider.                                                                                             | [Google](#Google)<br/><small>Optional</small>                                                      |
 | twitter                      | The configuration settings of the Twitter provider.                                                                                            | [Twitter](#Twitter)<br/><small>Optional</small>                                                    |
 
-<a id="IdentityProviders_STATUS"></a>IdentityProviders_STATUS
--------------------------------------------------------------
+IdentityProviders_STATUS{#IdentityProviders_STATUS}
+---------------------------------------------------
 
 The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization.
 
@@ -755,8 +755,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | google                       | The configuration settings of the Google provider.                                                                                             | [Google_STATUS](#Google_STATUS)<br/><small>Optional</small>                                                      |
 | twitter                      | The configuration settings of the Twitter provider.                                                                                            | [Twitter_STATUS](#Twitter_STATUS)<br/><small>Optional</small>                                                    |
 
-<a id="Job_Properties_ProvisioningState_STATUS"></a>Job_Properties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------
+Job_Properties_ProvisioningState_STATUS{#Job_Properties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [Job_STATUS](#Job_STATUS).
 
@@ -768,8 +768,8 @@ Used by: [Job_STATUS](#Job_STATUS).
 | "InProgress" |             |
 | "Succeeded"  |             |
 
-<a id="JobConfiguration"></a>JobConfiguration
----------------------------------------------
+JobConfiguration{#JobConfiguration}
+-----------------------------------
 
 Non versioned Container Apps Job configuration properties
 
@@ -786,8 +786,8 @@ Used by: [Job_Spec](#Job_Spec).
 | secrets               | Collection of secrets used by a Container Apps Job                                                                                        | [Secret[]](#Secret)<br/><small>Optional</small>                                                               |
 | triggerType           | Trigger type of the job                                                                                                                   | [JobConfiguration_TriggerType](#JobConfiguration_TriggerType)<br/><small>Required</small>                     |
 
-<a id="JobConfiguration_STATUS"></a>JobConfiguration_STATUS
------------------------------------------------------------
+JobConfiguration_STATUS{#JobConfiguration_STATUS}
+-------------------------------------------------
 
 Non versioned Container Apps Job configuration properties
 
@@ -804,8 +804,8 @@ Used by: [Job_STATUS](#Job_STATUS).
 | secrets               | Collection of secrets used by a Container Apps Job                                                                                        | [Secret_STATUS[]](#Secret_STATUS)<br/><small>Optional</small>                                                               |
 | triggerType           | Trigger type of the job                                                                                                                   | [JobConfiguration_TriggerType_STATUS](#JobConfiguration_TriggerType_STATUS)<br/><small>Optional</small>                     |
 
-<a id="JobOperatorSpec"></a>JobOperatorSpec
--------------------------------------------
+JobOperatorSpec{#JobOperatorSpec}
+---------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -816,8 +816,8 @@ Used by: [Job_Spec](#Job_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="JobTemplate"></a>JobTemplate
------------------------------------
+JobTemplate{#JobTemplate}
+-------------------------
 
 Container Apps Job versioned application definition. Defines the desired state of an immutable revision. Any changes to this section Will result in a new revision being created
 
@@ -829,8 +829,8 @@ Used by: [Job_Spec](#Job_Spec).
 | initContainers | List of specialized containers that run before app containers. | [BaseContainer[]](#BaseContainer)<br/><small>Optional</small> |
 | volumes        | List of volume definitions for the Container App.              | [Volume[]](#Volume)<br/><small>Optional</small>               |
 
-<a id="JobTemplate_STATUS"></a>JobTemplate_STATUS
--------------------------------------------------
+JobTemplate_STATUS{#JobTemplate_STATUS}
+---------------------------------------
 
 Container Apps Job versioned application definition. Defines the desired state of an immutable revision. Any changes to this section Will result in a new revision being created
 
@@ -842,8 +842,8 @@ Used by: [Job_STATUS](#Job_STATUS).
 | initContainers | List of specialized containers that run before app containers. | [BaseContainer_STATUS[]](#BaseContainer_STATUS)<br/><small>Optional</small> |
 | volumes        | List of volume definitions for the Container App.              | [Volume_STATUS[]](#Volume_STATUS)<br/><small>Optional</small>               |
 
-<a id="KedaConfiguration_STATUS"></a>KedaConfiguration_STATUS
--------------------------------------------------------------
+KedaConfiguration_STATUS{#KedaConfiguration_STATUS}
+---------------------------------------------------
 
 Configuration properties Keda component
 
@@ -853,8 +853,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 |----------|---------------------|------------------------------------|
 | version  | The version of Keda | string<br/><small>Optional</small> |
 
-<a id="Login"></a>Login
------------------------
+Login{#Login}
+-------------
 
 The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization.
 
@@ -869,8 +869,8 @@ Used by: [AuthConfig_Spec](#AuthConfig_Spec).
 | routes                        | The routes that specify the endpoints used for login and logout requests.                                                                                                                                                                                                                                        | [LoginRoutes](#LoginRoutes)<br/><small>Optional</small>           |
 | tokenStore                    | The configuration settings of the token store.                                                                                                                                                                                                                                                                   | [TokenStore](#TokenStore)<br/><small>Optional</small>             |
 
-<a id="Login_STATUS"></a>Login_STATUS
--------------------------------------
+Login_STATUS{#Login_STATUS}
+---------------------------
 
 The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization.
 
@@ -885,8 +885,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
 | routes                        | The routes that specify the endpoints used for login and logout requests.                                                                                                                                                                                                                                        | [LoginRoutes_STATUS](#LoginRoutes_STATUS)<br/><small>Optional</small>           |
 | tokenStore                    | The configuration settings of the token store.                                                                                                                                                                                                                                                                   | [TokenStore_STATUS](#TokenStore_STATUS)<br/><small>Optional</small>             |
 
-<a id="ManagedEnvironment_Properties_PeerAuthentication_Spec"></a>ManagedEnvironment_Properties_PeerAuthentication_Spec
------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerAuthentication_Spec{#ManagedEnvironment_Properties_PeerAuthentication_Spec}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 
@@ -894,8 +894,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 |----------|----------------------------------------------------------------|-------------------------------------------|
 | mtls     | Mutual TLS authentication settings for the Managed Environment | [Mtls](#Mtls)<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_PeerAuthentication_STATUS"></a>ManagedEnvironment_Properties_PeerAuthentication_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerAuthentication_STATUS{#ManagedEnvironment_Properties_PeerAuthentication_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 
@@ -903,8 +903,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 |----------|----------------------------------------------------------------|---------------------------------------------------------|
 | mtls     | Mutual TLS authentication settings for the Managed Environment | [Mtls_STATUS](#Mtls_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec"></a>ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec
------------------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec{#ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 
@@ -912,8 +912,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 |------------|--------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | encryption | Peer traffic encryption settings for the Managed Environment | [ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec](#ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec)<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS"></a>ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS{#ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 
@@ -921,8 +921,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 |------------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | encryption | Peer traffic encryption settings for the Managed Environment | [ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS](#ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_ProvisioningState_STATUS"></a>ManagedEnvironment_Properties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_ProvisioningState_STATUS{#ManagedEnvironment_Properties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 
@@ -939,8 +939,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 | "UpgradeRequested"              |             |
 | "Waiting"                       |             |
 
-<a id="ManagedEnvironmentOperatorSpec"></a>ManagedEnvironmentOperatorSpec
--------------------------------------------------------------------------
+ManagedEnvironmentOperatorSpec{#ManagedEnvironmentOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -951,8 +951,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -963,8 +963,8 @@ Used by: [ContainerApp_Spec](#ContainerApp_Spec), and [Job_Spec](#Job_Spec).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). | [ManagedServiceIdentityType](#ManagedServiceIdentityType)<br/><small>Required</small>     |
 | userAssignedIdentities |                                                                                                  | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -977,8 +977,8 @@ Used by: [ContainerApp_STATUS](#ContainerApp_STATUS), and [Job_STATUS](#Job_STAT
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).                              | [ManagedServiceIdentityType_STATUS](#ManagedServiceIdentityType_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities |                                                                                                                               | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>  |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -993,8 +993,8 @@ Used by: [AuthConfig_STATUS](#AuthConfig_STATUS), [ContainerApp_STATUS](#Contain
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Template"></a>Template
------------------------------
+Template{#Template}
+-------------------
 
 Container App versioned application definition. Defines the desired state of an immutable revision. Any changes to this section Will result in a new revision being created
 
@@ -1010,8 +1010,8 @@ Used by: [ContainerApp_Spec](#ContainerApp_Spec).
 | terminationGracePeriodSeconds | Optional duration in seconds the Container App Instance needs to terminate gracefully. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds. | int<br/><small>Optional</small>                               |
 | volumes                       | List of volume definitions for the Container App.                                                                                                                                                                                                                                                                                                                                           | [Volume[]](#Volume)<br/><small>Optional</small>               |
 
-<a id="Template_STATUS"></a>Template_STATUS
--------------------------------------------
+Template_STATUS{#Template_STATUS}
+---------------------------------
 
 Container App versioned application definition. Defines the desired state of an immutable revision. Any changes to this section Will result in a new revision being created
 
@@ -1027,8 +1027,8 @@ Used by: [ContainerApp_STATUS](#ContainerApp_STATUS).
 | terminationGracePeriodSeconds | Optional duration in seconds the Container App Instance needs to terminate gracefully. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds. | int<br/><small>Optional</small>                                             |
 | volumes                       | List of volume definitions for the Container App.                                                                                                                                                                                                                                                                                                                                           | [Volume_STATUS[]](#Volume_STATUS)<br/><small>Optional</small>               |
 
-<a id="VnetConfiguration"></a>VnetConfiguration
------------------------------------------------
+VnetConfiguration{#VnetConfiguration}
+-------------------------------------
 
 Configuration properties for apps environment to join a Virtual Network
 
@@ -1042,8 +1042,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 | platformReservedCidr          | IP range in CIDR notation that can be reserved for environment infrastructure IP addresses. Must not overlap with any other provided IP ranges.                                                       | string<br/><small>Optional</small>                                                                                                                         |
 | platformReservedDnsIP         | An IP address from the IP range defined by platformReservedCidr that will be reserved for the internal DNS server.                                                                                    | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="VnetConfiguration_STATUS"></a>VnetConfiguration_STATUS
--------------------------------------------------------------
+VnetConfiguration_STATUS{#VnetConfiguration_STATUS}
+---------------------------------------------------
 
 Configuration properties for apps environment to join a Virtual Network
 
@@ -1057,8 +1057,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 | platformReservedCidr   | IP range in CIDR notation that can be reserved for environment infrastructure IP addresses. Must not overlap with any other provided IP ranges.                                                       | string<br/><small>Optional</small> |
 | platformReservedDnsIP  | An IP address from the IP range defined by platformReservedCidr that will be reserved for the internal DNS server.                                                                                    | string<br/><small>Optional</small> |
 
-<a id="WorkloadProfile"></a>WorkloadProfile
--------------------------------------------
+WorkloadProfile{#WorkloadProfile}
+---------------------------------
 
 Workload profile to scope container app execution.
 
@@ -1071,8 +1071,8 @@ Used by: [ManagedEnvironment_Spec](#ManagedEnvironment_Spec).
 | name                | Workload profile type for the workloads to run on. | string<br/><small>Required</small> |
 | workloadProfileType | Workload profile type for the workloads to run on. | string<br/><small>Required</small> |
 
-<a id="WorkloadProfile_STATUS"></a>WorkloadProfile_STATUS
----------------------------------------------------------
+WorkloadProfile_STATUS{#WorkloadProfile_STATUS}
+-----------------------------------------------
 
 Workload profile to scope container app execution.
 
@@ -1085,8 +1085,8 @@ Used by: [ManagedEnvironment_STATUS](#ManagedEnvironment_STATUS).
 | name                | Workload profile type for the workloads to run on. | string<br/><small>Optional</small> |
 | workloadProfileType | Workload profile type for the workloads to run on. | string<br/><small>Optional</small> |
 
-<a id="Apple"></a>Apple
------------------------
+Apple{#Apple}
+-------------
 
 The configuration settings of the Apple provider.
 
@@ -1098,8 +1098,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | login        | The configuration settings of the login flow.                                                                              | [LoginScopes](#LoginScopes)<br/><small>Optional</small>             |
 | registration | The configuration settings of the Apple registration.                                                                      | [AppleRegistration](#AppleRegistration)<br/><small>Optional</small> |
 
-<a id="Apple_STATUS"></a>Apple_STATUS
--------------------------------------
+Apple_STATUS{#Apple_STATUS}
+---------------------------
 
 The configuration settings of the Apple provider.
 
@@ -1111,8 +1111,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | login        | The configuration settings of the login flow.                                                                              | [LoginScopes_STATUS](#LoginScopes_STATUS)<br/><small>Optional</small>             |
 | registration | The configuration settings of the Apple registration.                                                                      | [AppleRegistration_STATUS](#AppleRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="AzureActiveDirectory"></a>AzureActiveDirectory
------------------------------------------------------
+AzureActiveDirectory{#AzureActiveDirectory}
+-------------------------------------------
 
 The configuration settings of the Azure Active directory provider.
 
@@ -1126,8 +1126,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | registration      | The configuration settings of the Azure Active Directory app registration.                                                                                                                                                                    | [AzureActiveDirectoryRegistration](#AzureActiveDirectoryRegistration)<br/><small>Optional</small> |
 | validation        | The configuration settings of the Azure Active Directory token validation flow.                                                                                                                                                               | [AzureActiveDirectoryValidation](#AzureActiveDirectoryValidation)<br/><small>Optional</small>     |
 
-<a id="AzureActiveDirectory_STATUS"></a>AzureActiveDirectory_STATUS
--------------------------------------------------------------------
+AzureActiveDirectory_STATUS{#AzureActiveDirectory_STATUS}
+---------------------------------------------------------
 
 The configuration settings of the Azure Active directory provider.
 
@@ -1141,8 +1141,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | registration      | The configuration settings of the Azure Active Directory app registration.                                                                                                                                                                    | [AzureActiveDirectoryRegistration_STATUS](#AzureActiveDirectoryRegistration_STATUS)<br/><small>Optional</small> |
 | validation        | The configuration settings of the Azure Active Directory token validation flow.                                                                                                                                                               | [AzureActiveDirectoryValidation_STATUS](#AzureActiveDirectoryValidation_STATUS)<br/><small>Optional</small>     |
 
-<a id="AzureStaticWebApps"></a>AzureStaticWebApps
--------------------------------------------------
+AzureStaticWebApps{#AzureStaticWebApps}
+---------------------------------------
 
 The configuration settings of the Azure Static Web Apps provider.
 
@@ -1153,8 +1153,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | enabled      | <code>false</code> if the Azure Static Web Apps provider should not be enabled despite the set registration; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                                              |
 | registration | The configuration settings of the Azure Static Web Apps registration.                                                                      | [AzureStaticWebAppsRegistration](#AzureStaticWebAppsRegistration)<br/><small>Optional</small> |
 
-<a id="AzureStaticWebApps_STATUS"></a>AzureStaticWebApps_STATUS
----------------------------------------------------------------
+AzureStaticWebApps_STATUS{#AzureStaticWebApps_STATUS}
+-----------------------------------------------------
 
 The configuration settings of the Azure Static Web Apps provider.
 
@@ -1165,8 +1165,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | enabled      | <code>false</code> if the Azure Static Web Apps provider should not be enabled despite the set registration; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                                                            |
 | registration | The configuration settings of the Azure Static Web Apps registration.                                                                      | [AzureStaticWebAppsRegistration_STATUS](#AzureStaticWebAppsRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="BaseContainer"></a>BaseContainer
----------------------------------------
+BaseContainer{#BaseContainer}
+-----------------------------
 
 Container App base container definition.
 
@@ -1182,8 +1182,8 @@ Used by: [JobTemplate](#JobTemplate), and [Template](#Template).
 | resources    | Container resource requirements.   | [ContainerResources](#ContainerResources)<br/><small>Optional</small> |
 | volumeMounts | Container volume mounts.           | [VolumeMount[]](#VolumeMount)<br/><small>Optional</small>             |
 
-<a id="BaseContainer_STATUS"></a>BaseContainer_STATUS
------------------------------------------------------
+BaseContainer_STATUS{#BaseContainer_STATUS}
+-------------------------------------------
 
 Container App base container definition.
 
@@ -1199,8 +1199,8 @@ Used by: [JobTemplate_STATUS](#JobTemplate_STATUS), and [Template_STATUS](#Templ
 | resources    | Container resource requirements.   | [ContainerResources_STATUS](#ContainerResources_STATUS)<br/><small>Optional</small> |
 | volumeMounts | Container volume mounts.           | [VolumeMount_STATUS[]](#VolumeMount_STATUS)<br/><small>Optional</small>             |
 
-<a id="Configuration_ActiveRevisionsMode"></a>Configuration_ActiveRevisionsMode
--------------------------------------------------------------------------------
+Configuration_ActiveRevisionsMode{#Configuration_ActiveRevisionsMode}
+---------------------------------------------------------------------
 
 Used by: [Configuration](#Configuration).
 
@@ -1209,8 +1209,8 @@ Used by: [Configuration](#Configuration).
 | "Multiple" |             |
 | "Single"   |             |
 
-<a id="Configuration_ActiveRevisionsMode_STATUS"></a>Configuration_ActiveRevisionsMode_STATUS
----------------------------------------------------------------------------------------------
+Configuration_ActiveRevisionsMode_STATUS{#Configuration_ActiveRevisionsMode_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Configuration_STATUS](#Configuration_STATUS).
 
@@ -1219,8 +1219,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS).
 | "Multiple" |             |
 | "Single"   |             |
 
-<a id="Container"></a>Container
--------------------------------
+Container{#Container}
+---------------------
 
 Container App container definition
 
@@ -1237,8 +1237,8 @@ Used by: [JobTemplate](#JobTemplate), and [Template](#Template).
 | resources    | Container resource requirements.   | [ContainerResources](#ContainerResources)<br/><small>Optional</small> |
 | volumeMounts | Container volume mounts.           | [VolumeMount[]](#VolumeMount)<br/><small>Optional</small>             |
 
-<a id="Container_STATUS"></a>Container_STATUS
----------------------------------------------
+Container_STATUS{#Container_STATUS}
+-----------------------------------
 
 Container App container definition
 
@@ -1255,8 +1255,8 @@ Used by: [JobTemplate_STATUS](#JobTemplate_STATUS), and [Template_STATUS](#Templ
 | resources    | Container resource requirements.   | [ContainerResources_STATUS](#ContainerResources_STATUS)<br/><small>Optional</small> |
 | volumeMounts | Container volume mounts.           | [VolumeMount_STATUS[]](#VolumeMount_STATUS)<br/><small>Optional</small>             |
 
-<a id="ContainerAppOperatorConfigMaps"></a>ContainerAppOperatorConfigMaps
--------------------------------------------------------------------------
+ContainerAppOperatorConfigMaps{#ContainerAppOperatorConfigMaps}
+---------------------------------------------------------------
 
 Used by: [ContainerAppOperatorSpec](#ContainerAppOperatorSpec).
 
@@ -1265,8 +1265,8 @@ Used by: [ContainerAppOperatorSpec](#ContainerAppOperatorSpec).
 | eventStreamEndpoint | indicates where the EventStreamEndpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | fqdn                | indicates where the Fqdn config map should be placed. If omitted, no config map will be created.                | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="CookieExpiration"></a>CookieExpiration
----------------------------------------------
+CookieExpiration{#CookieExpiration}
+-----------------------------------
 
 The configuration settings of the session cookie's expiration.
 
@@ -1277,8 +1277,8 @@ Used by: [Login](#Login).
 | convention       | The convention used when determining the session cookie's expiration.     | [CookieExpiration_Convention](#CookieExpiration_Convention)<br/><small>Optional</small> |
 | timeToExpiration | The time after the request is made when the session cookie should expire. | string<br/><small>Optional</small>                                                      |
 
-<a id="CookieExpiration_STATUS"></a>CookieExpiration_STATUS
------------------------------------------------------------
+CookieExpiration_STATUS{#CookieExpiration_STATUS}
+-------------------------------------------------
 
 The configuration settings of the session cookie's expiration.
 
@@ -1289,8 +1289,8 @@ Used by: [Login_STATUS](#Login_STATUS).
 | convention       | The convention used when determining the session cookie's expiration.     | [CookieExpiration_Convention_STATUS](#CookieExpiration_Convention_STATUS)<br/><small>Optional</small> |
 | timeToExpiration | The time after the request is made when the session cookie should expire. | string<br/><small>Optional</small>                                                                    |
 
-<a id="CustomOpenIdConnectProvider"></a>CustomOpenIdConnectProvider
--------------------------------------------------------------------
+CustomOpenIdConnectProvider{#CustomOpenIdConnectProvider}
+---------------------------------------------------------
 
 The configuration settings of the custom Open ID Connect provider.
 
@@ -1302,8 +1302,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | login        | The configuration settings of the login flow of the custom Open ID Connect provider.                            | [OpenIdConnectLogin](#OpenIdConnectLogin)<br/><small>Optional</small>               |
 | registration | The configuration settings of the app registration for the custom Open ID Connect provider.                     | [OpenIdConnectRegistration](#OpenIdConnectRegistration)<br/><small>Optional</small> |
 
-<a id="CustomOpenIdConnectProvider_STATUS"></a>CustomOpenIdConnectProvider_STATUS
----------------------------------------------------------------------------------
+CustomOpenIdConnectProvider_STATUS{#CustomOpenIdConnectProvider_STATUS}
+-----------------------------------------------------------------------
 
 The configuration settings of the custom Open ID Connect provider.
 
@@ -1315,8 +1315,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | login        | The configuration settings of the login flow of the custom Open ID Connect provider.                            | [OpenIdConnectLogin_STATUS](#OpenIdConnectLogin_STATUS)<br/><small>Optional</small>               |
 | registration | The configuration settings of the app registration for the custom Open ID Connect provider.                     | [OpenIdConnectRegistration_STATUS](#OpenIdConnectRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="Dapr"></a>Dapr
----------------------
+Dapr{#Dapr}
+-----------
 
 Container App Dapr configuration.
 
@@ -1333,8 +1333,8 @@ Used by: [Configuration](#Configuration).
 | httpReadBufferSize | Dapr max size of http header read buffer in KB to handle when sending multi-KB headers. Default is 65KB.                     | int<br/><small>Optional</small>                                   |
 | logLevel           | Sets the log level for the Dapr sidecar. Allowed values are debug, info, warn, error. Default is info.                       | [Dapr_LogLevel](#Dapr_LogLevel)<br/><small>Optional</small>       |
 
-<a id="Dapr_STATUS"></a>Dapr_STATUS
------------------------------------
+Dapr_STATUS{#Dapr_STATUS}
+-------------------------
 
 Container App Dapr configuration.
 
@@ -1351,8 +1351,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS).
 | httpReadBufferSize | Dapr max size of http header read buffer in KB to handle when sending multi-KB headers. Default is 65KB.                     | int<br/><small>Optional</small>                                                 |
 | logLevel           | Sets the log level for the Dapr sidecar. Allowed values are debug, info, warn, error. Default is info.                       | [Dapr_LogLevel_STATUS](#Dapr_LogLevel_STATUS)<br/><small>Optional</small>       |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -1362,8 +1362,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------------|-------------|
 | "CustomLocation" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -1373,8 +1373,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------------|-------------|
 | "CustomLocation" |             |
 
-<a id="Facebook"></a>Facebook
------------------------------
+Facebook{#Facebook}
+-------------------
 
 The configuration settings of the Facebook provider.
 
@@ -1387,8 +1387,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | login           | The configuration settings of the login flow.                                                                                 | [LoginScopes](#LoginScopes)<br/><small>Optional</small>         |
 | registration    | The configuration settings of the app registration for the Facebook provider.                                                 | [AppRegistration](#AppRegistration)<br/><small>Optional</small> |
 
-<a id="Facebook_STATUS"></a>Facebook_STATUS
--------------------------------------------
+Facebook_STATUS{#Facebook_STATUS}
+---------------------------------
 
 The configuration settings of the Facebook provider.
 
@@ -1401,8 +1401,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | login           | The configuration settings of the login flow.                                                                                 | [LoginScopes_STATUS](#LoginScopes_STATUS)<br/><small>Optional</small>         |
 | registration    | The configuration settings of the app registration for the Facebook provider.                                                 | [AppRegistration_STATUS](#AppRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="ForwardProxy"></a>ForwardProxy
--------------------------------------
+ForwardProxy{#ForwardProxy}
+---------------------------
 
 The configuration settings of a forward proxy used to make the requests.
 
@@ -1414,8 +1414,8 @@ Used by: [HttpSettings](#HttpSettings).
 | customHostHeaderName  | The name of the header containing the host of the request.    | string<br/><small>Optional</small>                                              |
 | customProtoHeaderName | The name of the header containing the scheme of the request.  | string<br/><small>Optional</small>                                              |
 
-<a id="ForwardProxy_STATUS"></a>ForwardProxy_STATUS
----------------------------------------------------
+ForwardProxy_STATUS{#ForwardProxy_STATUS}
+-----------------------------------------
 
 The configuration settings of a forward proxy used to make the requests.
 
@@ -1427,8 +1427,8 @@ Used by: [HttpSettings_STATUS](#HttpSettings_STATUS).
 | customHostHeaderName  | The name of the header containing the host of the request.    | string<br/><small>Optional</small>                                                            |
 | customProtoHeaderName | The name of the header containing the scheme of the request.  | string<br/><small>Optional</small>                                                            |
 
-<a id="GitHub"></a>GitHub
--------------------------
+GitHub{#GitHub}
+---------------
 
 The configuration settings of the GitHub provider.
 
@@ -1440,8 +1440,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | login        | The configuration settings of the login flow.                                                                               | [LoginScopes](#LoginScopes)<br/><small>Optional</small>               |
 | registration | The configuration settings of the app registration for the GitHub provider.                                                 | [ClientRegistration](#ClientRegistration)<br/><small>Optional</small> |
 
-<a id="GitHub_STATUS"></a>GitHub_STATUS
----------------------------------------
+GitHub_STATUS{#GitHub_STATUS}
+-----------------------------
 
 The configuration settings of the GitHub provider.
 
@@ -1453,8 +1453,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | login        | The configuration settings of the login flow.                                                                               | [LoginScopes_STATUS](#LoginScopes_STATUS)<br/><small>Optional</small>               |
 | registration | The configuration settings of the app registration for the GitHub provider.                                                 | [ClientRegistration_STATUS](#ClientRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="GlobalValidation_UnauthenticatedClientAction"></a>GlobalValidation_UnauthenticatedClientAction
------------------------------------------------------------------------------------------------------
+GlobalValidation_UnauthenticatedClientAction{#GlobalValidation_UnauthenticatedClientAction}
+-------------------------------------------------------------------------------------------
 
 Used by: [GlobalValidation](#GlobalValidation).
 
@@ -1465,8 +1465,8 @@ Used by: [GlobalValidation](#GlobalValidation).
 | "Return401"           |             |
 | "Return403"           |             |
 
-<a id="GlobalValidation_UnauthenticatedClientAction_STATUS"></a>GlobalValidation_UnauthenticatedClientAction_STATUS
--------------------------------------------------------------------------------------------------------------------
+GlobalValidation_UnauthenticatedClientAction_STATUS{#GlobalValidation_UnauthenticatedClientAction_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [GlobalValidation_STATUS](#GlobalValidation_STATUS).
 
@@ -1477,8 +1477,8 @@ Used by: [GlobalValidation_STATUS](#GlobalValidation_STATUS).
 | "Return401"           |             |
 | "Return403"           |             |
 
-<a id="Google"></a>Google
--------------------------
+Google{#Google}
+---------------
 
 The configuration settings of the Google provider.
 
@@ -1491,8 +1491,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | registration | The configuration settings of the app registration for the Google provider.                                                 | [ClientRegistration](#ClientRegistration)<br/><small>Optional</small>                 |
 | validation   | The configuration settings of the Azure Active Directory token validation flow.                                             | [AllowedAudiencesValidation](#AllowedAudiencesValidation)<br/><small>Optional</small> |
 
-<a id="Google_STATUS"></a>Google_STATUS
----------------------------------------
+Google_STATUS{#Google_STATUS}
+-----------------------------
 
 The configuration settings of the Google provider.
 
@@ -1505,8 +1505,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | registration | The configuration settings of the app registration for the Google provider.                                                 | [ClientRegistration_STATUS](#ClientRegistration_STATUS)<br/><small>Optional</small>                 |
 | validation   | The configuration settings of the Azure Active Directory token validation flow.                                             | [AllowedAudiencesValidation_STATUS](#AllowedAudiencesValidation_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpSettingsRoutes"></a>HttpSettingsRoutes
--------------------------------------------------
+HttpSettingsRoutes{#HttpSettingsRoutes}
+---------------------------------------
 
 The configuration settings of the paths HTTP requests.
 
@@ -1516,8 +1516,8 @@ Used by: [HttpSettings](#HttpSettings).
 |-----------|----------------------------------------------------------------------------|------------------------------------|
 | apiPrefix | The prefix that should precede all the authentication/authorization paths. | string<br/><small>Optional</small> |
 
-<a id="HttpSettingsRoutes_STATUS"></a>HttpSettingsRoutes_STATUS
----------------------------------------------------------------
+HttpSettingsRoutes_STATUS{#HttpSettingsRoutes_STATUS}
+-----------------------------------------------------
 
 The configuration settings of the paths HTTP requests.
 
@@ -1527,8 +1527,8 @@ Used by: [HttpSettings_STATUS](#HttpSettings_STATUS).
 |-----------|----------------------------------------------------------------------------|------------------------------------|
 | apiPrefix | The prefix that should precede all the authentication/authorization paths. | string<br/><small>Optional</small> |
 
-<a id="Ingress"></a>Ingress
----------------------------
+Ingress{#Ingress}
+-----------------
 
 Container App Ingress configuration.
 
@@ -1549,8 +1549,8 @@ Used by: [Configuration](#Configuration).
 | traffic                | Traffic weights for app's revisions                                                                                                                                                                                                                                     | [TrafficWeight[]](#TrafficWeight)<br/><small>Optional</small>                               |
 | transport              | Ingress transport protocol                                                                                                                                                                                                                                              | [Ingress_Transport](#Ingress_Transport)<br/><small>Optional</small>                         |
 
-<a id="Ingress_STATUS"></a>Ingress_STATUS
------------------------------------------
+Ingress_STATUS{#Ingress_STATUS}
+-------------------------------
 
 Container App Ingress configuration.
 
@@ -1572,8 +1572,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS).
 | traffic                | Traffic weights for app's revisions                                                                                                                                                                                                                                     | [TrafficWeight_STATUS[]](#TrafficWeight_STATUS)<br/><small>Optional</small>                               |
 | transport              | Ingress transport protocol                                                                                                                                                                                                                                              | [Ingress_Transport_STATUS](#Ingress_Transport_STATUS)<br/><small>Optional</small>                         |
 
-<a id="JobConfiguration_EventTriggerConfig"></a>JobConfiguration_EventTriggerConfig
------------------------------------------------------------------------------------
+JobConfiguration_EventTriggerConfig{#JobConfiguration_EventTriggerConfig}
+-------------------------------------------------------------------------
 
 Used by: [JobConfiguration](#JobConfiguration).
 
@@ -1583,8 +1583,8 @@ Used by: [JobConfiguration](#JobConfiguration).
 | replicaCompletionCount |                                               | int<br/><small>Optional</small>                   |
 | scale                  | Scaling configurations for event driven jobs. | [JobScale](#JobScale)<br/><small>Optional</small> |
 
-<a id="JobConfiguration_EventTriggerConfig_STATUS"></a>JobConfiguration_EventTriggerConfig_STATUS
--------------------------------------------------------------------------------------------------
+JobConfiguration_EventTriggerConfig_STATUS{#JobConfiguration_EventTriggerConfig_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 
@@ -1594,8 +1594,8 @@ Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 | replicaCompletionCount |                                               | int<br/><small>Optional</small>                                 |
 | scale                  | Scaling configurations for event driven jobs. | [JobScale_STATUS](#JobScale_STATUS)<br/><small>Optional</small> |
 
-<a id="JobConfiguration_ManualTriggerConfig"></a>JobConfiguration_ManualTriggerConfig
--------------------------------------------------------------------------------------
+JobConfiguration_ManualTriggerConfig{#JobConfiguration_ManualTriggerConfig}
+---------------------------------------------------------------------------
 
 Used by: [JobConfiguration](#JobConfiguration).
 
@@ -1604,8 +1604,8 @@ Used by: [JobConfiguration](#JobConfiguration).
 | parallelism            |             | int<br/><small>Optional</small> |
 | replicaCompletionCount |             | int<br/><small>Optional</small> |
 
-<a id="JobConfiguration_ManualTriggerConfig_STATUS"></a>JobConfiguration_ManualTriggerConfig_STATUS
----------------------------------------------------------------------------------------------------
+JobConfiguration_ManualTriggerConfig_STATUS{#JobConfiguration_ManualTriggerConfig_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 
@@ -1614,8 +1614,8 @@ Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 | parallelism            |             | int<br/><small>Optional</small> |
 | replicaCompletionCount |             | int<br/><small>Optional</small> |
 
-<a id="JobConfiguration_ScheduleTriggerConfig"></a>JobConfiguration_ScheduleTriggerConfig
------------------------------------------------------------------------------------------
+JobConfiguration_ScheduleTriggerConfig{#JobConfiguration_ScheduleTriggerConfig}
+-------------------------------------------------------------------------------
 
 Used by: [JobConfiguration](#JobConfiguration).
 
@@ -1625,8 +1625,8 @@ Used by: [JobConfiguration](#JobConfiguration).
 | parallelism            |                                                                | int<br/><small>Optional</small>    |
 | replicaCompletionCount |                                                                | int<br/><small>Optional</small>    |
 
-<a id="JobConfiguration_ScheduleTriggerConfig_STATUS"></a>JobConfiguration_ScheduleTriggerConfig_STATUS
--------------------------------------------------------------------------------------------------------
+JobConfiguration_ScheduleTriggerConfig_STATUS{#JobConfiguration_ScheduleTriggerConfig_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 
@@ -1636,8 +1636,8 @@ Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 | parallelism            |                                                                | int<br/><small>Optional</small>    |
 | replicaCompletionCount |                                                                | int<br/><small>Optional</small>    |
 
-<a id="JobConfiguration_TriggerType"></a>JobConfiguration_TriggerType
----------------------------------------------------------------------
+JobConfiguration_TriggerType{#JobConfiguration_TriggerType}
+-----------------------------------------------------------
 
 Used by: [JobConfiguration](#JobConfiguration).
 
@@ -1647,8 +1647,8 @@ Used by: [JobConfiguration](#JobConfiguration).
 | "Manual"   |             |
 | "Schedule" |             |
 
-<a id="JobConfiguration_TriggerType_STATUS"></a>JobConfiguration_TriggerType_STATUS
------------------------------------------------------------------------------------
+JobConfiguration_TriggerType_STATUS{#JobConfiguration_TriggerType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 
@@ -1658,8 +1658,8 @@ Used by: [JobConfiguration_STATUS](#JobConfiguration_STATUS).
 | "Manual"   |             |
 | "Schedule" |             |
 
-<a id="LogAnalyticsConfiguration"></a>LogAnalyticsConfiguration
----------------------------------------------------------------
+LogAnalyticsConfiguration{#LogAnalyticsConfiguration}
+-----------------------------------------------------
 
 Log Analytics configuration, must only be provided when destination is configured as 'log-analytics'
 
@@ -1670,8 +1670,8 @@ Used by: [AppLogsConfiguration](#AppLogsConfiguration).
 | customerId | Log analytics customer id  | string<br/><small>Optional</small>                                                                                                                     |
 | sharedKey  | Log analytics customer key | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="LogAnalyticsConfiguration_STATUS"></a>LogAnalyticsConfiguration_STATUS
------------------------------------------------------------------------------
+LogAnalyticsConfiguration_STATUS{#LogAnalyticsConfiguration_STATUS}
+-------------------------------------------------------------------
 
 Log Analytics configuration, must only be provided when destination is configured as 'log-analytics'
 
@@ -1681,8 +1681,8 @@ Used by: [AppLogsConfiguration_STATUS](#AppLogsConfiguration_STATUS).
 |------------|---------------------------|------------------------------------|
 | customerId | Log analytics customer id | string<br/><small>Optional</small> |
 
-<a id="LoginRoutes"></a>LoginRoutes
------------------------------------
+LoginRoutes{#LoginRoutes}
+-------------------------
 
 The routes that specify the endpoints used for login and logout requests.
 
@@ -1692,8 +1692,8 @@ Used by: [Login](#Login).
 |----------------|--------------------------------------------------------|------------------------------------|
 | logoutEndpoint | The endpoint at which a logout request should be made. | string<br/><small>Optional</small> |
 
-<a id="LoginRoutes_STATUS"></a>LoginRoutes_STATUS
--------------------------------------------------
+LoginRoutes_STATUS{#LoginRoutes_STATUS}
+---------------------------------------
 
 The routes that specify the endpoints used for login and logout requests.
 
@@ -1703,8 +1703,8 @@ Used by: [Login_STATUS](#Login_STATUS).
 |----------------|--------------------------------------------------------|------------------------------------|
 | logoutEndpoint | The endpoint at which a logout request should be made. | string<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec"></a>ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec
----------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec{#ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_Spec}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec](#ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec).
 
@@ -1712,8 +1712,8 @@ Used by: [ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec](#ManagedE
 |----------|-------------------------------------------------------------------|----------------------------------|
 | enabled  | Boolean indicating whether the peer traffic encryption is enabled | bool<br/><small>Optional</small> |
 
-<a id="ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS"></a>ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS{#ManagedEnvironment_Properties_PeerTrafficConfiguration_Encryption_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS](#ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS).
 
@@ -1721,8 +1721,8 @@ Used by: [ManagedEnvironment_Properties_PeerTrafficConfiguration_STATUS](#Manage
 |----------|-------------------------------------------------------------------|----------------------------------|
 | enabled  | Boolean indicating whether the peer traffic encryption is enabled | bool<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentityType"></a>ManagedServiceIdentityType
------------------------------------------------------------------
+ManagedServiceIdentityType{#ManagedServiceIdentityType}
+-------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -1735,8 +1735,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentityType_STATUS"></a>ManagedServiceIdentityType_STATUS
--------------------------------------------------------------------------------
+ManagedServiceIdentityType_STATUS{#ManagedServiceIdentityType_STATUS}
+---------------------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -1749,8 +1749,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="Mtls"></a>Mtls
----------------------
+Mtls{#Mtls}
+-----------
 
 Configuration properties for mutual TLS authentication
 
@@ -1760,8 +1760,8 @@ Used by: [ManagedEnvironment_Properties_PeerAuthentication_Spec](#ManagedEnviron
 |----------|---------------------------------------------------------------------|----------------------------------|
 | enabled  | Boolean indicating whether the mutual TLS authentication is enabled | bool<br/><small>Optional</small> |
 
-<a id="Mtls_STATUS"></a>Mtls_STATUS
------------------------------------
+Mtls_STATUS{#Mtls_STATUS}
+-------------------------
 
 Configuration properties for mutual TLS authentication
 
@@ -1771,8 +1771,8 @@ Used by: [ManagedEnvironment_Properties_PeerAuthentication_STATUS](#ManagedEnvir
 |----------|---------------------------------------------------------------------|----------------------------------|
 | enabled  | Boolean indicating whether the mutual TLS authentication is enabled | bool<br/><small>Optional</small> |
 
-<a id="Nonce"></a>Nonce
------------------------
+Nonce{#Nonce}
+-------------
 
 The configuration settings of the nonce used in the login flow.
 
@@ -1783,8 +1783,8 @@ Used by: [Login](#Login).
 | nonceExpirationInterval | The time after the request is made when the nonce should expire.                                                       | string<br/><small>Optional</small> |
 | validateNonce           | <code>false</code> if the nonce should not be validated while completing the login flow; otherwise, <code>true</code>. | bool<br/><small>Optional</small>   |
 
-<a id="Nonce_STATUS"></a>Nonce_STATUS
--------------------------------------
+Nonce_STATUS{#Nonce_STATUS}
+---------------------------
 
 The configuration settings of the nonce used in the login flow.
 
@@ -1795,8 +1795,8 @@ Used by: [Login_STATUS](#Login_STATUS).
 | nonceExpirationInterval | The time after the request is made when the nonce should expire.                                                       | string<br/><small>Optional</small> |
 | validateNonce           | <code>false</code> if the nonce should not be validated while completing the login flow; otherwise, <code>true</code>. | bool<br/><small>Optional</small>   |
 
-<a id="RegistryCredentials"></a>RegistryCredentials
----------------------------------------------------
+RegistryCredentials{#RegistryCredentials}
+-----------------------------------------
 
 Container App Private Registry
 
@@ -1809,8 +1809,8 @@ Used by: [Configuration](#Configuration), and [JobConfiguration](#JobConfigurati
 | server            | Container Registry Server                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                         |
 | username          | Container Registry Username                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="RegistryCredentials_STATUS"></a>RegistryCredentials_STATUS
------------------------------------------------------------------
+RegistryCredentials_STATUS{#RegistryCredentials_STATUS}
+-------------------------------------------------------
 
 Container App Private Registry
 
@@ -1823,8 +1823,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS), and [JobConfiguration_ST
 | server            | Container Registry Server                                                                                                                                                                            | string<br/><small>Optional</small> |
 | username          | Container Registry Username                                                                                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="Scale"></a>Scale
------------------------
+Scale{#Scale}
+-------------
 
 Container App scaling configurations.
 
@@ -1836,8 +1836,8 @@ Used by: [Template](#Template).
 | minReplicas | Optional. Minimum number of container replicas.                            | int<br/><small>Optional</small>                       |
 | rules       | Scaling rules.                                                             | [ScaleRule[]](#ScaleRule)<br/><small>Optional</small> |
 
-<a id="Scale_STATUS"></a>Scale_STATUS
--------------------------------------
+Scale_STATUS{#Scale_STATUS}
+---------------------------
 
 Container App scaling configurations.
 
@@ -1849,8 +1849,8 @@ Used by: [Template_STATUS](#Template_STATUS).
 | minReplicas | Optional. Minimum number of container replicas.                            | int<br/><small>Optional</small>                                     |
 | rules       | Scaling rules.                                                             | [ScaleRule_STATUS[]](#ScaleRule_STATUS)<br/><small>Optional</small> |
 
-<a id="Secret"></a>Secret
--------------------------
+Secret{#Secret}
+---------------
 
 Secret definition.
 
@@ -1863,8 +1863,8 @@ Used by: [Configuration](#Configuration), and [JobConfiguration](#JobConfigurati
 | name              | Secret Name.                                                                                                         | string<br/><small>Optional</small>                                                                                                                         |
 | value             | Secret Value.                                                                                                        | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>     |
 
-<a id="Secret_STATUS"></a>Secret_STATUS
----------------------------------------
+Secret_STATUS{#Secret_STATUS}
+-----------------------------
 
 Secret definition.
 
@@ -1876,8 +1876,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS), and [JobConfiguration_ST
 | keyVaultUrl | Azure Key Vault URL pointing to the secret referenced by the container app.                                          | string<br/><small>Optional</small> |
 | name        | Secret Name.                                                                                                         | string<br/><small>Optional</small> |
 
-<a id="Service"></a>Service
----------------------------
+Service{#Service}
+-----------------
 
 Container App to be a dev service
 
@@ -1887,8 +1887,8 @@ Used by: [Configuration](#Configuration).
 |----------|-------------------------------|------------------------------------|
 | type     | Dev ContainerApp service type | string<br/><small>Required</small> |
 
-<a id="Service_STATUS"></a>Service_STATUS
------------------------------------------
+Service_STATUS{#Service_STATUS}
+-------------------------------
 
 Container App to be a dev service
 
@@ -1898,8 +1898,8 @@ Used by: [Configuration_STATUS](#Configuration_STATUS).
 |----------|-------------------------------|------------------------------------|
 | type     | Dev ContainerApp service type | string<br/><small>Optional</small> |
 
-<a id="ServiceBind"></a>ServiceBind
------------------------------------
+ServiceBind{#ServiceBind}
+-------------------------
 
 Configuration to bind a ContainerApp to a dev ContainerApp Service
 
@@ -1910,8 +1910,8 @@ Used by: [Template](#Template).
 | name             | Name of the service bind          | string<br/><small>Optional</small>                                                                                                                         |
 | serviceReference | Resource id of the target service | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ServiceBind_STATUS"></a>ServiceBind_STATUS
--------------------------------------------------
+ServiceBind_STATUS{#ServiceBind_STATUS}
+---------------------------------------
 
 Configuration to bind a ContainerApp to a dev ContainerApp Service
 
@@ -1922,7 +1922,19 @@ Used by: [Template_STATUS](#Template_STATUS).
 | name      | Name of the service bind          | string<br/><small>Optional</small> |
 | serviceId | Resource id of the target service | string<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1934,20 +1946,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="TokenStore"></a>TokenStore
----------------------------------
+TokenStore{#TokenStore}
+-----------------------
 
 The configuration settings of the token store.
 
@@ -1959,8 +1959,8 @@ Used by: [Login](#Login).
 | enabled                    | <code>true</code> to durably store platform-specific security tokens that are obtained during login flows; otherwise, <code>false</code>. The default is <code>false</code>. | bool<br/><small>Optional</small>                                            |
 | tokenRefreshExtensionHours | The number of hours after session token expiration that a session token can be used to call the token refresh API. The default is 72 hours.                                  | float64<br/><small>Optional</small>                                         |
 
-<a id="TokenStore_STATUS"></a>TokenStore_STATUS
------------------------------------------------
+TokenStore_STATUS{#TokenStore_STATUS}
+-------------------------------------
 
 The configuration settings of the token store.
 
@@ -1972,8 +1972,8 @@ Used by: [Login_STATUS](#Login_STATUS).
 | enabled                    | <code>true</code> to durably store platform-specific security tokens that are obtained during login flows; otherwise, <code>false</code>. The default is <code>false</code>. | bool<br/><small>Optional</small>                                                          |
 | tokenRefreshExtensionHours | The number of hours after session token expiration that a session token can be used to call the token refresh API. The default is 72 hours.                                  | float64<br/><small>Optional</small>                                                       |
 
-<a id="Twitter"></a>Twitter
----------------------------
+Twitter{#Twitter}
+-----------------
 
 The configuration settings of the Twitter provider.
 
@@ -1984,8 +1984,8 @@ Used by: [IdentityProviders](#IdentityProviders).
 | enabled      | <code>false</code> if the Twitter provider should not be enabled despite the set registration; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                        |
 | registration | The configuration settings of the app registration for the Twitter provider.                                                 | [TwitterRegistration](#TwitterRegistration)<br/><small>Optional</small> |
 
-<a id="Twitter_STATUS"></a>Twitter_STATUS
------------------------------------------
+Twitter_STATUS{#Twitter_STATUS}
+-------------------------------
 
 The configuration settings of the Twitter provider.
 
@@ -1996,8 +1996,8 @@ Used by: [IdentityProviders_STATUS](#IdentityProviders_STATUS).
 | enabled      | <code>false</code> if the Twitter provider should not be enabled despite the set registration; otherwise, <code>true</code>. | bool<br/><small>Optional</small>                                                      |
 | registration | The configuration settings of the app registration for the Twitter provider.                                                 | [TwitterRegistration_STATUS](#TwitterRegistration_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -2008,8 +2008,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2019,8 +2019,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Volume"></a>Volume
--------------------------
+Volume{#Volume}
+---------------
 
 Volume definitions for the Container App.
 
@@ -2034,8 +2034,8 @@ Used by: [JobTemplate](#JobTemplate), and [Template](#Template).
 | storageName  | Name of storage resource. No need to provide for EmptyDir and Secret.                                                 | string<br/><small>Optional</small>                                    |
 | storageType  | Storage type for the volume. If not provided, use EmptyDir.                                                           | [Volume_StorageType](#Volume_StorageType)<br/><small>Optional</small> |
 
-<a id="Volume_STATUS"></a>Volume_STATUS
----------------------------------------
+Volume_STATUS{#Volume_STATUS}
+-----------------------------
 
 Volume definitions for the Container App.
 
@@ -2049,8 +2049,8 @@ Used by: [JobTemplate_STATUS](#JobTemplate_STATUS), and [Template_STATUS](#Templ
 | storageName  | Name of storage resource. No need to provide for EmptyDir and Secret.                                                 | string<br/><small>Optional</small>                                                  |
 | storageType  | Storage type for the volume. If not provided, use EmptyDir.                                                           | [Volume_StorageType_STATUS](#Volume_StorageType_STATUS)<br/><small>Optional</small> |
 
-<a id="AllowedAudiencesValidation"></a>AllowedAudiencesValidation
------------------------------------------------------------------
+AllowedAudiencesValidation{#AllowedAudiencesValidation}
+-------------------------------------------------------
 
 The configuration settings of the Allowed Audiences validation flow.
 
@@ -2060,8 +2060,8 @@ Used by: [Google](#Google).
 |------------------|---------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedAudiences | The configuration settings of the allowed list of audiences from which to validate the JWT token. | string[]<br/><small>Optional</small> |
 
-<a id="AllowedAudiencesValidation_STATUS"></a>AllowedAudiencesValidation_STATUS
--------------------------------------------------------------------------------
+AllowedAudiencesValidation_STATUS{#AllowedAudiencesValidation_STATUS}
+---------------------------------------------------------------------
 
 The configuration settings of the Allowed Audiences validation flow.
 
@@ -2071,8 +2071,8 @@ Used by: [Google_STATUS](#Google_STATUS).
 |------------------|---------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedAudiences | The configuration settings of the allowed list of audiences from which to validate the JWT token. | string[]<br/><small>Optional</small> |
 
-<a id="AppleRegistration"></a>AppleRegistration
------------------------------------------------
+AppleRegistration{#AppleRegistration}
+-------------------------------------
 
 The configuration settings of the registration for the Apple provider
 
@@ -2083,8 +2083,8 @@ Used by: [Apple](#Apple).
 | clientId                | The Client ID of the app used for login.              | string<br/><small>Optional</small> |
 | clientSecretSettingName | The app setting name that contains the client secret. | string<br/><small>Optional</small> |
 
-<a id="AppleRegistration_STATUS"></a>AppleRegistration_STATUS
--------------------------------------------------------------
+AppleRegistration_STATUS{#AppleRegistration_STATUS}
+---------------------------------------------------
 
 The configuration settings of the registration for the Apple provider
 
@@ -2095,8 +2095,8 @@ Used by: [Apple_STATUS](#Apple_STATUS).
 | clientId                | The Client ID of the app used for login.              | string<br/><small>Optional</small> |
 | clientSecretSettingName | The app setting name that contains the client secret. | string<br/><small>Optional</small> |
 
-<a id="AppRegistration"></a>AppRegistration
--------------------------------------------
+AppRegistration{#AppRegistration}
+---------------------------------
 
 The configuration settings of the app registration for providers that have app ids and app secrets
 
@@ -2107,8 +2107,8 @@ Used by: [Facebook](#Facebook).
 | appId                | The App ID of the app used for login.              | string<br/><small>Optional</small> |
 | appSecretSettingName | The app setting name that contains the app secret. | string<br/><small>Optional</small> |
 
-<a id="AppRegistration_STATUS"></a>AppRegistration_STATUS
----------------------------------------------------------
+AppRegistration_STATUS{#AppRegistration_STATUS}
+-----------------------------------------------
 
 The configuration settings of the app registration for providers that have app ids and app secrets
 
@@ -2119,64 +2119,64 @@ Used by: [Facebook_STATUS](#Facebook_STATUS).
 | appId                | The App ID of the app used for login.              | string<br/><small>Optional</small> |
 | appSecretSettingName | The app setting name that contains the app secret. | string<br/><small>Optional</small> |
 
-<a id="AzureActiveDirectoryLogin"></a>AzureActiveDirectoryLogin
+AzureActiveDirectoryLogin{#AzureActiveDirectoryLogin}
+-----------------------------------------------------
+
+The configuration settings of the Azure Active Directory login flow.
+
+Used by: [AzureActiveDirectory](#AzureActiveDirectory).
+
+| Property               | Description                                                                                                                                | Type                                 |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| disableWWWAuthenticate | <code>true</code> if the www-authenticate provider should be omitted from the request; otherwise, <code>false</code>.                      | bool<br/><small>Optional</small>     |
+| loginParameters        | Login parameters to send to the OpenID Connect authorization endpoint when a user logs in. Each parameter must be in the form "key=value". | string[]<br/><small>Optional</small> |
+
+AzureActiveDirectoryLogin_STATUS{#AzureActiveDirectoryLogin_STATUS}
+-------------------------------------------------------------------
+
+The configuration settings of the Azure Active Directory login flow.
+
+Used by: [AzureActiveDirectory_STATUS](#AzureActiveDirectory_STATUS).
+
+| Property               | Description                                                                                                                                | Type                                 |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| disableWWWAuthenticate | <code>true</code> if the www-authenticate provider should be omitted from the request; otherwise, <code>false</code>.                      | bool<br/><small>Optional</small>     |
+| loginParameters        | Login parameters to send to the OpenID Connect authorization endpoint when a user logs in. Each parameter must be in the form "key=value". | string[]<br/><small>Optional</small> |
+
+AzureActiveDirectoryRegistration{#AzureActiveDirectoryRegistration}
+-------------------------------------------------------------------
+
+The configuration settings of the Azure Active Directory app registration.
+
+Used by: [AzureActiveDirectory](#AzureActiveDirectory).
+
+| Property                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                               |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| clientId                                      | The Client ID of this relying party application, known as the client_id. This setting is required for enabling OpenID Connection authentication with Azure Active Directory or other 3rd party OpenID Connect providers. More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html                                                                                                             | string<br/><small>Optional</small> |
+| clientSecretCertificateIssuer                 | An alternative to the client secret thumbprint, that is the issuer of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                                         | string<br/><small>Optional</small> |
+| clientSecretCertificateSubjectAlternativeName | An alternative to the client secret thumbprint, that is the subject alternative name of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                       | string<br/><small>Optional</small> |
+| clientSecretCertificateThumbprint             | An alternative to the client secret, that is the thumbprint of a certificate used for signing purposes. This property acts as a replacement for the Client Secret. It is also optional.                                                                                                                                                                                                                                       | string<br/><small>Optional</small> |
+| clientSecretSettingName                       | The app setting name that contains the client secret of the relying party application.                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small> |
+| openIdIssuer                                  | The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application. When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/. This URI is a case-sensitive identifier for the token issuer. More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html | string<br/><small>Optional</small> |
+
+AzureActiveDirectoryRegistration_STATUS{#AzureActiveDirectoryRegistration_STATUS}
+---------------------------------------------------------------------------------
+
+The configuration settings of the Azure Active Directory app registration.
+
+Used by: [AzureActiveDirectory_STATUS](#AzureActiveDirectory_STATUS).
+
+| Property                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                               |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| clientId                                      | The Client ID of this relying party application, known as the client_id. This setting is required for enabling OpenID Connection authentication with Azure Active Directory or other 3rd party OpenID Connect providers. More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html                                                                                                             | string<br/><small>Optional</small> |
+| clientSecretCertificateIssuer                 | An alternative to the client secret thumbprint, that is the issuer of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                                         | string<br/><small>Optional</small> |
+| clientSecretCertificateSubjectAlternativeName | An alternative to the client secret thumbprint, that is the subject alternative name of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                       | string<br/><small>Optional</small> |
+| clientSecretCertificateThumbprint             | An alternative to the client secret, that is the thumbprint of a certificate used for signing purposes. This property acts as a replacement for the Client Secret. It is also optional.                                                                                                                                                                                                                                       | string<br/><small>Optional</small> |
+| clientSecretSettingName                       | The app setting name that contains the client secret of the relying party application.                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small> |
+| openIdIssuer                                  | The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application. When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/. This URI is a case-sensitive identifier for the token issuer. More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html | string<br/><small>Optional</small> |
+
+AzureActiveDirectoryValidation{#AzureActiveDirectoryValidation}
 ---------------------------------------------------------------
-
-The configuration settings of the Azure Active Directory login flow.
-
-Used by: [AzureActiveDirectory](#AzureActiveDirectory).
-
-| Property               | Description                                                                                                                                | Type                                 |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| disableWWWAuthenticate | <code>true</code> if the www-authenticate provider should be omitted from the request; otherwise, <code>false</code>.                      | bool<br/><small>Optional</small>     |
-| loginParameters        | Login parameters to send to the OpenID Connect authorization endpoint when a user logs in. Each parameter must be in the form "key=value". | string[]<br/><small>Optional</small> |
-
-<a id="AzureActiveDirectoryLogin_STATUS"></a>AzureActiveDirectoryLogin_STATUS
------------------------------------------------------------------------------
-
-The configuration settings of the Azure Active Directory login flow.
-
-Used by: [AzureActiveDirectory_STATUS](#AzureActiveDirectory_STATUS).
-
-| Property               | Description                                                                                                                                | Type                                 |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| disableWWWAuthenticate | <code>true</code> if the www-authenticate provider should be omitted from the request; otherwise, <code>false</code>.                      | bool<br/><small>Optional</small>     |
-| loginParameters        | Login parameters to send to the OpenID Connect authorization endpoint when a user logs in. Each parameter must be in the form "key=value". | string[]<br/><small>Optional</small> |
-
-<a id="AzureActiveDirectoryRegistration"></a>AzureActiveDirectoryRegistration
------------------------------------------------------------------------------
-
-The configuration settings of the Azure Active Directory app registration.
-
-Used by: [AzureActiveDirectory](#AzureActiveDirectory).
-
-| Property                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                               |
-|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| clientId                                      | The Client ID of this relying party application, known as the client_id. This setting is required for enabling OpenID Connection authentication with Azure Active Directory or other 3rd party OpenID Connect providers. More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html                                                                                                             | string<br/><small>Optional</small> |
-| clientSecretCertificateIssuer                 | An alternative to the client secret thumbprint, that is the issuer of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                                         | string<br/><small>Optional</small> |
-| clientSecretCertificateSubjectAlternativeName | An alternative to the client secret thumbprint, that is the subject alternative name of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                       | string<br/><small>Optional</small> |
-| clientSecretCertificateThumbprint             | An alternative to the client secret, that is the thumbprint of a certificate used for signing purposes. This property acts as a replacement for the Client Secret. It is also optional.                                                                                                                                                                                                                                       | string<br/><small>Optional</small> |
-| clientSecretSettingName                       | The app setting name that contains the client secret of the relying party application.                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small> |
-| openIdIssuer                                  | The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application. When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/. This URI is a case-sensitive identifier for the token issuer. More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html | string<br/><small>Optional</small> |
-
-<a id="AzureActiveDirectoryRegistration_STATUS"></a>AzureActiveDirectoryRegistration_STATUS
--------------------------------------------------------------------------------------------
-
-The configuration settings of the Azure Active Directory app registration.
-
-Used by: [AzureActiveDirectory_STATUS](#AzureActiveDirectory_STATUS).
-
-| Property                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                               |
-|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| clientId                                      | The Client ID of this relying party application, known as the client_id. This setting is required for enabling OpenID Connection authentication with Azure Active Directory or other 3rd party OpenID Connect providers. More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html                                                                                                             | string<br/><small>Optional</small> |
-| clientSecretCertificateIssuer                 | An alternative to the client secret thumbprint, that is the issuer of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                                         | string<br/><small>Optional</small> |
-| clientSecretCertificateSubjectAlternativeName | An alternative to the client secret thumbprint, that is the subject alternative name of a certificate used for signing purposes. This property acts as a replacement for the Client Secret Certificate Thumbprint. It is also optional.                                                                                                                                                                                       | string<br/><small>Optional</small> |
-| clientSecretCertificateThumbprint             | An alternative to the client secret, that is the thumbprint of a certificate used for signing purposes. This property acts as a replacement for the Client Secret. It is also optional.                                                                                                                                                                                                                                       | string<br/><small>Optional</small> |
-| clientSecretSettingName                       | The app setting name that contains the client secret of the relying party application.                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small> |
-| openIdIssuer                                  | The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application. When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/. This URI is a case-sensitive identifier for the token issuer. More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html | string<br/><small>Optional</small> |
-
-<a id="AzureActiveDirectoryValidation"></a>AzureActiveDirectoryValidation
--------------------------------------------------------------------------
 
 The configuration settings of the Azure Active Directory token validation flow.
 
@@ -2188,8 +2188,8 @@ Used by: [AzureActiveDirectory](#AzureActiveDirectory).
 | defaultAuthorizationPolicy | The configuration settings of the default authorization policy.                               | [DefaultAuthorizationPolicy](#DefaultAuthorizationPolicy)<br/><small>Optional</small> |
 | jwtClaimChecks             | The configuration settings of the checks that should be made while validating the JWT Claims. | [JwtClaimChecks](#JwtClaimChecks)<br/><small>Optional</small>                         |
 
-<a id="AzureActiveDirectoryValidation_STATUS"></a>AzureActiveDirectoryValidation_STATUS
----------------------------------------------------------------------------------------
+AzureActiveDirectoryValidation_STATUS{#AzureActiveDirectoryValidation_STATUS}
+-----------------------------------------------------------------------------
 
 The configuration settings of the Azure Active Directory token validation flow.
 
@@ -2201,8 +2201,8 @@ Used by: [AzureActiveDirectory_STATUS](#AzureActiveDirectory_STATUS).
 | defaultAuthorizationPolicy | The configuration settings of the default authorization policy.                               | [DefaultAuthorizationPolicy_STATUS](#DefaultAuthorizationPolicy_STATUS)<br/><small>Optional</small> |
 | jwtClaimChecks             | The configuration settings of the checks that should be made while validating the JWT Claims. | [JwtClaimChecks_STATUS](#JwtClaimChecks_STATUS)<br/><small>Optional</small>                         |
 
-<a id="AzureStaticWebAppsRegistration"></a>AzureStaticWebAppsRegistration
--------------------------------------------------------------------------
+AzureStaticWebAppsRegistration{#AzureStaticWebAppsRegistration}
+---------------------------------------------------------------
 
 The configuration settings of the registration for the Azure Static Web Apps provider
 
@@ -2212,8 +2212,8 @@ Used by: [AzureStaticWebApps](#AzureStaticWebApps).
 |----------|------------------------------------------|------------------------------------|
 | clientId | The Client ID of the app used for login. | string<br/><small>Optional</small> |
 
-<a id="AzureStaticWebAppsRegistration_STATUS"></a>AzureStaticWebAppsRegistration_STATUS
----------------------------------------------------------------------------------------
+AzureStaticWebAppsRegistration_STATUS{#AzureStaticWebAppsRegistration_STATUS}
+-----------------------------------------------------------------------------
 
 The configuration settings of the registration for the Azure Static Web Apps provider
 
@@ -2223,8 +2223,8 @@ Used by: [AzureStaticWebApps_STATUS](#AzureStaticWebApps_STATUS).
 |----------|------------------------------------------|------------------------------------|
 | clientId | The Client ID of the app used for login. | string<br/><small>Optional</small> |
 
-<a id="BlobStorageTokenStore"></a>BlobStorageTokenStore
--------------------------------------------------------
+BlobStorageTokenStore{#BlobStorageTokenStore}
+---------------------------------------------
 
 The configuration settings of the storage of the tokens if blob storage is used.
 
@@ -2234,8 +2234,8 @@ Used by: [TokenStore](#TokenStore).
 |-------------------|-----------------------------------------------------------------------------------------------|------------------------------------|
 | sasUrlSettingName | The name of the app secrets containing the SAS URL of the blob storage containing the tokens. | string<br/><small>Required</small> |
 
-<a id="BlobStorageTokenStore_STATUS"></a>BlobStorageTokenStore_STATUS
----------------------------------------------------------------------
+BlobStorageTokenStore_STATUS{#BlobStorageTokenStore_STATUS}
+-----------------------------------------------------------
 
 The configuration settings of the storage of the tokens if blob storage is used.
 
@@ -2245,8 +2245,8 @@ Used by: [TokenStore_STATUS](#TokenStore_STATUS).
 |-------------------|-----------------------------------------------------------------------------------------------|------------------------------------|
 | sasUrlSettingName | The name of the app secrets containing the SAS URL of the blob storage containing the tokens. | string<br/><small>Optional</small> |
 
-<a id="ClientRegistration"></a>ClientRegistration
--------------------------------------------------
+ClientRegistration{#ClientRegistration}
+---------------------------------------
 
 The configuration settings of the app registration for providers that have client ids and client secrets
 
@@ -2257,8 +2257,8 @@ Used by: [GitHub](#GitHub), and [Google](#Google).
 | clientId                | The Client ID of the app used for login.              | string<br/><small>Optional</small> |
 | clientSecretSettingName | The app setting name that contains the client secret. | string<br/><small>Optional</small> |
 
-<a id="ClientRegistration_STATUS"></a>ClientRegistration_STATUS
----------------------------------------------------------------
+ClientRegistration_STATUS{#ClientRegistration_STATUS}
+-----------------------------------------------------
 
 The configuration settings of the app registration for providers that have client ids and client secrets
 
@@ -2269,8 +2269,8 @@ Used by: [GitHub_STATUS](#GitHub_STATUS), and [Google_STATUS](#Google_STATUS).
 | clientId                | The Client ID of the app used for login.              | string<br/><small>Optional</small> |
 | clientSecretSettingName | The app setting name that contains the client secret. | string<br/><small>Optional</small> |
 
-<a id="ContainerAppProbe"></a>ContainerAppProbe
------------------------------------------------
+ContainerAppProbe{#ContainerAppProbe}
+-------------------------------------
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
@@ -2288,8 +2288,8 @@ Used by: [Container](#Container).
 | timeoutSeconds                | Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 240.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                         |
 | type                          | The type of probe.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | [ContainerAppProbe_Type](#ContainerAppProbe_Type)<br/><small>Optional</small>           |
 
-<a id="ContainerAppProbe_STATUS"></a>ContainerAppProbe_STATUS
--------------------------------------------------------------
+ContainerAppProbe_STATUS{#ContainerAppProbe_STATUS}
+---------------------------------------------------
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
@@ -2307,8 +2307,8 @@ Used by: [Container_STATUS](#Container_STATUS).
 | timeoutSeconds                | Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 240.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                       |
 | type                          | The type of probe.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | [ContainerAppProbe_Type_STATUS](#ContainerAppProbe_Type_STATUS)<br/><small>Optional</small>           |
 
-<a id="ContainerResources"></a>ContainerResources
--------------------------------------------------
+ContainerResources{#ContainerResources}
+---------------------------------------
 
 Container App container resource requirements.
 
@@ -2319,8 +2319,8 @@ Used by: [BaseContainer](#BaseContainer), and [Container](#Container).
 | cpu      | Required CPU in cores, e.g. 0.5 | float64<br/><small>Optional</small> |
 | memory   | Required memory, e.g. "250Mb"   | string<br/><small>Optional</small>  |
 
-<a id="ContainerResources_STATUS"></a>ContainerResources_STATUS
----------------------------------------------------------------
+ContainerResources_STATUS{#ContainerResources_STATUS}
+-----------------------------------------------------
 
 Container App container resource requirements.
 
@@ -2332,8 +2332,8 @@ Used by: [BaseContainer_STATUS](#BaseContainer_STATUS), and [Container_STATUS](#
 | ephemeralStorage | Ephemeral Storage, e.g. "1Gi"   | string<br/><small>Optional</small>  |
 | memory           | Required memory, e.g. "250Mb"   | string<br/><small>Optional</small>  |
 
-<a id="CookieExpiration_Convention"></a>CookieExpiration_Convention
--------------------------------------------------------------------
+CookieExpiration_Convention{#CookieExpiration_Convention}
+---------------------------------------------------------
 
 Used by: [CookieExpiration](#CookieExpiration).
 
@@ -2342,8 +2342,8 @@ Used by: [CookieExpiration](#CookieExpiration).
 | "FixedTime"               |             |
 | "IdentityProviderDerived" |             |
 
-<a id="CookieExpiration_Convention_STATUS"></a>CookieExpiration_Convention_STATUS
----------------------------------------------------------------------------------
+CookieExpiration_Convention_STATUS{#CookieExpiration_Convention_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [CookieExpiration_STATUS](#CookieExpiration_STATUS).
 
@@ -2352,8 +2352,8 @@ Used by: [CookieExpiration_STATUS](#CookieExpiration_STATUS).
 | "FixedTime"               |             |
 | "IdentityProviderDerived" |             |
 
-<a id="CorsPolicy"></a>CorsPolicy
----------------------------------
+CorsPolicy{#CorsPolicy}
+-----------------------
 
 Cross-Origin-Resource-Sharing policy
 
@@ -2368,8 +2368,8 @@ Used by: [Ingress](#Ingress).
 | exposeHeaders    | Specifies the content for the access-control-expose-headers header | string[]<br/><small>Optional</small> |
 | maxAge           | Specifies the content for the access-control-max-age header        | int<br/><small>Optional</small>      |
 
-<a id="CorsPolicy_STATUS"></a>CorsPolicy_STATUS
------------------------------------------------
+CorsPolicy_STATUS{#CorsPolicy_STATUS}
+-------------------------------------
 
 Cross-Origin-Resource-Sharing policy
 
@@ -2384,8 +2384,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | exposeHeaders    | Specifies the content for the access-control-expose-headers header | string[]<br/><small>Optional</small> |
 | maxAge           | Specifies the content for the access-control-max-age header        | int<br/><small>Optional</small>      |
 
-<a id="CustomDomain"></a>CustomDomain
--------------------------------------
+CustomDomain{#CustomDomain}
+---------------------------
 
 Custom Domain of a Container App
 
@@ -2397,8 +2397,8 @@ Used by: [Ingress](#Ingress).
 | certificateReference | Resource Id of the Certificate to be bound to this hostname. Must exist in the Managed Environment. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | name                 | Hostname.                                                                                           | string<br/><small>Required</small>                                                                                                                         |
 
-<a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
----------------------------------------------------
+CustomDomain_STATUS{#CustomDomain_STATUS}
+-----------------------------------------
 
 Custom Domain of a Container App
 
@@ -2410,8 +2410,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | certificateId | Resource Id of the Certificate to be bound to this hostname. Must exist in the Managed Environment. | string<br/><small>Optional</small>                                                              |
 | name          | Hostname.                                                                                           | string<br/><small>Optional</small>                                                              |
 
-<a id="Dapr_AppProtocol"></a>Dapr_AppProtocol
----------------------------------------------
+Dapr_AppProtocol{#Dapr_AppProtocol}
+-----------------------------------
 
 Used by: [Dapr](#Dapr).
 
@@ -2420,8 +2420,8 @@ Used by: [Dapr](#Dapr).
 | "grpc" |             |
 | "http" |             |
 
-<a id="Dapr_AppProtocol_STATUS"></a>Dapr_AppProtocol_STATUS
------------------------------------------------------------
+Dapr_AppProtocol_STATUS{#Dapr_AppProtocol_STATUS}
+-------------------------------------------------
 
 Used by: [Dapr_STATUS](#Dapr_STATUS).
 
@@ -2430,8 +2430,8 @@ Used by: [Dapr_STATUS](#Dapr_STATUS).
 | "grpc" |             |
 | "http" |             |
 
-<a id="Dapr_LogLevel"></a>Dapr_LogLevel
----------------------------------------
+Dapr_LogLevel{#Dapr_LogLevel}
+-----------------------------
 
 Used by: [Dapr](#Dapr).
 
@@ -2442,8 +2442,8 @@ Used by: [Dapr](#Dapr).
 | "info"  |             |
 | "warn"  |             |
 
-<a id="Dapr_LogLevel_STATUS"></a>Dapr_LogLevel_STATUS
------------------------------------------------------
+Dapr_LogLevel_STATUS{#Dapr_LogLevel_STATUS}
+-------------------------------------------
 
 Used by: [Dapr_STATUS](#Dapr_STATUS).
 
@@ -2454,8 +2454,8 @@ Used by: [Dapr_STATUS](#Dapr_STATUS).
 | "info"  |             |
 | "warn"  |             |
 
-<a id="EnvironmentVar"></a>EnvironmentVar
------------------------------------------
+EnvironmentVar{#EnvironmentVar}
+-------------------------------
 
 Container App container environment variable.
 
@@ -2467,8 +2467,8 @@ Used by: [BaseContainer](#BaseContainer), and [Container](#Container).
 | secretRef | Name of the Container App secret from which to pull the environment variable value. | string<br/><small>Optional</small> |
 | value     | Non-secret environment variable value.                                              | string<br/><small>Optional</small> |
 
-<a id="EnvironmentVar_STATUS"></a>EnvironmentVar_STATUS
--------------------------------------------------------
+EnvironmentVar_STATUS{#EnvironmentVar_STATUS}
+---------------------------------------------
 
 Container App container environment variable.
 
@@ -2480,8 +2480,8 @@ Used by: [BaseContainer_STATUS](#BaseContainer_STATUS), and [Container_STATUS](#
 | secretRef | Name of the Container App secret from which to pull the environment variable value. | string<br/><small>Optional</small> |
 | value     | Non-secret environment variable value.                                              | string<br/><small>Optional</small> |
 
-<a id="ForwardProxy_Convention"></a>ForwardProxy_Convention
------------------------------------------------------------
+ForwardProxy_Convention{#ForwardProxy_Convention}
+-------------------------------------------------
 
 Used by: [ForwardProxy](#ForwardProxy).
 
@@ -2491,8 +2491,8 @@ Used by: [ForwardProxy](#ForwardProxy).
 | "NoProxy"  |             |
 | "Standard" |             |
 
-<a id="ForwardProxy_Convention_STATUS"></a>ForwardProxy_Convention_STATUS
--------------------------------------------------------------------------
+ForwardProxy_Convention_STATUS{#ForwardProxy_Convention_STATUS}
+---------------------------------------------------------------
 
 Used by: [ForwardProxy_STATUS](#ForwardProxy_STATUS).
 
@@ -2502,8 +2502,8 @@ Used by: [ForwardProxy_STATUS](#ForwardProxy_STATUS).
 | "NoProxy"  |             |
 | "Standard" |             |
 
-<a id="Ingress_ClientCertificateMode"></a>Ingress_ClientCertificateMode
------------------------------------------------------------------------
+Ingress_ClientCertificateMode{#Ingress_ClientCertificateMode}
+-------------------------------------------------------------
 
 Used by: [Ingress](#Ingress).
 
@@ -2513,8 +2513,8 @@ Used by: [Ingress](#Ingress).
 | "ignore"  |             |
 | "require" |             |
 
-<a id="Ingress_ClientCertificateMode_STATUS"></a>Ingress_ClientCertificateMode_STATUS
--------------------------------------------------------------------------------------
+Ingress_ClientCertificateMode_STATUS{#Ingress_ClientCertificateMode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [Ingress_STATUS](#Ingress_STATUS).
 
@@ -2524,8 +2524,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | "ignore"  |             |
 | "require" |             |
 
-<a id="Ingress_StickySessions"></a>Ingress_StickySessions
----------------------------------------------------------
+Ingress_StickySessions{#Ingress_StickySessions}
+-----------------------------------------------
 
 Used by: [Ingress](#Ingress).
 
@@ -2533,8 +2533,8 @@ Used by: [Ingress](#Ingress).
 |----------|-------------------------|-------------------------------------------------------------------------------------------------|
 | affinity | Sticky Session Affinity | [Ingress_StickySessions_Affinity](#Ingress_StickySessions_Affinity)<br/><small>Optional</small> |
 
-<a id="Ingress_StickySessions_STATUS"></a>Ingress_StickySessions_STATUS
------------------------------------------------------------------------
+Ingress_StickySessions_STATUS{#Ingress_StickySessions_STATUS}
+-------------------------------------------------------------
 
 Used by: [Ingress_STATUS](#Ingress_STATUS).
 
@@ -2542,8 +2542,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 |----------|-------------------------|---------------------------------------------------------------------------------------------------------------|
 | affinity | Sticky Session Affinity | [Ingress_StickySessions_Affinity_STATUS](#Ingress_StickySessions_Affinity_STATUS)<br/><small>Optional</small> |
 
-<a id="Ingress_Transport"></a>Ingress_Transport
------------------------------------------------
+Ingress_Transport{#Ingress_Transport}
+-------------------------------------
 
 Used by: [Ingress](#Ingress).
 
@@ -2554,8 +2554,8 @@ Used by: [Ingress](#Ingress).
 | "http2" |             |
 | "tcp"   |             |
 
-<a id="Ingress_Transport_STATUS"></a>Ingress_Transport_STATUS
--------------------------------------------------------------
+Ingress_Transport_STATUS{#Ingress_Transport_STATUS}
+---------------------------------------------------
 
 Used by: [Ingress_STATUS](#Ingress_STATUS).
 
@@ -2566,8 +2566,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | "http2" |             |
 | "tcp"   |             |
 
-<a id="IngressPortMapping"></a>IngressPortMapping
--------------------------------------------------
+IngressPortMapping{#IngressPortMapping}
+---------------------------------------
 
 Port mappings of container app ingress
 
@@ -2579,8 +2579,8 @@ Used by: [Ingress](#Ingress).
 | external    | Specifies whether the app port is accessible outside of the environment                      | bool<br/><small>Required</small> |
 | targetPort  | Specifies the port user's container listens on                                               | int<br/><small>Required</small>  |
 
-<a id="IngressPortMapping_STATUS"></a>IngressPortMapping_STATUS
----------------------------------------------------------------
+IngressPortMapping_STATUS{#IngressPortMapping_STATUS}
+-----------------------------------------------------
 
 Port mappings of container app ingress
 
@@ -2592,8 +2592,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | external    | Specifies whether the app port is accessible outside of the environment                      | bool<br/><small>Optional</small> |
 | targetPort  | Specifies the port user's container listens on                                               | int<br/><small>Optional</small>  |
 
-<a id="IpSecurityRestrictionRule"></a>IpSecurityRestrictionRule
----------------------------------------------------------------
+IpSecurityRestrictionRule{#IpSecurityRestrictionRule}
+-----------------------------------------------------
 
 Rule to restrict incoming IP address.
 
@@ -2606,8 +2606,8 @@ Used by: [Ingress](#Ingress).
 | ipAddressRange | CIDR notation to match incoming IP address                                                              | string<br/><small>Required</small>                                                                |
 | name           | Name for the IP restriction rule.                                                                       | string<br/><small>Required</small>                                                                |
 
-<a id="IpSecurityRestrictionRule_STATUS"></a>IpSecurityRestrictionRule_STATUS
------------------------------------------------------------------------------
+IpSecurityRestrictionRule_STATUS{#IpSecurityRestrictionRule_STATUS}
+-------------------------------------------------------------------
 
 Rule to restrict incoming IP address.
 
@@ -2620,8 +2620,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | ipAddressRange | CIDR notation to match incoming IP address                                                              | string<br/><small>Optional</small>                                                                              |
 | name           | Name for the IP restriction rule.                                                                       | string<br/><small>Optional</small>                                                                              |
 
-<a id="JobScale"></a>JobScale
------------------------------
+JobScale{#JobScale}
+-------------------
 
 Scaling configurations for event driven jobs.
 
@@ -2634,8 +2634,8 @@ Used by: [JobConfiguration_EventTriggerConfig](#JobConfiguration_EventTriggerCon
 | pollingInterval |                                                                               | int<br/><small>Optional</small>                             |
 | rules           | Scaling rules.                                                                | [JobScaleRule[]](#JobScaleRule)<br/><small>Optional</small> |
 
-<a id="JobScale_STATUS"></a>JobScale_STATUS
--------------------------------------------
+JobScale_STATUS{#JobScale_STATUS}
+---------------------------------
 
 Scaling configurations for event driven jobs.
 
@@ -2648,8 +2648,8 @@ Used by: [JobConfiguration_EventTriggerConfig_STATUS](#JobConfiguration_EventTri
 | pollingInterval |                                                                               | int<br/><small>Optional</small>                                           |
 | rules           | Scaling rules.                                                                | [JobScaleRule_STATUS[]](#JobScaleRule_STATUS)<br/><small>Optional</small> |
 
-<a id="LoginScopes"></a>LoginScopes
------------------------------------
+LoginScopes{#LoginScopes}
+-------------------------
 
 The configuration settings of the login flow, including the scopes that should be requested.
 
@@ -2659,8 +2659,8 @@ Used by: [Apple](#Apple), [Facebook](#Facebook), [GitHub](#GitHub), and [Google]
 |----------|---------------------------------------------------------------------|--------------------------------------|
 | scopes   | A list of the scopes that should be requested while authenticating. | string[]<br/><small>Optional</small> |
 
-<a id="LoginScopes_STATUS"></a>LoginScopes_STATUS
--------------------------------------------------
+LoginScopes_STATUS{#LoginScopes_STATUS}
+---------------------------------------
 
 The configuration settings of the login flow, including the scopes that should be requested.
 
@@ -2670,8 +2670,8 @@ Used by: [Apple_STATUS](#Apple_STATUS), [Facebook_STATUS](#Facebook_STATUS), [Gi
 |----------|---------------------------------------------------------------------|--------------------------------------|
 | scopes   | A list of the scopes that should be requested while authenticating. | string[]<br/><small>Optional</small> |
 
-<a id="OpenIdConnectLogin"></a>OpenIdConnectLogin
--------------------------------------------------
+OpenIdConnectLogin{#OpenIdConnectLogin}
+---------------------------------------
 
 The configuration settings of the login flow of the custom Open ID Connect provider.
 
@@ -2682,8 +2682,8 @@ Used by: [CustomOpenIdConnectProvider](#CustomOpenIdConnectProvider).
 | nameClaimType | The name of the claim that contains the users name.                 | string<br/><small>Optional</small>   |
 | scopes        | A list of the scopes that should be requested while authenticating. | string[]<br/><small>Optional</small> |
 
-<a id="OpenIdConnectLogin_STATUS"></a>OpenIdConnectLogin_STATUS
----------------------------------------------------------------
+OpenIdConnectLogin_STATUS{#OpenIdConnectLogin_STATUS}
+-----------------------------------------------------
 
 The configuration settings of the login flow of the custom Open ID Connect provider.
 
@@ -2694,8 +2694,8 @@ Used by: [CustomOpenIdConnectProvider_STATUS](#CustomOpenIdConnectProvider_STATU
 | nameClaimType | The name of the claim that contains the users name.                 | string<br/><small>Optional</small>   |
 | scopes        | A list of the scopes that should be requested while authenticating. | string[]<br/><small>Optional</small> |
 
-<a id="OpenIdConnectRegistration"></a>OpenIdConnectRegistration
----------------------------------------------------------------
+OpenIdConnectRegistration{#OpenIdConnectRegistration}
+-----------------------------------------------------
 
 The configuration settings of the app registration for the custom Open ID Connect provider.
 
@@ -2707,8 +2707,8 @@ Used by: [CustomOpenIdConnectProvider](#CustomOpenIdConnectProvider).
 | clientId                   | The client id of the custom Open ID Connect provider.                                     | string<br/><small>Optional</small>                                                          |
 | openIdConnectConfiguration | The configuration settings of the endpoints used for the custom Open ID Connect provider. | [OpenIdConnectConfig](#OpenIdConnectConfig)<br/><small>Optional</small>                     |
 
-<a id="OpenIdConnectRegistration_STATUS"></a>OpenIdConnectRegistration_STATUS
------------------------------------------------------------------------------
+OpenIdConnectRegistration_STATUS{#OpenIdConnectRegistration_STATUS}
+-------------------------------------------------------------------
 
 The configuration settings of the app registration for the custom Open ID Connect provider.
 
@@ -2720,8 +2720,8 @@ Used by: [CustomOpenIdConnectProvider_STATUS](#CustomOpenIdConnectProvider_STATU
 | clientId                   | The client id of the custom Open ID Connect provider.                                     | string<br/><small>Optional</small>                                                                        |
 | openIdConnectConfiguration | The configuration settings of the endpoints used for the custom Open ID Connect provider. | [OpenIdConnectConfig_STATUS](#OpenIdConnectConfig_STATUS)<br/><small>Optional</small>                     |
 
-<a id="ScaleRule"></a>ScaleRule
--------------------------------
+ScaleRule{#ScaleRule}
+---------------------
 
 Container App container scaling rule.
 
@@ -2735,8 +2735,8 @@ Used by: [Scale](#Scale).
 | name       | Scale Rule Name              | string<br/><small>Optional</small>                              |
 | tcp        | Tcp requests based scaling.  | [TcpScaleRule](#TcpScaleRule)<br/><small>Optional</small>       |
 
-<a id="ScaleRule_STATUS"></a>ScaleRule_STATUS
----------------------------------------------
+ScaleRule_STATUS{#ScaleRule_STATUS}
+-----------------------------------
 
 Container App container scaling rule.
 
@@ -2750,8 +2750,8 @@ Used by: [Scale_STATUS](#Scale_STATUS).
 | name       | Scale Rule Name              | string<br/><small>Optional</small>                                            |
 | tcp        | Tcp requests based scaling.  | [TcpScaleRule_STATUS](#TcpScaleRule_STATUS)<br/><small>Optional</small>       |
 
-<a id="SecretVolumeItem"></a>SecretVolumeItem
----------------------------------------------
+SecretVolumeItem{#SecretVolumeItem}
+-----------------------------------
 
 Secret to be added to volume.
 
@@ -2762,8 +2762,8 @@ Used by: [Volume](#Volume).
 | path      | Path to project secret to. If no path is provided, path defaults to name of secret listed in secretRef. | string<br/><small>Optional</small> |
 | secretRef | Name of the Container App secret from which to pull the secret value.                                   | string<br/><small>Optional</small> |
 
-<a id="SecretVolumeItem_STATUS"></a>SecretVolumeItem_STATUS
------------------------------------------------------------
+SecretVolumeItem_STATUS{#SecretVolumeItem_STATUS}
+-------------------------------------------------
 
 Secret to be added to volume.
 
@@ -2774,8 +2774,8 @@ Used by: [Volume_STATUS](#Volume_STATUS).
 | path      | Path to project secret to. If no path is provided, path defaults to name of secret listed in secretRef. | string<br/><small>Optional</small> |
 | secretRef | Name of the Container App secret from which to pull the secret value.                                   | string<br/><small>Optional</small> |
 
-<a id="TrafficWeight"></a>TrafficWeight
----------------------------------------
+TrafficWeight{#TrafficWeight}
+-----------------------------
 
 Traffic weight assigned to a revision
 
@@ -2788,8 +2788,8 @@ Used by: [Ingress](#Ingress).
 | revisionName   | Name of a revision                                                    | string<br/><small>Optional</small> |
 | weight         | Traffic weight assigned to a revision                                 | int<br/><small>Optional</small>    |
 
-<a id="TrafficWeight_STATUS"></a>TrafficWeight_STATUS
------------------------------------------------------
+TrafficWeight_STATUS{#TrafficWeight_STATUS}
+-------------------------------------------
 
 Traffic weight assigned to a revision
 
@@ -2802,8 +2802,8 @@ Used by: [Ingress_STATUS](#Ingress_STATUS).
 | revisionName   | Name of a revision                                                    | string<br/><small>Optional</small> |
 | weight         | Traffic weight assigned to a revision                                 | int<br/><small>Optional</small>    |
 
-<a id="TwitterRegistration"></a>TwitterRegistration
----------------------------------------------------
+TwitterRegistration{#TwitterRegistration}
+-----------------------------------------
 
 The configuration settings of the app registration for the Twitter provider.
 
@@ -2814,8 +2814,8 @@ Used by: [Twitter](#Twitter).
 | consumerKey               | The OAuth 1.0a consumer key of the Twitter application used for sign-in. This setting is required for enabling Twitter Sign-In. Twitter Sign-In documentation: https://dev.twitter.com/web/sign-in | string<br/><small>Optional</small> |
 | consumerSecretSettingName | The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.                                                                                     | string<br/><small>Optional</small> |
 
-<a id="TwitterRegistration_STATUS"></a>TwitterRegistration_STATUS
------------------------------------------------------------------
+TwitterRegistration_STATUS{#TwitterRegistration_STATUS}
+-------------------------------------------------------
 
 The configuration settings of the app registration for the Twitter provider.
 
@@ -2826,8 +2826,8 @@ Used by: [Twitter_STATUS](#Twitter_STATUS).
 | consumerKey               | The OAuth 1.0a consumer key of the Twitter application used for sign-in. This setting is required for enabling Twitter Sign-In. Twitter Sign-In documentation: https://dev.twitter.com/web/sign-in | string<br/><small>Optional</small> |
 | consumerSecretSettingName | The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.                                                                                     | string<br/><small>Optional</small> |
 
-<a id="Volume_StorageType"></a>Volume_StorageType
--------------------------------------------------
+Volume_StorageType{#Volume_StorageType}
+---------------------------------------
 
 Used by: [Volume](#Volume).
 
@@ -2837,8 +2837,8 @@ Used by: [Volume](#Volume).
 | "EmptyDir"  |             |
 | "Secret"    |             |
 
-<a id="Volume_StorageType_STATUS"></a>Volume_StorageType_STATUS
----------------------------------------------------------------
+Volume_StorageType_STATUS{#Volume_StorageType_STATUS}
+-----------------------------------------------------
 
 Used by: [Volume_STATUS](#Volume_STATUS).
 
@@ -2848,8 +2848,8 @@ Used by: [Volume_STATUS](#Volume_STATUS).
 | "EmptyDir"  |             |
 | "Secret"    |             |
 
-<a id="VolumeMount"></a>VolumeMount
------------------------------------
+VolumeMount{#VolumeMount}
+-------------------------
 
 Volume mount for the Container App.
 
@@ -2861,8 +2861,8 @@ Used by: [BaseContainer](#BaseContainer), and [Container](#Container).
 | subPath    | Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root). | string<br/><small>Optional</small> |
 | volumeName | This must match the Name of a Volume.                                                                       | string<br/><small>Optional</small> |
 
-<a id="VolumeMount_STATUS"></a>VolumeMount_STATUS
--------------------------------------------------
+VolumeMount_STATUS{#VolumeMount_STATUS}
+---------------------------------------
 
 Volume mount for the Container App.
 
@@ -2874,8 +2874,8 @@ Used by: [BaseContainer_STATUS](#BaseContainer_STATUS), and [Container_STATUS](#
 | subPath    | Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root). | string<br/><small>Optional</small> |
 | volumeName | This must match the Name of a Volume.                                                                       | string<br/><small>Optional</small> |
 
-<a id="ContainerAppProbe_HttpGet"></a>ContainerAppProbe_HttpGet
----------------------------------------------------------------
+ContainerAppProbe_HttpGet{#ContainerAppProbe_HttpGet}
+-----------------------------------------------------
 
 Used by: [ContainerAppProbe](#ContainerAppProbe).
 
@@ -2887,8 +2887,8 @@ Used by: [ContainerAppProbe](#ContainerAppProbe).
 | port        | Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. | int<br/><small>Required</small>                                                                               |
 | scheme      | Scheme to use for connecting to the host. Defaults to HTTP.                                                                   | [ContainerAppProbe_HttpGet_Scheme](#ContainerAppProbe_HttpGet_Scheme)<br/><small>Optional</small>             |
 
-<a id="ContainerAppProbe_HttpGet_STATUS"></a>ContainerAppProbe_HttpGet_STATUS
------------------------------------------------------------------------------
+ContainerAppProbe_HttpGet_STATUS{#ContainerAppProbe_HttpGet_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 
@@ -2900,8 +2900,8 @@ Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 | port        | Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. | int<br/><small>Optional</small>                                                                                             |
 | scheme      | Scheme to use for connecting to the host. Defaults to HTTP.                                                                   | [ContainerAppProbe_HttpGet_Scheme_STATUS](#ContainerAppProbe_HttpGet_Scheme_STATUS)<br/><small>Optional</small>             |
 
-<a id="ContainerAppProbe_TcpSocket"></a>ContainerAppProbe_TcpSocket
--------------------------------------------------------------------
+ContainerAppProbe_TcpSocket{#ContainerAppProbe_TcpSocket}
+---------------------------------------------------------
 
 Used by: [ContainerAppProbe](#ContainerAppProbe).
 
@@ -2910,8 +2910,8 @@ Used by: [ContainerAppProbe](#ContainerAppProbe).
 | host     | Optional: Host name to connect to, defaults to the pod IP.                                                                    | string<br/><small>Optional</small> |
 | port     | Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. | int<br/><small>Required</small>    |
 
-<a id="ContainerAppProbe_TcpSocket_STATUS"></a>ContainerAppProbe_TcpSocket_STATUS
----------------------------------------------------------------------------------
+ContainerAppProbe_TcpSocket_STATUS{#ContainerAppProbe_TcpSocket_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 
@@ -2920,8 +2920,8 @@ Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 | host     | Optional: Host name to connect to, defaults to the pod IP.                                                                    | string<br/><small>Optional</small> |
 | port     | Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. | int<br/><small>Optional</small>    |
 
-<a id="ContainerAppProbe_Type"></a>ContainerAppProbe_Type
----------------------------------------------------------
+ContainerAppProbe_Type{#ContainerAppProbe_Type}
+-----------------------------------------------
 
 Used by: [ContainerAppProbe](#ContainerAppProbe).
 
@@ -2931,8 +2931,8 @@ Used by: [ContainerAppProbe](#ContainerAppProbe).
 | "Readiness" |             |
 | "Startup"   |             |
 
-<a id="ContainerAppProbe_Type_STATUS"></a>ContainerAppProbe_Type_STATUS
------------------------------------------------------------------------
+ContainerAppProbe_Type_STATUS{#ContainerAppProbe_Type_STATUS}
+-------------------------------------------------------------
 
 Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 
@@ -2942,8 +2942,8 @@ Used by: [ContainerAppProbe_STATUS](#ContainerAppProbe_STATUS).
 | "Readiness" |             |
 | "Startup"   |             |
 
-<a id="CustomDomain_BindingType"></a>CustomDomain_BindingType
--------------------------------------------------------------
+CustomDomain_BindingType{#CustomDomain_BindingType}
+---------------------------------------------------
 
 Used by: [CustomDomain](#CustomDomain).
 
@@ -2952,8 +2952,8 @@ Used by: [CustomDomain](#CustomDomain).
 | "Disabled"   |             |
 | "SniEnabled" |             |
 
-<a id="CustomDomain_BindingType_STATUS"></a>CustomDomain_BindingType_STATUS
----------------------------------------------------------------------------
+CustomDomain_BindingType_STATUS{#CustomDomain_BindingType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [CustomDomain_STATUS](#CustomDomain_STATUS).
 
@@ -2962,8 +2962,8 @@ Used by: [CustomDomain_STATUS](#CustomDomain_STATUS).
 | "Disabled"   |             |
 | "SniEnabled" |             |
 
-<a id="CustomScaleRule"></a>CustomScaleRule
--------------------------------------------
+CustomScaleRule{#CustomScaleRule}
+---------------------------------
 
 Container App container Custom scaling rule.
 
@@ -2975,8 +2975,8 @@ Used by: [ScaleRule](#ScaleRule).
 | metadata | Metadata properties to describe custom scale rule.             | map[string]string<br/><small>Optional</small>                 |
 | type     | Type of the custom scale rule eg: azure-servicebus, redis etc. | string<br/><small>Optional</small>                            |
 
-<a id="CustomScaleRule_STATUS"></a>CustomScaleRule_STATUS
----------------------------------------------------------
+CustomScaleRule_STATUS{#CustomScaleRule_STATUS}
+-----------------------------------------------
 
 Container App container Custom scaling rule.
 
@@ -2988,8 +2988,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | metadata | Metadata properties to describe custom scale rule.             | map[string]string<br/><small>Optional</small>                               |
 | type     | Type of the custom scale rule eg: azure-servicebus, redis etc. | string<br/><small>Optional</small>                                          |
 
-<a id="DefaultAuthorizationPolicy"></a>DefaultAuthorizationPolicy
------------------------------------------------------------------
+DefaultAuthorizationPolicy{#DefaultAuthorizationPolicy}
+-------------------------------------------------------
 
 The configuration settings of the Azure Active Directory default authorization policy.
 
@@ -3000,8 +3000,8 @@ Used by: [AzureActiveDirectoryValidation](#AzureActiveDirectoryValidation).
 | allowedApplications | The configuration settings of the Azure Active Directory allowed applications. | string[]<br/><small>Optional</small>                                |
 | allowedPrincipals   | The configuration settings of the Azure Active Directory allowed principals.   | [AllowedPrincipals](#AllowedPrincipals)<br/><small>Optional</small> |
 
-<a id="DefaultAuthorizationPolicy_STATUS"></a>DefaultAuthorizationPolicy_STATUS
--------------------------------------------------------------------------------
+DefaultAuthorizationPolicy_STATUS{#DefaultAuthorizationPolicy_STATUS}
+---------------------------------------------------------------------
 
 The configuration settings of the Azure Active Directory default authorization policy.
 
@@ -3012,8 +3012,8 @@ Used by: [AzureActiveDirectoryValidation_STATUS](#AzureActiveDirectoryValidation
 | allowedApplications | The configuration settings of the Azure Active Directory allowed applications. | string[]<br/><small>Optional</small>                                              |
 | allowedPrincipals   | The configuration settings of the Azure Active Directory allowed principals.   | [AllowedPrincipals_STATUS](#AllowedPrincipals_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpScaleRule"></a>HttpScaleRule
----------------------------------------
+HttpScaleRule{#HttpScaleRule}
+-----------------------------
 
 Container App container Http scaling rule.
 
@@ -3024,8 +3024,8 @@ Used by: [ScaleRule](#ScaleRule).
 | auth     | Authentication secrets for the custom scale rule. | [ScaleRuleAuth[]](#ScaleRuleAuth)<br/><small>Optional</small> |
 | metadata | Metadata properties to describe http scale rule.  | map[string]string<br/><small>Optional</small>                 |
 
-<a id="HttpScaleRule_STATUS"></a>HttpScaleRule_STATUS
------------------------------------------------------
+HttpScaleRule_STATUS{#HttpScaleRule_STATUS}
+-------------------------------------------
 
 Container App container Http scaling rule.
 
@@ -3036,8 +3036,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | auth     | Authentication secrets for the custom scale rule. | [ScaleRuleAuth_STATUS[]](#ScaleRuleAuth_STATUS)<br/><small>Optional</small> |
 | metadata | Metadata properties to describe http scale rule.  | map[string]string<br/><small>Optional</small>                               |
 
-<a id="Ingress_StickySessions_Affinity"></a>Ingress_StickySessions_Affinity
----------------------------------------------------------------------------
+Ingress_StickySessions_Affinity{#Ingress_StickySessions_Affinity}
+-----------------------------------------------------------------
 
 Used by: [Ingress_StickySessions](#Ingress_StickySessions).
 
@@ -3046,8 +3046,8 @@ Used by: [Ingress_StickySessions](#Ingress_StickySessions).
 | "none"   |             |
 | "sticky" |             |
 
-<a id="Ingress_StickySessions_Affinity_STATUS"></a>Ingress_StickySessions_Affinity_STATUS
------------------------------------------------------------------------------------------
+Ingress_StickySessions_Affinity_STATUS{#Ingress_StickySessions_Affinity_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Ingress_StickySessions_STATUS](#Ingress_StickySessions_STATUS).
 
@@ -3056,8 +3056,8 @@ Used by: [Ingress_StickySessions_STATUS](#Ingress_StickySessions_STATUS).
 | "none"   |             |
 | "sticky" |             |
 
-<a id="IpSecurityRestrictionRule_Action"></a>IpSecurityRestrictionRule_Action
------------------------------------------------------------------------------
+IpSecurityRestrictionRule_Action{#IpSecurityRestrictionRule_Action}
+-------------------------------------------------------------------
 
 Used by: [IpSecurityRestrictionRule](#IpSecurityRestrictionRule).
 
@@ -3066,8 +3066,8 @@ Used by: [IpSecurityRestrictionRule](#IpSecurityRestrictionRule).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="IpSecurityRestrictionRule_Action_STATUS"></a>IpSecurityRestrictionRule_Action_STATUS
--------------------------------------------------------------------------------------------
+IpSecurityRestrictionRule_Action_STATUS{#IpSecurityRestrictionRule_Action_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [IpSecurityRestrictionRule_STATUS](#IpSecurityRestrictionRule_STATUS).
 
@@ -3076,8 +3076,8 @@ Used by: [IpSecurityRestrictionRule_STATUS](#IpSecurityRestrictionRule_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="JobScaleRule"></a>JobScaleRule
--------------------------------------
+JobScaleRule{#JobScaleRule}
+---------------------------
 
 Scaling rule.
 
@@ -3090,8 +3090,8 @@ Used by: [JobScale](#JobScale).
 | name     | Scale Rule Name                                         | string<br/><small>Optional</small>                            |
 | type     | Type of the scale rule eg: azure-servicebus, redis etc. | string<br/><small>Optional</small>                            |
 
-<a id="JobScaleRule_STATUS"></a>JobScaleRule_STATUS
----------------------------------------------------
+JobScaleRule_STATUS{#JobScaleRule_STATUS}
+-----------------------------------------
 
 Scaling rule.
 
@@ -3104,8 +3104,8 @@ Used by: [JobScale_STATUS](#JobScale_STATUS).
 | name     | Scale Rule Name                                         | string<br/><small>Optional</small>                                          |
 | type     | Type of the scale rule eg: azure-servicebus, redis etc. | string<br/><small>Optional</small>                                          |
 
-<a id="JwtClaimChecks"></a>JwtClaimChecks
------------------------------------------
+JwtClaimChecks{#JwtClaimChecks}
+-------------------------------
 
 The configuration settings of the checks that should be made while validating the JWT Claims.
 
@@ -3116,8 +3116,8 @@ Used by: [AzureActiveDirectoryValidation](#AzureActiveDirectoryValidation).
 | allowedClientApplications | The list of the allowed client applications. | string[]<br/><small>Optional</small> |
 | allowedGroups             | The list of the allowed groups.              | string[]<br/><small>Optional</small> |
 
-<a id="JwtClaimChecks_STATUS"></a>JwtClaimChecks_STATUS
--------------------------------------------------------
+JwtClaimChecks_STATUS{#JwtClaimChecks_STATUS}
+---------------------------------------------
 
 The configuration settings of the checks that should be made while validating the JWT Claims.
 
@@ -3128,8 +3128,8 @@ Used by: [AzureActiveDirectoryValidation_STATUS](#AzureActiveDirectoryValidation
 | allowedClientApplications | The list of the allowed client applications. | string[]<br/><small>Optional</small> |
 | allowedGroups             | The list of the allowed groups.              | string[]<br/><small>Optional</small> |
 
-<a id="OpenIdConnectClientCredential"></a>OpenIdConnectClientCredential
------------------------------------------------------------------------
+OpenIdConnectClientCredential{#OpenIdConnectClientCredential}
+-------------------------------------------------------------
 
 The authentication client credentials of the custom Open ID Connect provider.
 
@@ -3140,8 +3140,8 @@ Used by: [OpenIdConnectRegistration](#OpenIdConnectRegistration).
 | clientSecretSettingName | The app setting that contains the client secret for the custom Open ID Connect provider. | string<br/><small>Optional</small>                                                                        |
 | method                  | The method that should be used to authenticate the user.                                 | [OpenIdConnectClientCredential_Method](#OpenIdConnectClientCredential_Method)<br/><small>Optional</small> |
 
-<a id="OpenIdConnectClientCredential_STATUS"></a>OpenIdConnectClientCredential_STATUS
--------------------------------------------------------------------------------------
+OpenIdConnectClientCredential_STATUS{#OpenIdConnectClientCredential_STATUS}
+---------------------------------------------------------------------------
 
 The authentication client credentials of the custom Open ID Connect provider.
 
@@ -3152,8 +3152,8 @@ Used by: [OpenIdConnectRegistration_STATUS](#OpenIdConnectRegistration_STATUS).
 | clientSecretSettingName | The app setting that contains the client secret for the custom Open ID Connect provider. | string<br/><small>Optional</small>                                                                                      |
 | method                  | The method that should be used to authenticate the user.                                 | [OpenIdConnectClientCredential_Method_STATUS](#OpenIdConnectClientCredential_Method_STATUS)<br/><small>Optional</small> |
 
-<a id="OpenIdConnectConfig"></a>OpenIdConnectConfig
----------------------------------------------------
+OpenIdConnectConfig{#OpenIdConnectConfig}
+-----------------------------------------
 
 The configuration settings of the endpoints used for the custom Open ID Connect provider.
 
@@ -3167,8 +3167,8 @@ Used by: [OpenIdConnectRegistration](#OpenIdConnectRegistration).
 | tokenEndpoint                | The endpoint to be used to request a token.                                  | string<br/><small>Optional</small> |
 | wellKnownOpenIdConfiguration | The endpoint that contains all the configuration endpoints for the provider. | string<br/><small>Optional</small> |
 
-<a id="OpenIdConnectConfig_STATUS"></a>OpenIdConnectConfig_STATUS
------------------------------------------------------------------
+OpenIdConnectConfig_STATUS{#OpenIdConnectConfig_STATUS}
+-------------------------------------------------------
 
 The configuration settings of the endpoints used for the custom Open ID Connect provider.
 
@@ -3182,8 +3182,8 @@ Used by: [OpenIdConnectRegistration_STATUS](#OpenIdConnectRegistration_STATUS).
 | tokenEndpoint                | The endpoint to be used to request a token.                                  | string<br/><small>Optional</small> |
 | wellKnownOpenIdConfiguration | The endpoint that contains all the configuration endpoints for the provider. | string<br/><small>Optional</small> |
 
-<a id="QueueScaleRule"></a>QueueScaleRule
------------------------------------------
+QueueScaleRule{#QueueScaleRule}
+-------------------------------
 
 Container App container Azure Queue based scaling rule.
 
@@ -3195,8 +3195,8 @@ Used by: [ScaleRule](#ScaleRule).
 | queueLength | Queue length.                                    | int<br/><small>Optional</small>                               |
 | queueName   | Queue name.                                      | string<br/><small>Optional</small>                            |
 
-<a id="QueueScaleRule_STATUS"></a>QueueScaleRule_STATUS
--------------------------------------------------------
+QueueScaleRule_STATUS{#QueueScaleRule_STATUS}
+---------------------------------------------
 
 Container App container Azure Queue based scaling rule.
 
@@ -3208,8 +3208,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | queueLength | Queue length.                                    | int<br/><small>Optional</small>                                             |
 | queueName   | Queue name.                                      | string<br/><small>Optional</small>                                          |
 
-<a id="TcpScaleRule"></a>TcpScaleRule
--------------------------------------
+TcpScaleRule{#TcpScaleRule}
+---------------------------
 
 Container App container Tcp scaling rule.
 
@@ -3220,8 +3220,8 @@ Used by: [ScaleRule](#ScaleRule).
 | auth     | Authentication secrets for the tcp scale rule.  | [ScaleRuleAuth[]](#ScaleRuleAuth)<br/><small>Optional</small> |
 | metadata | Metadata properties to describe tcp scale rule. | map[string]string<br/><small>Optional</small>                 |
 
-<a id="TcpScaleRule_STATUS"></a>TcpScaleRule_STATUS
----------------------------------------------------
+TcpScaleRule_STATUS{#TcpScaleRule_STATUS}
+-----------------------------------------
 
 Container App container Tcp scaling rule.
 
@@ -3232,8 +3232,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | auth     | Authentication secrets for the tcp scale rule.  | [ScaleRuleAuth_STATUS[]](#ScaleRuleAuth_STATUS)<br/><small>Optional</small> |
 | metadata | Metadata properties to describe tcp scale rule. | map[string]string<br/><small>Optional</small>                               |
 
-<a id="AllowedPrincipals"></a>AllowedPrincipals
------------------------------------------------
+AllowedPrincipals{#AllowedPrincipals}
+-------------------------------------
 
 The configuration settings of the Azure Active Directory allowed principals.
 
@@ -3244,8 +3244,8 @@ Used by: [DefaultAuthorizationPolicy](#DefaultAuthorizationPolicy).
 | groups     | The list of the allowed groups.     | string[]<br/><small>Optional</small> |
 | identities | The list of the allowed identities. | string[]<br/><small>Optional</small> |
 
-<a id="AllowedPrincipals_STATUS"></a>AllowedPrincipals_STATUS
--------------------------------------------------------------
+AllowedPrincipals_STATUS{#AllowedPrincipals_STATUS}
+---------------------------------------------------
 
 The configuration settings of the Azure Active Directory allowed principals.
 
@@ -3256,8 +3256,8 @@ Used by: [DefaultAuthorizationPolicy_STATUS](#DefaultAuthorizationPolicy_STATUS)
 | groups     | The list of the allowed groups.     | string[]<br/><small>Optional</small> |
 | identities | The list of the allowed identities. | string[]<br/><small>Optional</small> |
 
-<a id="ContainerAppProbe_HttpGet_HttpHeaders"></a>ContainerAppProbe_HttpGet_HttpHeaders
----------------------------------------------------------------------------------------
+ContainerAppProbe_HttpGet_HttpHeaders{#ContainerAppProbe_HttpGet_HttpHeaders}
+-----------------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_HttpGet](#ContainerAppProbe_HttpGet).
 
@@ -3266,8 +3266,8 @@ Used by: [ContainerAppProbe_HttpGet](#ContainerAppProbe_HttpGet).
 | name     | The header field name  | string<br/><small>Required</small> |
 | value    | The header field value | string<br/><small>Required</small> |
 
-<a id="ContainerAppProbe_HttpGet_HttpHeaders_STATUS"></a>ContainerAppProbe_HttpGet_HttpHeaders_STATUS
------------------------------------------------------------------------------------------------------
+ContainerAppProbe_HttpGet_HttpHeaders_STATUS{#ContainerAppProbe_HttpGet_HttpHeaders_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_HttpGet_STATUS](#ContainerAppProbe_HttpGet_STATUS).
 
@@ -3276,8 +3276,8 @@ Used by: [ContainerAppProbe_HttpGet_STATUS](#ContainerAppProbe_HttpGet_STATUS).
 | name     | The header field name  | string<br/><small>Optional</small> |
 | value    | The header field value | string<br/><small>Optional</small> |
 
-<a id="ContainerAppProbe_HttpGet_Scheme"></a>ContainerAppProbe_HttpGet_Scheme
------------------------------------------------------------------------------
+ContainerAppProbe_HttpGet_Scheme{#ContainerAppProbe_HttpGet_Scheme}
+-------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_HttpGet](#ContainerAppProbe_HttpGet).
 
@@ -3286,8 +3286,8 @@ Used by: [ContainerAppProbe_HttpGet](#ContainerAppProbe_HttpGet).
 | "HTTP"  |             |
 | "HTTPS" |             |
 
-<a id="ContainerAppProbe_HttpGet_Scheme_STATUS"></a>ContainerAppProbe_HttpGet_Scheme_STATUS
--------------------------------------------------------------------------------------------
+ContainerAppProbe_HttpGet_Scheme_STATUS{#ContainerAppProbe_HttpGet_Scheme_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ContainerAppProbe_HttpGet_STATUS](#ContainerAppProbe_HttpGet_STATUS).
 
@@ -3296,8 +3296,8 @@ Used by: [ContainerAppProbe_HttpGet_STATUS](#ContainerAppProbe_HttpGet_STATUS).
 | "HTTP"  |             |
 | "HTTPS" |             |
 
-<a id="OpenIdConnectClientCredential_Method"></a>OpenIdConnectClientCredential_Method
--------------------------------------------------------------------------------------
+OpenIdConnectClientCredential_Method{#OpenIdConnectClientCredential_Method}
+---------------------------------------------------------------------------
 
 Used by: [OpenIdConnectClientCredential](#OpenIdConnectClientCredential).
 
@@ -3305,8 +3305,8 @@ Used by: [OpenIdConnectClientCredential](#OpenIdConnectClientCredential).
 |--------------------|-------------|
 | "ClientSecretPost" |             |
 
-<a id="OpenIdConnectClientCredential_Method_STATUS"></a>OpenIdConnectClientCredential_Method_STATUS
----------------------------------------------------------------------------------------------------
+OpenIdConnectClientCredential_Method_STATUS{#OpenIdConnectClientCredential_Method_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [OpenIdConnectClientCredential_STATUS](#OpenIdConnectClientCredential_STATUS).
 
@@ -3314,8 +3314,8 @@ Used by: [OpenIdConnectClientCredential_STATUS](#OpenIdConnectClientCredential_S
 |--------------------|-------------|
 | "ClientSecretPost" |             |
 
-<a id="ScaleRuleAuth"></a>ScaleRuleAuth
----------------------------------------
+ScaleRuleAuth{#ScaleRuleAuth}
+-----------------------------
 
 Auth Secrets for Scale Rule
 
@@ -3326,8 +3326,8 @@ Used by: [CustomScaleRule](#CustomScaleRule), [HttpScaleRule](#HttpScaleRule), [
 | secretRef        | Name of the secret from which to pull the auth params. | string<br/><small>Optional</small> |
 | triggerParameter | Trigger Parameter that uses the secret                 | string<br/><small>Optional</small> |
 
-<a id="ScaleRuleAuth_STATUS"></a>ScaleRuleAuth_STATUS
------------------------------------------------------
+ScaleRuleAuth_STATUS{#ScaleRuleAuth_STATUS}
+-------------------------------------------
 
 Auth Secrets for Scale Rule
 

--- a/docs/hugo/content/reference/appconfiguration/v1api20220501.md
+++ b/docs/hugo/content/reference/appconfiguration/v1api20220501.md
@@ -5,15 +5,15 @@ title: appconfiguration.azure.com/v1api20220501
 linktitle: v1api20220501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-05-01" |             |
 
-<a id="ConfigurationStore"></a>ConfigurationStore
--------------------------------------------------
+ConfigurationStore{#ConfigurationStore}
+---------------------------------------
 
 Generator information: - Generated from: /appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/appconfiguration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.AppConfiguration/configurationStores/{configStoreName}
 
@@ -26,7 +26,7 @@ Used by: [ConfigurationStoreList](#ConfigurationStoreList).
 | spec                                                                                    |             | [ConfigurationStore_Spec](#ConfigurationStore_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ConfigurationStore_STATUS](#ConfigurationStore_STATUS)<br/><small>Optional</small> |
 
-### <a id="ConfigurationStore_Spec"></a>ConfigurationStore_Spec
+### ConfigurationStore_Spec {#ConfigurationStore_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [ConfigurationStoreList](#ConfigurationStoreList).
 | systemData                | Resource system metadata.                                                                                                                                                                                                                                                                    | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags                      | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="ConfigurationStore_STATUS"></a>ConfigurationStore_STATUS
+### ConfigurationStore_STATUS{#ConfigurationStore_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,8 +69,8 @@ Used by: [ConfigurationStoreList](#ConfigurationStoreList).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ConfigurationStoreList"></a>ConfigurationStoreList
----------------------------------------------------------
+ConfigurationStoreList{#ConfigurationStoreList}
+-----------------------------------------------
 
 Generator information: - Generated from: /appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/appconfiguration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.AppConfiguration/configurationStores/{configStoreName}
 
@@ -80,8 +80,8 @@ Generator information: - Generated from: /appconfiguration/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ConfigurationStore[]](#ConfigurationStore)<br/><small>Optional</small> |
 
-<a id="ConfigurationStore_Spec"></a>ConfigurationStore_Spec
------------------------------------------------------------
+ConfigurationStore_Spec{#ConfigurationStore_Spec}
+-------------------------------------------------
 
 Used by: [ConfigurationStore](#ConfigurationStore).
 
@@ -102,8 +102,8 @@ Used by: [ConfigurationStore](#ConfigurationStore).
 | systemData                | Resource system metadata.                                                                                                                                                                                                                                                                    | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags                      | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ConfigurationStore_STATUS"></a>ConfigurationStore_STATUS
----------------------------------------------------------------
+ConfigurationStore_STATUS{#ConfigurationStore_STATUS}
+-----------------------------------------------------
 
 The configuration store along with all resource properties. The Configuration Store will have all information to begin utilizing it.
 
@@ -131,8 +131,8 @@ Used by: [ConfigurationStore](#ConfigurationStore).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ConfigurationStoreOperatorSpec"></a>ConfigurationStoreOperatorSpec
--------------------------------------------------------------------------
+ConfigurationStoreOperatorSpec{#ConfigurationStoreOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -144,8 +144,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ConfigurationStoreOperatorSecrets](#ConfigurationStoreOperatorSecrets)<br/><small>Optional</small>                                                                 |
 
-<a id="ConfigurationStoreProperties_CreateMode"></a>ConfigurationStoreProperties_CreateMode
--------------------------------------------------------------------------------------------
+ConfigurationStoreProperties_CreateMode{#ConfigurationStoreProperties_CreateMode}
+---------------------------------------------------------------------------------
 
 Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 
@@ -154,8 +154,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 | "Default" |             |
 | "Recover" |             |
 
-<a id="ConfigurationStoreProperties_CreateMode_STATUS"></a>ConfigurationStoreProperties_CreateMode_STATUS
----------------------------------------------------------------------------------------------------------
+ConfigurationStoreProperties_CreateMode_STATUS{#ConfigurationStoreProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 
@@ -164,8 +164,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 | "Default" |             |
 | "Recover" |             |
 
-<a id="ConfigurationStoreProperties_ProvisioningState_STATUS"></a>ConfigurationStoreProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------
+ConfigurationStoreProperties_ProvisioningState_STATUS{#ConfigurationStoreProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 
@@ -178,8 +178,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ConfigurationStoreProperties_PublicNetworkAccess"></a>ConfigurationStoreProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------------------------------
+ConfigurationStoreProperties_PublicNetworkAccess{#ConfigurationStoreProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 
@@ -188,8 +188,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ConfigurationStoreProperties_PublicNetworkAccess_STATUS"></a>ConfigurationStoreProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ConfigurationStoreProperties_PublicNetworkAccess_STATUS{#ConfigurationStoreProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 
@@ -198,8 +198,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EncryptionProperties"></a>EncryptionProperties
------------------------------------------------------
+EncryptionProperties{#EncryptionProperties}
+-------------------------------------------
 
 The encryption settings for a configuration store.
 
@@ -209,8 +209,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 |--------------------|-----------------------|-----------------------------------------------------------------------|
 | keyVaultProperties | Key vault properties. | [KeyVaultProperties](#KeyVaultProperties)<br/><small>Optional</small> |
 
-<a id="EncryptionProperties_STATUS"></a>EncryptionProperties_STATUS
--------------------------------------------------------------------
+EncryptionProperties_STATUS{#EncryptionProperties_STATUS}
+---------------------------------------------------------
 
 The encryption settings for a configuration store.
 
@@ -220,8 +220,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 |--------------------|-----------------------|-------------------------------------------------------------------------------------|
 | keyVaultProperties | Key vault properties. | [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnectionReference_STATUS"></a>PrivateEndpointConnectionReference_STATUS
------------------------------------------------------------------------------------------------
+PrivateEndpointConnectionReference_STATUS{#PrivateEndpointConnectionReference_STATUS}
+-------------------------------------------------------------------------------------
 
 A reference to a related private endpoint connection.
 
@@ -231,8 +231,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 |----------|------------------|------------------------------------|
 | id       | The resource ID. | string<br/><small>Optional</small> |
 
-<a id="ResourceIdentity"></a>ResourceIdentity
----------------------------------------------
+ResourceIdentity{#ResourceIdentity}
+-----------------------------------
 
 An identity that can be associated with a resource.
 
@@ -243,8 +243,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 | type                   | The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove any identities.                                                                                                                                                                                          | [ResourceIdentity_Type](#ResourceIdentity_Type)<br/><small>Optional</small>               |
 | userAssignedIdentities | The list of user-assigned identities associated with the resource. The user-assigned identity dictionary keys will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ResourceIdentity_STATUS"></a>ResourceIdentity_STATUS
------------------------------------------------------------
+ResourceIdentity_STATUS{#ResourceIdentity_STATUS}
+-------------------------------------------------
 
 An identity that can be associated with a resource.
 
@@ -257,8 +257,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 | type                   | The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove any identities.                                                                                                                                                                                          | [ResourceIdentity_Type_STATUS](#ResourceIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user-assigned identities associated with the resource. The user-assigned identity dictionary keys will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentity_STATUS](#UserIdentity_STATUS)<br/><small>Optional</small>        |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Describes a configuration store SKU.
 
@@ -268,8 +268,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 |----------|------------------------------------------|------------------------------------|
 | name     | The SKU name of the configuration store. | string<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Describes a configuration store SKU.
 
@@ -279,8 +279,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 |----------|------------------------------------------|------------------------------------|
 | name     | The SKU name of the configuration store. | string<br/><small>Optional</small> |
 
-<a id="SystemData"></a>SystemData
----------------------------------
+SystemData{#SystemData}
+-----------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -295,8 +295,8 @@ Used by: [ConfigurationStore_Spec](#ConfigurationStore_Spec).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                          |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType](#SystemData_LastModifiedByType)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -311,8 +311,8 @@ Used by: [ConfigurationStore_STATUS](#ConfigurationStore_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationStoreOperatorSecrets"></a>ConfigurationStoreOperatorSecrets
--------------------------------------------------------------------------------
+ConfigurationStoreOperatorSecrets{#ConfigurationStoreOperatorSecrets}
+---------------------------------------------------------------------
 
 Used by: [ConfigurationStoreOperatorSpec](#ConfigurationStoreOperatorSpec).
 
@@ -331,8 +331,8 @@ Used by: [ConfigurationStoreOperatorSpec](#ConfigurationStoreOperatorSpec).
 | secondaryReadOnlyKey              | indicates where the SecondaryReadOnlyKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryReadOnlyKeyID            | indicates where the SecondaryReadOnlyKeyID secret should be placed. If omitted, the secret will not be retrieved from Azure.            | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Settings concerning key vault encryption for a configuration store.
 
@@ -343,8 +343,8 @@ Used by: [EncryptionProperties](#EncryptionProperties).
 | identityClientId | The client id of the identity which will be used to access key vault. | string<br/><small>Optional</small> |
 | keyIdentifier    | The URI of the key vault key used to encrypt data.                    | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Settings concerning key vault encryption for a configuration store.
 
@@ -355,8 +355,8 @@ Used by: [EncryptionProperties_STATUS](#EncryptionProperties_STATUS).
 | identityClientId | The client id of the identity which will be used to access key vault. | string<br/><small>Optional</small> |
 | keyIdentifier    | The URI of the key vault key used to encrypt data.                    | string<br/><small>Optional</small> |
 
-<a id="ResourceIdentity_Type"></a>ResourceIdentity_Type
--------------------------------------------------------
+ResourceIdentity_Type{#ResourceIdentity_Type}
+---------------------------------------------
 
 Used by: [ResourceIdentity](#ResourceIdentity).
 
@@ -367,8 +367,8 @@ Used by: [ResourceIdentity](#ResourceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ResourceIdentity_Type_STATUS"></a>ResourceIdentity_Type_STATUS
----------------------------------------------------------------------
+ResourceIdentity_Type_STATUS{#ResourceIdentity_Type_STATUS}
+-----------------------------------------------------------
 
 Used by: [ResourceIdentity_STATUS](#ResourceIdentity_STATUS).
 
@@ -379,7 +379,31 @@ Used by: [ResourceIdentity_STATUS](#ResourceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="SystemData_CreatedByType"></a>SystemData_CreatedByType
+SystemData_CreatedByType{#SystemData_CreatedByType}
+---------------------------------------------------
+
+Used by: [SystemData](#SystemData).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType{#SystemData_LastModifiedByType}
 -------------------------------------------------------------
 
 Used by: [SystemData](#SystemData).
@@ -391,7 +415,7 @@ Used by: [SystemData](#SystemData).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -403,32 +427,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType"></a>SystemData_LastModifiedByType
------------------------------------------------------------------------
-
-Used by: [SystemData](#SystemData).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -438,8 +438,8 @@ Used by: [ResourceIdentity](#ResourceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentity_STATUS"></a>UserIdentity_STATUS
----------------------------------------------------
+UserIdentity_STATUS{#UserIdentity_STATUS}
+-----------------------------------------
 
 A resource identity that is managed by the user of the service.
 

--- a/docs/hugo/content/reference/authorization/v1api20200801preview.md
+++ b/docs/hugo/content/reference/authorization/v1api20200801preview.md
@@ -5,15 +5,15 @@ title: authorization.azure.com/v1api20200801preview
 linktitle: v1api20200801preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2020-08-01-preview" |             |
 
-<a id="RoleAssignment"></a>RoleAssignment
------------------------------------------
+RoleAssignment{#RoleAssignment}
+-------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/preview/2020-08-01-preview/authorization-RoleAssignmentsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}
 
@@ -26,7 +26,7 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | spec                                                                                    |             | [RoleAssignment_Spec](#RoleAssignment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RoleAssignment_STATUS](#RoleAssignment_STATUS)<br/><small>Optional</small> |
 
-### <a id="RoleAssignment_Spec"></a>RoleAssignment_Spec
+### RoleAssignment_Spec {#RoleAssignment_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | principalType                             | The principal type of the assigned principal ID.                                                                                                                                                                                                                                                             | [RoleAssignmentProperties_PrincipalType](#RoleAssignmentProperties_PrincipalType)<br/><small>Optional</small>                                                          |
 | roleDefinitionReference                   | The role definition ID.                                                                                                                                                                                                                                                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>             |
 
-### <a id="RoleAssignment_STATUS"></a>RoleAssignment_STATUS
+### RoleAssignment_STATUS{#RoleAssignment_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                     | Type                                                                                                                                                    |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,8 +63,8 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | updatedBy                          | Id of the user who updated the assignment                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn                          | Time it was updated                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoleAssignmentList"></a>RoleAssignmentList
--------------------------------------------------
+RoleAssignmentList{#RoleAssignmentList}
+---------------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/preview/2020-08-01-preview/authorization-RoleAssignmentsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}
 
@@ -74,8 +74,8 @@ Generator information: - Generated from: /authorization/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [RoleAssignment[]](#RoleAssignment)<br/><small>Optional</small> |
 
-<a id="RoleAssignment_Spec"></a>RoleAssignment_Spec
----------------------------------------------------
+RoleAssignment_Spec{#RoleAssignment_Spec}
+-----------------------------------------
 
 Used by: [RoleAssignment](#RoleAssignment).
 
@@ -93,8 +93,8 @@ Used by: [RoleAssignment](#RoleAssignment).
 | principalType                             | The principal type of the assigned principal ID.                                                                                                                                                                                                                                                             | [RoleAssignmentProperties_PrincipalType](#RoleAssignmentProperties_PrincipalType)<br/><small>Optional</small>                                                          |
 | roleDefinitionReference                   | The role definition ID.                                                                                                                                                                                                                                                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>             |
 
-<a id="RoleAssignment_STATUS"></a>RoleAssignment_STATUS
--------------------------------------------------------
+RoleAssignment_STATUS{#RoleAssignment_STATUS}
+---------------------------------------------
 
 Role Assignments
 
@@ -119,8 +119,8 @@ Used by: [RoleAssignment](#RoleAssignment).
 | updatedBy                          | Id of the user who updated the assignment                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn                          | Time it was updated                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoleAssignmentOperatorSpec"></a>RoleAssignmentOperatorSpec
------------------------------------------------------------------
+RoleAssignmentOperatorSpec{#RoleAssignmentOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -132,8 +132,8 @@ Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 | namingConvention     | The uuid generation technique to use for any role without an explicit AzureName. One of 'stable' or 'random'. | string<br/><small>Optional</small>                                                                                                                                  |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).                    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RoleAssignmentProperties_PrincipalType"></a>RoleAssignmentProperties_PrincipalType
------------------------------------------------------------------------------------------
+RoleAssignmentProperties_PrincipalType{#RoleAssignmentProperties_PrincipalType}
+-------------------------------------------------------------------------------
 
 Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 
@@ -144,8 +144,8 @@ Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 | "ServicePrincipal" |             |
 | "User"             |             |
 
-<a id="RoleAssignmentProperties_PrincipalType_STATUS"></a>RoleAssignmentProperties_PrincipalType_STATUS
--------------------------------------------------------------------------------------------------------
+RoleAssignmentProperties_PrincipalType_STATUS{#RoleAssignmentProperties_PrincipalType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [RoleAssignment_STATUS](#RoleAssignment_STATUS).
 

--- a/docs/hugo/content/reference/authorization/v1api20220401.md
+++ b/docs/hugo/content/reference/authorization/v1api20220401.md
@@ -5,15 +5,15 @@ title: authorization.azure.com/v1api20220401
 linktitle: v1api20220401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-04-01" |             |
 
-<a id="RoleAssignment"></a>RoleAssignment
------------------------------------------
+RoleAssignment{#RoleAssignment}
+-------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}
 
@@ -26,7 +26,7 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | spec                                                                                    |             | [RoleAssignment_Spec](#RoleAssignment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RoleAssignment_STATUS](#RoleAssignment_STATUS)<br/><small>Optional</small> |
 
-### <a id="RoleAssignment_Spec"></a>RoleAssignment_Spec
+### RoleAssignment_Spec {#RoleAssignment_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | principalType                             | The principal type of the assigned principal ID.                                                                                                                                                                                                                                                             | [RoleAssignmentProperties_PrincipalType](#RoleAssignmentProperties_PrincipalType)<br/><small>Optional</small>                                                          |
 | roleDefinitionReference                   | The role definition ID.                                                                                                                                                                                                                                                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>             |
 
-### <a id="RoleAssignment_STATUS"></a>RoleAssignment_STATUS
+### RoleAssignment_STATUS{#RoleAssignment_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                     | Type                                                                                                                                                    |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,8 +63,8 @@ Used by: [RoleAssignmentList](#RoleAssignmentList).
 | updatedBy                          | Id of the user who updated the assignment                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn                          | Time it was updated                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoleAssignmentList"></a>RoleAssignmentList
--------------------------------------------------
+RoleAssignmentList{#RoleAssignmentList}
+---------------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}
 
@@ -74,8 +74,8 @@ Generator information: - Generated from: /authorization/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [RoleAssignment[]](#RoleAssignment)<br/><small>Optional</small> |
 
-<a id="RoleDefinition"></a>RoleDefinition
------------------------------------------
+RoleDefinition{#RoleDefinition}
+-------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/stable/2022-04-01/authorization-RoleDefinitionsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}
 
@@ -88,7 +88,7 @@ Used by: [RoleDefinitionList](#RoleDefinitionList).
 | spec                                                                                    |             | [RoleDefinition_Spec](#RoleDefinition_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RoleDefinition_STATUS](#RoleDefinition_STATUS)<br/><small>Optional</small> |
 
-### <a id="RoleDefinition_Spec"></a>RoleDefinition_Spec
+### RoleDefinition_Spec {#RoleDefinition_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,7 +101,7 @@ Used by: [RoleDefinitionList](#RoleDefinitionList).
 | roleName                   | The role name.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                     |
 | type                       | The role type.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="RoleDefinition_STATUS"></a>RoleDefinition_STATUS
+### RoleDefinition_STATUS{#RoleDefinition_STATUS}
 
 | Property         | Description                               | Type                                                                                                                                                    |
 |------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -119,8 +119,8 @@ Used by: [RoleDefinitionList](#RoleDefinitionList).
 | updatedBy        | Id of the user who updated the assignment | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn        | Time it was updated                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoleDefinitionList"></a>RoleDefinitionList
--------------------------------------------------
+RoleDefinitionList{#RoleDefinitionList}
+---------------------------------------
 
 Generator information: - Generated from: /authorization/resource-manager/Microsoft.Authorization/stable/2022-04-01/authorization-RoleDefinitionsCalls.json - ARM URI: /{scope}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}
 
@@ -130,8 +130,8 @@ Generator information: - Generated from: /authorization/resource-manager/Microso
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [RoleDefinition[]](#RoleDefinition)<br/><small>Optional</small> |
 
-<a id="RoleAssignment_Spec"></a>RoleAssignment_Spec
----------------------------------------------------
+RoleAssignment_Spec{#RoleAssignment_Spec}
+-----------------------------------------
 
 Used by: [RoleAssignment](#RoleAssignment).
 
@@ -149,8 +149,8 @@ Used by: [RoleAssignment](#RoleAssignment).
 | principalType                             | The principal type of the assigned principal ID.                                                                                                                                                                                                                                                             | [RoleAssignmentProperties_PrincipalType](#RoleAssignmentProperties_PrincipalType)<br/><small>Optional</small>                                                          |
 | roleDefinitionReference                   | The role definition ID.                                                                                                                                                                                                                                                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>             |
 
-<a id="RoleAssignment_STATUS"></a>RoleAssignment_STATUS
--------------------------------------------------------
+RoleAssignment_STATUS{#RoleAssignment_STATUS}
+---------------------------------------------
 
 Role Assignments
 
@@ -175,8 +175,8 @@ Used by: [RoleAssignment](#RoleAssignment).
 | updatedBy                          | Id of the user who updated the assignment                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn                          | Time it was updated                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoleDefinition_Spec"></a>RoleDefinition_Spec
----------------------------------------------------
+RoleDefinition_Spec{#RoleDefinition_Spec}
+-----------------------------------------
 
 Used by: [RoleDefinition](#RoleDefinition).
 
@@ -191,8 +191,8 @@ Used by: [RoleDefinition](#RoleDefinition).
 | roleName                   | The role name.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                     |
 | type                       | The role type.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="RoleDefinition_STATUS"></a>RoleDefinition_STATUS
--------------------------------------------------------
+RoleDefinition_STATUS{#RoleDefinition_STATUS}
+---------------------------------------------
 
 Role definition.
 
@@ -214,8 +214,8 @@ Used by: [RoleDefinition](#RoleDefinition).
 | updatedBy        | Id of the user who updated the assignment | string<br/><small>Optional</small>                                                                                                                      |
 | updatedOn        | Time it was updated                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Permission"></a>Permission
----------------------------------
+Permission{#Permission}
+-----------------------
 
 Role definition permissions.
 
@@ -228,8 +228,8 @@ Used by: [RoleDefinition_Spec](#RoleDefinition_Spec).
 | notActions     | Denied actions.       | string[]<br/><small>Optional</small> |
 | notDataActions | Denied Data actions.  | string[]<br/><small>Optional</small> |
 
-<a id="Permission_STATUS"></a>Permission_STATUS
------------------------------------------------
+Permission_STATUS{#Permission_STATUS}
+-------------------------------------
 
 Role definition permissions.
 
@@ -242,8 +242,8 @@ Used by: [RoleDefinition_STATUS](#RoleDefinition_STATUS).
 | notActions     | Denied actions.       | string[]<br/><small>Optional</small> |
 | notDataActions | Denied Data actions.  | string[]<br/><small>Optional</small> |
 
-<a id="RoleAssignmentOperatorSpec"></a>RoleAssignmentOperatorSpec
------------------------------------------------------------------
+RoleAssignmentOperatorSpec{#RoleAssignmentOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -255,8 +255,8 @@ Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 | namingConvention     | The uuid generation technique to use for any role without an explicit AzureName. One of 'stable' or 'random'. | string<br/><small>Optional</small>                                                                                                                                  |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).                    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RoleAssignmentProperties_PrincipalType"></a>RoleAssignmentProperties_PrincipalType
------------------------------------------------------------------------------------------
+RoleAssignmentProperties_PrincipalType{#RoleAssignmentProperties_PrincipalType}
+-------------------------------------------------------------------------------
 
 Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 
@@ -268,8 +268,8 @@ Used by: [RoleAssignment_Spec](#RoleAssignment_Spec).
 | "ServicePrincipal" |             |
 | "User"             |             |
 
-<a id="RoleAssignmentProperties_PrincipalType_STATUS"></a>RoleAssignmentProperties_PrincipalType_STATUS
--------------------------------------------------------------------------------------------------------
+RoleAssignmentProperties_PrincipalType_STATUS{#RoleAssignmentProperties_PrincipalType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [RoleAssignment_STATUS](#RoleAssignment_STATUS).
 
@@ -281,8 +281,8 @@ Used by: [RoleAssignment_STATUS](#RoleAssignment_STATUS).
 | "ServicePrincipal" |             |
 | "User"             |             |
 
-<a id="RoleDefinitionOperatorSpec"></a>RoleDefinitionOperatorSpec
------------------------------------------------------------------
+RoleDefinitionOperatorSpec{#RoleDefinitionOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 

--- a/docs/hugo/content/reference/batch/v1api20210101.md
+++ b/docs/hugo/content/reference/batch/v1api20210101.md
@@ -5,15 +5,15 @@ title: batch.azure.com/v1api20210101
 linktitle: v1api20210101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-01-01" |             |
 
-<a id="BatchAccount"></a>BatchAccount
--------------------------------------
+BatchAccount{#BatchAccount}
+---------------------------
 
 Generator information: - Generated from: /batch/resource-manager/Microsoft.Batch/stable/2021-01-01/BatchManagement.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Batch/batchAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [BatchAccountList](#BatchAccountList).
 | spec                                                                                    |             | [BatchAccount_Spec](#BatchAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BatchAccount_STATUS](#BatchAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="BatchAccount_Spec"></a>BatchAccount_Spec
+### BatchAccount_Spec {#BatchAccount_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [BatchAccountList](#BatchAccountList).
 | publicNetworkAccess | If not specified, the default value is 'enabled'.                                                                                                                                                                                                                                                      | [PublicNetworkAccessType](#PublicNetworkAccessType)<br/><small>Optional</small>                                                                                      |
 | tags                | The user-specified tags associated with the account.                                                                                                                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="BatchAccount_STATUS"></a>BatchAccount_STATUS
+### BatchAccount_STATUS{#BatchAccount_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -68,8 +68,8 @@ Used by: [BatchAccountList](#BatchAccountList).
 | tags                                  | The tags of the resource.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BatchAccountList"></a>BatchAccountList
----------------------------------------------
+BatchAccountList{#BatchAccountList}
+-----------------------------------
 
 Generator information: - Generated from: /batch/resource-manager/Microsoft.Batch/stable/2021-01-01/BatchManagement.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Batch/batchAccounts/{accountName}
 
@@ -79,8 +79,8 @@ Generator information: - Generated from: /batch/resource-manager/Microsoft.Batch
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [BatchAccount[]](#BatchAccount)<br/><small>Optional</small> |
 
-<a id="BatchAccount_Spec"></a>BatchAccount_Spec
------------------------------------------------
+BatchAccount_Spec{#BatchAccount_Spec}
+-------------------------------------
 
 Used by: [BatchAccount](#BatchAccount).
 
@@ -98,8 +98,8 @@ Used by: [BatchAccount](#BatchAccount).
 | publicNetworkAccess | If not specified, the default value is 'enabled'.                                                                                                                                                                                                                                                      | [PublicNetworkAccessType](#PublicNetworkAccessType)<br/><small>Optional</small>                                                                                      |
 | tags                | The user-specified tags associated with the account.                                                                                                                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="BatchAccount_STATUS"></a>BatchAccount_STATUS
----------------------------------------------------
+BatchAccount_STATUS{#BatchAccount_STATUS}
+-----------------------------------------
 
 Contains information about an Azure Batch account.
 
@@ -129,8 +129,8 @@ Used by: [BatchAccount](#BatchAccount).
 | tags                                  | The tags of the resource.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AutoStorageBaseProperties"></a>AutoStorageBaseProperties
----------------------------------------------------------------
+AutoStorageBaseProperties{#AutoStorageBaseProperties}
+-----------------------------------------------------
 
 The properties related to the auto-storage account.
 
@@ -140,8 +140,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 |-------------------------|-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | storageAccountReference | The resource ID of the storage account to be used for auto-storage account. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="AutoStorageProperties_STATUS"></a>AutoStorageProperties_STATUS
----------------------------------------------------------------------
+AutoStorageProperties_STATUS{#AutoStorageProperties_STATUS}
+-----------------------------------------------------------
 
 Contains information about the auto-storage account associated with a Batch account.
 
@@ -152,8 +152,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | lastKeySync      | The UTC time at which storage keys were last synchronized with the Batch account. | string<br/><small>Optional</small> |
 | storageAccountId | The resource ID of the storage account to be used for auto-storage account.       | string<br/><small>Optional</small> |
 
-<a id="BatchAccountIdentity"></a>BatchAccountIdentity
------------------------------------------------------
+BatchAccountIdentity{#BatchAccountIdentity}
+-------------------------------------------
 
 The identity of the Batch account, if configured. This is only used when the user specifies 'Microsoft.KeyVault' as their Batch account encryption configuration.
 
@@ -164,8 +164,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | type                   | The type of identity used for the Batch account.                                                                                                                                                                                                                                                                                                                                                 | [BatchAccountIdentity_Type](#BatchAccountIdentity_Type)<br/><small>Required</small>       |
 | userAssignedIdentities | The list of user identities associated with the Batch account. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="BatchAccountIdentity_STATUS"></a>BatchAccountIdentity_STATUS
--------------------------------------------------------------------
+BatchAccountIdentity_STATUS{#BatchAccountIdentity_STATUS}
+---------------------------------------------------------
 
 The identity of the Batch account, if configured. This is only used when the user specifies 'Microsoft.KeyVault' as their Batch account encryption configuration.
 
@@ -178,8 +178,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | type                   | The type of identity used for the Batch account.                                                                                                                                                                                                                                                                                                                                                 | [BatchAccountIdentity_Type_STATUS](#BatchAccountIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the Batch account. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]BatchAccountIdentity_UserAssignedIdentities_STATUS](#BatchAccountIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="BatchAccountOperatorSpec"></a>BatchAccountOperatorSpec
--------------------------------------------------------------
+BatchAccountOperatorSpec{#BatchAccountOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -190,8 +190,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BatchAccountProperties_ProvisioningState_STATUS"></a>BatchAccountProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------
+BatchAccountProperties_ProvisioningState_STATUS{#BatchAccountProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 
@@ -204,8 +204,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | "Invalid"   |             |
 | "Succeeded" |             |
 
-<a id="EncryptionProperties"></a>EncryptionProperties
------------------------------------------------------
+EncryptionProperties{#EncryptionProperties}
+-------------------------------------------
 
 Configures how customer data is encrypted inside the Batch account. By default, accounts are encrypted using a Microsoft managed key. For additional control, a customer-managed key can be used instead.
 
@@ -216,8 +216,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | keySource          | Type of the key source.                          | [EncryptionProperties_KeySource](#EncryptionProperties_KeySource)<br/><small>Optional</small> |
 | keyVaultProperties | Additional details when using Microsoft.KeyVault | [KeyVaultProperties](#KeyVaultProperties)<br/><small>Optional</small>                         |
 
-<a id="EncryptionProperties_STATUS"></a>EncryptionProperties_STATUS
--------------------------------------------------------------------
+EncryptionProperties_STATUS{#EncryptionProperties_STATUS}
+---------------------------------------------------------
 
 Configures how customer data is encrypted inside the Batch account. By default, accounts are encrypted using a Microsoft managed key. For additional control, a customer-managed key can be used instead.
 
@@ -228,8 +228,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | keySource          | Type of the key source.                          | [EncryptionProperties_KeySource_STATUS](#EncryptionProperties_KeySource_STATUS)<br/><small>Optional</small> |
 | keyVaultProperties | Additional details when using Microsoft.KeyVault | [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS)<br/><small>Optional</small>                         |
 
-<a id="KeyVaultReference"></a>KeyVaultReference
------------------------------------------------
+KeyVaultReference{#KeyVaultReference}
+-------------------------------------
 
 Identifies the Azure key vault associated with a Batch account.
 
@@ -240,8 +240,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | reference | The resource ID of the Azure key vault associated with the Batch account. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 | url       | The URL of the Azure key vault associated with the Batch account.         | string<br/><small>Required</small>                                                                                                                         |
 
-<a id="KeyVaultReference_STATUS"></a>KeyVaultReference_STATUS
--------------------------------------------------------------
+KeyVaultReference_STATUS{#KeyVaultReference_STATUS}
+---------------------------------------------------
 
 Identifies the Azure key vault associated with a Batch account.
 
@@ -252,8 +252,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | id       | The resource ID of the Azure key vault associated with the Batch account. | string<br/><small>Optional</small> |
 | url      | The URL of the Azure key vault associated with the Batch account.         | string<br/><small>Optional</small> |
 
-<a id="PoolAllocationMode"></a>PoolAllocationMode
--------------------------------------------------
+PoolAllocationMode{#PoolAllocationMode}
+---------------------------------------
 
 The allocation mode for creating pools in the Batch account.
 
@@ -264,8 +264,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | "BatchService"     |             |
 | "UserSubscription" |             |
 
-<a id="PoolAllocationMode_STATUS"></a>PoolAllocationMode_STATUS
----------------------------------------------------------------
+PoolAllocationMode_STATUS{#PoolAllocationMode_STATUS}
+-----------------------------------------------------
 
 The allocation mode for creating pools in the Batch account.
 
@@ -276,8 +276,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | "BatchService"     |             |
 | "UserSubscription" |             |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Contains information about a private link resource.
 
@@ -287,8 +287,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 |----------|-------------------------|------------------------------------|
 | id       | The ID of the resource. | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccessType"></a>PublicNetworkAccessType
------------------------------------------------------------
+PublicNetworkAccessType{#PublicNetworkAccessType}
+-------------------------------------------------
 
 The network access type for operating on the resources in the Batch account.
 
@@ -299,8 +299,8 @@ Used by: [BatchAccount_Spec](#BatchAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PublicNetworkAccessType_STATUS"></a>PublicNetworkAccessType_STATUS
--------------------------------------------------------------------------
+PublicNetworkAccessType_STATUS{#PublicNetworkAccessType_STATUS}
+---------------------------------------------------------------
 
 The network access type for operating on the resources in the Batch account.
 
@@ -311,8 +311,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="VirtualMachineFamilyCoreQuota_STATUS"></a>VirtualMachineFamilyCoreQuota_STATUS
--------------------------------------------------------------------------------------
+VirtualMachineFamilyCoreQuota_STATUS{#VirtualMachineFamilyCoreQuota_STATUS}
+---------------------------------------------------------------------------
 
 A VM Family and its associated core quota for the Batch account.
 
@@ -323,8 +323,8 @@ Used by: [BatchAccount_STATUS](#BatchAccount_STATUS).
 | coreQuota | The core quota for the VM family for the Batch account. | int<br/><small>Optional</small>    |
 | name      | The Virtual Machine family name.                        | string<br/><small>Optional</small> |
 
-<a id="BatchAccountIdentity_Type"></a>BatchAccountIdentity_Type
----------------------------------------------------------------
+BatchAccountIdentity_Type{#BatchAccountIdentity_Type}
+-----------------------------------------------------
 
 Used by: [BatchAccountIdentity](#BatchAccountIdentity).
 
@@ -334,8 +334,8 @@ Used by: [BatchAccountIdentity](#BatchAccountIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="BatchAccountIdentity_Type_STATUS"></a>BatchAccountIdentity_Type_STATUS
------------------------------------------------------------------------------
+BatchAccountIdentity_Type_STATUS{#BatchAccountIdentity_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [BatchAccountIdentity_STATUS](#BatchAccountIdentity_STATUS).
 
@@ -345,8 +345,8 @@ Used by: [BatchAccountIdentity_STATUS](#BatchAccountIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="BatchAccountIdentity_UserAssignedIdentities_STATUS"></a>BatchAccountIdentity_UserAssignedIdentities_STATUS
------------------------------------------------------------------------------------------------------------------
+BatchAccountIdentity_UserAssignedIdentities_STATUS{#BatchAccountIdentity_UserAssignedIdentities_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [BatchAccountIdentity_STATUS](#BatchAccountIdentity_STATUS).
 
@@ -355,40 +355,40 @@ Used by: [BatchAccountIdentity_STATUS](#BatchAccountIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="EncryptionProperties_KeySource"></a>EncryptionProperties_KeySource
--------------------------------------------------------------------------
-
-Used by: [EncryptionProperties](#EncryptionProperties).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Microsoft.Batch"    |             |
-| "Microsoft.KeyVault" |             |
-
-<a id="EncryptionProperties_KeySource_STATUS"></a>EncryptionProperties_KeySource_STATUS
----------------------------------------------------------------------------------------
-
-Used by: [EncryptionProperties_STATUS](#EncryptionProperties_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Microsoft.Batch"    |             |
-| "Microsoft.KeyVault" |             |
-
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
-
-KeyVault configuration when using an encryption KeySource of Microsoft.KeyVault.
-
-Used by: [EncryptionProperties](#EncryptionProperties).
-
-| Property      | Description                                                                                                                                                                                                                                                                                                                                                                      | Type                               |
-|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| keyIdentifier | Full path to the versioned secret. Example https://mykeyvault.vault.azure.net/keys/testkey/6e34a81fef704045975661e297a4c053. To be usable the following prerequisites must be met: The Batch Account has a System Assigned identity The account identity has been granted Key/Get, Key/Unwrap and Key/Wrap permissions The KeyVault has soft-delete and purge protection enabled | string<br/><small>Optional</small> |
-
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
+EncryptionProperties_KeySource{#EncryptionProperties_KeySource}
 ---------------------------------------------------------------
 
+Used by: [EncryptionProperties](#EncryptionProperties).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Microsoft.Batch"    |             |
+| "Microsoft.KeyVault" |             |
+
+EncryptionProperties_KeySource_STATUS{#EncryptionProperties_KeySource_STATUS}
+-----------------------------------------------------------------------------
+
+Used by: [EncryptionProperties_STATUS](#EncryptionProperties_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Microsoft.Batch"    |             |
+| "Microsoft.KeyVault" |             |
+
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
+
+KeyVault configuration when using an encryption KeySource of Microsoft.KeyVault.
+
+Used by: [EncryptionProperties](#EncryptionProperties).
+
+| Property      | Description                                                                                                                                                                                                                                                                                                                                                                      | Type                               |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| keyIdentifier | Full path to the versioned secret. Example https://mykeyvault.vault.azure.net/keys/testkey/6e34a81fef704045975661e297a4c053. To be usable the following prerequisites must be met: The Batch Account has a System Assigned identity The account identity has been granted Key/Get, Key/Unwrap and Key/Wrap permissions The KeyVault has soft-delete and purge protection enabled | string<br/><small>Optional</small> |
+
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
+
 KeyVault configuration when using an encryption KeySource of Microsoft.KeyVault.
 
 Used by: [EncryptionProperties_STATUS](#EncryptionProperties_STATUS).
@@ -397,8 +397,8 @@ Used by: [EncryptionProperties_STATUS](#EncryptionProperties_STATUS).
 |---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyIdentifier | Full path to the versioned secret. Example https://mykeyvault.vault.azure.net/keys/testkey/6e34a81fef704045975661e297a4c053. To be usable the following prerequisites must be met: The Batch Account has a System Assigned identity The account identity has been granted Key/Get, Key/Unwrap and Key/Wrap permissions The KeyVault has soft-delete and purge protection enabled | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/cache/v1api20201201.md
+++ b/docs/hugo/content/reference/cache/v1api20201201.md
@@ -5,15 +5,15 @@ title: cache.azure.com/v1api20201201
 linktitle: v1api20201201
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-12-01" |             |
 
-<a id="Redis"></a>Redis
------------------------
+Redis{#Redis}
+-------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -26,7 +26,7 @@ Used by: [RedisList](#RedisList).
 | spec                                                                                    |             | [Redis_Spec](#Redis_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Redis_STATUS](#Redis_STATUS)<br/><small>Optional</small> |
 
-### <a id="Redis_Spec"></a>Redis_Spec
+### Redis_Spec {#Redis_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,7 +49,7 @@ Used by: [RedisList](#RedisList).
 | tenantSettings      | A dictionary of tenant settings                                                                                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Redis_STATUS"></a>Redis_STATUS
+### Redis_STATUS{#Redis_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -80,8 +80,8 @@ Used by: [RedisList](#RedisList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule"></a>RedisFirewallRule
------------------------------------------------
+RedisFirewallRule{#RedisFirewallRule}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -94,7 +94,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | spec                                                                                    |             | [RedisFirewallRule_Spec](#RedisFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisFirewallRule_STATUS](#RedisFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
+### RedisFirewallRule_Spec {#RedisFirewallRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -104,7 +104,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
+### RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -115,8 +115,8 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisFirewallRuleList"></a>RedisFirewallRuleList
--------------------------------------------------------
+RedisFirewallRuleList{#RedisFirewallRuleList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -126,8 +126,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisFirewallRule[]](#RedisFirewallRule)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer"></a>RedisLinkedServer
------------------------------------------------
+RedisLinkedServer{#RedisLinkedServer}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -140,7 +140,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | spec                                                                                    |             | [RedisLinkedServer_Spec](#RedisLinkedServer_Spec)<br/><small>Optional</small>       |
 | status                                                                                  |             | [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
+### RedisLinkedServer_Spec {#RedisLinkedServer_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -151,7 +151,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-### <a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
+### Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -164,8 +164,8 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | serverRole               | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServerList"></a>RedisLinkedServerList
--------------------------------------------------------
+RedisLinkedServerList{#RedisLinkedServerList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -175,8 +175,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisLinkedServer[]](#RedisLinkedServer)<br/><small>Optional</small> |
 
-<a id="RedisList"></a>RedisList
--------------------------------
+RedisList{#RedisList}
+---------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -186,8 +186,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Redis[]](#Redis)<br/><small>Optional</small> |
 
-<a id="RedisPatchSchedule"></a>RedisPatchSchedule
--------------------------------------------------
+RedisPatchSchedule{#RedisPatchSchedule}
+---------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -200,7 +200,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | spec                                                                                    |             | [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
+### RedisPatchSchedule_Spec {#RedisPatchSchedule_Spec}
 
 | Property        | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -208,7 +208,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-### <a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
+### RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
 
 | Property        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -219,8 +219,8 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisPatchScheduleList"></a>RedisPatchScheduleList
----------------------------------------------------------
+RedisPatchScheduleList{#RedisPatchScheduleList}
+-----------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -230,8 +230,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [RedisPatchSchedule[]](#RedisPatchSchedule)<br/><small>Optional</small> |
 
-<a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
----------------------------------------------------------------
+Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -246,8 +246,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | serverRole               | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Redis_Spec"></a>Redis_Spec
----------------------------------
+Redis_Spec{#Redis_Spec}
+-----------------------
 
 Used by: [Redis](#Redis).
 
@@ -272,8 +272,8 @@ Used by: [Redis](#Redis).
 | tenantSettings      | A dictionary of tenant settings                                                                                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Redis_STATUS"></a>Redis_STATUS
--------------------------------------
+Redis_STATUS{#Redis_STATUS}
+---------------------------
 
 Used by: [Redis](#Redis).
 
@@ -306,8 +306,8 @@ Used by: [Redis](#Redis).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
----------------------------------------------------------
+RedisFirewallRule_Spec{#RedisFirewallRule_Spec}
+-----------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -319,8 +319,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
--------------------------------------------------------------
+RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
+---------------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -333,8 +333,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
----------------------------------------------------------
+RedisLinkedServer_Spec{#RedisLinkedServer_Spec}
+-----------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -347,8 +347,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-<a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
------------------------------------------------------------
+RedisPatchSchedule_Spec{#RedisPatchSchedule_Spec}
+-------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -358,8 +358,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-<a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
----------------------------------------------------------------
+RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -372,8 +372,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -383,8 +383,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RedisCreateProperties_MinimumTlsVersion"></a>RedisCreateProperties_MinimumTlsVersion
--------------------------------------------------------------------------------------------
+RedisCreateProperties_MinimumTlsVersion{#RedisCreateProperties_MinimumTlsVersion}
+---------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -394,8 +394,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisCreateProperties_PublicNetworkAccess"></a>RedisCreateProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------
+RedisCreateProperties_PublicNetworkAccess{#RedisCreateProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -404,8 +404,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisCreateProperties_RedisConfiguration"></a>RedisCreateProperties_RedisConfiguration
----------------------------------------------------------------------------------------------
+RedisCreateProperties_RedisConfiguration{#RedisCreateProperties_RedisConfiguration}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -425,8 +425,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | rdb-backup-max-snapshot-count   | Specifies the maximum number of snapshots for rdb backup                                                                   | string<br/><small>Optional</small>            |
 | rdb-storage-connection-string   | The storage account connection string for storing rdb file                                                                 | string<br/><small>Optional</small>            |
 
-<a id="RedisFirewallRuleOperatorSpec"></a>RedisFirewallRuleOperatorSpec
------------------------------------------------------------------------
+RedisFirewallRuleOperatorSpec{#RedisFirewallRuleOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -437,8 +437,8 @@ Used by: [RedisFirewallRule_Spec](#RedisFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisInstanceDetails_STATUS"></a>RedisInstanceDetails_STATUS
--------------------------------------------------------------------
+RedisInstanceDetails_STATUS{#RedisInstanceDetails_STATUS}
+---------------------------------------------------------
 
 Details of single instance of redis.
 
@@ -453,8 +453,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | sslPort    | Redis instance SSL port.                                                                          | int<br/><small>Optional</small>    |
 | zone       | If the Cache uses availability zones, specifies availability zone where this instance is located. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer_STATUS"></a>RedisLinkedServer_STATUS
--------------------------------------------------------------
+RedisLinkedServer_STATUS{#RedisLinkedServer_STATUS}
+---------------------------------------------------
 
 Linked server Id
 
@@ -464,8 +464,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|-------------------|------------------------------------|
 | id       | Linked server Id. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerCreateProperties_ServerRole"></a>RedisLinkedServerCreateProperties_ServerRole
------------------------------------------------------------------------------------------------------
+RedisLinkedServerCreateProperties_ServerRole{#RedisLinkedServerCreateProperties_ServerRole}
+-------------------------------------------------------------------------------------------
 
 Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 
@@ -474,8 +474,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisLinkedServerOperatorSpec"></a>RedisLinkedServerOperatorSpec
------------------------------------------------------------------------
+RedisLinkedServerOperatorSpec{#RedisLinkedServerOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -486,8 +486,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerProperties_ServerRole_STATUS"></a>RedisLinkedServerProperties_ServerRole_STATUS
--------------------------------------------------------------------------------------------------------
+RedisLinkedServerProperties_ServerRole_STATUS{#RedisLinkedServerProperties_ServerRole_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 
@@ -496,8 +496,8 @@ Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisOperatorSpec"></a>RedisOperatorSpec
------------------------------------------------
+RedisOperatorSpec{#RedisOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -509,8 +509,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [RedisOperatorSecrets](#RedisOperatorSecrets)<br/><small>Optional</small>                                                                                           |
 
-<a id="RedisPatchScheduleOperatorSpec"></a>RedisPatchScheduleOperatorSpec
--------------------------------------------------------------------------
+RedisPatchScheduleOperatorSpec{#RedisPatchScheduleOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -521,8 +521,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisProperties_MinimumTlsVersion_STATUS"></a>RedisProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_MinimumTlsVersion_STATUS{#RedisProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -532,8 +532,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisProperties_ProvisioningState_STATUS"></a>RedisProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_ProvisioningState_STATUS{#RedisProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -552,8 +552,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Unprovisioning"         |             |
 | "Updating"               |             |
 
-<a id="RedisProperties_PublicNetworkAccess_STATUS"></a>RedisProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------
+RedisProperties_PublicNetworkAccess_STATUS{#RedisProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -562,8 +562,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisProperties_RedisConfiguration_STATUS"></a>RedisProperties_RedisConfiguration_STATUS
------------------------------------------------------------------------------------------------
+RedisProperties_RedisConfiguration_STATUS{#RedisProperties_RedisConfiguration_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -585,8 +585,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | rdb-storage-connection-string   | The storage account connection string for storing rdb file                                                                 | string<br/><small>Optional</small>            |
 | zonal-configuration             | Zonal Configuration                                                                                                        | string<br/><small>Optional</small>            |
 
-<a id="ScheduleEntry"></a>ScheduleEntry
----------------------------------------
+ScheduleEntry{#ScheduleEntry}
+-----------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -598,8 +598,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                              |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Required</small>                                                 |
 
-<a id="ScheduleEntry_STATUS"></a>ScheduleEntry_STATUS
------------------------------------------------------
+ScheduleEntry_STATUS{#ScheduleEntry_STATUS}
+-------------------------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -611,8 +611,8 @@ Used by: [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                                            |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Optional</small>                                                               |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -624,8 +624,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family](#Sku_Family)<br/><small>Required</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name](#Sku_Name)<br/><small>Required</small>     |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -637,8 +637,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family_STATUS](#Sku_Family_STATUS)<br/><small>Optional</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small>     |
 
-<a id="RedisOperatorSecrets"></a>RedisOperatorSecrets
------------------------------------------------------
+RedisOperatorSecrets{#RedisOperatorSecrets}
+-------------------------------------------
 
 Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 
@@ -650,8 +650,8 @@ Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 | secondaryKey | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | sslPort      | indicates where the SSLPort secret should be placed. If omitted, the secret will not be retrieved from Azure.      | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ScheduleEntry_DayOfWeek"></a>ScheduleEntry_DayOfWeek
------------------------------------------------------------
+ScheduleEntry_DayOfWeek{#ScheduleEntry_DayOfWeek}
+-------------------------------------------------
 
 Used by: [ScheduleEntry](#ScheduleEntry).
 
@@ -667,8 +667,8 @@ Used by: [ScheduleEntry](#ScheduleEntry).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="ScheduleEntry_DayOfWeek_STATUS"></a>ScheduleEntry_DayOfWeek_STATUS
--------------------------------------------------------------------------
+ScheduleEntry_DayOfWeek_STATUS{#ScheduleEntry_DayOfWeek_STATUS}
+---------------------------------------------------------------
 
 Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 
@@ -684,8 +684,8 @@ Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="Sku_Family"></a>Sku_Family
----------------------------------
+Sku_Family{#Sku_Family}
+-----------------------
 
 Used by: [Sku](#Sku).
 
@@ -694,8 +694,8 @@ Used by: [Sku](#Sku).
 | "C"   |             |
 | "P"   |             |
 
-<a id="Sku_Family_STATUS"></a>Sku_Family_STATUS
------------------------------------------------
+Sku_Family_STATUS{#Sku_Family_STATUS}
+-------------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -704,8 +704,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "C"   |             |
 | "P"   |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -715,8 +715,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 

--- a/docs/hugo/content/reference/cache/v1api20210301.md
+++ b/docs/hugo/content/reference/cache/v1api20210301.md
@@ -5,15 +5,15 @@ title: cache.azure.com/v1api20210301
 linktitle: v1api20210301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-03-01" |             |
 
-<a id="RedisEnterprise"></a>RedisEnterprise
--------------------------------------------
+RedisEnterprise{#RedisEnterprise}
+---------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2021-03-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}
 
@@ -26,7 +26,7 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | spec                                                                                    |             | [RedisEnterprise_Spec](#RedisEnterprise_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisEnterprise_STATUS](#RedisEnterprise_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisEnterprise_Spec"></a>RedisEnterprise_Spec
+### RedisEnterprise_Spec {#RedisEnterprise_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones             | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="RedisEnterprise_STATUS"></a>RedisEnterprise_STATUS
+### RedisEnterprise_STATUS{#RedisEnterprise_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -58,8 +58,8 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisEnterpriseDatabase"></a>RedisEnterpriseDatabase
------------------------------------------------------------
+RedisEnterpriseDatabase{#RedisEnterpriseDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2021-03-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}
 
@@ -72,7 +72,7 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | spec                                                                                    |             | [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisEnterpriseDatabase_Spec"></a>RedisEnterpriseDatabase_Spec
+### RedisEnterpriseDatabase_Spec {#RedisEnterpriseDatabase_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -86,7 +86,7 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | persistence      | Persistence settings                                                                                                                                                                                                                                                                       | [Persistence](#Persistence)<br/><small>Optional</small>                                                                                                              |
 | port             | TCP port of the database endpoint. Specified at create time. Defaults to an available port.                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="RedisEnterpriseDatabase_STATUS"></a>RedisEnterpriseDatabase_STATUS
+### RedisEnterpriseDatabase_STATUS{#RedisEnterpriseDatabase_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -103,8 +103,8 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | resourceState     | Current resource status of the database                                                                                                                                                                                                                                                                                   | [ResourceState_STATUS](#ResourceState_STATUS)<br/><small>Optional</small>                                                                               |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisEnterpriseDatabaseList"></a>RedisEnterpriseDatabaseList
--------------------------------------------------------------------
+RedisEnterpriseDatabaseList{#RedisEnterpriseDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2021-03-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}
 
@@ -114,8 +114,8 @@ Generator information: - Generated from: /redisenterprise/resource-manager/Micro
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [RedisEnterpriseDatabase[]](#RedisEnterpriseDatabase)<br/><small>Optional</small> |
 
-<a id="RedisEnterpriseList"></a>RedisEnterpriseList
----------------------------------------------------
+RedisEnterpriseList{#RedisEnterpriseList}
+-----------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2021-03-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}
 
@@ -125,8 +125,8 @@ Generator information: - Generated from: /redisenterprise/resource-manager/Micro
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [RedisEnterprise[]](#RedisEnterprise)<br/><small>Optional</small> |
 
-<a id="RedisEnterprise_Spec"></a>RedisEnterprise_Spec
------------------------------------------------------
+RedisEnterprise_Spec{#RedisEnterprise_Spec}
+-------------------------------------------
 
 Used by: [RedisEnterprise](#RedisEnterprise).
 
@@ -141,8 +141,8 @@ Used by: [RedisEnterprise](#RedisEnterprise).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones             | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="RedisEnterprise_STATUS"></a>RedisEnterprise_STATUS
----------------------------------------------------------
+RedisEnterprise_STATUS{#RedisEnterprise_STATUS}
+-----------------------------------------------
 
 Used by: [RedisEnterprise](#RedisEnterprise).
 
@@ -163,8 +163,8 @@ Used by: [RedisEnterprise](#RedisEnterprise).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisEnterpriseDatabase_Spec"></a>RedisEnterpriseDatabase_Spec
----------------------------------------------------------------------
+RedisEnterpriseDatabase_Spec{#RedisEnterpriseDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 
@@ -180,8 +180,8 @@ Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 | persistence      | Persistence settings                                                                                                                                                                                                                                                                       | [Persistence](#Persistence)<br/><small>Optional</small>                                                                                                              |
 | port             | TCP port of the database endpoint. Specified at create time. Defaults to an available port.                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="RedisEnterpriseDatabase_STATUS"></a>RedisEnterpriseDatabase_STATUS
--------------------------------------------------------------------------
+RedisEnterpriseDatabase_STATUS{#RedisEnterpriseDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 
@@ -200,8 +200,8 @@ Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 | resourceState     | Current resource status of the database                                                                                                                                                                                                                                                                                   | [ResourceState_STATUS](#ResourceState_STATUS)<br/><small>Optional</small>                                                                               |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ClusterProperties_MinimumTlsVersion"></a>ClusterProperties_MinimumTlsVersion
------------------------------------------------------------------------------------
+ClusterProperties_MinimumTlsVersion{#ClusterProperties_MinimumTlsVersion}
+-------------------------------------------------------------------------
 
 Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 
@@ -211,8 +211,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="ClusterProperties_MinimumTlsVersion_STATUS"></a>ClusterProperties_MinimumTlsVersion_STATUS
--------------------------------------------------------------------------------------------------
+ClusterProperties_MinimumTlsVersion_STATUS{#ClusterProperties_MinimumTlsVersion_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 
@@ -222,8 +222,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="DatabaseProperties_ClientProtocol"></a>DatabaseProperties_ClientProtocol
--------------------------------------------------------------------------------
+DatabaseProperties_ClientProtocol{#DatabaseProperties_ClientProtocol}
+---------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
@@ -232,19 +232,19 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "Encrypted" |             |
 | "Plaintext" |             |
 
-<a id="DatabaseProperties_ClientProtocol_STATUS"></a>DatabaseProperties_ClientProtocol_STATUS
----------------------------------------------------------------------------------------------
-
-Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Encrypted" |             |
-| "Plaintext" |             |
-
-<a id="DatabaseProperties_ClusteringPolicy"></a>DatabaseProperties_ClusteringPolicy
+DatabaseProperties_ClientProtocol_STATUS{#DatabaseProperties_ClientProtocol_STATUS}
 -----------------------------------------------------------------------------------
 
+Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Encrypted" |             |
+| "Plaintext" |             |
+
+DatabaseProperties_ClusteringPolicy{#DatabaseProperties_ClusteringPolicy}
+-------------------------------------------------------------------------
+
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
 | Value               | Description |
@@ -252,8 +252,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "EnterpriseCluster" |             |
 | "OSSCluster"        |             |
 
-<a id="DatabaseProperties_ClusteringPolicy_STATUS"></a>DatabaseProperties_ClusteringPolicy_STATUS
--------------------------------------------------------------------------------------------------
+DatabaseProperties_ClusteringPolicy_STATUS{#DatabaseProperties_ClusteringPolicy_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 
@@ -262,8 +262,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | "EnterpriseCluster" |             |
 | "OSSCluster"        |             |
 
-<a id="DatabaseProperties_EvictionPolicy"></a>DatabaseProperties_EvictionPolicy
--------------------------------------------------------------------------------
+DatabaseProperties_EvictionPolicy{#DatabaseProperties_EvictionPolicy}
+---------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
@@ -278,8 +278,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "VolatileRandom" |             |
 | "VolatileTTL"    |             |
 
-<a id="DatabaseProperties_EvictionPolicy_STATUS"></a>DatabaseProperties_EvictionPolicy_STATUS
----------------------------------------------------------------------------------------------
+DatabaseProperties_EvictionPolicy_STATUS{#DatabaseProperties_EvictionPolicy_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 
@@ -294,8 +294,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | "VolatileRandom" |             |
 | "VolatileTTL"    |             |
 
-<a id="Module"></a>Module
--------------------------
+Module{#Module}
+---------------
 
 Specifies configuration of a redis module
 
@@ -306,8 +306,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | args     | Configuration options for the module, e.g. 'ERROR_RATE 0.00 INITIAL_SIZE 400'. | string<br/><small>Optional</small> |
 | name     | The name of the module, e.g. 'RedisBloom', 'RediSearch', 'RedisTimeSeries'     | string<br/><small>Required</small> |
 
-<a id="Module_STATUS"></a>Module_STATUS
----------------------------------------
+Module_STATUS{#Module_STATUS}
+-----------------------------
 
 Specifies configuration of a redis module
 
@@ -319,8 +319,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | name     | The name of the module, e.g. 'RedisBloom', 'RediSearch', 'RedisTimeSeries'     | string<br/><small>Optional</small> |
 | version  | The version of the module, e.g. '1.0'.                                         | string<br/><small>Optional</small> |
 
-<a id="Persistence"></a>Persistence
------------------------------------
+Persistence{#Persistence}
+-------------------------
 
 Persistence-related configuration for the RedisEnterprise database
 
@@ -333,8 +333,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | rdbEnabled   | Sets whether RDB is enabled.                                       | bool<br/><small>Optional</small>                                                  |
 | rdbFrequency | Sets the frequency at which a snapshot of the database is created. | [Persistence_RdbFrequency](#Persistence_RdbFrequency)<br/><small>Optional</small> |
 
-<a id="Persistence_STATUS"></a>Persistence_STATUS
--------------------------------------------------
+Persistence_STATUS{#Persistence_STATUS}
+---------------------------------------
 
 Persistence-related configuration for the RedisEnterprise database
 
@@ -347,8 +347,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | rdbEnabled   | Sets whether RDB is enabled.                                       | bool<br/><small>Optional</small>                                                                |
 | rdbFrequency | Sets the frequency at which a snapshot of the database is created. | [Persistence_RdbFrequency_STATUS](#Persistence_RdbFrequency_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -358,8 +358,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 Current provisioning status
 
@@ -374,8 +374,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS), and [RedisEnterprise
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RedisEnterpriseDatabaseOperatorSpec"></a>RedisEnterpriseDatabaseOperatorSpec
------------------------------------------------------------------------------------
+RedisEnterpriseDatabaseOperatorSpec{#RedisEnterpriseDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -386,8 +386,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisEnterpriseOperatorSpec"></a>RedisEnterpriseOperatorSpec
--------------------------------------------------------------------
+RedisEnterpriseOperatorSpec{#RedisEnterpriseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -398,8 +398,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ResourceState_STATUS"></a>ResourceState_STATUS
------------------------------------------------------
+ResourceState_STATUS{#ResourceState_STATUS}
+-------------------------------------------
 
 Current resource status
 
@@ -420,8 +420,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS), and [RedisEnterprise
 | "UpdateFailed"  |             |
 | "Updating"      |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create RedisEnterprise operation.
 
@@ -432,8 +432,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | capacity | The size of the RedisEnterprise cluster. Defaults to 2 or 3 depending on SKU. Valid values are (2, 4, 6, ...) for Enterprise SKUs and (3, 9, 15, ...) for Flash SKUs. | int<br/><small>Optional</small>                   |
 | name     | The type of RedisEnterprise cluster to deploy. Possible values: (Enterprise_E10, EnterpriseFlash_F300 etc.)                                                           | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create RedisEnterprise operation.
 
@@ -444,8 +444,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 | capacity | The size of the RedisEnterprise cluster. Defaults to 2 or 3 depending on SKU. Valid values are (2, 4, 6, ...) for Enterprise SKUs and (3, 9, 15, ...) for Flash SKUs. | int<br/><small>Optional</small>                                 |
 | name     | The type of RedisEnterprise cluster to deploy. Possible values: (Enterprise_E10, EnterpriseFlash_F300 etc.)                                                           | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="Persistence_AofFrequency"></a>Persistence_AofFrequency
--------------------------------------------------------------
+Persistence_AofFrequency{#Persistence_AofFrequency}
+---------------------------------------------------
 
 Used by: [Persistence](#Persistence).
 
@@ -454,8 +454,8 @@ Used by: [Persistence](#Persistence).
 | "1s"     |             |
 | "always" |             |
 
-<a id="Persistence_AofFrequency_STATUS"></a>Persistence_AofFrequency_STATUS
----------------------------------------------------------------------------
+Persistence_AofFrequency_STATUS{#Persistence_AofFrequency_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Persistence_STATUS](#Persistence_STATUS).
 
@@ -464,8 +464,8 @@ Used by: [Persistence_STATUS](#Persistence_STATUS).
 | "1s"     |             |
 | "always" |             |
 
-<a id="Persistence_RdbFrequency"></a>Persistence_RdbFrequency
--------------------------------------------------------------
+Persistence_RdbFrequency{#Persistence_RdbFrequency}
+---------------------------------------------------
 
 Used by: [Persistence](#Persistence).
 
@@ -475,8 +475,8 @@ Used by: [Persistence](#Persistence).
 | "1h"  |             |
 | "6h"  |             |
 
-<a id="Persistence_RdbFrequency_STATUS"></a>Persistence_RdbFrequency_STATUS
----------------------------------------------------------------------------
+Persistence_RdbFrequency_STATUS{#Persistence_RdbFrequency_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Persistence_STATUS](#Persistence_STATUS).
 
@@ -486,8 +486,8 @@ Used by: [Persistence_STATUS](#Persistence_STATUS).
 | "1h"  |             |
 | "6h"  |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -501,8 +501,8 @@ Used by: [Sku](#Sku).
 | "Enterprise_E20"        |             |
 | "Enterprise_E50"        |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 

--- a/docs/hugo/content/reference/cache/v1api20230401.md
+++ b/docs/hugo/content/reference/cache/v1api20230401.md
@@ -5,15 +5,15 @@ title: cache.azure.com/v1api20230401
 linktitle: v1api20230401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-04-01" |             |
 
-<a id="Redis"></a>Redis
------------------------
+Redis{#Redis}
+-------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -26,7 +26,7 @@ Used by: [RedisList](#RedisList).
 | spec                                                                                    |             | [Redis_Spec](#Redis_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Redis_STATUS](#Redis_STATUS)<br/><small>Optional</small> |
 
-### <a id="Redis_Spec"></a>Redis_Spec
+### Redis_Spec {#Redis_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,7 +50,7 @@ Used by: [RedisList](#RedisList).
 | tenantSettings      | A dictionary of tenant settings                                                                                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Redis_STATUS"></a>Redis_STATUS
+### Redis_STATUS{#Redis_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -82,8 +82,8 @@ Used by: [RedisList](#RedisList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule"></a>RedisFirewallRule
------------------------------------------------
+RedisFirewallRule{#RedisFirewallRule}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -96,7 +96,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | spec                                                                                    |             | [RedisFirewallRule_Spec](#RedisFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisFirewallRule_STATUS](#RedisFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
+### RedisFirewallRule_Spec {#RedisFirewallRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -106,7 +106,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
+### RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -117,8 +117,8 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisFirewallRuleList"></a>RedisFirewallRuleList
--------------------------------------------------------
+RedisFirewallRuleList{#RedisFirewallRuleList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -128,8 +128,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisFirewallRule[]](#RedisFirewallRule)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer"></a>RedisLinkedServer
------------------------------------------------
+RedisLinkedServer{#RedisLinkedServer}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -142,7 +142,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | spec                                                                                    |             | [RedisLinkedServer_Spec](#RedisLinkedServer_Spec)<br/><small>Optional</small>       |
 | status                                                                                  |             | [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
+### RedisLinkedServer_Spec {#RedisLinkedServer_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -153,7 +153,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-### <a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
+### Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -168,8 +168,8 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | serverRole                   | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServerList"></a>RedisLinkedServerList
--------------------------------------------------------
+RedisLinkedServerList{#RedisLinkedServerList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -179,8 +179,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisLinkedServer[]](#RedisLinkedServer)<br/><small>Optional</small> |
 
-<a id="RedisList"></a>RedisList
--------------------------------
+RedisList{#RedisList}
+---------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -190,8 +190,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Redis[]](#Redis)<br/><small>Optional</small> |
 
-<a id="RedisPatchSchedule"></a>RedisPatchSchedule
--------------------------------------------------
+RedisPatchSchedule{#RedisPatchSchedule}
+---------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -204,7 +204,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | spec                                                                                    |             | [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
+### RedisPatchSchedule_Spec {#RedisPatchSchedule_Spec}
 
 | Property        | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -212,7 +212,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-### <a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
+### RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
 
 | Property        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -223,8 +223,8 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisPatchScheduleList"></a>RedisPatchScheduleList
----------------------------------------------------------
+RedisPatchScheduleList{#RedisPatchScheduleList}
+-----------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-04-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -234,8 +234,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [RedisPatchSchedule[]](#RedisPatchSchedule)<br/><small>Optional</small> |
 
-<a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
----------------------------------------------------------------
+Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -252,8 +252,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | serverRole                   | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Redis_Spec"></a>Redis_Spec
----------------------------------
+Redis_Spec{#Redis_Spec}
+-----------------------
 
 Used by: [Redis](#Redis).
 
@@ -279,8 +279,8 @@ Used by: [Redis](#Redis).
 | tenantSettings      | A dictionary of tenant settings                                                                                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Redis_STATUS"></a>Redis_STATUS
--------------------------------------
+Redis_STATUS{#Redis_STATUS}
+---------------------------
 
 Used by: [Redis](#Redis).
 
@@ -314,8 +314,8 @@ Used by: [Redis](#Redis).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
----------------------------------------------------------
+RedisFirewallRule_Spec{#RedisFirewallRule_Spec}
+-----------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -327,8 +327,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
--------------------------------------------------------------
+RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
+---------------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -341,8 +341,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
----------------------------------------------------------
+RedisLinkedServer_Spec{#RedisLinkedServer_Spec}
+-----------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -355,8 +355,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-<a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
------------------------------------------------------------
+RedisPatchSchedule_Spec{#RedisPatchSchedule_Spec}
+-------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -366,8 +366,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-<a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
----------------------------------------------------------------
+RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -380,8 +380,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -392,8 +392,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). | [ManagedServiceIdentityType](#ManagedServiceIdentityType)<br/><small>Required</small>     |
 | userAssignedIdentities |                                                                                                  | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -406,8 +406,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).                              | [ManagedServiceIdentityType_STATUS](#ManagedServiceIdentityType_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities |                                                                                                                               | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>  |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -417,8 +417,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RedisCreateProperties_MinimumTlsVersion"></a>RedisCreateProperties_MinimumTlsVersion
--------------------------------------------------------------------------------------------
+RedisCreateProperties_MinimumTlsVersion{#RedisCreateProperties_MinimumTlsVersion}
+---------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -428,8 +428,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisCreateProperties_PublicNetworkAccess"></a>RedisCreateProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------
+RedisCreateProperties_PublicNetworkAccess{#RedisCreateProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -438,8 +438,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisCreateProperties_RedisConfiguration"></a>RedisCreateProperties_RedisConfiguration
----------------------------------------------------------------------------------------------
+RedisCreateProperties_RedisConfiguration{#RedisCreateProperties_RedisConfiguration}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -460,8 +460,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | rdb-storage-connection-string          | The storage account connection string for storing rdb file                                                                              | string<br/><small>Optional</small> |
 | storage-subscription-id                | SubscriptionId of the storage account for persistence (aof/rdb) using ManagedIdentity.                                                  | string<br/><small>Optional</small> |
 
-<a id="RedisFirewallRuleOperatorSpec"></a>RedisFirewallRuleOperatorSpec
------------------------------------------------------------------------
+RedisFirewallRuleOperatorSpec{#RedisFirewallRuleOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -472,8 +472,8 @@ Used by: [RedisFirewallRule_Spec](#RedisFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisInstanceDetails_STATUS"></a>RedisInstanceDetails_STATUS
--------------------------------------------------------------------
+RedisInstanceDetails_STATUS{#RedisInstanceDetails_STATUS}
+---------------------------------------------------------
 
 Details of single instance of redis.
 
@@ -488,8 +488,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | sslPort    | Redis instance SSL port.                                                                          | int<br/><small>Optional</small>    |
 | zone       | If the Cache uses availability zones, specifies availability zone where this instance is located. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer_STATUS"></a>RedisLinkedServer_STATUS
--------------------------------------------------------------
+RedisLinkedServer_STATUS{#RedisLinkedServer_STATUS}
+---------------------------------------------------
 
 Linked server Id
 
@@ -499,8 +499,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|-------------------|------------------------------------|
 | id       | Linked server Id. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerCreateProperties_ServerRole"></a>RedisLinkedServerCreateProperties_ServerRole
------------------------------------------------------------------------------------------------------
+RedisLinkedServerCreateProperties_ServerRole{#RedisLinkedServerCreateProperties_ServerRole}
+-------------------------------------------------------------------------------------------
 
 Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 
@@ -509,8 +509,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisLinkedServerOperatorSpec"></a>RedisLinkedServerOperatorSpec
------------------------------------------------------------------------
+RedisLinkedServerOperatorSpec{#RedisLinkedServerOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -521,8 +521,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerProperties_ServerRole_STATUS"></a>RedisLinkedServerProperties_ServerRole_STATUS
--------------------------------------------------------------------------------------------------------
+RedisLinkedServerProperties_ServerRole_STATUS{#RedisLinkedServerProperties_ServerRole_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 
@@ -531,8 +531,8 @@ Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisOperatorSpec"></a>RedisOperatorSpec
------------------------------------------------
+RedisOperatorSpec{#RedisOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -544,8 +544,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [RedisOperatorSecrets](#RedisOperatorSecrets)<br/><small>Optional</small>                                                                                           |
 
-<a id="RedisPatchScheduleOperatorSpec"></a>RedisPatchScheduleOperatorSpec
--------------------------------------------------------------------------
+RedisPatchScheduleOperatorSpec{#RedisPatchScheduleOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -556,8 +556,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisProperties_MinimumTlsVersion_STATUS"></a>RedisProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_MinimumTlsVersion_STATUS{#RedisProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -567,8 +567,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisProperties_ProvisioningState_STATUS"></a>RedisProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_ProvisioningState_STATUS{#RedisProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -587,8 +587,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Unprovisioning"         |             |
 | "Updating"               |             |
 
-<a id="RedisProperties_PublicNetworkAccess_STATUS"></a>RedisProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------
+RedisProperties_PublicNetworkAccess_STATUS{#RedisProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -597,8 +597,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisProperties_RedisConfiguration_STATUS"></a>RedisProperties_RedisConfiguration_STATUS
------------------------------------------------------------------------------------------------
+RedisProperties_RedisConfiguration_STATUS{#RedisProperties_RedisConfiguration_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -622,8 +622,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | storage-subscription-id                | SubscriptionId of the storage account for persistence (aof/rdb) using ManagedIdentity.                                                  | string<br/><small>Optional</small> |
 | zonal-configuration                    | Zonal Configuration                                                                                                                     | string<br/><small>Optional</small> |
 
-<a id="ScheduleEntry"></a>ScheduleEntry
----------------------------------------
+ScheduleEntry{#ScheduleEntry}
+-----------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -635,8 +635,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                              |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Required</small>                                                 |
 
-<a id="ScheduleEntry_STATUS"></a>ScheduleEntry_STATUS
------------------------------------------------------
+ScheduleEntry_STATUS{#ScheduleEntry_STATUS}
+-------------------------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -648,8 +648,8 @@ Used by: [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                                            |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Optional</small>                                                               |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -661,8 +661,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family](#Sku_Family)<br/><small>Required</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name](#Sku_Name)<br/><small>Required</small>     |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -674,8 +674,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family_STATUS](#Sku_Family_STATUS)<br/><small>Optional</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small>     |
 
-<a id="ManagedServiceIdentityType"></a>ManagedServiceIdentityType
------------------------------------------------------------------
+ManagedServiceIdentityType{#ManagedServiceIdentityType}
+-------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -688,8 +688,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentityType_STATUS"></a>ManagedServiceIdentityType_STATUS
--------------------------------------------------------------------------------
+ManagedServiceIdentityType_STATUS{#ManagedServiceIdentityType_STATUS}
+---------------------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -702,8 +702,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="RedisOperatorSecrets"></a>RedisOperatorSecrets
------------------------------------------------------
+RedisOperatorSecrets{#RedisOperatorSecrets}
+-------------------------------------------
 
 Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 
@@ -715,8 +715,8 @@ Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 | secondaryKey | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | sslPort      | indicates where the SSLPort secret should be placed. If omitted, the secret will not be retrieved from Azure.      | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ScheduleEntry_DayOfWeek"></a>ScheduleEntry_DayOfWeek
------------------------------------------------------------
+ScheduleEntry_DayOfWeek{#ScheduleEntry_DayOfWeek}
+-------------------------------------------------
 
 Used by: [ScheduleEntry](#ScheduleEntry).
 
@@ -732,8 +732,8 @@ Used by: [ScheduleEntry](#ScheduleEntry).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="ScheduleEntry_DayOfWeek_STATUS"></a>ScheduleEntry_DayOfWeek_STATUS
--------------------------------------------------------------------------
+ScheduleEntry_DayOfWeek_STATUS{#ScheduleEntry_DayOfWeek_STATUS}
+---------------------------------------------------------------
 
 Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 
@@ -749,40 +749,40 @@ Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="Sku_Family"></a>Sku_Family
+Sku_Family{#Sku_Family}
+-----------------------
+
+Used by: [Sku](#Sku).
+
+| Value | Description |
+|-------|-------------|
+| "C"   |             |
+| "P"   |             |
+
+Sku_Family_STATUS{#Sku_Family_STATUS}
+-------------------------------------
+
+Used by: [Sku_STATUS](#Sku_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "C"   |             |
+| "P"   |             |
+
+Sku_Name{#Sku_Name}
+-------------------
+
+Used by: [Sku](#Sku).
+
+| Value      | Description |
+|------------|-------------|
+| "Basic"    |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+Sku_Name_STATUS{#Sku_Name_STATUS}
 ---------------------------------
 
-Used by: [Sku](#Sku).
-
-| Value | Description |
-|-------|-------------|
-| "C"   |             |
-| "P"   |             |
-
-<a id="Sku_Family_STATUS"></a>Sku_Family_STATUS
------------------------------------------------
-
-Used by: [Sku_STATUS](#Sku_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "C"   |             |
-| "P"   |             |
-
-<a id="Sku_Name"></a>Sku_Name
------------------------------
-
-Used by: [Sku](#Sku).
-
-| Value      | Description |
-|------------|-------------|
-| "Basic"    |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
-
 Used by: [Sku_STATUS](#Sku_STATUS).
 
 | Value      | Description |
@@ -791,8 +791,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -803,8 +803,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/cache/v1api20230701.md
+++ b/docs/hugo/content/reference/cache/v1api20230701.md
@@ -5,15 +5,15 @@ title: cache.azure.com/v1api20230701
 linktitle: v1api20230701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-07-01" |             |
 
-<a id="RedisEnterprise"></a>RedisEnterprise
--------------------------------------------
+RedisEnterprise{#RedisEnterprise}
+---------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2023-07-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}
 
@@ -26,7 +26,7 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | spec                                                                                    |             | [RedisEnterprise_Spec](#RedisEnterprise_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisEnterprise_STATUS](#RedisEnterprise_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisEnterprise_Spec"></a>RedisEnterprise_Spec
+### RedisEnterprise_Spec {#RedisEnterprise_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones             | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="RedisEnterprise_STATUS"></a>RedisEnterprise_STATUS
+### RedisEnterprise_STATUS{#RedisEnterprise_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -58,8 +58,8 @@ Used by: [RedisEnterpriseList](#RedisEnterpriseList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisEnterpriseDatabase"></a>RedisEnterpriseDatabase
------------------------------------------------------------
+RedisEnterpriseDatabase{#RedisEnterpriseDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2023-07-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}
 
@@ -72,7 +72,7 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | spec                                                                                    |             | [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisEnterpriseDatabase_Spec"></a>RedisEnterpriseDatabase_Spec
+### RedisEnterpriseDatabase_Spec {#RedisEnterpriseDatabase_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -87,7 +87,7 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | persistence      | Persistence settings                                                                                                                                                                                                                                                                       | [Persistence](#Persistence)<br/><small>Optional</small>                                                                                                              |
 | port             | TCP port of the database endpoint. Specified at create time. Defaults to an available port.                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="RedisEnterpriseDatabase_STATUS"></a>RedisEnterpriseDatabase_STATUS
+### RedisEnterpriseDatabase_STATUS{#RedisEnterpriseDatabase_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -105,8 +105,8 @@ Used by: [RedisEnterpriseDatabaseList](#RedisEnterpriseDatabaseList).
 | resourceState     | Current resource status of the database                                                                                                                                                                                                                                                                                   | [ResourceState_STATUS](#ResourceState_STATUS)<br/><small>Optional</small>                                                                               |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisEnterpriseDatabaseList"></a>RedisEnterpriseDatabaseList
--------------------------------------------------------------------
+RedisEnterpriseDatabaseList{#RedisEnterpriseDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2023-07-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}
 
@@ -116,8 +116,8 @@ Generator information: - Generated from: /redisenterprise/resource-manager/Micro
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [RedisEnterpriseDatabase[]](#RedisEnterpriseDatabase)<br/><small>Optional</small> |
 
-<a id="RedisEnterpriseList"></a>RedisEnterpriseList
----------------------------------------------------
+RedisEnterpriseList{#RedisEnterpriseList}
+-----------------------------------------
 
 Generator information: - Generated from: /redisenterprise/resource-manager/Microsoft.Cache/stable/2023-07-01/redisenterprise.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redisEnterprise/{clusterName}
 
@@ -127,8 +127,8 @@ Generator information: - Generated from: /redisenterprise/resource-manager/Micro
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [RedisEnterprise[]](#RedisEnterprise)<br/><small>Optional</small> |
 
-<a id="RedisEnterprise_Spec"></a>RedisEnterprise_Spec
------------------------------------------------------
+RedisEnterprise_Spec{#RedisEnterprise_Spec}
+-------------------------------------------
 
 Used by: [RedisEnterprise](#RedisEnterprise).
 
@@ -143,8 +143,8 @@ Used by: [RedisEnterprise](#RedisEnterprise).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones             | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="RedisEnterprise_STATUS"></a>RedisEnterprise_STATUS
----------------------------------------------------------
+RedisEnterprise_STATUS{#RedisEnterprise_STATUS}
+-----------------------------------------------
 
 Used by: [RedisEnterprise](#RedisEnterprise).
 
@@ -165,8 +165,8 @@ Used by: [RedisEnterprise](#RedisEnterprise).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                      | The Availability Zones where this cluster will be deployed.                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisEnterpriseDatabase_Spec"></a>RedisEnterpriseDatabase_Spec
----------------------------------------------------------------------
+RedisEnterpriseDatabase_Spec{#RedisEnterpriseDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 
@@ -183,8 +183,8 @@ Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 | persistence      | Persistence settings                                                                                                                                                                                                                                                                       | [Persistence](#Persistence)<br/><small>Optional</small>                                                                                                              |
 | port             | TCP port of the database endpoint. Specified at create time. Defaults to an available port.                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="RedisEnterpriseDatabase_STATUS"></a>RedisEnterpriseDatabase_STATUS
--------------------------------------------------------------------------
+RedisEnterpriseDatabase_STATUS{#RedisEnterpriseDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 
@@ -204,8 +204,8 @@ Used by: [RedisEnterpriseDatabase](#RedisEnterpriseDatabase).
 | resourceState     | Current resource status of the database                                                                                                                                                                                                                                                                                   | [ResourceState_STATUS](#ResourceState_STATUS)<br/><small>Optional</small>                                                                               |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ClusterProperties_MinimumTlsVersion"></a>ClusterProperties_MinimumTlsVersion
------------------------------------------------------------------------------------
+ClusterProperties_MinimumTlsVersion{#ClusterProperties_MinimumTlsVersion}
+-------------------------------------------------------------------------
 
 Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 
@@ -215,8 +215,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="ClusterProperties_MinimumTlsVersion_STATUS"></a>ClusterProperties_MinimumTlsVersion_STATUS
--------------------------------------------------------------------------------------------------
+ClusterProperties_MinimumTlsVersion_STATUS{#ClusterProperties_MinimumTlsVersion_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 
@@ -226,8 +226,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="DatabaseProperties_ClientProtocol"></a>DatabaseProperties_ClientProtocol
--------------------------------------------------------------------------------
+DatabaseProperties_ClientProtocol{#DatabaseProperties_ClientProtocol}
+---------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
@@ -236,19 +236,19 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "Encrypted" |             |
 | "Plaintext" |             |
 
-<a id="DatabaseProperties_ClientProtocol_STATUS"></a>DatabaseProperties_ClientProtocol_STATUS
----------------------------------------------------------------------------------------------
-
-Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Encrypted" |             |
-| "Plaintext" |             |
-
-<a id="DatabaseProperties_ClusteringPolicy"></a>DatabaseProperties_ClusteringPolicy
+DatabaseProperties_ClientProtocol_STATUS{#DatabaseProperties_ClientProtocol_STATUS}
 -----------------------------------------------------------------------------------
 
+Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Encrypted" |             |
+| "Plaintext" |             |
+
+DatabaseProperties_ClusteringPolicy{#DatabaseProperties_ClusteringPolicy}
+-------------------------------------------------------------------------
+
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
 | Value               | Description |
@@ -256,8 +256,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "EnterpriseCluster" |             |
 | "OSSCluster"        |             |
 
-<a id="DatabaseProperties_ClusteringPolicy_STATUS"></a>DatabaseProperties_ClusteringPolicy_STATUS
--------------------------------------------------------------------------------------------------
+DatabaseProperties_ClusteringPolicy_STATUS{#DatabaseProperties_ClusteringPolicy_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 
@@ -266,8 +266,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | "EnterpriseCluster" |             |
 | "OSSCluster"        |             |
 
-<a id="DatabaseProperties_EvictionPolicy"></a>DatabaseProperties_EvictionPolicy
--------------------------------------------------------------------------------
+DatabaseProperties_EvictionPolicy{#DatabaseProperties_EvictionPolicy}
+---------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
@@ -282,8 +282,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | "VolatileRandom" |             |
 | "VolatileTTL"    |             |
 
-<a id="DatabaseProperties_EvictionPolicy_STATUS"></a>DatabaseProperties_EvictionPolicy_STATUS
----------------------------------------------------------------------------------------------
+DatabaseProperties_EvictionPolicy_STATUS{#DatabaseProperties_EvictionPolicy_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 
@@ -298,8 +298,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | "VolatileRandom" |             |
 | "VolatileTTL"    |             |
 
-<a id="DatabaseProperties_GeoReplication"></a>DatabaseProperties_GeoReplication
--------------------------------------------------------------------------------
+DatabaseProperties_GeoReplication{#DatabaseProperties_GeoReplication}
+---------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 
@@ -308,8 +308,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | groupNickname   | Name for the group of linked database resources       | string<br/><small>Optional</small>                              |
 | linkedDatabases | List of database resources to link with this database | [LinkedDatabase[]](#LinkedDatabase)<br/><small>Optional</small> |
 
-<a id="DatabaseProperties_GeoReplication_STATUS"></a>DatabaseProperties_GeoReplication_STATUS
----------------------------------------------------------------------------------------------
+DatabaseProperties_GeoReplication_STATUS{#DatabaseProperties_GeoReplication_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 
@@ -318,8 +318,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | groupNickname   | Name for the group of linked database resources       | string<br/><small>Optional</small>                                            |
 | linkedDatabases | List of database resources to link with this database | [LinkedDatabase_STATUS[]](#LinkedDatabase_STATUS)<br/><small>Optional</small> |
 
-<a id="Module"></a>Module
--------------------------
+Module{#Module}
+---------------
 
 Specifies configuration of a redis module
 
@@ -330,8 +330,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | args     | Configuration options for the module, e.g. 'ERROR_RATE 0.01 INITIAL_SIZE 400'. | string<br/><small>Optional</small> |
 | name     | The name of the module, e.g. 'RedisBloom', 'RediSearch', 'RedisTimeSeries'     | string<br/><small>Required</small> |
 
-<a id="Module_STATUS"></a>Module_STATUS
----------------------------------------
+Module_STATUS{#Module_STATUS}
+-----------------------------
 
 Specifies configuration of a redis module
 
@@ -343,8 +343,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | name     | The name of the module, e.g. 'RedisBloom', 'RediSearch', 'RedisTimeSeries'     | string<br/><small>Optional</small> |
 | version  | The version of the module, e.g. '1.0'.                                         | string<br/><small>Optional</small> |
 
-<a id="Persistence"></a>Persistence
------------------------------------
+Persistence{#Persistence}
+-------------------------
 
 Persistence-related configuration for the RedisEnterprise database
 
@@ -357,8 +357,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | rdbEnabled   | Sets whether RDB is enabled.                                       | bool<br/><small>Optional</small>                                                  |
 | rdbFrequency | Sets the frequency at which a snapshot of the database is created. | [Persistence_RdbFrequency](#Persistence_RdbFrequency)<br/><small>Optional</small> |
 
-<a id="Persistence_STATUS"></a>Persistence_STATUS
--------------------------------------------------
+Persistence_STATUS{#Persistence_STATUS}
+---------------------------------------
 
 Persistence-related configuration for the RedisEnterprise database
 
@@ -371,8 +371,8 @@ Used by: [RedisEnterpriseDatabase_STATUS](#RedisEnterpriseDatabase_STATUS).
 | rdbEnabled   | Sets whether RDB is enabled.                                       | bool<br/><small>Optional</small>                                                                |
 | rdbFrequency | Sets the frequency at which a snapshot of the database is created. | [Persistence_RdbFrequency_STATUS](#Persistence_RdbFrequency_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -382,8 +382,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 Current provisioning status
 
@@ -398,8 +398,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS), and [RedisEnterprise
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RedisEnterpriseDatabaseOperatorSpec"></a>RedisEnterpriseDatabaseOperatorSpec
------------------------------------------------------------------------------------
+RedisEnterpriseDatabaseOperatorSpec{#RedisEnterpriseDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -410,8 +410,8 @@ Used by: [RedisEnterpriseDatabase_Spec](#RedisEnterpriseDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisEnterpriseOperatorSpec"></a>RedisEnterpriseOperatorSpec
--------------------------------------------------------------------
+RedisEnterpriseOperatorSpec{#RedisEnterpriseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -422,8 +422,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ResourceState_STATUS"></a>ResourceState_STATUS
------------------------------------------------------
+ResourceState_STATUS{#ResourceState_STATUS}
+-------------------------------------------
 
 Current resource status
 
@@ -444,8 +444,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS), and [RedisEnterprise
 | "UpdateFailed"  |             |
 | "Updating"      |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create RedisEnterprise operation.
 
@@ -456,8 +456,8 @@ Used by: [RedisEnterprise_Spec](#RedisEnterprise_Spec).
 | capacity | The size of the RedisEnterprise cluster. Defaults to 2 or 3 depending on SKU. Valid values are (2, 4, 6, ...) for Enterprise SKUs and (3, 9, 15, ...) for Flash SKUs. | int<br/><small>Optional</small>                   |
 | name     | The type of RedisEnterprise cluster to deploy. Possible values: (Enterprise_E10, EnterpriseFlash_F300 etc.)                                                           | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create RedisEnterprise operation.
 
@@ -468,8 +468,8 @@ Used by: [RedisEnterprise_STATUS](#RedisEnterprise_STATUS).
 | capacity | The size of the RedisEnterprise cluster. Defaults to 2 or 3 depending on SKU. Valid values are (2, 4, 6, ...) for Enterprise SKUs and (3, 9, 15, ...) for Flash SKUs. | int<br/><small>Optional</small>                                 |
 | name     | The type of RedisEnterprise cluster to deploy. Possible values: (Enterprise_E10, EnterpriseFlash_F300 etc.)                                                           | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="LinkedDatabase"></a>LinkedDatabase
------------------------------------------
+LinkedDatabase{#LinkedDatabase}
+-------------------------------
 
 Specifies details of a linked database resource.
 
@@ -479,8 +479,8 @@ Used by: [DatabaseProperties_GeoReplication](#DatabaseProperties_GeoReplication)
 |-----------|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID of a database resource to link with this database. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="LinkedDatabase_STATUS"></a>LinkedDatabase_STATUS
--------------------------------------------------------
+LinkedDatabase_STATUS{#LinkedDatabase_STATUS}
+---------------------------------------------
 
 Specifies details of a linked database resource.
 
@@ -491,8 +491,8 @@ Used by: [DatabaseProperties_GeoReplication_STATUS](#DatabaseProperties_GeoRepli
 | id       | Resource ID of a database resource to link with this database. | string<br/><small>Optional</small>                                                      |
 | state    | State of the link between the database resources.              | [LinkedDatabase_State_STATUS](#LinkedDatabase_State_STATUS)<br/><small>Optional</small> |
 
-<a id="Persistence_AofFrequency"></a>Persistence_AofFrequency
--------------------------------------------------------------
+Persistence_AofFrequency{#Persistence_AofFrequency}
+---------------------------------------------------
 
 Used by: [Persistence](#Persistence).
 
@@ -501,8 +501,8 @@ Used by: [Persistence](#Persistence).
 | "1s"     |             |
 | "always" |             |
 
-<a id="Persistence_AofFrequency_STATUS"></a>Persistence_AofFrequency_STATUS
----------------------------------------------------------------------------
+Persistence_AofFrequency_STATUS{#Persistence_AofFrequency_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Persistence_STATUS](#Persistence_STATUS).
 
@@ -511,8 +511,8 @@ Used by: [Persistence_STATUS](#Persistence_STATUS).
 | "1s"     |             |
 | "always" |             |
 
-<a id="Persistence_RdbFrequency"></a>Persistence_RdbFrequency
--------------------------------------------------------------
+Persistence_RdbFrequency{#Persistence_RdbFrequency}
+---------------------------------------------------
 
 Used by: [Persistence](#Persistence).
 
@@ -522,8 +522,8 @@ Used by: [Persistence](#Persistence).
 | "1h"  |             |
 | "6h"  |             |
 
-<a id="Persistence_RdbFrequency_STATUS"></a>Persistence_RdbFrequency_STATUS
----------------------------------------------------------------------------
+Persistence_RdbFrequency_STATUS{#Persistence_RdbFrequency_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Persistence_STATUS](#Persistence_STATUS).
 
@@ -533,8 +533,8 @@ Used by: [Persistence_STATUS](#Persistence_STATUS).
 | "1h"  |             |
 | "6h"  |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -548,8 +548,8 @@ Used by: [Sku](#Sku).
 | "Enterprise_E20"        |             |
 | "Enterprise_E50"        |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -563,8 +563,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Enterprise_E20"        |             |
 | "Enterprise_E50"        |             |
 
-<a id="LinkedDatabase_State_STATUS"></a>LinkedDatabase_State_STATUS
--------------------------------------------------------------------
+LinkedDatabase_State_STATUS{#LinkedDatabase_State_STATUS}
+---------------------------------------------------------
 
 Used by: [LinkedDatabase_STATUS](#LinkedDatabase_STATUS).
 

--- a/docs/hugo/content/reference/cache/v1api20230801.md
+++ b/docs/hugo/content/reference/cache/v1api20230801.md
@@ -5,15 +5,15 @@ title: cache.azure.com/v1api20230801
 linktitle: v1api20230801
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-08-01" |             |
 
-<a id="Redis"></a>Redis
------------------------
+Redis{#Redis}
+-------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -26,7 +26,7 @@ Used by: [RedisList](#RedisList).
 | spec                                                                                    |             | [Redis_Spec](#Redis_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Redis_STATUS](#Redis_STATUS)<br/><small>Optional</small> |
 
-### <a id="Redis_Spec"></a>Redis_Spec
+### Redis_Spec {#Redis_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -51,7 +51,7 @@ Used by: [RedisList](#RedisList).
 | updateChannel       | Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates at least 4 weeks ahead of 'Stable' channel caches. Default value is 'Stable'.                                                                                                                                                           | [RedisCreateProperties_UpdateChannel](#RedisCreateProperties_UpdateChannel)<br/><small>Optional</small>                                                              |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Redis_STATUS"></a>Redis_STATUS
+### Redis_STATUS{#Redis_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -84,8 +84,8 @@ Used by: [RedisList](#RedisList).
 | updateChannel              | Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates at least 4 weeks ahead of 'Stable' channel caches. Default value is 'Stable'.                                                                                                                                                           | [RedisProperties_UpdateChannel_STATUS](#RedisProperties_UpdateChannel_STATUS)<br/><small>Optional</small>                                               |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule"></a>RedisFirewallRule
------------------------------------------------
+RedisFirewallRule{#RedisFirewallRule}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -98,7 +98,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | spec                                                                                    |             | [RedisFirewallRule_Spec](#RedisFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisFirewallRule_STATUS](#RedisFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
+### RedisFirewallRule_Spec {#RedisFirewallRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -108,7 +108,7 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
+### RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -119,8 +119,8 @@ Used by: [RedisFirewallRuleList](#RedisFirewallRuleList).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisFirewallRuleList"></a>RedisFirewallRuleList
--------------------------------------------------------
+RedisFirewallRuleList{#RedisFirewallRuleList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{cacheName}/firewallRules/{ruleName}
 
@@ -130,8 +130,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisFirewallRule[]](#RedisFirewallRule)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer"></a>RedisLinkedServer
------------------------------------------------
+RedisLinkedServer{#RedisLinkedServer}
+-------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -144,7 +144,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | spec                                                                                    |             | [RedisLinkedServer_Spec](#RedisLinkedServer_Spec)<br/><small>Optional</small>       |
 | status                                                                                  |             | [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
+### RedisLinkedServer_Spec {#RedisLinkedServer_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -155,7 +155,7 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-### <a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
+### Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -170,8 +170,8 @@ Used by: [RedisLinkedServerList](#RedisLinkedServerList).
 | serverRole                   | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServerList"></a>RedisLinkedServerList
--------------------------------------------------------
+RedisLinkedServerList{#RedisLinkedServerList}
+---------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}
 
@@ -181,8 +181,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [RedisLinkedServer[]](#RedisLinkedServer)<br/><small>Optional</small> |
 
-<a id="RedisList"></a>RedisList
--------------------------------
+RedisList{#RedisList}
+---------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}
 
@@ -192,8 +192,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Redis[]](#Redis)<br/><small>Optional</small> |
 
-<a id="RedisPatchSchedule"></a>RedisPatchSchedule
--------------------------------------------------
+RedisPatchSchedule{#RedisPatchSchedule}
+---------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -206,7 +206,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | spec                                                                                    |             | [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS)<br/><small>Optional</small> |
 
-### <a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
+### RedisPatchSchedule_Spec {#RedisPatchSchedule_Spec}
 
 | Property        | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -214,7 +214,7 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-### <a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
+### RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
 
 | Property        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -225,8 +225,8 @@ Used by: [RedisPatchScheduleList](#RedisPatchScheduleList).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisPatchScheduleList"></a>RedisPatchScheduleList
----------------------------------------------------------
+RedisPatchScheduleList{#RedisPatchScheduleList}
+-----------------------------------------------
 
 Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cache/redis/{name}/patchSchedules/default
 
@@ -236,8 +236,8 @@ Generator information: - Generated from: /redis/resource-manager/Microsoft.Cache
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [RedisPatchSchedule[]](#RedisPatchSchedule)<br/><small>Optional</small> |
 
-<a id="Redis_LinkedServer_STATUS"></a>Redis_LinkedServer_STATUS
----------------------------------------------------------------
+Redis_LinkedServer_STATUS{#Redis_LinkedServer_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -254,8 +254,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | serverRole                   | Role of the linked server.                                                                                                                                                                                                                                                                                                | [RedisLinkedServerProperties_ServerRole_STATUS](#RedisLinkedServerProperties_ServerRole_STATUS)<br/><small>Optional</small>                             |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Redis_Spec"></a>Redis_Spec
----------------------------------
+Redis_Spec{#Redis_Spec}
+-----------------------
 
 Used by: [Redis](#Redis).
 
@@ -282,8 +282,8 @@ Used by: [Redis](#Redis).
 | updateChannel       | Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates at least 4 weeks ahead of 'Stable' channel caches. Default value is 'Stable'.                                                                                                                                                           | [RedisCreateProperties_UpdateChannel](#RedisCreateProperties_UpdateChannel)<br/><small>Optional</small>                                                              |
 | zones               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Redis_STATUS"></a>Redis_STATUS
--------------------------------------
+Redis_STATUS{#Redis_STATUS}
+---------------------------
 
 Used by: [Redis](#Redis).
 
@@ -318,8 +318,8 @@ Used by: [Redis](#Redis).
 | updateChannel              | Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates at least 4 weeks ahead of 'Stable' channel caches. Default value is 'Stable'.                                                                                                                                                           | [RedisProperties_UpdateChannel_STATUS](#RedisProperties_UpdateChannel_STATUS)<br/><small>Optional</small>                                               |
 | zones                      | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RedisFirewallRule_Spec"></a>RedisFirewallRule_Spec
----------------------------------------------------------
+RedisFirewallRule_Spec{#RedisFirewallRule_Spec}
+-----------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -331,8 +331,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIP      | lowest IP address included in the range                                                                                                                                                                                                                                          | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="RedisFirewallRule_STATUS"></a>RedisFirewallRule_STATUS
--------------------------------------------------------------
+RedisFirewallRule_STATUS{#RedisFirewallRule_STATUS}
+---------------------------------------------------
 
 Used by: [RedisFirewallRule](#RedisFirewallRule).
 
@@ -345,8 +345,8 @@ Used by: [RedisFirewallRule](#RedisFirewallRule).
 | startIP    | lowest IP address included in the range                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RedisLinkedServer_Spec"></a>RedisLinkedServer_Spec
----------------------------------------------------------
+RedisLinkedServer_Spec{#RedisLinkedServer_Spec}
+-----------------------------------------------
 
 Used by: [RedisLinkedServer](#RedisLinkedServer).
 
@@ -359,8 +359,8 @@ Used by: [RedisLinkedServer](#RedisLinkedServer).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | serverRole                | Role of the linked server.                                                                                                                                                                                                                                                       | [RedisLinkedServerCreateProperties_ServerRole](#RedisLinkedServerCreateProperties_ServerRole)<br/><small>Required</small>                                            |
 
-<a id="RedisPatchSchedule_Spec"></a>RedisPatchSchedule_Spec
------------------------------------------------------------
+RedisPatchSchedule_Spec{#RedisPatchSchedule_Spec}
+-------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -370,8 +370,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cache.azure.com/Redis resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                       | [ScheduleEntry[]](#ScheduleEntry)<br/><small>Required</small>                                                                                                        |
 
-<a id="RedisPatchSchedule_STATUS"></a>RedisPatchSchedule_STATUS
----------------------------------------------------------------
+RedisPatchSchedule_STATUS{#RedisPatchSchedule_STATUS}
+-----------------------------------------------------
 
 Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 
@@ -384,8 +384,8 @@ Used by: [RedisPatchSchedule](#RedisPatchSchedule).
 | scheduleEntries | List of patch schedules for a Redis cache.                                                                                                                                                                                                                                                                                | [ScheduleEntry_STATUS[]](#ScheduleEntry_STATUS)<br/><small>Optional</small>                                                                             |
 | type            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -396,8 +396,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). | [ManagedServiceIdentityType](#ManagedServiceIdentityType)<br/><small>Required</small>     |
 | userAssignedIdentities |                                                                                                  | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -410,8 +410,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).                              | [ManagedServiceIdentityType_STATUS](#ManagedServiceIdentityType_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities |                                                                                                                               | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>  |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -421,8 +421,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RedisCreateProperties_MinimumTlsVersion"></a>RedisCreateProperties_MinimumTlsVersion
--------------------------------------------------------------------------------------------
+RedisCreateProperties_MinimumTlsVersion{#RedisCreateProperties_MinimumTlsVersion}
+---------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -432,8 +432,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisCreateProperties_PublicNetworkAccess"></a>RedisCreateProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------
+RedisCreateProperties_PublicNetworkAccess{#RedisCreateProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -442,8 +442,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisCreateProperties_RedisConfiguration"></a>RedisCreateProperties_RedisConfiguration
----------------------------------------------------------------------------------------------
+RedisCreateProperties_RedisConfiguration{#RedisCreateProperties_RedisConfiguration}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -466,8 +466,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | rdb-storage-connection-string          | The storage account connection string for storing rdb file                                                                              | string<br/><small>Optional</small> |
 | storage-subscription-id                | SubscriptionId of the storage account for persistence (aof/rdb) using ManagedIdentity.                                                  | string<br/><small>Optional</small> |
 
-<a id="RedisCreateProperties_UpdateChannel"></a>RedisCreateProperties_UpdateChannel
------------------------------------------------------------------------------------
+RedisCreateProperties_UpdateChannel{#RedisCreateProperties_UpdateChannel}
+-------------------------------------------------------------------------
 
 Used by: [Redis_Spec](#Redis_Spec).
 
@@ -476,8 +476,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | "Preview" |             |
 | "Stable"  |             |
 
-<a id="RedisFirewallRuleOperatorSpec"></a>RedisFirewallRuleOperatorSpec
------------------------------------------------------------------------
+RedisFirewallRuleOperatorSpec{#RedisFirewallRuleOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -488,8 +488,8 @@ Used by: [RedisFirewallRule_Spec](#RedisFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisInstanceDetails_STATUS"></a>RedisInstanceDetails_STATUS
--------------------------------------------------------------------
+RedisInstanceDetails_STATUS{#RedisInstanceDetails_STATUS}
+---------------------------------------------------------
 
 Details of single instance of redis.
 
@@ -504,8 +504,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | sslPort    | Redis instance SSL port.                                                                          | int<br/><small>Optional</small>    |
 | zone       | If the Cache uses availability zones, specifies availability zone where this instance is located. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServer_STATUS"></a>RedisLinkedServer_STATUS
--------------------------------------------------------------
+RedisLinkedServer_STATUS{#RedisLinkedServer_STATUS}
+---------------------------------------------------
 
 Linked server Id
 
@@ -515,8 +515,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 |----------|-------------------|------------------------------------|
 | id       | Linked server Id. | string<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerCreateProperties_ServerRole"></a>RedisLinkedServerCreateProperties_ServerRole
------------------------------------------------------------------------------------------------------
+RedisLinkedServerCreateProperties_ServerRole{#RedisLinkedServerCreateProperties_ServerRole}
+-------------------------------------------------------------------------------------------
 
 Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 
@@ -525,8 +525,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisLinkedServerOperatorSpec"></a>RedisLinkedServerOperatorSpec
------------------------------------------------------------------------
+RedisLinkedServerOperatorSpec{#RedisLinkedServerOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -537,8 +537,8 @@ Used by: [RedisLinkedServer_Spec](#RedisLinkedServer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisLinkedServerProperties_ServerRole_STATUS"></a>RedisLinkedServerProperties_ServerRole_STATUS
--------------------------------------------------------------------------------------------------------
+RedisLinkedServerProperties_ServerRole_STATUS{#RedisLinkedServerProperties_ServerRole_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 
@@ -547,8 +547,8 @@ Used by: [Redis_LinkedServer_STATUS](#Redis_LinkedServer_STATUS).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="RedisOperatorSpec"></a>RedisOperatorSpec
------------------------------------------------
+RedisOperatorSpec{#RedisOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -560,8 +560,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [RedisOperatorSecrets](#RedisOperatorSecrets)<br/><small>Optional</small>                                                                                           |
 
-<a id="RedisPatchScheduleOperatorSpec"></a>RedisPatchScheduleOperatorSpec
--------------------------------------------------------------------------
+RedisPatchScheduleOperatorSpec{#RedisPatchScheduleOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -572,8 +572,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RedisProperties_MinimumTlsVersion_STATUS"></a>RedisProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_MinimumTlsVersion_STATUS{#RedisProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -583,8 +583,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="RedisProperties_ProvisioningState_STATUS"></a>RedisProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+RedisProperties_ProvisioningState_STATUS{#RedisProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -604,8 +604,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Unprovisioning"         |             |
 | "Updating"               |             |
 
-<a id="RedisProperties_PublicNetworkAccess_STATUS"></a>RedisProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------
+RedisProperties_PublicNetworkAccess_STATUS{#RedisProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -614,8 +614,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RedisProperties_RedisConfiguration_STATUS"></a>RedisProperties_RedisConfiguration_STATUS
------------------------------------------------------------------------------------------------
+RedisProperties_RedisConfiguration_STATUS{#RedisProperties_RedisConfiguration_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -641,8 +641,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | storage-subscription-id                | SubscriptionId of the storage account for persistence (aof/rdb) using ManagedIdentity.                                                  | string<br/><small>Optional</small> |
 | zonal-configuration                    | Zonal Configuration                                                                                                                     | string<br/><small>Optional</small> |
 
-<a id="RedisProperties_UpdateChannel_STATUS"></a>RedisProperties_UpdateChannel_STATUS
--------------------------------------------------------------------------------------
+RedisProperties_UpdateChannel_STATUS{#RedisProperties_UpdateChannel_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [Redis_STATUS](#Redis_STATUS).
 
@@ -651,8 +651,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | "Preview" |             |
 | "Stable"  |             |
 
-<a id="ScheduleEntry"></a>ScheduleEntry
----------------------------------------
+ScheduleEntry{#ScheduleEntry}
+-----------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -664,8 +664,8 @@ Used by: [RedisPatchSchedule_Spec](#RedisPatchSchedule_Spec).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                              |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Required</small>                                                 |
 
-<a id="ScheduleEntry_STATUS"></a>ScheduleEntry_STATUS
------------------------------------------------------
+ScheduleEntry_STATUS{#ScheduleEntry_STATUS}
+-------------------------------------------
 
 Patch schedule entry for a Premium Redis Cache.
 
@@ -677,8 +677,8 @@ Used by: [RedisPatchSchedule_STATUS](#RedisPatchSchedule_STATUS).
 | maintenanceWindow | ISO8601 timespan specifying how much time cache patching can take. | string<br/><small>Optional</small>                                                            |
 | startHourUtc      | Start hour after which cache patching can start.                   | int<br/><small>Optional</small>                                                               |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -690,8 +690,8 @@ Used by: [Redis_Spec](#Redis_Spec).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family](#Sku_Family)<br/><small>Required</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name](#Sku_Name)<br/><small>Required</small>     |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create Redis operation.
 
@@ -703,8 +703,8 @@ Used by: [Redis_STATUS](#Redis_STATUS).
 | family   | The SKU family to use. Valid values: (C, P). (C = Basic/Standard, P = Premium).                                                                | [Sku_Family_STATUS](#Sku_Family_STATUS)<br/><small>Optional</small> |
 | name     | The type of Redis cache to deploy. Valid values: (Basic, Standard, Premium)                                                                    | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small>     |
 
-<a id="ManagedServiceIdentityType"></a>ManagedServiceIdentityType
------------------------------------------------------------------
+ManagedServiceIdentityType{#ManagedServiceIdentityType}
+-------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -717,8 +717,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentityType_STATUS"></a>ManagedServiceIdentityType_STATUS
--------------------------------------------------------------------------------
+ManagedServiceIdentityType_STATUS{#ManagedServiceIdentityType_STATUS}
+---------------------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -731,8 +731,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="RedisOperatorSecrets"></a>RedisOperatorSecrets
------------------------------------------------------
+RedisOperatorSecrets{#RedisOperatorSecrets}
+-------------------------------------------
 
 Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 
@@ -744,8 +744,8 @@ Used by: [RedisOperatorSpec](#RedisOperatorSpec).
 | secondaryKey | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | sslPort      | indicates where the SSLPort secret should be placed. If omitted, the secret will not be retrieved from Azure.      | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ScheduleEntry_DayOfWeek"></a>ScheduleEntry_DayOfWeek
------------------------------------------------------------
+ScheduleEntry_DayOfWeek{#ScheduleEntry_DayOfWeek}
+-------------------------------------------------
 
 Used by: [ScheduleEntry](#ScheduleEntry).
 
@@ -761,8 +761,8 @@ Used by: [ScheduleEntry](#ScheduleEntry).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="ScheduleEntry_DayOfWeek_STATUS"></a>ScheduleEntry_DayOfWeek_STATUS
--------------------------------------------------------------------------
+ScheduleEntry_DayOfWeek_STATUS{#ScheduleEntry_DayOfWeek_STATUS}
+---------------------------------------------------------------
 
 Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 
@@ -778,40 +778,40 @@ Used by: [ScheduleEntry_STATUS](#ScheduleEntry_STATUS).
 | "Wednesday" |             |
 | "Weekend"   |             |
 
-<a id="Sku_Family"></a>Sku_Family
+Sku_Family{#Sku_Family}
+-----------------------
+
+Used by: [Sku](#Sku).
+
+| Value | Description |
+|-------|-------------|
+| "C"   |             |
+| "P"   |             |
+
+Sku_Family_STATUS{#Sku_Family_STATUS}
+-------------------------------------
+
+Used by: [Sku_STATUS](#Sku_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "C"   |             |
+| "P"   |             |
+
+Sku_Name{#Sku_Name}
+-------------------
+
+Used by: [Sku](#Sku).
+
+| Value      | Description |
+|------------|-------------|
+| "Basic"    |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+Sku_Name_STATUS{#Sku_Name_STATUS}
 ---------------------------------
 
-Used by: [Sku](#Sku).
-
-| Value | Description |
-|-------|-------------|
-| "C"   |             |
-| "P"   |             |
-
-<a id="Sku_Family_STATUS"></a>Sku_Family_STATUS
------------------------------------------------
-
-Used by: [Sku_STATUS](#Sku_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "C"   |             |
-| "P"   |             |
-
-<a id="Sku_Name"></a>Sku_Name
------------------------------
-
-Used by: [Sku](#Sku).
-
-| Value      | Description |
-|------------|-------------|
-| "Basic"    |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
-
 Used by: [Sku_STATUS](#Sku_STATUS).
 
 | Value      | Description |
@@ -820,8 +820,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -832,8 +832,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/cdn/v1api20210601.md
+++ b/docs/hugo/content/reference/cdn/v1api20210601.md
@@ -5,15 +5,15 @@ title: cdn.azure.com/v1api20210601
 linktitle: v1api20210601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-06-01" |             |
 
-<a id="Profile"></a>Profile
----------------------------
+Profile{#Profile}
+-----------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}
 
@@ -26,7 +26,7 @@ Used by: [ProfileList](#ProfileList).
 | spec                                                                                    |             | [Profile_Spec](#Profile_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Profile_STATUS](#Profile_STATUS)<br/><small>Optional</small> |
 
-### <a id="Profile_Spec"></a>Profile_Spec
+### Profile_Spec {#Profile_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,7 +38,7 @@ Used by: [ProfileList](#ProfileList).
 | sku                          | The pricing tier (defines Azure Front Door Standard or Premium or a CDN provider, feature list and rate) of the profile.                                                                                                                                                                     | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Profile_STATUS"></a>Profile_STATUS
+### Profile_STATUS{#Profile_STATUS}
 
 | Property                     | Description                                                                                                              | Type                                                                                                                                                    |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,8 +56,8 @@ Used by: [ProfileList](#ProfileList).
 | tags                         | Resource tags.                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | Resource type.                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProfileList"></a>ProfileList
------------------------------------
+ProfileList{#ProfileList}
+-------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}
 
@@ -67,8 +67,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Profile[]](#Profile)<br/><small>Optional</small> |
 
-<a id="ProfilesEndpoint"></a>ProfilesEndpoint
----------------------------------------------
+ProfilesEndpoint{#ProfilesEndpoint}
+-----------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
 
@@ -81,7 +81,7 @@ Used by: [ProfilesEndpointList](#ProfilesEndpointList).
 | spec                                                                                    |             | [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="ProfilesEndpoint_Spec"></a>ProfilesEndpoint_Spec
+### ProfilesEndpoint_Spec {#ProfilesEndpoint_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -107,7 +107,7 @@ Used by: [ProfilesEndpointList](#ProfilesEndpointList).
 | urlSigningKeys                   | List of keys used to validate the signed URL hashes.                                                                                                                                                                                                                                                                                                                                                                     | [UrlSigningKey[]](#UrlSigningKey)<br/><small>Optional</small>                                                                                                        |
 | webApplicationFirewallPolicyLink | Defines the Web Application Firewall policy for the endpoint (if applicable)                                                                                                                                                                                                                                                                                                                                             | [EndpointProperties_WebApplicationFirewallPolicyLink](#EndpointProperties_WebApplicationFirewallPolicyLink)<br/><small>Optional</small>                              |
 
-### <a id="ProfilesEndpoint_STATUS"></a>ProfilesEndpoint_STATUS
+### ProfilesEndpoint_STATUS{#ProfilesEndpoint_STATUS}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -139,8 +139,8 @@ Used by: [ProfilesEndpointList](#ProfilesEndpointList).
 | urlSigningKeys                   | List of keys used to validate the signed URL hashes.                                                                                                                                                                                                                                                                                                                                                                     | [UrlSigningKey_STATUS[]](#UrlSigningKey_STATUS)<br/><small>Optional</small>                                                                             |
 | webApplicationFirewallPolicyLink | Defines the Web Application Firewall policy for the endpoint (if applicable)                                                                                                                                                                                                                                                                                                                                             | [EndpointProperties_WebApplicationFirewallPolicyLink_STATUS](#EndpointProperties_WebApplicationFirewallPolicyLink_STATUS)<br/><small>Optional</small>   |
 
-<a id="ProfilesEndpointList"></a>ProfilesEndpointList
------------------------------------------------------
+ProfilesEndpointList{#ProfilesEndpointList}
+-------------------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
 
@@ -150,8 +150,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [ProfilesEndpoint[]](#ProfilesEndpoint)<br/><small>Optional</small> |
 
-<a id="Profile_Spec"></a>Profile_Spec
--------------------------------------
+Profile_Spec{#Profile_Spec}
+---------------------------
 
 Used by: [Profile](#Profile).
 
@@ -165,8 +165,8 @@ Used by: [Profile](#Profile).
 | sku                          | The pricing tier (defines Azure Front Door Standard or Premium or a CDN provider, feature list and rate) of the profile.                                                                                                                                                                     | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Profile_STATUS"></a>Profile_STATUS
------------------------------------------
+Profile_STATUS{#Profile_STATUS}
+-------------------------------
 
 A profile is a logical grouping of endpoints that share the same settings.
 
@@ -188,8 +188,8 @@ Used by: [Profile](#Profile).
 | tags                         | Resource tags.                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | Resource type.                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProfilesEndpoint_Spec"></a>ProfilesEndpoint_Spec
--------------------------------------------------------
+ProfilesEndpoint_Spec{#ProfilesEndpoint_Spec}
+---------------------------------------------
 
 Used by: [ProfilesEndpoint](#ProfilesEndpoint).
 
@@ -217,8 +217,8 @@ Used by: [ProfilesEndpoint](#ProfilesEndpoint).
 | urlSigningKeys                   | List of keys used to validate the signed URL hashes.                                                                                                                                                                                                                                                                                                                                                                     | [UrlSigningKey[]](#UrlSigningKey)<br/><small>Optional</small>                                                                                                        |
 | webApplicationFirewallPolicyLink | Defines the Web Application Firewall policy for the endpoint (if applicable)                                                                                                                                                                                                                                                                                                                                             | [EndpointProperties_WebApplicationFirewallPolicyLink](#EndpointProperties_WebApplicationFirewallPolicyLink)<br/><small>Optional</small>                              |
 
-<a id="ProfilesEndpoint_STATUS"></a>ProfilesEndpoint_STATUS
------------------------------------------------------------
+ProfilesEndpoint_STATUS{#ProfilesEndpoint_STATUS}
+-------------------------------------------------
 
 Used by: [ProfilesEndpoint](#ProfilesEndpoint).
 
@@ -252,8 +252,8 @@ Used by: [ProfilesEndpoint](#ProfilesEndpoint).
 | urlSigningKeys                   | List of keys used to validate the signed URL hashes.                                                                                                                                                                                                                                                                                                                                                                     | [UrlSigningKey_STATUS[]](#UrlSigningKey_STATUS)<br/><small>Optional</small>                                                                             |
 | webApplicationFirewallPolicyLink | Defines the Web Application Firewall policy for the endpoint (if applicable)                                                                                                                                                                                                                                                                                                                                             | [EndpointProperties_WebApplicationFirewallPolicyLink_STATUS](#EndpointProperties_WebApplicationFirewallPolicyLink_STATUS)<br/><small>Optional</small>   |
 
-<a id="DeepCreatedCustomDomain_STATUS"></a>DeepCreatedCustomDomain_STATUS
--------------------------------------------------------------------------
+DeepCreatedCustomDomain_STATUS{#DeepCreatedCustomDomain_STATUS}
+---------------------------------------------------------------
 
 Custom domains created on the CDN endpoint.
 
@@ -265,8 +265,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | name           | Custom domain name.                                                                                                                                                                                 | string<br/><small>Optional</small> |
 | validationData | Special validation or data may be required when delivering CDN to some regions due to local compliance reasons. E.g. ICP license number of a custom domain is required to deliver content in China. | string<br/><small>Optional</small> |
 
-<a id="DeepCreatedOrigin"></a>DeepCreatedOrigin
------------------------------------------------
+DeepCreatedOrigin{#DeepCreatedOrigin}
+-------------------------------------
 
 The main origin of CDN content which is added when creating a CDN endpoint.
 
@@ -287,8 +287,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | privateLinkResourceReference | The Resource Id of the Private Link resource. Populating this optional field indicates that this backend is 'Private'                                                                                                                                                          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | weight                       | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                      | int<br/><small>Optional</small>                                                                                                                            |
 
-<a id="DeepCreatedOrigin_STATUS"></a>DeepCreatedOrigin_STATUS
--------------------------------------------------------------
+DeepCreatedOrigin_STATUS{#DeepCreatedOrigin_STATUS}
+---------------------------------------------------
 
 The main origin of CDN content which is added when creating a CDN endpoint.
 
@@ -310,8 +310,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | privateLinkResourceId      | The Resource Id of the Private Link resource. Populating this optional field indicates that this backend is 'Private'                                                                                                                                                          | string<br/><small>Optional</small>                                                        |
 | weight                     | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                      | int<br/><small>Optional</small>                                                           |
 
-<a id="DeepCreatedOriginGroup"></a>DeepCreatedOriginGroup
----------------------------------------------------------
+DeepCreatedOriginGroup{#DeepCreatedOriginGroup}
+-----------------------------------------------
 
 The origin group for CDN content which is added when creating a CDN endpoint. Traffic is sent to the origins within the origin group based on origin health.
 
@@ -325,8 +325,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | responseBasedOriginErrorDetectionSettings             | The JSON object that contains the properties to determine origin health using real requests/responses.This property is currently not supported.                                                   | [ResponseBasedOriginErrorDetectionParameters](#ResponseBasedOriginErrorDetectionParameters)<br/><small>Optional</small> |
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported. | int<br/><small>Optional</small>                                                                                         |
 
-<a id="DeepCreatedOriginGroup_STATUS"></a>DeepCreatedOriginGroup_STATUS
------------------------------------------------------------------------
+DeepCreatedOriginGroup_STATUS{#DeepCreatedOriginGroup_STATUS}
+-------------------------------------------------------------
 
 The origin group for CDN content which is added when creating a CDN endpoint. Traffic is sent to the origins within the origin group based on origin health.
 
@@ -340,8 +340,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | responseBasedOriginErrorDetectionSettings             | The JSON object that contains the properties to determine origin health using real requests/responses.This property is currently not supported.                                                   | [ResponseBasedOriginErrorDetectionParameters_STATUS](#ResponseBasedOriginErrorDetectionParameters_STATUS)<br/><small>Optional</small> |
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported. | int<br/><small>Optional</small>                                                                                                       |
 
-<a id="EndpointProperties_DeliveryPolicy"></a>EndpointProperties_DeliveryPolicy
--------------------------------------------------------------------------------
+EndpointProperties_DeliveryPolicy{#EndpointProperties_DeliveryPolicy}
+---------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 
@@ -350,8 +350,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | description | User-friendly description of the policy. | string<br/><small>Optional</small>                          |
 | rules       | A list of the delivery rules.            | [DeliveryRule[]](#DeliveryRule)<br/><small>Required</small> |
 
-<a id="EndpointProperties_DeliveryPolicy_STATUS"></a>EndpointProperties_DeliveryPolicy_STATUS
----------------------------------------------------------------------------------------------
+EndpointProperties_DeliveryPolicy_STATUS{#EndpointProperties_DeliveryPolicy_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 
@@ -360,8 +360,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | description | User-friendly description of the policy. | string<br/><small>Optional</small>                                        |
 | rules       | A list of the delivery rules.            | [DeliveryRule_STATUS[]](#DeliveryRule_STATUS)<br/><small>Optional</small> |
 
-<a id="EndpointProperties_ProvisioningState_STATUS"></a>EndpointProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------
+EndpointProperties_ProvisioningState_STATUS{#EndpointProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 
@@ -373,8 +373,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="EndpointProperties_ResourceState_STATUS"></a>EndpointProperties_ResourceState_STATUS
--------------------------------------------------------------------------------------------
+EndpointProperties_ResourceState_STATUS{#EndpointProperties_ResourceState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 
@@ -387,8 +387,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | "Stopped"  |             |
 | "Stopping" |             |
 
-<a id="EndpointProperties_WebApplicationFirewallPolicyLink"></a>EndpointProperties_WebApplicationFirewallPolicyLink
--------------------------------------------------------------------------------------------------------------------
+EndpointProperties_WebApplicationFirewallPolicyLink{#EndpointProperties_WebApplicationFirewallPolicyLink}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 
@@ -396,8 +396,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EndpointProperties_WebApplicationFirewallPolicyLink_STATUS"></a>EndpointProperties_WebApplicationFirewallPolicyLink_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+EndpointProperties_WebApplicationFirewallPolicyLink_STATUS{#EndpointProperties_WebApplicationFirewallPolicyLink_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 
@@ -405,8 +405,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="GeoFilter"></a>GeoFilter
--------------------------------
+GeoFilter{#GeoFilter}
+---------------------
 
 Rules defining user's geo access within a CDN endpoint.
 
@@ -418,8 +418,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | countryCodes | Two letter country or region codes defining user country or region access in a geo filter, e.g. AU, MX, US. | string[]<br/><small>Required</small>                              |
 | relativePath | Relative path applicable to geo filter. (e.g. '/mypictures', '/mypicture/kitty.jpg', and etc.)              | string<br/><small>Required</small>                                |
 
-<a id="GeoFilter_STATUS"></a>GeoFilter_STATUS
----------------------------------------------
+GeoFilter_STATUS{#GeoFilter_STATUS}
+-----------------------------------
 
 Rules defining user's geo access within a CDN endpoint.
 
@@ -431,8 +431,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | countryCodes | Two letter country or region codes defining user country or region access in a geo filter, e.g. AU, MX, US. | string[]<br/><small>Optional</small>                                            |
 | relativePath | Relative path applicable to geo filter. (e.g. '/mypictures', '/mypicture/kitty.jpg', and etc.)              | string<br/><small>Optional</small>                                              |
 
-<a id="OptimizationType"></a>OptimizationType
----------------------------------------------
+OptimizationType{#OptimizationType}
+-----------------------------------
 
 Specifies what scenario the customer wants this CDN endpoint to optimize, e.g. Download, Media services. With this information we can apply scenario driven optimization.
 
@@ -446,8 +446,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | "LargeFileDownload"           |             |
 | "VideoOnDemandMediaStreaming" |             |
 
-<a id="OptimizationType_STATUS"></a>OptimizationType_STATUS
------------------------------------------------------------
+OptimizationType_STATUS{#OptimizationType_STATUS}
+-------------------------------------------------
 
 Specifies what scenario the customer wants this CDN endpoint to optimize, e.g. Download, Media services. With this information we can apply scenario driven optimization.
 
@@ -461,8 +461,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | "LargeFileDownload"           |             |
 | "VideoOnDemandMediaStreaming" |             |
 
-<a id="ProfileOperatorSpec"></a>ProfileOperatorSpec
----------------------------------------------------
+ProfileOperatorSpec{#ProfileOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -473,8 +473,8 @@ Used by: [Profile_Spec](#Profile_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProfileProperties_ProvisioningState_STATUS"></a>ProfileProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+ProfileProperties_ProvisioningState_STATUS{#ProfileProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Profile_STATUS](#Profile_STATUS).
 
@@ -486,8 +486,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ProfileProperties_ResourceState_STATUS"></a>ProfileProperties_ResourceState_STATUS
------------------------------------------------------------------------------------------
+ProfileProperties_ResourceState_STATUS{#ProfileProperties_ResourceState_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Profile_STATUS](#Profile_STATUS).
 
@@ -498,8 +498,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 | "Deleting" |             |
 | "Disabled" |             |
 
-<a id="ProfilesEndpointOperatorSpec"></a>ProfilesEndpointOperatorSpec
----------------------------------------------------------------------
+ProfilesEndpointOperatorSpec{#ProfilesEndpointOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -510,8 +510,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="QueryStringCachingBehavior"></a>QueryStringCachingBehavior
------------------------------------------------------------------
+QueryStringCachingBehavior{#QueryStringCachingBehavior}
+-------------------------------------------------------
 
 Defines how CDN caches requests that include query strings. You can ignore any query strings when caching, bypass caching to prevent requests that contain query strings from being cached, or cache every request with a unique URL.
 
@@ -524,8 +524,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | "NotSet"            |             |
 | "UseQueryString"    |             |
 
-<a id="QueryStringCachingBehavior_STATUS"></a>QueryStringCachingBehavior_STATUS
--------------------------------------------------------------------------------
+QueryStringCachingBehavior_STATUS{#QueryStringCachingBehavior_STATUS}
+---------------------------------------------------------------------
 
 Defines how CDN caches requests that include query strings. You can ignore any query strings when caching, bypass caching to prevent requests that contain query strings from being cached, or cache every request with a unique URL.
 
@@ -538,8 +538,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | "NotSet"            |             |
 | "UseQueryString"    |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Reference to another resource.
 
@@ -549,8 +549,8 @@ Used by: [DeepCreatedOriginGroup](#DeepCreatedOriginGroup), [OriginGroupOverride
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Reference to another resource.
 
@@ -560,8 +560,8 @@ Used by: [DeepCreatedOriginGroup_STATUS](#DeepCreatedOriginGroup_STATUS), [Origi
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Standard_Verizon = The SKU name for a Standard Verizon CDN profile. Premium_Verizon = The SKU name for a Premium Verizon CDN profile. Custom_Verizon = The SKU name for a Custom Verizon CDN profile. Standard_Akamai = The SKU name for an Akamai CDN profile. Standard_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using GB based billing model. Standard_Microsoft = The SKU name for a Standard Microsoft CDN profile. Standard_AzureFrontDoor = The SKU name for an Azure Front Door Standard profile. Premium_AzureFrontDoor = The SKU name for an Azure Front Door Premium profile. Standard_955BandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using 95-5 peak bandwidth billing model. Standard_AvgBandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using monthly average peak bandwidth billing model. StandardPlus_ChinaCdn = The SKU name for a China CDN profile for live-streaming using GB based billing model. StandardPlus_955BandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using 95-5 peak bandwidth billing model. StandardPlus_AvgBandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using monthly average peak bandwidth billing model.
 
@@ -571,8 +571,8 @@ Used by: [Profile_Spec](#Profile_Spec).
 |----------|---------------------------|---------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Standard_Verizon = The SKU name for a Standard Verizon CDN profile. Premium_Verizon = The SKU name for a Premium Verizon CDN profile. Custom_Verizon = The SKU name for a Custom Verizon CDN profile. Standard_Akamai = The SKU name for an Akamai CDN profile. Standard_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using GB based billing model. Standard_Microsoft = The SKU name for a Standard Microsoft CDN profile. Standard_AzureFrontDoor = The SKU name for an Azure Front Door Standard profile. Premium_AzureFrontDoor = The SKU name for an Azure Front Door Premium profile. Standard_955BandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using 95-5 peak bandwidth billing model. Standard_AvgBandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using monthly average peak bandwidth billing model. StandardPlus_ChinaCdn = The SKU name for a China CDN profile for live-streaming using GB based billing model. StandardPlus_955BandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using 95-5 peak bandwidth billing model. StandardPlus_AvgBandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using monthly average peak bandwidth billing model.
 
@@ -582,8 +582,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 |----------|---------------------------|-----------------------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Read only system data
 
@@ -598,8 +598,8 @@ Used by: [Profile_STATUS](#Profile_STATUS), and [ProfilesEndpoint_STATUS](#Profi
 | lastModifiedBy     | An identifier for the identity that last modified the resource | string<br/><small>Optional</small>                                      |
 | lastModifiedByType | The type of identity that last modified the resource           | [IdentityType_STATUS](#IdentityType_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningKey"></a>UrlSigningKey
----------------------------------------
+UrlSigningKey{#UrlSigningKey}
+-----------------------------
 
 Url signing key
 
@@ -610,8 +610,8 @@ Used by: [ProfilesEndpoint_Spec](#ProfilesEndpoint_Spec).
 | keyId               | Defines the customer defined key Id. This id will exist in the incoming request to indicate the key used to form the hash. | string<br/><small>Required</small>                                                        |
 | keySourceParameters | Defines the parameters for using customer key vault for Url Signing Key.                                                   | [KeyVaultSigningKeyParameters](#KeyVaultSigningKeyParameters)<br/><small>Required</small> |
 
-<a id="UrlSigningKey_STATUS"></a>UrlSigningKey_STATUS
------------------------------------------------------
+UrlSigningKey_STATUS{#UrlSigningKey_STATUS}
+-------------------------------------------
 
 Url signing key
 
@@ -622,8 +622,8 @@ Used by: [ProfilesEndpoint_STATUS](#ProfilesEndpoint_STATUS).
 | keyId               | Defines the customer defined key Id. This id will exist in the incoming request to indicate the key used to form the hash. | string<br/><small>Optional</small>                                                                      |
 | keySourceParameters | Defines the parameters for using customer key vault for Url Signing Key.                                                   | [KeyVaultSigningKeyParameters_STATUS](#KeyVaultSigningKeyParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="DeliveryRule"></a>DeliveryRule
--------------------------------------
+DeliveryRule{#DeliveryRule}
+---------------------------
 
 A rule that specifies a set of actions and conditions
 
@@ -636,8 +636,8 @@ Used by: [EndpointProperties_DeliveryPolicy](#EndpointProperties_DeliveryPolicy)
 | name       | Name of the rule                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                            |
 | order      | The order in which the rules are applied for the endpoint. Possible values {0,1,2,3,………}. A rule with a lesser order will be applied before a rule with a greater order. Rule with order 0 is a special rule. It does not require any condition and actions listed in it will always be applied. | int<br/><small>Required</small>                                               |
 
-<a id="DeliveryRule_STATUS"></a>DeliveryRule_STATUS
----------------------------------------------------
+DeliveryRule_STATUS{#DeliveryRule_STATUS}
+-----------------------------------------
 
 A rule that specifies a set of actions and conditions
 
@@ -650,8 +650,8 @@ Used by: [EndpointProperties_DeliveryPolicy_STATUS](#EndpointProperties_Delivery
 | name       | Name of the rule                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                          |
 | order      | The order in which the rules are applied for the endpoint. Possible values {0,1,2,3,………}. A rule with a lesser order will be applied before a rule with a greater order. Rule with order 0 is a special rule. It does not require any condition and actions listed in it will always be applied. | int<br/><small>Optional</small>                                                             |
 
-<a id="GeoFilter_Action"></a>GeoFilter_Action
----------------------------------------------
+GeoFilter_Action{#GeoFilter_Action}
+-----------------------------------
 
 Used by: [GeoFilter](#GeoFilter).
 
@@ -660,8 +660,8 @@ Used by: [GeoFilter](#GeoFilter).
 | "Allow" |             |
 | "Block" |             |
 
-<a id="GeoFilter_Action_STATUS"></a>GeoFilter_Action_STATUS
------------------------------------------------------------
+GeoFilter_Action_STATUS{#GeoFilter_Action_STATUS}
+-------------------------------------------------
 
 Used by: [GeoFilter_STATUS](#GeoFilter_STATUS).
 
@@ -670,8 +670,8 @@ Used by: [GeoFilter_STATUS](#GeoFilter_STATUS).
 | "Allow" |             |
 | "Block" |             |
 
-<a id="HealthProbeParameters"></a>HealthProbeParameters
--------------------------------------------------------
+HealthProbeParameters{#HealthProbeParameters}
+---------------------------------------------
 
 The JSON object that contains the properties to send health probes to origin.
 
@@ -684,8 +684,8 @@ Used by: [DeepCreatedOriginGroup](#DeepCreatedOriginGroup).
 | probeProtocol          | Protocol to use for health probe.                                                   | [HealthProbeParameters_ProbeProtocol](#HealthProbeParameters_ProbeProtocol)<br/><small>Optional</small>       |
 | probeRequestType       | The type of health probe request that is made.                                      | [HealthProbeParameters_ProbeRequestType](#HealthProbeParameters_ProbeRequestType)<br/><small>Optional</small> |
 
-<a id="HealthProbeParameters_STATUS"></a>HealthProbeParameters_STATUS
----------------------------------------------------------------------
+HealthProbeParameters_STATUS{#HealthProbeParameters_STATUS}
+-----------------------------------------------------------
 
 The JSON object that contains the properties to send health probes to origin.
 
@@ -698,8 +698,8 @@ Used by: [DeepCreatedOriginGroup_STATUS](#DeepCreatedOriginGroup_STATUS).
 | probeProtocol          | Protocol to use for health probe.                                                   | [HealthProbeParameters_ProbeProtocol_STATUS](#HealthProbeParameters_ProbeProtocol_STATUS)<br/><small>Optional</small>       |
 | probeRequestType       | The type of health probe request that is made.                                      | [HealthProbeParameters_ProbeRequestType_STATUS](#HealthProbeParameters_ProbeRequestType_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityType_STATUS"></a>IdentityType_STATUS
----------------------------------------------------
+IdentityType_STATUS{#IdentityType_STATUS}
+-----------------------------------------
 
 The type of identity that creates/modifies resources
 
@@ -712,8 +712,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS), and [SystemData_STATUS](#Syste
 | "managedIdentity" |             |
 | "user"            |             |
 
-<a id="KeyVaultSigningKeyParameters"></a>KeyVaultSigningKeyParameters
----------------------------------------------------------------------
+KeyVaultSigningKeyParameters{#KeyVaultSigningKeyParameters}
+-----------------------------------------------------------
 
 Describes the parameters for using a user's KeyVault for URL Signing Key.
 
@@ -728,8 +728,8 @@ Used by: [UrlSigningKey](#UrlSigningKey).
 | typeName          |                                                               | [KeyVaultSigningKeyParameters_TypeName](#KeyVaultSigningKeyParameters_TypeName)<br/><small>Required</small> |
 | vaultName         | The name of the user's Key Vault containing the secret        | string<br/><small>Required</small>                                                                          |
 
-<a id="KeyVaultSigningKeyParameters_STATUS"></a>KeyVaultSigningKeyParameters_STATUS
------------------------------------------------------------------------------------
+KeyVaultSigningKeyParameters_STATUS{#KeyVaultSigningKeyParameters_STATUS}
+-------------------------------------------------------------------------
 
 Describes the parameters for using a user's KeyVault for URL Signing Key.
 
@@ -744,8 +744,8 @@ Used by: [UrlSigningKey_STATUS](#UrlSigningKey_STATUS).
 | typeName          |                                                               | [KeyVaultSigningKeyParameters_TypeName_STATUS](#KeyVaultSigningKeyParameters_TypeName_STATUS)<br/><small>Optional</small> |
 | vaultName         | The name of the user's Key Vault containing the secret        | string<br/><small>Optional</small>                                                                                        |
 
-<a id="PrivateEndpointStatus_STATUS"></a>PrivateEndpointStatus_STATUS
----------------------------------------------------------------------
+PrivateEndpointStatus_STATUS{#PrivateEndpointStatus_STATUS}
+-----------------------------------------------------------
 
 The approval status for the connection to the Private Link
 
@@ -759,8 +759,8 @@ Used by: [DeepCreatedOrigin_STATUS](#DeepCreatedOrigin_STATUS).
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="ResponseBasedOriginErrorDetectionParameters"></a>ResponseBasedOriginErrorDetectionParameters
----------------------------------------------------------------------------------------------------
+ResponseBasedOriginErrorDetectionParameters{#ResponseBasedOriginErrorDetectionParameters}
+-----------------------------------------------------------------------------------------
 
 The JSON object that contains the properties to determine origin health using real requests/responses.
 
@@ -772,8 +772,8 @@ Used by: [DeepCreatedOriginGroup](#DeepCreatedOriginGroup).
 | responseBasedDetectedErrorTypes          | Type of response errors for real user requests for which origin will be deemed unhealthy                           | [ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes](#ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes)<br/><small>Optional</small> |
 | responseBasedFailoverThresholdPercentage | The percentage of failed requests in the sample where failover should trigger.                                     | int<br/><small>Optional</small>                                                                                                                                                         |
 
-<a id="ResponseBasedOriginErrorDetectionParameters_STATUS"></a>ResponseBasedOriginErrorDetectionParameters_STATUS
------------------------------------------------------------------------------------------------------------------
+ResponseBasedOriginErrorDetectionParameters_STATUS{#ResponseBasedOriginErrorDetectionParameters_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 The JSON object that contains the properties to determine origin health using real requests/responses.
 
@@ -785,8 +785,8 @@ Used by: [DeepCreatedOriginGroup_STATUS](#DeepCreatedOriginGroup_STATUS).
 | responseBasedDetectedErrorTypes          | Type of response errors for real user requests for which origin will be deemed unhealthy                           | [ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS](#ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS)<br/><small>Optional</small> |
 | responseBasedFailoverThresholdPercentage | The percentage of failed requests in the sample where failover should trigger.                                     | int<br/><small>Optional</small>                                                                                                                                                                       |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -806,8 +806,8 @@ Used by: [Sku](#Sku).
 | "Standard_Microsoft"                 |             |
 | "Standard_Verizon"                   |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -827,8 +827,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Standard_Microsoft"                 |             |
 | "Standard_Verizon"                   |             |
 
-<a id="DeliveryRuleAction"></a>DeliveryRuleAction
--------------------------------------------------
+DeliveryRuleAction{#DeliveryRuleAction}
+---------------------------------------
 
 An action for the delivery rule.
 
@@ -846,8 +846,8 @@ Used by: [DeliveryRule](#DeliveryRule).
 | urlRewrite                 | Mutually exclusive with all other properties | [UrlRewriteAction](#UrlRewriteAction)<br/><small>Optional</small>                                                         |
 | urlSigning                 | Mutually exclusive with all other properties | [UrlSigningAction](#UrlSigningAction)<br/><small>Optional</small>                                                         |
 
-<a id="DeliveryRuleAction_STATUS"></a>DeliveryRuleAction_STATUS
----------------------------------------------------------------
+DeliveryRuleAction_STATUS{#DeliveryRuleAction_STATUS}
+-----------------------------------------------------
 
 An action for the delivery rule.
 
@@ -865,8 +865,8 @@ Used by: [DeliveryRule_STATUS](#DeliveryRule_STATUS).
 | urlRewrite                 | Mutually exclusive with all other properties | [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS)<br/><small>Optional</small>                                                         |
 | urlSigning                 | Mutually exclusive with all other properties | [UrlSigningAction_STATUS](#UrlSigningAction_STATUS)<br/><small>Optional</small>                                                         |
 
-<a id="DeliveryRuleCondition"></a>DeliveryRuleCondition
--------------------------------------------------------
+DeliveryRuleCondition{#DeliveryRuleCondition}
+---------------------------------------------
 
 A condition for the delivery rule.
 
@@ -894,8 +894,8 @@ Used by: [DeliveryRule](#DeliveryRule).
 | urlFileName      | Mutually exclusive with all other properties | [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition)<br/><small>Optional</small>           |
 | urlPath          | Mutually exclusive with all other properties | [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition)<br/><small>Optional</small>                   |
 
-<a id="DeliveryRuleCondition_STATUS"></a>DeliveryRuleCondition_STATUS
----------------------------------------------------------------------
+DeliveryRuleCondition_STATUS{#DeliveryRuleCondition_STATUS}
+-----------------------------------------------------------
 
 A condition for the delivery rule.
 
@@ -923,8 +923,8 @@ Used by: [DeliveryRule_STATUS](#DeliveryRule_STATUS).
 | urlFileName      | Mutually exclusive with all other properties | [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondition_STATUS)<br/><small>Optional</small>           |
 | urlPath          | Mutually exclusive with all other properties | [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STATUS)<br/><small>Optional</small>                   |
 
-<a id="HealthProbeParameters_ProbeProtocol"></a>HealthProbeParameters_ProbeProtocol
------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeProtocol{#HealthProbeParameters_ProbeProtocol}
+-------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters](#HealthProbeParameters).
 
@@ -934,8 +934,8 @@ Used by: [HealthProbeParameters](#HealthProbeParameters).
 | "Https"  |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeProtocol_STATUS"></a>HealthProbeParameters_ProbeProtocol_STATUS
--------------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeProtocol_STATUS{#HealthProbeParameters_ProbeProtocol_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 
@@ -945,8 +945,8 @@ Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 | "Https"  |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeRequestType"></a>HealthProbeParameters_ProbeRequestType
------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeRequestType{#HealthProbeParameters_ProbeRequestType}
+-------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters](#HealthProbeParameters).
 
@@ -956,8 +956,8 @@ Used by: [HealthProbeParameters](#HealthProbeParameters).
 | "HEAD"   |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeRequestType_STATUS"></a>HealthProbeParameters_ProbeRequestType_STATUS
--------------------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeRequestType_STATUS{#HealthProbeParameters_ProbeRequestType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 
@@ -967,8 +967,8 @@ Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 | "HEAD"   |             |
 | "NotSet" |             |
 
-<a id="HttpErrorRangeParameters"></a>HttpErrorRangeParameters
--------------------------------------------------------------
+HttpErrorRangeParameters{#HttpErrorRangeParameters}
+---------------------------------------------------
 
 The JSON object that represents the range for http status codes
 
@@ -979,8 +979,8 @@ Used by: [ResponseBasedOriginErrorDetectionParameters](#ResponseBasedOriginError
 | begin    | The inclusive start of the http status code range. | int<br/><small>Optional</small> |
 | end      | The inclusive end of the http status code range.   | int<br/><small>Optional</small> |
 
-<a id="HttpErrorRangeParameters_STATUS"></a>HttpErrorRangeParameters_STATUS
----------------------------------------------------------------------------
+HttpErrorRangeParameters_STATUS{#HttpErrorRangeParameters_STATUS}
+-----------------------------------------------------------------
 
 The JSON object that represents the range for http status codes
 
@@ -991,8 +991,8 @@ Used by: [ResponseBasedOriginErrorDetectionParameters_STATUS](#ResponseBasedOrig
 | begin    | The inclusive start of the http status code range. | int<br/><small>Optional</small> |
 | end      | The inclusive end of the http status code range.   | int<br/><small>Optional</small> |
 
-<a id="KeyVaultSigningKeyParameters_TypeName"></a>KeyVaultSigningKeyParameters_TypeName
----------------------------------------------------------------------------------------
+KeyVaultSigningKeyParameters_TypeName{#KeyVaultSigningKeyParameters_TypeName}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultSigningKeyParameters](#KeyVaultSigningKeyParameters).
 
@@ -1000,8 +1000,8 @@ Used by: [KeyVaultSigningKeyParameters](#KeyVaultSigningKeyParameters).
 |--------------------------------|-------------|
 | "KeyVaultSigningKeyParameters" |             |
 
-<a id="KeyVaultSigningKeyParameters_TypeName_STATUS"></a>KeyVaultSigningKeyParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------
+KeyVaultSigningKeyParameters_TypeName_STATUS{#KeyVaultSigningKeyParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [KeyVaultSigningKeyParameters_STATUS](#KeyVaultSigningKeyParameters_STATUS).
 
@@ -1009,8 +1009,8 @@ Used by: [KeyVaultSigningKeyParameters_STATUS](#KeyVaultSigningKeyParameters_STA
 |--------------------------------|-------------|
 | "KeyVaultSigningKeyParameters" |             |
 
-<a id="ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes"></a>ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes{#ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes}
+---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ResponseBasedOriginErrorDetectionParameters](#ResponseBasedOriginErrorDetectionParameters).
 
@@ -1020,8 +1020,8 @@ Used by: [ResponseBasedOriginErrorDetectionParameters](#ResponseBasedOriginError
 | "TcpAndHttpErrors" |             |
 | "TcpErrorsOnly"    |             |
 
-<a id="ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS"></a>ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS{#ResponseBasedOriginErrorDetectionParameters_ResponseBasedDetectedErrorTypes_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ResponseBasedOriginErrorDetectionParameters_STATUS](#ResponseBasedOriginErrorDetectionParameters_STATUS).
 
@@ -1031,8 +1031,8 @@ Used by: [ResponseBasedOriginErrorDetectionParameters_STATUS](#ResponseBasedOrig
 | "TcpAndHttpErrors" |             |
 | "TcpErrorsOnly"    |             |
 
-<a id="DeliveryRuleCacheExpirationAction"></a>DeliveryRuleCacheExpirationAction
--------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction{#DeliveryRuleCacheExpirationAction}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1041,8 +1041,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheExpirationAction_Name](#DeliveryRuleCacheExpirationAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [CacheExpirationActionParameters](#CacheExpirationActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleCacheExpirationAction_STATUS"></a>DeliveryRuleCacheExpirationAction_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_STATUS{#DeliveryRuleCacheExpirationAction_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1051,8 +1051,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheExpirationAction_Name_STATUS](#DeliveryRuleCacheExpirationAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction"></a>DeliveryRuleCacheKeyQueryStringAction
----------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction{#DeliveryRuleCacheKeyQueryStringAction}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1061,8 +1061,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheKeyQueryStringAction_Name](#DeliveryRuleCacheKeyQueryStringAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_STATUS"></a>DeliveryRuleCacheKeyQueryStringAction_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_STATUS{#DeliveryRuleCacheKeyQueryStringAction_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1071,8 +1071,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheKeyQueryStringAction_Name_STATUS](#DeliveryRuleCacheKeyQueryStringAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleClientPortCondition"></a>DeliveryRuleClientPortCondition
----------------------------------------------------------------------------
+DeliveryRuleClientPortCondition{#DeliveryRuleClientPortCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1081,8 +1081,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleClientPortCondition_Name](#DeliveryRuleClientPortCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleClientPortCondition_STATUS"></a>DeliveryRuleClientPortCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_STATUS{#DeliveryRuleClientPortCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1091,8 +1091,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleClientPortCondition_Name_STATUS](#DeliveryRuleClientPortCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleCookiesCondition"></a>DeliveryRuleCookiesCondition
----------------------------------------------------------------------
+DeliveryRuleCookiesCondition{#DeliveryRuleCookiesCondition}
+-----------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1101,8 +1101,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleCookiesCondition_Name](#DeliveryRuleCookiesCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [CookiesMatchConditionParameters](#CookiesMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleCookiesCondition_STATUS"></a>DeliveryRuleCookiesCondition_STATUS
------------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_STATUS{#DeliveryRuleCookiesCondition_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1111,8 +1111,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleCookiesCondition_Name_STATUS](#DeliveryRuleCookiesCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleHostNameCondition"></a>DeliveryRuleHostNameCondition
------------------------------------------------------------------------
+DeliveryRuleHostNameCondition{#DeliveryRuleHostNameCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1121,8 +1121,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHostNameCondition_Name](#DeliveryRuleHostNameCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [HostNameMatchConditionParameters](#HostNameMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleHostNameCondition_STATUS"></a>DeliveryRuleHostNameCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_STATUS{#DeliveryRuleHostNameCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1131,8 +1131,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHostNameCondition_Name_STATUS](#DeliveryRuleHostNameCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleHttpVersionCondition"></a>DeliveryRuleHttpVersionCondition
------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition{#DeliveryRuleHttpVersionCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1141,8 +1141,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHttpVersionCondition_Name](#DeliveryRuleHttpVersionCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleHttpVersionCondition_STATUS"></a>DeliveryRuleHttpVersionCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_STATUS{#DeliveryRuleHttpVersionCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1151,8 +1151,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHttpVersionCondition_Name_STATUS](#DeliveryRuleHttpVersionCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleIsDeviceCondition"></a>DeliveryRuleIsDeviceCondition
------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition{#DeliveryRuleIsDeviceCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1161,8 +1161,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleIsDeviceCondition_Name](#DeliveryRuleIsDeviceCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleIsDeviceCondition_STATUS"></a>DeliveryRuleIsDeviceCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_STATUS{#DeliveryRuleIsDeviceCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1171,8 +1171,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleIsDeviceCondition_Name_STATUS](#DeliveryRuleIsDeviceCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRulePostArgsCondition"></a>DeliveryRulePostArgsCondition
------------------------------------------------------------------------
+DeliveryRulePostArgsCondition{#DeliveryRulePostArgsCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1181,8 +1181,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRulePostArgsCondition_Name](#DeliveryRulePostArgsCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRulePostArgsCondition_STATUS"></a>DeliveryRulePostArgsCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_STATUS{#DeliveryRulePostArgsCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1191,8 +1191,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRulePostArgsCondition_Name_STATUS](#DeliveryRulePostArgsCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleQueryStringCondition"></a>DeliveryRuleQueryStringCondition
------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition{#DeliveryRuleQueryStringCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1201,8 +1201,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleQueryStringCondition_Name](#DeliveryRuleQueryStringCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleQueryStringCondition_STATUS"></a>DeliveryRuleQueryStringCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_STATUS{#DeliveryRuleQueryStringCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1211,8 +1211,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleQueryStringCondition_Name_STATUS](#DeliveryRuleQueryStringCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRemoteAddressCondition"></a>DeliveryRuleRemoteAddressCondition
----------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition{#DeliveryRuleRemoteAddressCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1221,8 +1221,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRemoteAddressCondition_Name](#DeliveryRuleRemoteAddressCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRemoteAddressCondition_STATUS"></a>DeliveryRuleRemoteAddressCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_STATUS{#DeliveryRuleRemoteAddressCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1231,8 +1231,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRemoteAddressCondition_Name_STATUS](#DeliveryRuleRemoteAddressCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestBodyCondition"></a>DeliveryRuleRequestBodyCondition
------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition{#DeliveryRuleRequestBodyCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1241,8 +1241,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestBodyCondition_Name](#DeliveryRuleRequestBodyCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestBodyCondition_STATUS"></a>DeliveryRuleRequestBodyCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_STATUS{#DeliveryRuleRequestBodyCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1251,8 +1251,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestBodyCondition_Name_STATUS](#DeliveryRuleRequestBodyCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestHeaderAction"></a>DeliveryRuleRequestHeaderAction
----------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction{#DeliveryRuleRequestHeaderAction}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1261,8 +1261,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRequestHeaderAction_Name](#DeliveryRuleRequestHeaderAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters](#HeaderActionParameters)<br/><small>Required</small>                             |
 
-<a id="DeliveryRuleRequestHeaderAction_STATUS"></a>DeliveryRuleRequestHeaderAction_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_STATUS{#DeliveryRuleRequestHeaderAction_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1271,8 +1271,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRequestHeaderAction_Name_STATUS](#DeliveryRuleRequestHeaderAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS)<br/><small>Optional</small>                             |
 
-<a id="DeliveryRuleRequestHeaderCondition"></a>DeliveryRuleRequestHeaderCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition{#DeliveryRuleRequestHeaderCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1281,8 +1281,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestHeaderCondition_Name](#DeliveryRuleRequestHeaderCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestHeaderCondition_STATUS"></a>DeliveryRuleRequestHeaderCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_STATUS{#DeliveryRuleRequestHeaderCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1291,8 +1291,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestHeaderCondition_Name_STATUS](#DeliveryRuleRequestHeaderCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestMethodCondition"></a>DeliveryRuleRequestMethodCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition{#DeliveryRuleRequestMethodCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1301,8 +1301,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestMethodCondition_Name](#DeliveryRuleRequestMethodCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestMethodCondition_STATUS"></a>DeliveryRuleRequestMethodCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_STATUS{#DeliveryRuleRequestMethodCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1311,8 +1311,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestMethodCondition_Name_STATUS](#DeliveryRuleRequestMethodCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestSchemeCondition"></a>DeliveryRuleRequestSchemeCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition{#DeliveryRuleRequestSchemeCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1321,8 +1321,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestSchemeCondition_Name](#DeliveryRuleRequestSchemeCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestSchemeCondition_STATUS"></a>DeliveryRuleRequestSchemeCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_STATUS{#DeliveryRuleRequestSchemeCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1331,8 +1331,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestSchemeCondition_Name_STATUS](#DeliveryRuleRequestSchemeCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestUriCondition"></a>DeliveryRuleRequestUriCondition
----------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition{#DeliveryRuleRequestUriCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1341,8 +1341,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestUriCondition_Name](#DeliveryRuleRequestUriCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestUriCondition_STATUS"></a>DeliveryRuleRequestUriCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_STATUS{#DeliveryRuleRequestUriCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1351,8 +1351,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestUriCondition_Name_STATUS](#DeliveryRuleRequestUriCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleResponseHeaderAction"></a>DeliveryRuleResponseHeaderAction
------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction{#DeliveryRuleResponseHeaderAction}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1361,8 +1361,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleResponseHeaderAction_Name](#DeliveryRuleResponseHeaderAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters](#HeaderActionParameters)<br/><small>Required</small>                               |
 
-<a id="DeliveryRuleResponseHeaderAction_STATUS"></a>DeliveryRuleResponseHeaderAction_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_STATUS{#DeliveryRuleResponseHeaderAction_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1371,8 +1371,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleResponseHeaderAction_Name_STATUS](#DeliveryRuleResponseHeaderAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS)<br/><small>Optional</small>                               |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction"></a>DeliveryRuleRouteConfigurationOverrideAction
------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction{#DeliveryRuleRouteConfigurationOverrideAction}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1381,8 +1381,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRouteConfigurationOverrideAction_Name](#DeliveryRuleRouteConfigurationOverrideAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrideActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_STATUS"></a>DeliveryRuleRouteConfigurationOverrideAction_STATUS
--------------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_STATUS{#DeliveryRuleRouteConfigurationOverrideAction_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1391,8 +1391,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS](#DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfigurationOverrideActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleServerPortCondition"></a>DeliveryRuleServerPortCondition
----------------------------------------------------------------------------
+DeliveryRuleServerPortCondition{#DeliveryRuleServerPortCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1401,8 +1401,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleServerPortCondition_Name](#DeliveryRuleServerPortCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleServerPortCondition_STATUS"></a>DeliveryRuleServerPortCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_STATUS{#DeliveryRuleServerPortCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1411,8 +1411,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleServerPortCondition_Name_STATUS](#DeliveryRuleServerPortCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleSocketAddrCondition"></a>DeliveryRuleSocketAddrCondition
----------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition{#DeliveryRuleSocketAddrCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1421,8 +1421,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSocketAddrCondition_Name](#DeliveryRuleSocketAddrCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleSocketAddrCondition_STATUS"></a>DeliveryRuleSocketAddrCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_STATUS{#DeliveryRuleSocketAddrCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1431,8 +1431,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSocketAddrCondition_Name_STATUS](#DeliveryRuleSocketAddrCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleSslProtocolCondition"></a>DeliveryRuleSslProtocolCondition
------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition{#DeliveryRuleSslProtocolCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1441,8 +1441,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSslProtocolCondition_Name](#DeliveryRuleSslProtocolCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleSslProtocolCondition_STATUS"></a>DeliveryRuleSslProtocolCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_STATUS{#DeliveryRuleSslProtocolCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1451,8 +1451,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSslProtocolCondition_Name_STATUS](#DeliveryRuleSslProtocolCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlFileExtensionCondition"></a>DeliveryRuleUrlFileExtensionCondition
----------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition{#DeliveryRuleUrlFileExtensionCondition}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1461,8 +1461,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileExtensionCondition_Name](#DeliveryRuleUrlFileExtensionCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_STATUS"></a>DeliveryRuleUrlFileExtensionCondition_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_STATUS{#DeliveryRuleUrlFileExtensionCondition_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1471,8 +1471,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileExtensionCondition_Name_STATUS](#DeliveryRuleUrlFileExtensionCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlFileNameCondition"></a>DeliveryRuleUrlFileNameCondition
------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition{#DeliveryRuleUrlFileNameCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1481,8 +1481,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileNameCondition_Name](#DeliveryRuleUrlFileNameCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlFileNameCondition_STATUS"></a>DeliveryRuleUrlFileNameCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_STATUS{#DeliveryRuleUrlFileNameCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1491,8 +1491,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileNameCondition_Name_STATUS](#DeliveryRuleUrlFileNameCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlPathCondition"></a>DeliveryRuleUrlPathCondition
----------------------------------------------------------------------
+DeliveryRuleUrlPathCondition{#DeliveryRuleUrlPathCondition}
+-----------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -1501,8 +1501,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlPathCondition_Name](#DeliveryRuleUrlPathCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlPathCondition_STATUS"></a>DeliveryRuleUrlPathCondition_STATUS
------------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_STATUS{#DeliveryRuleUrlPathCondition_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -1511,8 +1511,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlPathCondition_Name_STATUS](#DeliveryRuleUrlPathCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="OriginGroupOverrideAction"></a>OriginGroupOverrideAction
----------------------------------------------------------------
+OriginGroupOverrideAction{#OriginGroupOverrideAction}
+-----------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1521,8 +1521,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [OriginGroupOverrideAction_Name](#OriginGroupOverrideAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParameters)<br/><small>Required</small> |
 
-<a id="OriginGroupOverrideAction_STATUS"></a>OriginGroupOverrideAction_STATUS
------------------------------------------------------------------------------
+OriginGroupOverrideAction_STATUS{#OriginGroupOverrideAction_STATUS}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1531,8 +1531,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [OriginGroupOverrideAction_Name_STATUS](#OriginGroupOverrideAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlRedirectAction"></a>UrlRedirectAction
------------------------------------------------
+UrlRedirectAction{#UrlRedirectAction}
+-------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1541,8 +1541,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlRedirectAction_Name](#UrlRedirectAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRedirectActionParameters](#UrlRedirectActionParameters)<br/><small>Required</small> |
 
-<a id="UrlRedirectAction_STATUS"></a>UrlRedirectAction_STATUS
--------------------------------------------------------------
+UrlRedirectAction_STATUS{#UrlRedirectAction_STATUS}
+---------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1551,8 +1551,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlRedirectAction_Name_STATUS](#UrlRedirectAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlRewriteAction"></a>UrlRewriteAction
----------------------------------------------
+UrlRewriteAction{#UrlRewriteAction}
+-----------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1561,8 +1561,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlRewriteAction_Name](#UrlRewriteAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRewriteActionParameters](#UrlRewriteActionParameters)<br/><small>Required</small> |
 
-<a id="UrlRewriteAction_STATUS"></a>UrlRewriteAction_STATUS
------------------------------------------------------------
+UrlRewriteAction_STATUS{#UrlRewriteAction_STATUS}
+-------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1571,8 +1571,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlRewriteAction_Name_STATUS](#UrlRewriteAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningAction"></a>UrlSigningAction
----------------------------------------------
+UrlSigningAction{#UrlSigningAction}
+-----------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -1581,8 +1581,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlSigningAction_Name](#UrlSigningAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlSigningActionParameters](#UrlSigningActionParameters)<br/><small>Required</small> |
 
-<a id="UrlSigningAction_STATUS"></a>UrlSigningAction_STATUS
------------------------------------------------------------
+UrlSigningAction_STATUS{#UrlSigningAction_STATUS}
+-------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -1591,8 +1591,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlSigningAction_Name_STATUS](#UrlSigningAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="CacheExpirationActionParameters"></a>CacheExpirationActionParameters
----------------------------------------------------------------------------
+CacheExpirationActionParameters{#CacheExpirationActionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for the cache expiration action.
 
@@ -1605,8 +1605,8 @@ Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction)
 | cacheType     | The level at which the content needs to be cached.                                    | [CacheExpirationActionParameters_CacheType](#CacheExpirationActionParameters_CacheType)<br/><small>Required</small>         |
 | typeName      |                                                                                       | [CacheExpirationActionParameters_TypeName](#CacheExpirationActionParameters_TypeName)<br/><small>Required</small>           |
 
-<a id="CacheExpirationActionParameters_STATUS"></a>CacheExpirationActionParameters_STATUS
------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_STATUS{#CacheExpirationActionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for the cache expiration action.
 
@@ -1619,8 +1619,8 @@ Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpiration
 | cacheType     | The level at which the content needs to be cached.                                    | [CacheExpirationActionParameters_CacheType_STATUS](#CacheExpirationActionParameters_CacheType_STATUS)<br/><small>Optional</small>         |
 | typeName      |                                                                                       | [CacheExpirationActionParameters_TypeName_STATUS](#CacheExpirationActionParameters_TypeName_STATUS)<br/><small>Optional</small>           |
 
-<a id="CacheKeyQueryStringActionParameters"></a>CacheKeyQueryStringActionParameters
------------------------------------------------------------------------------------
+CacheKeyQueryStringActionParameters{#CacheKeyQueryStringActionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for the cache-key query string action.
 
@@ -1632,8 +1632,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStrin
 | queryStringBehavior | Caching behavior for the requests                         | [CacheKeyQueryStringActionParameters_QueryStringBehavior](#CacheKeyQueryStringActionParameters_QueryStringBehavior)<br/><small>Required</small> |
 | typeName            |                                                           | [CacheKeyQueryStringActionParameters_TypeName](#CacheKeyQueryStringActionParameters_TypeName)<br/><small>Required</small>                       |
 
-<a id="CacheKeyQueryStringActionParameters_STATUS"></a>CacheKeyQueryStringActionParameters_STATUS
--------------------------------------------------------------------------------------------------
+CacheKeyQueryStringActionParameters_STATUS{#CacheKeyQueryStringActionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the cache-key query string action.
 
@@ -1645,8 +1645,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQue
 | queryStringBehavior | Caching behavior for the requests                         | [CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS](#CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS)<br/><small>Optional</small> |
 | typeName            |                                                           | [CacheKeyQueryStringActionParameters_TypeName_STATUS](#CacheKeyQueryStringActionParameters_TypeName_STATUS)<br/><small>Optional</small>                       |
 
-<a id="ClientPortMatchConditionParameters"></a>ClientPortMatchConditionParameters
----------------------------------------------------------------------------------
+ClientPortMatchConditionParameters{#ClientPortMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for ClientPort match conditions
 
@@ -1660,8 +1660,8 @@ Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ClientPortMatchConditionParameters_TypeName](#ClientPortMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="ClientPortMatchConditionParameters_STATUS"></a>ClientPortMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+ClientPortMatchConditionParameters_STATUS{#ClientPortMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for ClientPort match conditions
 
@@ -1675,8 +1675,8 @@ Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ClientPortMatchConditionParameters_TypeName_STATUS](#ClientPortMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="CookiesMatchConditionParameters"></a>CookiesMatchConditionParameters
----------------------------------------------------------------------------
+CookiesMatchConditionParameters{#CookiesMatchConditionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for Cookies match conditions
 
@@ -1691,8 +1691,8 @@ Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [CookiesMatchConditionParameters_TypeName](#CookiesMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="CookiesMatchConditionParameters_STATUS"></a>CookiesMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------
+CookiesMatchConditionParameters_STATUS{#CookiesMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for Cookies match conditions
 
@@ -1707,8 +1707,8 @@ Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STA
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [CookiesMatchConditionParameters_TypeName_STATUS](#CookiesMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="DeliveryRuleCacheExpirationAction_Name"></a>DeliveryRuleCacheExpirationAction_Name
------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_Name{#DeliveryRuleCacheExpirationAction_Name}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction).
 
@@ -1716,8 +1716,8 @@ Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction)
 |-------------------|-------------|
 | "CacheExpiration" |             |
 
-<a id="DeliveryRuleCacheExpirationAction_Name_STATUS"></a>DeliveryRuleCacheExpirationAction_Name_STATUS
--------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_Name_STATUS{#DeliveryRuleCacheExpirationAction_Name_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpirationAction_STATUS).
 
@@ -1725,8 +1725,8 @@ Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpiration
 |-------------------|-------------|
 | "CacheExpiration" |             |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_Name"></a>DeliveryRuleCacheKeyQueryStringAction_Name
--------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_Name{#DeliveryRuleCacheKeyQueryStringAction_Name}
+---------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStringAction).
 
@@ -1734,8 +1734,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStrin
 |-----------------------|-------------|
 | "CacheKeyQueryString" |             |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_Name_STATUS"></a>DeliveryRuleCacheKeyQueryStringAction_Name_STATUS
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_Name_STATUS{#DeliveryRuleCacheKeyQueryStringAction_Name_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQueryStringAction_STATUS).
 
@@ -1743,8 +1743,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQue
 |-----------------------|-------------|
 | "CacheKeyQueryString" |             |
 
-<a id="DeliveryRuleClientPortCondition_Name"></a>DeliveryRuleClientPortCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_Name{#DeliveryRuleClientPortCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 
@@ -1752,8 +1752,8 @@ Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 |--------------|-------------|
 | "ClientPort" |             |
 
-<a id="DeliveryRuleClientPortCondition_Name_STATUS"></a>DeliveryRuleClientPortCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_Name_STATUS{#DeliveryRuleClientPortCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortCondition_STATUS).
 
@@ -1761,8 +1761,8 @@ Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortConditi
 |--------------|-------------|
 | "ClientPort" |             |
 
-<a id="DeliveryRuleCookiesCondition_Name"></a>DeliveryRuleCookiesCondition_Name
--------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_Name{#DeliveryRuleCookiesCondition_Name}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 
@@ -1770,8 +1770,8 @@ Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 |-----------|-------------|
 | "Cookies" |             |
 
-<a id="DeliveryRuleCookiesCondition_Name_STATUS"></a>DeliveryRuleCookiesCondition_Name_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_Name_STATUS{#DeliveryRuleCookiesCondition_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STATUS).
 
@@ -1779,8 +1779,8 @@ Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STA
 |-----------|-------------|
 | "Cookies" |             |
 
-<a id="DeliveryRuleHostNameCondition_Name"></a>DeliveryRuleHostNameCondition_Name
----------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_Name{#DeliveryRuleHostNameCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 
@@ -1788,8 +1788,8 @@ Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 |------------|-------------|
 | "HostName" |             |
 
-<a id="DeliveryRuleHostNameCondition_Name_STATUS"></a>DeliveryRuleHostNameCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_Name_STATUS{#DeliveryRuleHostNameCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_STATUS).
 
@@ -1797,8 +1797,8 @@ Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_S
 |------------|-------------|
 | "HostName" |             |
 
-<a id="DeliveryRuleHttpVersionCondition_Name"></a>DeliveryRuleHttpVersionCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_Name{#DeliveryRuleHttpVersionCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 
@@ -1806,8 +1806,8 @@ Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 |---------------|-------------|
 | "HttpVersion" |             |
 
-<a id="DeliveryRuleHttpVersionCondition_Name_STATUS"></a>DeliveryRuleHttpVersionCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_Name_STATUS{#DeliveryRuleHttpVersionCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondition_STATUS).
 
@@ -1815,8 +1815,8 @@ Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondi
 |---------------|-------------|
 | "HttpVersion" |             |
 
-<a id="DeliveryRuleIsDeviceCondition_Name"></a>DeliveryRuleIsDeviceCondition_Name
----------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_Name{#DeliveryRuleIsDeviceCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 
@@ -1824,8 +1824,8 @@ Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 |------------|-------------|
 | "IsDevice" |             |
 
-<a id="DeliveryRuleIsDeviceCondition_Name_STATUS"></a>DeliveryRuleIsDeviceCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_Name_STATUS{#DeliveryRuleIsDeviceCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_STATUS).
 
@@ -1833,8 +1833,8 @@ Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_S
 |------------|-------------|
 | "IsDevice" |             |
 
-<a id="DeliveryRulePostArgsCondition_Name"></a>DeliveryRulePostArgsCondition_Name
----------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_Name{#DeliveryRulePostArgsCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 
@@ -1842,8 +1842,8 @@ Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 |------------|-------------|
 | "PostArgs" |             |
 
-<a id="DeliveryRulePostArgsCondition_Name_STATUS"></a>DeliveryRulePostArgsCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_Name_STATUS{#DeliveryRulePostArgsCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_STATUS).
 
@@ -1851,8 +1851,8 @@ Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_S
 |------------|-------------|
 | "PostArgs" |             |
 
-<a id="DeliveryRuleQueryStringCondition_Name"></a>DeliveryRuleQueryStringCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_Name{#DeliveryRuleQueryStringCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 
@@ -1860,8 +1860,8 @@ Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 |---------------|-------------|
 | "QueryString" |             |
 
-<a id="DeliveryRuleQueryStringCondition_Name_STATUS"></a>DeliveryRuleQueryStringCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_Name_STATUS{#DeliveryRuleQueryStringCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondition_STATUS).
 
@@ -1869,8 +1869,8 @@ Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondi
 |---------------|-------------|
 | "QueryString" |             |
 
-<a id="DeliveryRuleRemoteAddressCondition_Name"></a>DeliveryRuleRemoteAddressCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_Name{#DeliveryRuleRemoteAddressCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressCondition).
 
@@ -1878,8 +1878,8 @@ Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressConditio
 |-----------------|-------------|
 | "RemoteAddress" |             |
 
-<a id="DeliveryRuleRemoteAddressCondition_Name_STATUS"></a>DeliveryRuleRemoteAddressCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_Name_STATUS{#DeliveryRuleRemoteAddressCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressCondition_STATUS).
 
@@ -1887,8 +1887,8 @@ Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressC
 |-----------------|-------------|
 | "RemoteAddress" |             |
 
-<a id="DeliveryRuleRequestBodyCondition_Name"></a>DeliveryRuleRequestBodyCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_Name{#DeliveryRuleRequestBodyCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 
@@ -1896,8 +1896,8 @@ Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 |---------------|-------------|
 | "RequestBody" |             |
 
-<a id="DeliveryRuleRequestBodyCondition_Name_STATUS"></a>DeliveryRuleRequestBodyCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_Name_STATUS{#DeliveryRuleRequestBodyCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondition_STATUS).
 
@@ -1905,8 +1905,8 @@ Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondi
 |---------------|-------------|
 | "RequestBody" |             |
 
-<a id="DeliveryRuleRequestHeaderAction_Name"></a>DeliveryRuleRequestHeaderAction_Name
--------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_Name{#DeliveryRuleRequestHeaderAction_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction).
 
@@ -1914,8 +1914,8 @@ Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction).
 |-----------------------|-------------|
 | "ModifyRequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderAction_Name_STATUS"></a>DeliveryRuleRequestHeaderAction_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_Name_STATUS{#DeliveryRuleRequestHeaderAction_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderAction_STATUS).
 
@@ -1923,8 +1923,8 @@ Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderActi
 |-----------------------|-------------|
 | "ModifyRequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderCondition_Name"></a>DeliveryRuleRequestHeaderCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_Name{#DeliveryRuleRequestHeaderCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderCondition).
 
@@ -1932,8 +1932,8 @@ Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderConditio
 |-----------------|-------------|
 | "RequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderCondition_Name_STATUS"></a>DeliveryRuleRequestHeaderCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_Name_STATUS{#DeliveryRuleRequestHeaderCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderCondition_STATUS).
 
@@ -1941,8 +1941,8 @@ Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderC
 |-----------------|-------------|
 | "RequestHeader" |             |
 
-<a id="DeliveryRuleRequestMethodCondition_Name"></a>DeliveryRuleRequestMethodCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_Name{#DeliveryRuleRequestMethodCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodCondition).
 
@@ -1950,8 +1950,8 @@ Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodConditio
 |-----------------|-------------|
 | "RequestMethod" |             |
 
-<a id="DeliveryRuleRequestMethodCondition_Name_STATUS"></a>DeliveryRuleRequestMethodCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_Name_STATUS{#DeliveryRuleRequestMethodCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodCondition_STATUS).
 
@@ -1959,8 +1959,8 @@ Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodC
 |-----------------|-------------|
 | "RequestMethod" |             |
 
-<a id="DeliveryRuleRequestSchemeCondition_Name"></a>DeliveryRuleRequestSchemeCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_Name{#DeliveryRuleRequestSchemeCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeCondition).
 
@@ -1968,8 +1968,8 @@ Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeConditio
 |-----------------|-------------|
 | "RequestScheme" |             |
 
-<a id="DeliveryRuleRequestSchemeCondition_Name_STATUS"></a>DeliveryRuleRequestSchemeCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_Name_STATUS{#DeliveryRuleRequestSchemeCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeCondition_STATUS).
 
@@ -1977,8 +1977,8 @@ Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeC
 |-----------------|-------------|
 | "RequestScheme" |             |
 
-<a id="DeliveryRuleRequestUriCondition_Name"></a>DeliveryRuleRequestUriCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_Name{#DeliveryRuleRequestUriCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 
@@ -1986,8 +1986,8 @@ Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 |--------------|-------------|
 | "RequestUri" |             |
 
-<a id="DeliveryRuleRequestUriCondition_Name_STATUS"></a>DeliveryRuleRequestUriCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_Name_STATUS{#DeliveryRuleRequestUriCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriCondition_STATUS).
 
@@ -1995,8 +1995,8 @@ Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriConditi
 |--------------|-------------|
 | "RequestUri" |             |
 
-<a id="DeliveryRuleResponseHeaderAction_Name"></a>DeliveryRuleResponseHeaderAction_Name
----------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_Name{#DeliveryRuleResponseHeaderAction_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleResponseHeaderAction](#DeliveryRuleResponseHeaderAction).
 
@@ -2004,8 +2004,8 @@ Used by: [DeliveryRuleResponseHeaderAction](#DeliveryRuleResponseHeaderAction).
 |------------------------|-------------|
 | "ModifyResponseHeader" |             |
 
-<a id="DeliveryRuleResponseHeaderAction_Name_STATUS"></a>DeliveryRuleResponseHeaderAction_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_Name_STATUS{#DeliveryRuleResponseHeaderAction_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleResponseHeaderAction_STATUS](#DeliveryRuleResponseHeaderAction_STATUS).
 
@@ -2013,8 +2013,8 @@ Used by: [DeliveryRuleResponseHeaderAction_STATUS](#DeliveryRuleResponseHeaderAc
 |------------------------|-------------|
 | "ModifyResponseHeader" |             |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_Name"></a>DeliveryRuleRouteConfigurationOverrideAction_Name
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_Name{#DeliveryRuleRouteConfigurationOverrideAction_Name}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfigurationOverrideAction).
 
@@ -2022,8 +2022,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfig
 |------------------------------|-------------|
 | "RouteConfigurationOverride" |             |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS"></a>DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS
------------------------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS{#DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRouteConfigurationOverrideAction_STATUS).
 
@@ -2031,8 +2031,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRout
 |------------------------------|-------------|
 | "RouteConfigurationOverride" |             |
 
-<a id="DeliveryRuleServerPortCondition_Name"></a>DeliveryRuleServerPortCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_Name{#DeliveryRuleServerPortCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 
@@ -2040,8 +2040,8 @@ Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 |--------------|-------------|
 | "ServerPort" |             |
 
-<a id="DeliveryRuleServerPortCondition_Name_STATUS"></a>DeliveryRuleServerPortCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_Name_STATUS{#DeliveryRuleServerPortCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortCondition_STATUS).
 
@@ -2049,8 +2049,8 @@ Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortConditi
 |--------------|-------------|
 | "ServerPort" |             |
 
-<a id="DeliveryRuleSocketAddrCondition_Name"></a>DeliveryRuleSocketAddrCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_Name{#DeliveryRuleSocketAddrCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 
@@ -2058,8 +2058,8 @@ Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 |--------------|-------------|
 | "SocketAddr" |             |
 
-<a id="DeliveryRuleSocketAddrCondition_Name_STATUS"></a>DeliveryRuleSocketAddrCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_Name_STATUS{#DeliveryRuleSocketAddrCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrCondition_STATUS).
 
@@ -2067,8 +2067,8 @@ Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrConditi
 |--------------|-------------|
 | "SocketAddr" |             |
 
-<a id="DeliveryRuleSslProtocolCondition_Name"></a>DeliveryRuleSslProtocolCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_Name{#DeliveryRuleSslProtocolCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 
@@ -2076,8 +2076,8 @@ Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 |---------------|-------------|
 | "SslProtocol" |             |
 
-<a id="DeliveryRuleSslProtocolCondition_Name_STATUS"></a>DeliveryRuleSslProtocolCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_Name_STATUS{#DeliveryRuleSslProtocolCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondition_STATUS).
 
@@ -2085,8 +2085,8 @@ Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondi
 |---------------|-------------|
 | "SslProtocol" |             |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_Name"></a>DeliveryRuleUrlFileExtensionCondition_Name
--------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_Name{#DeliveryRuleUrlFileExtensionCondition_Name}
+---------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCondition).
 
@@ -2094,8 +2094,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCo
 |--------------------|-------------|
 | "UrlFileExtension" |             |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_Name_STATUS"></a>DeliveryRuleUrlFileExtensionCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_Name_STATUS{#DeliveryRuleUrlFileExtensionCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExtensionCondition_STATUS).
 
@@ -2103,8 +2103,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExte
 |--------------------|-------------|
 | "UrlFileExtension" |             |
 
-<a id="DeliveryRuleUrlFileNameCondition_Name"></a>DeliveryRuleUrlFileNameCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_Name{#DeliveryRuleUrlFileNameCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 
@@ -2112,8 +2112,8 @@ Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 |---------------|-------------|
 | "UrlFileName" |             |
 
-<a id="DeliveryRuleUrlFileNameCondition_Name_STATUS"></a>DeliveryRuleUrlFileNameCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_Name_STATUS{#DeliveryRuleUrlFileNameCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondition_STATUS).
 
@@ -2121,8 +2121,8 @@ Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondi
 |---------------|-------------|
 | "UrlFileName" |             |
 
-<a id="DeliveryRuleUrlPathCondition_Name"></a>DeliveryRuleUrlPathCondition_Name
--------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_Name{#DeliveryRuleUrlPathCondition_Name}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 
@@ -2130,8 +2130,8 @@ Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 |-----------|-------------|
 | "UrlPath" |             |
 
-<a id="DeliveryRuleUrlPathCondition_Name_STATUS"></a>DeliveryRuleUrlPathCondition_Name_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_Name_STATUS{#DeliveryRuleUrlPathCondition_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STATUS).
 
@@ -2139,8 +2139,8 @@ Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STA
 |-----------|-------------|
 | "UrlPath" |             |
 
-<a id="HeaderActionParameters"></a>HeaderActionParameters
----------------------------------------------------------
+HeaderActionParameters{#HeaderActionParameters}
+-----------------------------------------------
 
 Defines the parameters for the request header action.
 
@@ -2153,8 +2153,8 @@ Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction), an
 | typeName     |                                | [HeaderActionParameters_TypeName](#HeaderActionParameters_TypeName)<br/><small>Required</small>         |
 | value        | Value for the specified action | string<br/><small>Optional</small>                                                                      |
 
-<a id="HeaderActionParameters_STATUS"></a>HeaderActionParameters_STATUS
------------------------------------------------------------------------
+HeaderActionParameters_STATUS{#HeaderActionParameters_STATUS}
+-------------------------------------------------------------
 
 Defines the parameters for the request header action.
 
@@ -2167,8 +2167,8 @@ Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderActi
 | typeName     |                                | [HeaderActionParameters_TypeName_STATUS](#HeaderActionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 | value        | Value for the specified action | string<br/><small>Optional</small>                                                                                    |
 
-<a id="HostNameMatchConditionParameters"></a>HostNameMatchConditionParameters
------------------------------------------------------------------------------
+HostNameMatchConditionParameters{#HostNameMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for HostName match conditions
 
@@ -2182,8 +2182,8 @@ Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [HostNameMatchConditionParameters_TypeName](#HostNameMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="HostNameMatchConditionParameters_STATUS"></a>HostNameMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_STATUS{#HostNameMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for HostName match conditions
 
@@ -2197,8 +2197,8 @@ Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [HostNameMatchConditionParameters_TypeName_STATUS](#HostNameMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpVersionMatchConditionParameters"></a>HttpVersionMatchConditionParameters
------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters{#HttpVersionMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for HttpVersion match conditions
 
@@ -2212,8 +2212,8 @@ Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [HttpVersionMatchConditionParameters_TypeName](#HttpVersionMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="HttpVersionMatchConditionParameters_STATUS"></a>HttpVersionMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_STATUS{#HttpVersionMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for HttpVersion match conditions
 
@@ -2227,8 +2227,8 @@ Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [HttpVersionMatchConditionParameters_TypeName_STATUS](#HttpVersionMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="IsDeviceMatchConditionParameters"></a>IsDeviceMatchConditionParameters
------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters{#IsDeviceMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for IsDevice match conditions
 
@@ -2242,8 +2242,8 @@ Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                       |
 | typeName        |                                                        | [IsDeviceMatchConditionParameters_TypeName](#IsDeviceMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="IsDeviceMatchConditionParameters_STATUS"></a>IsDeviceMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_STATUS{#IsDeviceMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for IsDevice match conditions
 
@@ -2257,8 +2257,8 @@ Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                       |
 | typeName        |                                                        | [IsDeviceMatchConditionParameters_TypeName_STATUS](#IsDeviceMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="OriginGroupOverrideAction_Name"></a>OriginGroupOverrideAction_Name
--------------------------------------------------------------------------
+OriginGroupOverrideAction_Name{#OriginGroupOverrideAction_Name}
+---------------------------------------------------------------
 
 Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 
@@ -2266,8 +2266,8 @@ Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 |-----------------------|-------------|
 | "OriginGroupOverride" |             |
 
-<a id="OriginGroupOverrideAction_Name_STATUS"></a>OriginGroupOverrideAction_Name_STATUS
----------------------------------------------------------------------------------------
+OriginGroupOverrideAction_Name_STATUS{#OriginGroupOverrideAction_Name_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 
@@ -2275,8 +2275,8 @@ Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 |-----------------------|-------------|
 | "OriginGroupOverride" |             |
 
-<a id="OriginGroupOverrideActionParameters"></a>OriginGroupOverrideActionParameters
------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters{#OriginGroupOverrideActionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for the origin group override action.
 
@@ -2287,8 +2287,8 @@ Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 | originGroup | defines the OriginGroup that would override the DefaultOriginGroup. | [ResourceReference](#ResourceReference)<br/><small>Required</small>                                                       |
 | typeName    |                                                                     | [OriginGroupOverrideActionParameters_TypeName](#OriginGroupOverrideActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="OriginGroupOverrideActionParameters_STATUS"></a>OriginGroupOverrideActionParameters_STATUS
--------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_STATUS{#OriginGroupOverrideActionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the origin group override action.
 
@@ -2299,8 +2299,8 @@ Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 | originGroup | defines the OriginGroup that would override the DefaultOriginGroup. | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                                       |
 | typeName    |                                                                     | [OriginGroupOverrideActionParameters_TypeName_STATUS](#OriginGroupOverrideActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="PostArgsMatchConditionParameters"></a>PostArgsMatchConditionParameters
------------------------------------------------------------------------------
+PostArgsMatchConditionParameters{#PostArgsMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for PostArgs match conditions
 
@@ -2315,8 +2315,8 @@ Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [PostArgsMatchConditionParameters_TypeName](#PostArgsMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="PostArgsMatchConditionParameters_STATUS"></a>PostArgsMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_STATUS{#PostArgsMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for PostArgs match conditions
 
@@ -2331,8 +2331,8 @@ Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [PostArgsMatchConditionParameters_TypeName_STATUS](#PostArgsMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="QueryStringMatchConditionParameters"></a>QueryStringMatchConditionParameters
------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters{#QueryStringMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for QueryString match conditions
 
@@ -2346,8 +2346,8 @@ Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [QueryStringMatchConditionParameters_TypeName](#QueryStringMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="QueryStringMatchConditionParameters_STATUS"></a>QueryStringMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_STATUS{#QueryStringMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for QueryString match conditions
 
@@ -2361,8 +2361,8 @@ Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [QueryStringMatchConditionParameters_TypeName_STATUS](#QueryStringMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RemoteAddressMatchConditionParameters"></a>RemoteAddressMatchConditionParameters
----------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters{#RemoteAddressMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RemoteAddress match conditions
 
@@ -2376,8 +2376,8 @@ Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressConditio
 | transforms      | List of transforms                                                                                                                                                                                    | [Transform[]](#Transform)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                                                                                                                                                                       | [RemoteAddressMatchConditionParameters_TypeName](#RemoteAddressMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RemoteAddressMatchConditionParameters_STATUS"></a>RemoteAddressMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_STATUS{#RemoteAddressMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RemoteAddress match conditions
 
@@ -2391,8 +2391,8 @@ Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressC
 | transforms      | List of transforms                                                                                                                                                                                    | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                                                                                                                                                                       | [RemoteAddressMatchConditionParameters_TypeName_STATUS](#RemoteAddressMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestBodyMatchConditionParameters"></a>RequestBodyMatchConditionParameters
------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters{#RequestBodyMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for RequestBody match conditions
 
@@ -2406,8 +2406,8 @@ Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [RequestBodyMatchConditionParameters_TypeName](#RequestBodyMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestBodyMatchConditionParameters_STATUS"></a>RequestBodyMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_STATUS{#RequestBodyMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for RequestBody match conditions
 
@@ -2421,8 +2421,8 @@ Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [RequestBodyMatchConditionParameters_TypeName_STATUS](#RequestBodyMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestHeaderMatchConditionParameters"></a>RequestHeaderMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters{#RequestHeaderMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestHeader match conditions
 
@@ -2437,8 +2437,8 @@ Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                        | [RequestHeaderMatchConditionParameters_TypeName](#RequestHeaderMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestHeaderMatchConditionParameters_STATUS"></a>RequestHeaderMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_STATUS{#RequestHeaderMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestHeader match conditions
 
@@ -2453,8 +2453,8 @@ Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                        | [RequestHeaderMatchConditionParameters_TypeName_STATUS](#RequestHeaderMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestMethodMatchConditionParameters"></a>RequestMethodMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters{#RequestMethodMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestMethod match conditions
 
@@ -2468,8 +2468,8 @@ Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestMethodMatchConditionParameters_TypeName](#RequestMethodMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="RequestMethodMatchConditionParameters_STATUS"></a>RequestMethodMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters_STATUS{#RequestMethodMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestMethod match conditions
 
@@ -2483,8 +2483,8 @@ Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestMethodMatchConditionParameters_TypeName_STATUS](#RequestMethodMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="RequestSchemeMatchConditionParameters"></a>RequestSchemeMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestSchemeMatchConditionParameters{#RequestSchemeMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestScheme match conditions
 
@@ -2498,8 +2498,8 @@ Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestSchemeMatchConditionParameters_TypeName](#RequestSchemeMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="RequestSchemeMatchConditionParameters_STATUS"></a>RequestSchemeMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestSchemeMatchConditionParameters_STATUS{#RequestSchemeMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestScheme match conditions
 
@@ -2513,8 +2513,8 @@ Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestSchemeMatchConditionParameters_TypeName_STATUS](#RequestSchemeMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="RequestUriMatchConditionParameters"></a>RequestUriMatchConditionParameters
----------------------------------------------------------------------------------
+RequestUriMatchConditionParameters{#RequestUriMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for RequestUri match conditions
 
@@ -2528,8 +2528,8 @@ Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [RequestUriMatchConditionParameters_TypeName](#RequestUriMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestUriMatchConditionParameters_STATUS"></a>RequestUriMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+RequestUriMatchConditionParameters_STATUS{#RequestUriMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for RequestUri match conditions
 
@@ -2543,8 +2543,8 @@ Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [RequestUriMatchConditionParameters_TypeName_STATUS](#RequestUriMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RouteConfigurationOverrideActionParameters"></a>RouteConfigurationOverrideActionParameters
--------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters{#RouteConfigurationOverrideActionParameters}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the route configuration override action.
 
@@ -2556,8 +2556,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfig
 | originGroupOverride | A reference to the origin group override configuration. Leave empty to use the default origin group on route.        | [OriginGroupOverride](#OriginGroupOverride)<br/><small>Optional</small>                                                                 |
 | typeName            |                                                                                                                      | [RouteConfigurationOverrideActionParameters_TypeName](#RouteConfigurationOverrideActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RouteConfigurationOverrideActionParameters_STATUS"></a>RouteConfigurationOverrideActionParameters_STATUS
----------------------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters_STATUS{#RouteConfigurationOverrideActionParameters_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Defines the parameters for the route configuration override action.
 
@@ -2569,8 +2569,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRout
 | originGroupOverride | A reference to the origin group override configuration. Leave empty to use the default origin group on route.        | [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS)<br/><small>Optional</small>                                                                 |
 | typeName            |                                                                                                                      | [RouteConfigurationOverrideActionParameters_TypeName_STATUS](#RouteConfigurationOverrideActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerPortMatchConditionParameters"></a>ServerPortMatchConditionParameters
----------------------------------------------------------------------------------
+ServerPortMatchConditionParameters{#ServerPortMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for ServerPort match conditions
 
@@ -2584,8 +2584,8 @@ Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ServerPortMatchConditionParameters_TypeName](#ServerPortMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="ServerPortMatchConditionParameters_STATUS"></a>ServerPortMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_STATUS{#ServerPortMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for ServerPort match conditions
 
@@ -2599,8 +2599,8 @@ Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ServerPortMatchConditionParameters_TypeName_STATUS](#ServerPortMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="SocketAddrMatchConditionParameters"></a>SocketAddrMatchConditionParameters
----------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters{#SocketAddrMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for SocketAddress match conditions
 
@@ -2614,8 +2614,8 @@ Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [SocketAddrMatchConditionParameters_TypeName](#SocketAddrMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="SocketAddrMatchConditionParameters_STATUS"></a>SocketAddrMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_STATUS{#SocketAddrMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for SocketAddress match conditions
 
@@ -2629,8 +2629,8 @@ Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [SocketAddrMatchConditionParameters_TypeName_STATUS](#SocketAddrMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="SslProtocolMatchConditionParameters"></a>SslProtocolMatchConditionParameters
------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters{#SslProtocolMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for SslProtocol match conditions
 
@@ -2644,8 +2644,8 @@ Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [SslProtocolMatchConditionParameters_TypeName](#SslProtocolMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="SslProtocolMatchConditionParameters_STATUS"></a>SslProtocolMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_STATUS{#SslProtocolMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for SslProtocol match conditions
 
@@ -2659,8 +2659,8 @@ Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [SslProtocolMatchConditionParameters_TypeName_STATUS](#SslProtocolMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlFileExtensionMatchConditionParameters"></a>UrlFileExtensionMatchConditionParameters
----------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters{#UrlFileExtensionMatchConditionParameters}
+-----------------------------------------------------------------------------------
 
 Defines the parameters for UrlFileExtension match conditions
 
@@ -2674,8 +2674,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCo
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                               |
 | typeName        |                                                        | [UrlFileExtensionMatchConditionParameters_TypeName](#UrlFileExtensionMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlFileExtensionMatchConditionParameters_STATUS"></a>UrlFileExtensionMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_STATUS{#UrlFileExtensionMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Defines the parameters for UrlFileExtension match conditions
 
@@ -2689,8 +2689,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExte
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                               |
 | typeName        |                                                        | [UrlFileExtensionMatchConditionParameters_TypeName_STATUS](#UrlFileExtensionMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlFileNameMatchConditionParameters"></a>UrlFileNameMatchConditionParameters
------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters{#UrlFileNameMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for UrlFilename match conditions
 
@@ -2704,8 +2704,8 @@ Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [UrlFileNameMatchConditionParameters_TypeName](#UrlFileNameMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlFileNameMatchConditionParameters_STATUS"></a>UrlFileNameMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_STATUS{#UrlFileNameMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for UrlFilename match conditions
 
@@ -2719,8 +2719,8 @@ Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [UrlFileNameMatchConditionParameters_TypeName_STATUS](#UrlFileNameMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlPathMatchConditionParameters"></a>UrlPathMatchConditionParameters
----------------------------------------------------------------------------
+UrlPathMatchConditionParameters{#UrlPathMatchConditionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for UrlPath match conditions
 
@@ -2734,8 +2734,8 @@ Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [UrlPathMatchConditionParameters_TypeName](#UrlPathMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlPathMatchConditionParameters_STATUS"></a>UrlPathMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------
+UrlPathMatchConditionParameters_STATUS{#UrlPathMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for UrlPath match conditions
 
@@ -2749,8 +2749,8 @@ Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STA
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [UrlPathMatchConditionParameters_TypeName_STATUS](#UrlPathMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlRedirectAction_Name"></a>UrlRedirectAction_Name
----------------------------------------------------------
+UrlRedirectAction_Name{#UrlRedirectAction_Name}
+-----------------------------------------------
 
 Used by: [UrlRedirectAction](#UrlRedirectAction).
 
@@ -2758,8 +2758,8 @@ Used by: [UrlRedirectAction](#UrlRedirectAction).
 |---------------|-------------|
 | "UrlRedirect" |             |
 
-<a id="UrlRedirectAction_Name_STATUS"></a>UrlRedirectAction_Name_STATUS
------------------------------------------------------------------------
+UrlRedirectAction_Name_STATUS{#UrlRedirectAction_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 
@@ -2767,8 +2767,8 @@ Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 |---------------|-------------|
 | "UrlRedirect" |             |
 
-<a id="UrlRedirectActionParameters"></a>UrlRedirectActionParameters
--------------------------------------------------------------------
+UrlRedirectActionParameters{#UrlRedirectActionParameters}
+---------------------------------------------------------
 
 Defines the parameters for the url redirect action.
 
@@ -2784,8 +2784,8 @@ Used by: [UrlRedirectAction](#UrlRedirectAction).
 | redirectType        | The redirect type the rule will use when redirecting traffic.                                                                                                                                                                                                                       | [UrlRedirectActionParameters_RedirectType](#UrlRedirectActionParameters_RedirectType)<br/><small>Required</small>               |
 | typeName            |                                                                                                                                                                                                                                                                                     | [UrlRedirectActionParameters_TypeName](#UrlRedirectActionParameters_TypeName)<br/><small>Required</small>                       |
 
-<a id="UrlRedirectActionParameters_STATUS"></a>UrlRedirectActionParameters_STATUS
----------------------------------------------------------------------------------
+UrlRedirectActionParameters_STATUS{#UrlRedirectActionParameters_STATUS}
+-----------------------------------------------------------------------
 
 Defines the parameters for the url redirect action.
 
@@ -2801,8 +2801,8 @@ Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 | redirectType        | The redirect type the rule will use when redirecting traffic.                                                                                                                                                                                                                       | [UrlRedirectActionParameters_RedirectType_STATUS](#UrlRedirectActionParameters_RedirectType_STATUS)<br/><small>Optional</small>               |
 | typeName            |                                                                                                                                                                                                                                                                                     | [UrlRedirectActionParameters_TypeName_STATUS](#UrlRedirectActionParameters_TypeName_STATUS)<br/><small>Optional</small>                       |
 
-<a id="UrlRewriteAction_Name"></a>UrlRewriteAction_Name
--------------------------------------------------------
+UrlRewriteAction_Name{#UrlRewriteAction_Name}
+---------------------------------------------
 
 Used by: [UrlRewriteAction](#UrlRewriteAction).
 
@@ -2810,8 +2810,8 @@ Used by: [UrlRewriteAction](#UrlRewriteAction).
 |--------------|-------------|
 | "UrlRewrite" |             |
 
-<a id="UrlRewriteAction_Name_STATUS"></a>UrlRewriteAction_Name_STATUS
----------------------------------------------------------------------
+UrlRewriteAction_Name_STATUS{#UrlRewriteAction_Name_STATUS}
+-----------------------------------------------------------
 
 Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 
@@ -2819,8 +2819,8 @@ Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 |--------------|-------------|
 | "UrlRewrite" |             |
 
-<a id="UrlRewriteActionParameters"></a>UrlRewriteActionParameters
------------------------------------------------------------------
+UrlRewriteActionParameters{#UrlRewriteActionParameters}
+-------------------------------------------------------
 
 Defines the parameters for the url rewrite action.
 
@@ -2833,8 +2833,8 @@ Used by: [UrlRewriteAction](#UrlRewriteAction).
 | sourcePattern         | define a request URI pattern that identifies the type of requests that may be rewritten. If value is blank, all strings are matched. | string<br/><small>Required</small>                                                                      |
 | typeName              |                                                                                                                                      | [UrlRewriteActionParameters_TypeName](#UrlRewriteActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlRewriteActionParameters_STATUS"></a>UrlRewriteActionParameters_STATUS
--------------------------------------------------------------------------------
+UrlRewriteActionParameters_STATUS{#UrlRewriteActionParameters_STATUS}
+---------------------------------------------------------------------
 
 Defines the parameters for the url rewrite action.
 
@@ -2847,8 +2847,8 @@ Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 | sourcePattern         | define a request URI pattern that identifies the type of requests that may be rewritten. If value is blank, all strings are matched. | string<br/><small>Optional</small>                                                                                    |
 | typeName              |                                                                                                                                      | [UrlRewriteActionParameters_TypeName_STATUS](#UrlRewriteActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningAction_Name"></a>UrlSigningAction_Name
--------------------------------------------------------
+UrlSigningAction_Name{#UrlSigningAction_Name}
+---------------------------------------------
 
 Used by: [UrlSigningAction](#UrlSigningAction).
 
@@ -2856,8 +2856,8 @@ Used by: [UrlSigningAction](#UrlSigningAction).
 |--------------|-------------|
 | "UrlSigning" |             |
 
-<a id="UrlSigningAction_Name_STATUS"></a>UrlSigningAction_Name_STATUS
----------------------------------------------------------------------
+UrlSigningAction_Name_STATUS{#UrlSigningAction_Name_STATUS}
+-----------------------------------------------------------
 
 Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 
@@ -2865,8 +2865,8 @@ Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 |--------------|-------------|
 | "UrlSigning" |             |
 
-<a id="UrlSigningActionParameters"></a>UrlSigningActionParameters
------------------------------------------------------------------
+UrlSigningActionParameters{#UrlSigningActionParameters}
+-------------------------------------------------------
 
 Defines the parameters for the Url Signing action.
 
@@ -2878,8 +2878,8 @@ Used by: [UrlSigningAction](#UrlSigningAction).
 | parameterNameOverride | Defines which query string parameters in the url to be considered for expires, key id etc. | [UrlSigningParamIdentifier[]](#UrlSigningParamIdentifier)<br/><small>Optional</small>                     |
 | typeName              |                                                                                            | [UrlSigningActionParameters_TypeName](#UrlSigningActionParameters_TypeName)<br/><small>Required</small>   |
 
-<a id="UrlSigningActionParameters_STATUS"></a>UrlSigningActionParameters_STATUS
--------------------------------------------------------------------------------
+UrlSigningActionParameters_STATUS{#UrlSigningActionParameters_STATUS}
+---------------------------------------------------------------------
 
 Defines the parameters for the Url Signing action.
 
@@ -2891,8 +2891,8 @@ Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 | parameterNameOverride | Defines which query string parameters in the url to be considered for expires, key id etc. | [UrlSigningParamIdentifier_STATUS[]](#UrlSigningParamIdentifier_STATUS)<br/><small>Optional</small>                     |
 | typeName              |                                                                                            | [UrlSigningActionParameters_TypeName_STATUS](#UrlSigningActionParameters_TypeName_STATUS)<br/><small>Optional</small>   |
 
-<a id="CacheConfiguration"></a>CacheConfiguration
--------------------------------------------------
+CacheConfiguration{#CacheConfiguration}
+---------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -2906,8 +2906,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                          |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings.                                                       | [CacheConfiguration_QueryStringCachingBehavior](#CacheConfiguration_QueryStringCachingBehavior)<br/><small>Optional</small> |
 
-<a id="CacheConfiguration_STATUS"></a>CacheConfiguration_STATUS
----------------------------------------------------------------
+CacheConfiguration_STATUS{#CacheConfiguration_STATUS}
+-----------------------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -2921,8 +2921,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                        |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings.                                                       | [CacheConfiguration_QueryStringCachingBehavior_STATUS](#CacheConfiguration_QueryStringCachingBehavior_STATUS)<br/><small>Optional</small> |
 
-<a id="CacheExpirationActionParameters_CacheBehavior"></a>CacheExpirationActionParameters_CacheBehavior
--------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheBehavior{#CacheExpirationActionParameters_CacheBehavior}
+---------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
@@ -2932,8 +2932,8 @@ Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 | "Override"     |             |
 | "SetIfMissing" |             |
 
-<a id="CacheExpirationActionParameters_CacheBehavior_STATUS"></a>CacheExpirationActionParameters_CacheBehavior_STATUS
----------------------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheBehavior_STATUS{#CacheExpirationActionParameters_CacheBehavior_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
 
@@ -2943,8 +2943,8 @@ Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParamete
 | "Override"     |             |
 | "SetIfMissing" |             |
 
-<a id="CacheExpirationActionParameters_CacheType"></a>CacheExpirationActionParameters_CacheType
------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheType{#CacheExpirationActionParameters_CacheType}
+-------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
@@ -2952,8 +2952,8 @@ Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 |-------|-------------|
 | "All" |             |
 
-<a id="CacheExpirationActionParameters_CacheType_STATUS"></a>CacheExpirationActionParameters_CacheType_STATUS
--------------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheType_STATUS{#CacheExpirationActionParameters_CacheType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
 
@@ -2961,188 +2961,188 @@ Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParamete
 |-------|-------------|
 | "All" |             |
 
-<a id="CacheExpirationActionParameters_TypeName"></a>CacheExpirationActionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleCacheExpirationActionParameters" |             |
-
-<a id="CacheExpirationActionParameters_TypeName_STATUS"></a>CacheExpirationActionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleCacheExpirationActionParameters" |             |
-
-<a id="CacheKeyQueryStringActionParameters_QueryStringBehavior"></a>CacheKeyQueryStringActionParameters_QueryStringBehavior
----------------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
-
-| Value        | Description |
-|--------------|-------------|
-| "Exclude"    |             |
-| "ExcludeAll" |             |
-| "Include"    |             |
-| "IncludeAll" |             |
-
-<a id="CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS"></a>CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Exclude"    |             |
-| "ExcludeAll" |             |
-| "Include"    |             |
-| "IncludeAll" |             |
-
-<a id="CacheKeyQueryStringActionParameters_TypeName"></a>CacheKeyQueryStringActionParameters_TypeName
------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
-
-| Value                                                     | Description |
-|-----------------------------------------------------------|-------------|
-| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
-
-<a id="CacheKeyQueryStringActionParameters_TypeName_STATUS"></a>CacheKeyQueryStringActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
-
-| Value                                                     | Description |
-|-----------------------------------------------------------|-------------|
-| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
-
-<a id="ClientPortMatchConditionParameters_Operator"></a>ClientPortMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="ClientPortMatchConditionParameters_Operator_STATUS"></a>ClientPortMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="ClientPortMatchConditionParameters_TypeName"></a>ClientPortMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleClientPortConditionParameters" |             |
-
-<a id="ClientPortMatchConditionParameters_TypeName_STATUS"></a>ClientPortMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleClientPortConditionParameters" |             |
-
-<a id="CookiesMatchConditionParameters_Operator"></a>CookiesMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="CookiesMatchConditionParameters_Operator_STATUS"></a>CookiesMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="CookiesMatchConditionParameters_TypeName"></a>CookiesMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
-
-| Value                                    | Description |
-|------------------------------------------|-------------|
-| "DeliveryRuleCookiesConditionParameters" |             |
-
-<a id="CookiesMatchConditionParameters_TypeName_STATUS"></a>CookiesMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
-
-| Value                                    | Description |
-|------------------------------------------|-------------|
-| "DeliveryRuleCookiesConditionParameters" |             |
-
-<a id="HeaderActionParameters_HeaderAction"></a>HeaderActionParameters_HeaderAction
+CacheExpirationActionParameters_TypeName{#CacheExpirationActionParameters_TypeName}
 -----------------------------------------------------------------------------------
 
-Used by: [HeaderActionParameters](#HeaderActionParameters).
+Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
-| Value       | Description |
-|-------------|-------------|
-| "Append"    |             |
-| "Delete"    |             |
-| "Overwrite" |             |
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleCacheExpirationActionParameters" |             |
 
-<a id="HeaderActionParameters_HeaderAction_STATUS"></a>HeaderActionParameters_HeaderAction_STATUS
+CacheExpirationActionParameters_TypeName_STATUS{#CacheExpirationActionParameters_TypeName_STATUS}
 -------------------------------------------------------------------------------------------------
 
+Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleCacheExpirationActionParameters" |             |
+
+CacheKeyQueryStringActionParameters_QueryStringBehavior{#CacheKeyQueryStringActionParameters_QueryStringBehavior}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
+
+| Value        | Description |
+|--------------|-------------|
+| "Exclude"    |             |
+| "ExcludeAll" |             |
+| "Include"    |             |
+| "IncludeAll" |             |
+
+CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS{#CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Exclude"    |             |
+| "ExcludeAll" |             |
+| "Include"    |             |
+| "IncludeAll" |             |
+
+CacheKeyQueryStringActionParameters_TypeName{#CacheKeyQueryStringActionParameters_TypeName}
+-------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
+
+| Value                                                     | Description |
+|-----------------------------------------------------------|-------------|
+| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
+
+CacheKeyQueryStringActionParameters_TypeName_STATUS{#CacheKeyQueryStringActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
+
+| Value                                                     | Description |
+|-----------------------------------------------------------|-------------|
+| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
+
+ClientPortMatchConditionParameters_Operator{#ClientPortMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+ClientPortMatchConditionParameters_Operator_STATUS{#ClientPortMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+ClientPortMatchConditionParameters_TypeName{#ClientPortMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleClientPortConditionParameters" |             |
+
+ClientPortMatchConditionParameters_TypeName_STATUS{#ClientPortMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleClientPortConditionParameters" |             |
+
+CookiesMatchConditionParameters_Operator{#CookiesMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+CookiesMatchConditionParameters_Operator_STATUS{#CookiesMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+CookiesMatchConditionParameters_TypeName{#CookiesMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
+
+| Value                                    | Description |
+|------------------------------------------|-------------|
+| "DeliveryRuleCookiesConditionParameters" |             |
+
+CookiesMatchConditionParameters_TypeName_STATUS{#CookiesMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
+
+| Value                                    | Description |
+|------------------------------------------|-------------|
+| "DeliveryRuleCookiesConditionParameters" |             |
+
+HeaderActionParameters_HeaderAction{#HeaderActionParameters_HeaderAction}
+-------------------------------------------------------------------------
+
+Used by: [HeaderActionParameters](#HeaderActionParameters).
+
+| Value       | Description |
+|-------------|-------------|
+| "Append"    |             |
+| "Delete"    |             |
+| "Overwrite" |             |
+
+HeaderActionParameters_HeaderAction_STATUS{#HeaderActionParameters_HeaderAction_STATUS}
+---------------------------------------------------------------------------------------
+
 Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 
 | Value       | Description |
@@ -3151,8 +3151,8 @@ Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 | "Delete"    |             |
 | "Overwrite" |             |
 
-<a id="HeaderActionParameters_TypeName"></a>HeaderActionParameters_TypeName
----------------------------------------------------------------------------
+HeaderActionParameters_TypeName{#HeaderActionParameters_TypeName}
+-----------------------------------------------------------------
 
 Used by: [HeaderActionParameters](#HeaderActionParameters).
 
@@ -3160,8 +3160,8 @@ Used by: [HeaderActionParameters](#HeaderActionParameters).
 |--------------------------------------|-------------|
 | "DeliveryRuleHeaderActionParameters" |             |
 
-<a id="HeaderActionParameters_TypeName_STATUS"></a>HeaderActionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------
+HeaderActionParameters_TypeName_STATUS{#HeaderActionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 
@@ -3169,8 +3169,8 @@ Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 |--------------------------------------|-------------|
 | "DeliveryRuleHeaderActionParameters" |             |
 
-<a id="HostNameMatchConditionParameters_Operator"></a>HostNameMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_Operator{#HostNameMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 
@@ -3187,8 +3187,8 @@ Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="HostNameMatchConditionParameters_Operator_STATUS"></a>HostNameMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_Operator_STATUS{#HostNameMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS).
 
@@ -3205,8 +3205,8 @@ Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParame
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="HostNameMatchConditionParameters_TypeName"></a>HostNameMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_TypeName{#HostNameMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 
@@ -3214,8 +3214,8 @@ Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRuleHostNameConditionParameters" |             |
 
-<a id="HostNameMatchConditionParameters_TypeName_STATUS"></a>HostNameMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_TypeName_STATUS{#HostNameMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS).
 
@@ -3223,8 +3223,8 @@ Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRuleHostNameConditionParameters" |             |
 
-<a id="HttpVersionMatchConditionParameters_Operator"></a>HttpVersionMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_Operator{#HttpVersionMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters).
 
@@ -3232,8 +3232,8 @@ Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParamet
 |---------|-------------|
 | "Equal" |             |
 
-<a id="HttpVersionMatchConditionParameters_Operator_STATUS"></a>HttpVersionMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_Operator_STATUS{#HttpVersionMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS).
 
@@ -3241,8 +3241,8 @@ Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchCondition
 |---------|-------------|
 | "Equal" |             |
 
-<a id="HttpVersionMatchConditionParameters_TypeName"></a>HttpVersionMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_TypeName{#HttpVersionMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters).
 
@@ -3250,8 +3250,8 @@ Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleHttpVersionConditionParameters" |             |
 
-<a id="HttpVersionMatchConditionParameters_TypeName_STATUS"></a>HttpVersionMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_TypeName_STATUS{#HttpVersionMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS).
 
@@ -3259,8 +3259,8 @@ Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleHttpVersionConditionParameters" |             |
 
-<a id="IsDeviceMatchConditionParameters_MatchValues"></a>IsDeviceMatchConditionParameters_MatchValues
------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_MatchValues{#IsDeviceMatchConditionParameters_MatchValues}
+-------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -3269,8 +3269,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 | "Desktop" |             |
 | "Mobile"  |             |
 
-<a id="IsDeviceMatchConditionParameters_MatchValues_STATUS"></a>IsDeviceMatchConditionParameters_MatchValues_STATUS
--------------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_MatchValues_STATUS{#IsDeviceMatchConditionParameters_MatchValues_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -3279,8 +3279,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 | "Desktop" |             |
 | "Mobile"  |             |
 
-<a id="IsDeviceMatchConditionParameters_Operator"></a>IsDeviceMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_Operator{#IsDeviceMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -3288,8 +3288,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 |---------|-------------|
 | "Equal" |             |
 
-<a id="IsDeviceMatchConditionParameters_Operator_STATUS"></a>IsDeviceMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_Operator_STATUS{#IsDeviceMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -3297,8 +3297,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 |---------|-------------|
 | "Equal" |             |
 
-<a id="IsDeviceMatchConditionParameters_TypeName"></a>IsDeviceMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_TypeName{#IsDeviceMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -3306,8 +3306,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRuleIsDeviceConditionParameters" |             |
 
-<a id="IsDeviceMatchConditionParameters_TypeName_STATUS"></a>IsDeviceMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_TypeName_STATUS{#IsDeviceMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -3315,8 +3315,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRuleIsDeviceConditionParameters" |             |
 
-<a id="OriginGroupOverride"></a>OriginGroupOverride
----------------------------------------------------
+OriginGroupOverride{#OriginGroupOverride}
+-----------------------------------------
 
 Defines the parameters for the origin group override configuration.
 
@@ -3327,8 +3327,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 | forwardingProtocol | Protocol this rule will use when forwarding traffic to backends.             | [OriginGroupOverride_ForwardingProtocol](#OriginGroupOverride_ForwardingProtocol)<br/><small>Optional</small> |
 | originGroup        | defines the OriginGroup that would override the DefaultOriginGroup on route. | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                           |
 
-<a id="OriginGroupOverride_STATUS"></a>OriginGroupOverride_STATUS
------------------------------------------------------------------
+OriginGroupOverride_STATUS{#OriginGroupOverride_STATUS}
+-------------------------------------------------------
 
 Defines the parameters for the origin group override configuration.
 
@@ -3339,8 +3339,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 | forwardingProtocol | Protocol this rule will use when forwarding traffic to backends.             | [OriginGroupOverride_ForwardingProtocol_STATUS](#OriginGroupOverride_ForwardingProtocol_STATUS)<br/><small>Optional</small> |
 | originGroup        | defines the OriginGroup that would override the DefaultOriginGroup on route. | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="OriginGroupOverrideActionParameters_TypeName"></a>OriginGroupOverrideActionParameters_TypeName
------------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_TypeName{#OriginGroupOverrideActionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParameters).
 
@@ -3348,8 +3348,8 @@ Used by: [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParamet
 |---------------------------------------------------|-------------|
 | "DeliveryRuleOriginGroupOverrideActionParameters" |             |
 
-<a id="OriginGroupOverrideActionParameters_TypeName_STATUS"></a>OriginGroupOverrideActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_TypeName_STATUS{#OriginGroupOverrideActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideActionParameters_STATUS).
 
@@ -3357,8 +3357,8 @@ Used by: [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideAction
 |---------------------------------------------------|-------------|
 | "DeliveryRuleOriginGroupOverrideActionParameters" |             |
 
-<a id="PostArgsMatchConditionParameters_Operator"></a>PostArgsMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_Operator{#PostArgsMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 
@@ -3375,8 +3375,8 @@ Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="PostArgsMatchConditionParameters_Operator_STATUS"></a>PostArgsMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_Operator_STATUS{#PostArgsMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS).
 
@@ -3393,8 +3393,8 @@ Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParame
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="PostArgsMatchConditionParameters_TypeName"></a>PostArgsMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_TypeName{#PostArgsMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 
@@ -3402,8 +3402,8 @@ Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRulePostArgsConditionParameters" |             |
 
-<a id="PostArgsMatchConditionParameters_TypeName_STATUS"></a>PostArgsMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_TypeName_STATUS{#PostArgsMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS).
 
@@ -3411,8 +3411,8 @@ Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRulePostArgsConditionParameters" |             |
 
-<a id="QueryStringMatchConditionParameters_Operator"></a>QueryStringMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_Operator{#QueryStringMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters).
 
@@ -3429,8 +3429,8 @@ Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="QueryStringMatchConditionParameters_Operator_STATUS"></a>QueryStringMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_Operator_STATUS{#QueryStringMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS).
 
@@ -3447,8 +3447,8 @@ Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="QueryStringMatchConditionParameters_TypeName"></a>QueryStringMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_TypeName{#QueryStringMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters).
 
@@ -3456,8 +3456,8 @@ Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleQueryStringConditionParameters" |             |
 
-<a id="QueryStringMatchConditionParameters_TypeName_STATUS"></a>QueryStringMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_TypeName_STATUS{#QueryStringMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS).
 
@@ -3465,8 +3465,8 @@ Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleQueryStringConditionParameters" |             |
 
-<a id="RemoteAddressMatchConditionParameters_Operator"></a>RemoteAddressMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_Operator{#RemoteAddressMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters).
 
@@ -3476,8 +3476,8 @@ Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionPar
 | "GeoMatch" |             |
 | "IPMatch"  |             |
 
-<a id="RemoteAddressMatchConditionParameters_Operator_STATUS"></a>RemoteAddressMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_Operator_STATUS{#RemoteAddressMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS).
 
@@ -3487,8 +3487,8 @@ Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchCondi
 | "GeoMatch" |             |
 | "IPMatch"  |             |
 
-<a id="RemoteAddressMatchConditionParameters_TypeName"></a>RemoteAddressMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_TypeName{#RemoteAddressMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters).
 
@@ -3496,8 +3496,8 @@ Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionPar
 |------------------------------------------------|-------------|
 | "DeliveryRuleRemoteAddressConditionParameters" |             |
 
-<a id="RemoteAddressMatchConditionParameters_TypeName_STATUS"></a>RemoteAddressMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_TypeName_STATUS{#RemoteAddressMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS).
 
@@ -3505,8 +3505,8 @@ Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchCondi
 |------------------------------------------------|-------------|
 | "DeliveryRuleRemoteAddressConditionParameters" |             |
 
-<a id="RequestBodyMatchConditionParameters_Operator"></a>RequestBodyMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_Operator{#RequestBodyMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters).
 
@@ -3523,8 +3523,8 @@ Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestBodyMatchConditionParameters_Operator_STATUS"></a>RequestBodyMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_Operator_STATUS{#RequestBodyMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS).
 
@@ -3541,8 +3541,8 @@ Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestBodyMatchConditionParameters_TypeName"></a>RequestBodyMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_TypeName{#RequestBodyMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters).
 
@@ -3550,8 +3550,8 @@ Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleRequestBodyConditionParameters" |             |
 
-<a id="RequestBodyMatchConditionParameters_TypeName_STATUS"></a>RequestBodyMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_TypeName_STATUS{#RequestBodyMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS).
 
@@ -3559,8 +3559,8 @@ Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleRequestBodyConditionParameters" |             |
 
-<a id="RequestHeaderMatchConditionParameters_Operator"></a>RequestHeaderMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_Operator{#RequestHeaderMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters).
 
@@ -3577,8 +3577,8 @@ Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionPar
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestHeaderMatchConditionParameters_Operator_STATUS"></a>RequestHeaderMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_Operator_STATUS{#RequestHeaderMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS).
 
@@ -3595,8 +3595,8 @@ Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchCondi
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestHeaderMatchConditionParameters_TypeName"></a>RequestHeaderMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_TypeName{#RequestHeaderMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters).
 
@@ -3604,8 +3604,8 @@ Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionPar
 |------------------------------------------------|-------------|
 | "DeliveryRuleRequestHeaderConditionParameters" |             |
 
-<a id="RequestHeaderMatchConditionParameters_TypeName_STATUS"></a>RequestHeaderMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_TypeName_STATUS{#RequestHeaderMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS).
 
@@ -3613,8 +3613,8 @@ Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchCondi
 |------------------------------------------------|-------------|
 | "DeliveryRuleRequestHeaderConditionParameters" |             |
 
-<a id="RequestMethodMatchConditionParameters_MatchValues"></a>RequestMethodMatchConditionParameters_MatchValues
----------------------------------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters_MatchValues{#RequestMethodMatchConditionParameters_MatchValues}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
 
@@ -3628,169 +3628,169 @@ Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionPar
 | "PUT"     |             |
 | "TRACE"   |             |
 
-<a id="RequestMethodMatchConditionParameters_MatchValues_STATUS"></a>RequestMethodMatchConditionParameters_MatchValues_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "DELETE"  |             |
-| "GET"     |             |
-| "HEAD"    |             |
-| "OPTIONS" |             |
-| "POST"    |             |
-| "PUT"     |             |
-| "TRACE"   |             |
-
-<a id="RequestMethodMatchConditionParameters_Operator"></a>RequestMethodMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestMethodMatchConditionParameters_Operator_STATUS"></a>RequestMethodMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestMethodMatchConditionParameters_TypeName"></a>RequestMethodMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestMethodConditionParameters" |             |
-
-<a id="RequestMethodMatchConditionParameters_TypeName_STATUS"></a>RequestMethodMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestMethodConditionParameters" |             |
-
-<a id="RequestSchemeMatchConditionParameters_MatchValues"></a>RequestSchemeMatchConditionParameters_MatchValues
----------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "HTTP"  |             |
-| "HTTPS" |             |
-
-<a id="RequestSchemeMatchConditionParameters_MatchValues_STATUS"></a>RequestSchemeMatchConditionParameters_MatchValues_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "HTTP"  |             |
-| "HTTPS" |             |
-
-<a id="RequestSchemeMatchConditionParameters_Operator"></a>RequestSchemeMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestSchemeMatchConditionParameters_Operator_STATUS"></a>RequestSchemeMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestSchemeMatchConditionParameters_TypeName"></a>RequestSchemeMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestSchemeConditionParameters" |             |
-
-<a id="RequestSchemeMatchConditionParameters_TypeName_STATUS"></a>RequestSchemeMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestSchemeConditionParameters" |             |
-
-<a id="RequestUriMatchConditionParameters_Operator"></a>RequestUriMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="RequestUriMatchConditionParameters_Operator_STATUS"></a>RequestUriMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="RequestUriMatchConditionParameters_TypeName"></a>RequestUriMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleRequestUriConditionParameters" |             |
-
-<a id="RequestUriMatchConditionParameters_TypeName_STATUS"></a>RequestUriMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleRequestUriConditionParameters" |             |
-
-<a id="RouteConfigurationOverrideActionParameters_TypeName"></a>RouteConfigurationOverrideActionParameters_TypeName
+RequestMethodMatchConditionParameters_MatchValues_STATUS{#RequestMethodMatchConditionParameters_MatchValues_STATUS}
 -------------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "DELETE"  |             |
+| "GET"     |             |
+| "HEAD"    |             |
+| "OPTIONS" |             |
+| "POST"    |             |
+| "PUT"     |             |
+| "TRACE"   |             |
+
+RequestMethodMatchConditionParameters_Operator{#RequestMethodMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestMethodMatchConditionParameters_Operator_STATUS{#RequestMethodMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestMethodMatchConditionParameters_TypeName{#RequestMethodMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestMethodConditionParameters" |             |
+
+RequestMethodMatchConditionParameters_TypeName_STATUS{#RequestMethodMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestMethodConditionParameters" |             |
+
+RequestSchemeMatchConditionParameters_MatchValues{#RequestSchemeMatchConditionParameters_MatchValues}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "HTTP"  |             |
+| "HTTPS" |             |
+
+RequestSchemeMatchConditionParameters_MatchValues_STATUS{#RequestSchemeMatchConditionParameters_MatchValues_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "HTTP"  |             |
+| "HTTPS" |             |
+
+RequestSchemeMatchConditionParameters_Operator{#RequestSchemeMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestSchemeMatchConditionParameters_Operator_STATUS{#RequestSchemeMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestSchemeMatchConditionParameters_TypeName{#RequestSchemeMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestSchemeConditionParameters" |             |
+
+RequestSchemeMatchConditionParameters_TypeName_STATUS{#RequestSchemeMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestSchemeConditionParameters" |             |
+
+RequestUriMatchConditionParameters_Operator{#RequestUriMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+RequestUriMatchConditionParameters_Operator_STATUS{#RequestUriMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+RequestUriMatchConditionParameters_TypeName{#RequestUriMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleRequestUriConditionParameters" |             |
+
+RequestUriMatchConditionParameters_TypeName_STATUS{#RequestUriMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleRequestUriConditionParameters" |             |
+
+RouteConfigurationOverrideActionParameters_TypeName{#RouteConfigurationOverrideActionParameters_TypeName}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrideActionParameters).
 
@@ -3798,8 +3798,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 |----------------------------------------------------------|-------------|
 | "DeliveryRuleRouteConfigurationOverrideActionParameters" |             |
 
-<a id="RouteConfigurationOverrideActionParameters_TypeName_STATUS"></a>RouteConfigurationOverrideActionParameters_TypeName_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters_TypeName_STATUS{#RouteConfigurationOverrideActionParameters_TypeName_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfigurationOverrideActionParameters_STATUS).
 
@@ -3807,8 +3807,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 |----------------------------------------------------------|-------------|
 | "DeliveryRuleRouteConfigurationOverrideActionParameters" |             |
 
-<a id="ServerPortMatchConditionParameters_Operator"></a>ServerPortMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_Operator{#ServerPortMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters).
 
@@ -3825,8 +3825,8 @@ Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameter
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="ServerPortMatchConditionParameters_Operator_STATUS"></a>ServerPortMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_Operator_STATUS{#ServerPortMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS).
 
@@ -3843,8 +3843,8 @@ Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionPa
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="ServerPortMatchConditionParameters_TypeName"></a>ServerPortMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_TypeName{#ServerPortMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters).
 
@@ -3852,8 +3852,8 @@ Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameter
 |---------------------------------------------|-------------|
 | "DeliveryRuleServerPortConditionParameters" |             |
 
-<a id="ServerPortMatchConditionParameters_TypeName_STATUS"></a>ServerPortMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_TypeName_STATUS{#ServerPortMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS).
 
@@ -3861,8 +3861,8 @@ Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionPa
 |---------------------------------------------|-------------|
 | "DeliveryRuleServerPortConditionParameters" |             |
 
-<a id="SocketAddrMatchConditionParameters_Operator"></a>SocketAddrMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_Operator{#SocketAddrMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters).
 
@@ -3871,8 +3871,8 @@ Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameter
 | "Any"     |             |
 | "IPMatch" |             |
 
-<a id="SocketAddrMatchConditionParameters_Operator_STATUS"></a>SocketAddrMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_Operator_STATUS{#SocketAddrMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS).
 
@@ -3881,8 +3881,8 @@ Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionPa
 | "Any"     |             |
 | "IPMatch" |             |
 
-<a id="SocketAddrMatchConditionParameters_TypeName"></a>SocketAddrMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_TypeName{#SocketAddrMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters).
 
@@ -3890,8 +3890,8 @@ Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameter
 |---------------------------------------------|-------------|
 | "DeliveryRuleSocketAddrConditionParameters" |             |
 
-<a id="SocketAddrMatchConditionParameters_TypeName_STATUS"></a>SocketAddrMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_TypeName_STATUS{#SocketAddrMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS).
 
@@ -3899,8 +3899,8 @@ Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionPa
 |---------------------------------------------|-------------|
 | "DeliveryRuleSocketAddrConditionParameters" |             |
 
-<a id="SslProtocol"></a>SslProtocol
------------------------------------
+SslProtocol{#SslProtocol}
+-------------------------
 
 The protocol of an established TLS connection.
 
@@ -3912,8 +3912,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 | "TLSv1.1" |             |
 | "TLSv1.2" |             |
 
-<a id="SslProtocol_STATUS"></a>SslProtocol_STATUS
--------------------------------------------------
+SslProtocol_STATUS{#SslProtocol_STATUS}
+---------------------------------------
 
 The protocol of an established TLS connection.
 
@@ -3925,8 +3925,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 | "TLSv1.1" |             |
 | "TLSv1.2" |             |
 
-<a id="SslProtocolMatchConditionParameters_Operator"></a>SslProtocolMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_Operator{#SslProtocolMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters).
 
@@ -3934,8 +3934,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 |---------|-------------|
 | "Equal" |             |
 
-<a id="SslProtocolMatchConditionParameters_Operator_STATUS"></a>SslProtocolMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_Operator_STATUS{#SslProtocolMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS).
 
@@ -3943,8 +3943,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 |---------|-------------|
 | "Equal" |             |
 
-<a id="SslProtocolMatchConditionParameters_TypeName"></a>SslProtocolMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_TypeName{#SslProtocolMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters).
 
@@ -3952,8 +3952,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleSslProtocolConditionParameters" |             |
 
-<a id="SslProtocolMatchConditionParameters_TypeName_STATUS"></a>SslProtocolMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_TypeName_STATUS{#SslProtocolMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS).
 
@@ -3961,8 +3961,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleSslProtocolConditionParameters" |             |
 
-<a id="Transform"></a>Transform
--------------------------------
+Transform{#Transform}
+---------------------
 
 Describes what transforms are applied before matching
 
@@ -3977,8 +3977,8 @@ Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameter
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="Transform_STATUS"></a>Transform_STATUS
----------------------------------------------
+Transform_STATUS{#Transform_STATUS}
+-----------------------------------
 
 Describes what transforms are applied before matching
 
@@ -3993,8 +3993,8 @@ Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionPa
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_Operator"></a>UrlFileExtensionMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_Operator{#UrlFileExtensionMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters).
 
@@ -4011,8 +4011,8 @@ Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchCondit
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_Operator_STATUS"></a>UrlFileExtensionMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_Operator_STATUS{#UrlFileExtensionMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS).
 
@@ -4029,8 +4029,8 @@ Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatc
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_TypeName"></a>UrlFileExtensionMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_TypeName{#UrlFileExtensionMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters).
 
@@ -4038,8 +4038,8 @@ Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchCondit
 |--------------------------------------------------------|-------------|
 | "DeliveryRuleUrlFileExtensionMatchConditionParameters" |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_TypeName_STATUS"></a>UrlFileExtensionMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_TypeName_STATUS{#UrlFileExtensionMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS).
 
@@ -4047,8 +4047,8 @@ Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatc
 |--------------------------------------------------------|-------------|
 | "DeliveryRuleUrlFileExtensionMatchConditionParameters" |             |
 
-<a id="UrlFileNameMatchConditionParameters_Operator"></a>UrlFileNameMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_Operator{#UrlFileNameMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters).
 
@@ -4065,8 +4065,8 @@ Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileNameMatchConditionParameters_Operator_STATUS"></a>UrlFileNameMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_Operator_STATUS{#UrlFileNameMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS).
 
@@ -4083,8 +4083,8 @@ Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileNameMatchConditionParameters_TypeName"></a>UrlFileNameMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_TypeName{#UrlFileNameMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters).
 
@@ -4092,8 +4092,8 @@ Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleUrlFilenameConditionParameters" |             |
 
-<a id="UrlFileNameMatchConditionParameters_TypeName_STATUS"></a>UrlFileNameMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_TypeName_STATUS{#UrlFileNameMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS).
 
@@ -4101,128 +4101,128 @@ Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleUrlFilenameConditionParameters" |             |
 
-<a id="UrlPathMatchConditionParameters_Operator"></a>UrlPathMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-| "Wildcard"           |             |
-
-<a id="UrlPathMatchConditionParameters_Operator_STATUS"></a>UrlPathMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-| "Wildcard"           |             |
-
-<a id="UrlPathMatchConditionParameters_TypeName"></a>UrlPathMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleUrlPathMatchConditionParameters" |             |
-
-<a id="UrlPathMatchConditionParameters_TypeName_STATUS"></a>UrlPathMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleUrlPathMatchConditionParameters" |             |
-
-<a id="UrlRedirectActionParameters_DestinationProtocol"></a>UrlRedirectActionParameters_DestinationProtocol
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value          | Description |
-|----------------|-------------|
-| "Http"         |             |
-| "Https"        |             |
-| "MatchRequest" |             |
-
-<a id="UrlRedirectActionParameters_DestinationProtocol_STATUS"></a>UrlRedirectActionParameters_DestinationProtocol_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value          | Description |
-|----------------|-------------|
-| "Http"         |             |
-| "Https"        |             |
-| "MatchRequest" |             |
-
-<a id="UrlRedirectActionParameters_RedirectType"></a>UrlRedirectActionParameters_RedirectType
----------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value               | Description |
-|---------------------|-------------|
-| "Found"             |             |
-| "Moved"             |             |
-| "PermanentRedirect" |             |
-| "TemporaryRedirect" |             |
-
-<a id="UrlRedirectActionParameters_RedirectType_STATUS"></a>UrlRedirectActionParameters_RedirectType_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value               | Description |
-|---------------------|-------------|
-| "Found"             |             |
-| "Moved"             |             |
-| "PermanentRedirect" |             |
-| "TemporaryRedirect" |             |
-
-<a id="UrlRedirectActionParameters_TypeName"></a>UrlRedirectActionParameters_TypeName
--------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value                                     | Description |
-|-------------------------------------------|-------------|
-| "DeliveryRuleUrlRedirectActionParameters" |             |
-
-<a id="UrlRedirectActionParameters_TypeName_STATUS"></a>UrlRedirectActionParameters_TypeName_STATUS
----------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value                                     | Description |
-|-------------------------------------------|-------------|
-| "DeliveryRuleUrlRedirectActionParameters" |             |
-
-<a id="UrlRewriteActionParameters_TypeName"></a>UrlRewriteActionParameters_TypeName
+UrlPathMatchConditionParameters_Operator{#UrlPathMatchConditionParameters_Operator}
 -----------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+| "Wildcard"           |             |
+
+UrlPathMatchConditionParameters_Operator_STATUS{#UrlPathMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+| "Wildcard"           |             |
+
+UrlPathMatchConditionParameters_TypeName{#UrlPathMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleUrlPathMatchConditionParameters" |             |
+
+UrlPathMatchConditionParameters_TypeName_STATUS{#UrlPathMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleUrlPathMatchConditionParameters" |             |
+
+UrlRedirectActionParameters_DestinationProtocol{#UrlRedirectActionParameters_DestinationProtocol}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value          | Description |
+|----------------|-------------|
+| "Http"         |             |
+| "Https"        |             |
+| "MatchRequest" |             |
+
+UrlRedirectActionParameters_DestinationProtocol_STATUS{#UrlRedirectActionParameters_DestinationProtocol_STATUS}
+---------------------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value          | Description |
+|----------------|-------------|
+| "Http"         |             |
+| "Https"        |             |
+| "MatchRequest" |             |
+
+UrlRedirectActionParameters_RedirectType{#UrlRedirectActionParameters_RedirectType}
+-----------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value               | Description |
+|---------------------|-------------|
+| "Found"             |             |
+| "Moved"             |             |
+| "PermanentRedirect" |             |
+| "TemporaryRedirect" |             |
+
+UrlRedirectActionParameters_RedirectType_STATUS{#UrlRedirectActionParameters_RedirectType_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value               | Description |
+|---------------------|-------------|
+| "Found"             |             |
+| "Moved"             |             |
+| "PermanentRedirect" |             |
+| "TemporaryRedirect" |             |
+
+UrlRedirectActionParameters_TypeName{#UrlRedirectActionParameters_TypeName}
+---------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value                                     | Description |
+|-------------------------------------------|-------------|
+| "DeliveryRuleUrlRedirectActionParameters" |             |
+
+UrlRedirectActionParameters_TypeName_STATUS{#UrlRedirectActionParameters_TypeName_STATUS}
+-----------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value                                     | Description |
+|-------------------------------------------|-------------|
+| "DeliveryRuleUrlRedirectActionParameters" |             |
+
+UrlRewriteActionParameters_TypeName{#UrlRewriteActionParameters_TypeName}
+-------------------------------------------------------------------------
 
 Used by: [UrlRewriteActionParameters](#UrlRewriteActionParameters).
 
@@ -4230,8 +4230,8 @@ Used by: [UrlRewriteActionParameters](#UrlRewriteActionParameters).
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlRewriteActionParameters" |             |
 
-<a id="UrlRewriteActionParameters_TypeName_STATUS"></a>UrlRewriteActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------
+UrlRewriteActionParameters_TypeName_STATUS{#UrlRewriteActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS).
 
@@ -4239,8 +4239,8 @@ Used by: [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS)
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlRewriteActionParameters" |             |
 
-<a id="UrlSigningActionParameters_Algorithm"></a>UrlSigningActionParameters_Algorithm
--------------------------------------------------------------------------------------
+UrlSigningActionParameters_Algorithm{#UrlSigningActionParameters_Algorithm}
+---------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 
@@ -4248,8 +4248,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 |----------|-------------|
 | "SHA256" |             |
 
-<a id="UrlSigningActionParameters_Algorithm_STATUS"></a>UrlSigningActionParameters_Algorithm_STATUS
----------------------------------------------------------------------------------------------------
+UrlSigningActionParameters_Algorithm_STATUS{#UrlSigningActionParameters_Algorithm_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS).
 
@@ -4257,8 +4257,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 |----------|-------------|
 | "SHA256" |             |
 
-<a id="UrlSigningActionParameters_TypeName"></a>UrlSigningActionParameters_TypeName
------------------------------------------------------------------------------------
+UrlSigningActionParameters_TypeName{#UrlSigningActionParameters_TypeName}
+-------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 
@@ -4266,8 +4266,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlSigningActionParameters" |             |
 
-<a id="UrlSigningActionParameters_TypeName_STATUS"></a>UrlSigningActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------
+UrlSigningActionParameters_TypeName_STATUS{#UrlSigningActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS).
 
@@ -4275,8 +4275,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlSigningActionParameters" |             |
 
-<a id="UrlSigningParamIdentifier"></a>UrlSigningParamIdentifier
----------------------------------------------------------------
+UrlSigningParamIdentifier{#UrlSigningParamIdentifier}
+-----------------------------------------------------
 
 Defines how to identify a parameter for a specific purpose e.g. expires
 
@@ -4287,8 +4287,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 | paramIndicator | Indicates the purpose of the parameter | [UrlSigningParamIdentifier_ParamIndicator](#UrlSigningParamIdentifier_ParamIndicator)<br/><small>Required</small> |
 | paramName      | Parameter name                         | string<br/><small>Required</small>                                                                                |
 
-<a id="UrlSigningParamIdentifier_STATUS"></a>UrlSigningParamIdentifier_STATUS
------------------------------------------------------------------------------
+UrlSigningParamIdentifier_STATUS{#UrlSigningParamIdentifier_STATUS}
+-------------------------------------------------------------------
 
 Defines how to identify a parameter for a specific purpose e.g. expires
 
@@ -4299,8 +4299,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 | paramIndicator | Indicates the purpose of the parameter | [UrlSigningParamIdentifier_ParamIndicator_STATUS](#UrlSigningParamIdentifier_ParamIndicator_STATUS)<br/><small>Optional</small> |
 | paramName      | Parameter name                         | string<br/><small>Optional</small>                                                                                              |
 
-<a id="CacheConfiguration_CacheBehavior"></a>CacheConfiguration_CacheBehavior
------------------------------------------------------------------------------
+CacheConfiguration_CacheBehavior{#CacheConfiguration_CacheBehavior}
+-------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -4310,8 +4310,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "OverrideAlways"          |             |
 | "OverrideIfOriginMissing" |             |
 
-<a id="CacheConfiguration_CacheBehavior_STATUS"></a>CacheConfiguration_CacheBehavior_STATUS
--------------------------------------------------------------------------------------------
+CacheConfiguration_CacheBehavior_STATUS{#CacheConfiguration_CacheBehavior_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -4321,8 +4321,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "OverrideAlways"          |             |
 | "OverrideIfOriginMissing" |             |
 
-<a id="CacheConfiguration_IsCompressionEnabled"></a>CacheConfiguration_IsCompressionEnabled
--------------------------------------------------------------------------------------------
+CacheConfiguration_IsCompressionEnabled{#CacheConfiguration_IsCompressionEnabled}
+---------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -4331,8 +4331,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CacheConfiguration_IsCompressionEnabled_STATUS"></a>CacheConfiguration_IsCompressionEnabled_STATUS
----------------------------------------------------------------------------------------------------------
+CacheConfiguration_IsCompressionEnabled_STATUS{#CacheConfiguration_IsCompressionEnabled_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -4341,8 +4341,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CacheConfiguration_QueryStringCachingBehavior"></a>CacheConfiguration_QueryStringCachingBehavior
--------------------------------------------------------------------------------------------------------
+CacheConfiguration_QueryStringCachingBehavior{#CacheConfiguration_QueryStringCachingBehavior}
+---------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -4353,8 +4353,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="CacheConfiguration_QueryStringCachingBehavior_STATUS"></a>CacheConfiguration_QueryStringCachingBehavior_STATUS
----------------------------------------------------------------------------------------------------------------------
+CacheConfiguration_QueryStringCachingBehavior_STATUS{#CacheConfiguration_QueryStringCachingBehavior_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -4365,8 +4365,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="OriginGroupOverride_ForwardingProtocol"></a>OriginGroupOverride_ForwardingProtocol
------------------------------------------------------------------------------------------
+OriginGroupOverride_ForwardingProtocol{#OriginGroupOverride_ForwardingProtocol}
+-------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverride](#OriginGroupOverride).
 
@@ -4376,8 +4376,8 @@ Used by: [OriginGroupOverride](#OriginGroupOverride).
 | "HttpsOnly"    |             |
 | "MatchRequest" |             |
 
-<a id="OriginGroupOverride_ForwardingProtocol_STATUS"></a>OriginGroupOverride_ForwardingProtocol_STATUS
--------------------------------------------------------------------------------------------------------
+OriginGroupOverride_ForwardingProtocol_STATUS{#OriginGroupOverride_ForwardingProtocol_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS).
 
@@ -4387,8 +4387,8 @@ Used by: [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS).
 | "HttpsOnly"    |             |
 | "MatchRequest" |             |
 
-<a id="UrlSigningParamIdentifier_ParamIndicator"></a>UrlSigningParamIdentifier_ParamIndicator
----------------------------------------------------------------------------------------------
+UrlSigningParamIdentifier_ParamIndicator{#UrlSigningParamIdentifier_ParamIndicator}
+-----------------------------------------------------------------------------------
 
 Used by: [UrlSigningParamIdentifier](#UrlSigningParamIdentifier).
 
@@ -4398,8 +4398,8 @@ Used by: [UrlSigningParamIdentifier](#UrlSigningParamIdentifier).
 | "KeyId"     |             |
 | "Signature" |             |
 
-<a id="UrlSigningParamIdentifier_ParamIndicator_STATUS"></a>UrlSigningParamIdentifier_ParamIndicator_STATUS
------------------------------------------------------------------------------------------------------------
+UrlSigningParamIdentifier_ParamIndicator_STATUS{#UrlSigningParamIdentifier_ParamIndicator_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [UrlSigningParamIdentifier_STATUS](#UrlSigningParamIdentifier_STATUS).
 

--- a/docs/hugo/content/reference/cdn/v1api20230501.md
+++ b/docs/hugo/content/reference/cdn/v1api20230501.md
@@ -5,8 +5,8 @@ title: cdn.azure.com/v1api20230501
 linktitle: v1api20230501
 ------------------------
 
-<a id="AfdCustomDomain"></a>AfdCustomDomain
--------------------------------------------
+AfdCustomDomain{#AfdCustomDomain}
+---------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}
 
@@ -19,7 +19,7 @@ Used by: [AfdCustomDomainList](#AfdCustomDomainList).
 | spec                                                                                    |             | [AfdCustomDomain_Spec](#AfdCustomDomain_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS)<br/><small>Optional</small> |
 
-### <a id="AfdCustomDomain_Spec"></a>AfdCustomDomain_Spec
+### AfdCustomDomain_Spec {#AfdCustomDomain_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -32,7 +32,7 @@ Used by: [AfdCustomDomainList](#AfdCustomDomainList).
 | preValidatedCustomDomainResourceId | Resource reference to the Azure resource where custom domain ownership was prevalidated                                                                                                                                                                                          | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                                                                                  |
 | tlsSettings                        | The configuration specifying how to enable HTTPS for the domain - using AzureFrontDoor managed certificate or user's own certificate. If not specified, enabling ssl uses AzureFrontDoor managed certificate by default.                                                         | [AFDDomainHttpsParameters](#AFDDomainHttpsParameters)<br/><small>Optional</small>                                                                                    |
 
-### <a id="AfdCustomDomain_STATUS"></a>AfdCustomDomain_STATUS
+### AfdCustomDomain_STATUS{#AfdCustomDomain_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,8 +52,8 @@ Used by: [AfdCustomDomainList](#AfdCustomDomainList).
 | type                               | Resource type.                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | validationProperties               | Values the customer needs to validate domain ownership                                                                                                                                                                   | [DomainValidationProperties_STATUS](#DomainValidationProperties_STATUS)<br/><small>Optional</small>                                                     |
 
-<a id="AfdCustomDomainList"></a>AfdCustomDomainList
----------------------------------------------------
+AfdCustomDomainList{#AfdCustomDomainList}
+-----------------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}
 
@@ -63,8 +63,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [AfdCustomDomain[]](#AfdCustomDomain)<br/><small>Optional</small> |
 
-<a id="AfdEndpoint"></a>AfdEndpoint
------------------------------------
+AfdEndpoint{#AfdEndpoint}
+-------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}
 
@@ -77,7 +77,7 @@ Used by: [AfdEndpointList](#AfdEndpointList).
 | spec                                                                                    |             | [AfdEndpoint_Spec](#AfdEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AfdEndpoint_STATUS](#AfdEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="AfdEndpoint_Spec"></a>AfdEndpoint_Spec
+### AfdEndpoint_Spec {#AfdEndpoint_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -89,7 +89,7 @@ Used by: [AfdEndpointList](#AfdEndpointList).
 | owner                             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                              | Resource tags.                                                                                                                                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="AfdEndpoint_STATUS"></a>AfdEndpoint_STATUS
+### AfdEndpoint_STATUS{#AfdEndpoint_STATUS}
 
 | Property                          | Description                                                                                      | Type                                                                                                                                                    |
 |-----------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -107,8 +107,8 @@ Used by: [AfdEndpointList](#AfdEndpointList).
 | tags                              | Resource tags.                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type.                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AfdEndpointList"></a>AfdEndpointList
--------------------------------------------
+AfdEndpointList{#AfdEndpointList}
+---------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}
 
@@ -118,8 +118,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [AfdEndpoint[]](#AfdEndpoint)<br/><small>Optional</small> |
 
-<a id="AfdOrigin"></a>AfdOrigin
--------------------------------
+AfdOrigin{#AfdOrigin}
+---------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}/origins/{originName}
 
@@ -132,7 +132,7 @@ Used by: [AfdOriginList](#AfdOriginList).
 | spec                                                                                    |             | [AfdOrigin_Spec](#AfdOrigin_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AfdOrigin_STATUS](#AfdOrigin_STATUS)<br/><small>Optional</small> |
 
-### <a id="AfdOrigin_Spec"></a>AfdOrigin_Spec
+### AfdOrigin_Spec {#AfdOrigin_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -150,7 +150,7 @@ Used by: [AfdOriginList](#AfdOriginList).
 | sharedPrivateLinkResource   | The properties of the private link resource for private origin.                                                                                                                                                                                                                                                                          | [SharedPrivateLinkResourceProperties](#SharedPrivateLinkResourceProperties)<br/><small>Optional</small>                                                              |
 | weight                      | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="AfdOrigin_STATUS"></a>AfdOrigin_STATUS
+### AfdOrigin_STATUS{#AfdOrigin_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -173,8 +173,8 @@ Used by: [AfdOriginList](#AfdOriginList).
 | type                        | Resource type.                                                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | weight                      | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="AfdOriginGroup"></a>AfdOriginGroup
------------------------------------------
+AfdOriginGroup{#AfdOriginGroup}
+-------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}
 
@@ -187,7 +187,7 @@ Used by: [AfdOriginGroupList](#AfdOriginGroupList).
 | spec                                                                                    |             | [AfdOriginGroup_Spec](#AfdOriginGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="AfdOriginGroup_Spec"></a>AfdOriginGroup_Spec
+### AfdOriginGroup_Spec {#AfdOriginGroup_Spec}
 
 | Property                                              | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -199,7 +199,7 @@ Used by: [AfdOriginGroupList](#AfdOriginGroupList).
 | sessionAffinityState                                  | Whether to allow session affinity on this host. Valid options are 'Enabled' or 'Disabled'                                                                                                                                                                                        | [AFDOriginGroupProperties_SessionAffinityState](#AFDOriginGroupProperties_SessionAffinityState)<br/><small>Optional</small>                                          |
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported.                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="AfdOriginGroup_STATUS"></a>AfdOriginGroup_STATUS
+### AfdOriginGroup_STATUS{#AfdOriginGroup_STATUS}
 
 | Property                                              | Description                                                                                                                                                                                       | Type                                                                                                                                                    |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -216,8 +216,8 @@ Used by: [AfdOriginGroupList](#AfdOriginGroupList).
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported. | int<br/><small>Optional</small>                                                                                                                         |
 | type                                                  | Resource type.                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AfdOriginGroupList"></a>AfdOriginGroupList
--------------------------------------------------
+AfdOriginGroupList{#AfdOriginGroupList}
+---------------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}
 
@@ -227,8 +227,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [AfdOriginGroup[]](#AfdOriginGroup)<br/><small>Optional</small> |
 
-<a id="AfdOriginList"></a>AfdOriginList
----------------------------------------
+AfdOriginList{#AfdOriginList}
+-----------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}/origins/{originName}
 
@@ -238,15 +238,15 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [AfdOrigin[]](#AfdOrigin)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-05-01" |             |
 
-<a id="Profile"></a>Profile
----------------------------
+Profile{#Profile}
+-----------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}
 
@@ -259,7 +259,7 @@ Used by: [ProfileList](#ProfileList).
 | spec                                                                                    |             | [Profile_Spec](#Profile_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Profile_STATUS](#Profile_STATUS)<br/><small>Optional</small> |
 
-### <a id="Profile_Spec"></a>Profile_Spec
+### Profile_Spec {#Profile_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -272,7 +272,7 @@ Used by: [ProfileList](#ProfileList).
 | sku                          | The pricing tier (defines Azure Front Door Standard or Premium or a CDN provider, feature list and rate) of the profile.                                                                                                                                                                     | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Profile_STATUS"></a>Profile_STATUS
+### Profile_STATUS{#Profile_STATUS}
 
 | Property                     | Description                                                                                                              | Type                                                                                                                                                    |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -292,8 +292,8 @@ Used by: [ProfileList](#ProfileList).
 | tags                         | Resource tags.                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | Resource type.                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ProfileList"></a>ProfileList
------------------------------------
+ProfileList{#ProfileList}
+-------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}
 
@@ -303,8 +303,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Profile[]](#Profile)<br/><small>Optional</small> |
 
-<a id="Route"></a>Route
------------------------
+Route{#Route}
+-------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/routes/{routeName}
 
@@ -317,7 +317,7 @@ Used by: [RouteList](#RouteList).
 | spec                                                                                    |             | [Route_Spec](#Route_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Route_STATUS](#Route_STATUS)<br/><small>Optional</small> |
 
-### <a id="Route_Spec"></a>Route_Spec
+### Route_Spec {#Route_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -336,7 +336,7 @@ Used by: [RouteList](#RouteList).
 | ruleSets            | rule sets referenced by this endpoint.                                                                                                                                                                                                                                               | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small>                                                                                                |
 | supportedProtocols  | List of supported protocols for this route.                                                                                                                                                                                                                                          | [AFDEndpointProtocols[]](#AFDEndpointProtocols)<br/><small>Optional</small>                                                                                          |
 
-### <a id="Route_STATUS"></a>Route_STATUS
+### Route_STATUS{#Route_STATUS}
 
 | Property            | Description                                                                                                                                                         | Type                                                                                                                                                                                                  |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -360,8 +360,8 @@ Used by: [RouteList](#RouteList).
 | systemData          | Read only system data                                                                                                                                               | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                                                   |
 | type                | Resource type.                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                                                    |
 
-<a id="RouteList"></a>RouteList
--------------------------------
+RouteList{#RouteList}
+---------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/routes/{routeName}
 
@@ -371,8 +371,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Route[]](#Route)<br/><small>Optional</small> |
 
-<a id="Rule"></a>Rule
----------------------
+Rule{#Rule}
+-----------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}/rules/{ruleName}
 
@@ -385,7 +385,7 @@ Used by: [RuleList](#RuleList).
 | spec                                                                                    |             | [Rule_Spec](#Rule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Rule_STATUS](#Rule_STATUS)<br/><small>Optional</small> |
 
-### <a id="Rule_Spec"></a>Rule_Spec
+### Rule_Spec {#Rule_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -397,7 +397,7 @@ Used by: [RuleList](#RuleList).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/RuleSet resource                 | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | ruleconditions          | A list of conditions that must be matched for the actions to be executed                                                                                                                                                                                                                         | [DeliveryRuleCondition[]](#DeliveryRuleCondition)<br/><small>Optional</small>                                                                                        |
 
-### <a id="Rule_STATUS"></a>Rule_STATUS
+### Rule_STATUS{#Rule_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                    |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -414,8 +414,8 @@ Used by: [RuleList](#RuleList).
 | systemData              | Read only system data                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                    | Resource type.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RuleList"></a>RuleList
------------------------------
+RuleList{#RuleList}
+-------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}/rules/{ruleName}
 
@@ -425,8 +425,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [Rule[]](#Rule)<br/><small>Optional</small> |
 
-<a id="RuleSet"></a>RuleSet
----------------------------
+RuleSet{#RuleSet}
+-----------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}
 
@@ -439,7 +439,7 @@ Used by: [RuleSetList](#RuleSetList).
 | spec                                                                                    |             | [RuleSet_Spec](#RuleSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RuleSet_STATUS](#RuleSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="RuleSet_Spec"></a>RuleSet_Spec
+### RuleSet_Spec {#RuleSet_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -447,7 +447,7 @@ Used by: [RuleSetList](#RuleSetList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                  | [RuleSetOperatorSpec](#RuleSetOperatorSpec)<br/><small>Optional</small>                                                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="RuleSet_STATUS"></a>RuleSet_STATUS
+### RuleSet_STATUS{#RuleSet_STATUS}
 
 | Property          | Description                                       | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -460,8 +460,8 @@ Used by: [RuleSetList](#RuleSetList).
 | systemData        | Read only system data                             | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RuleSetList"></a>RuleSetList
------------------------------------
+RuleSetList{#RuleSetList}
+-------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}
 
@@ -471,8 +471,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [RuleSet[]](#RuleSet)<br/><small>Optional</small> |
 
-<a id="Secret"></a>Secret
--------------------------
+Secret{#Secret}
+---------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/secrets/{secretName}
 
@@ -485,7 +485,7 @@ Used by: [SecretList](#SecretList).
 | spec                                                                                    |             | [Secret_Spec](#Secret_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Secret_STATUS](#Secret_STATUS)<br/><small>Optional</small> |
 
-### <a id="Secret_Spec"></a>Secret_Spec
+### Secret_Spec {#Secret_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -494,7 +494,7 @@ Used by: [SecretList](#SecretList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters   | object which contains secret parameters                                                                                                                                                                                                                                          | [SecretParameters](#SecretParameters)<br/><small>Optional</small>                                                                                                    |
 
-### <a id="Secret_STATUS"></a>Secret_STATUS
+### Secret_STATUS{#Secret_STATUS}
 
 | Property          | Description                                     | Type                                                                                                                                                    |
 |-------------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -508,8 +508,8 @@ Used by: [SecretList](#SecretList).
 | systemData        | Read only system data                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SecretList"></a>SecretList
----------------------------------
+SecretList{#SecretList}
+-----------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/secrets/{secretName}
 
@@ -519,8 +519,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Secret[]](#Secret)<br/><small>Optional</small> |
 
-<a id="SecurityPolicy"></a>SecurityPolicy
------------------------------------------
+SecurityPolicy{#SecurityPolicy}
+-------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/securityPolicies/{securityPolicyName}
 
@@ -533,7 +533,7 @@ Used by: [SecurityPolicyList](#SecurityPolicyList).
 | spec                                                                                    |             | [SecurityPolicy_Spec](#SecurityPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SecurityPolicy_STATUS](#SecurityPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="SecurityPolicy_Spec"></a>SecurityPolicy_Spec
+### SecurityPolicy_Spec {#SecurityPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -542,7 +542,7 @@ Used by: [SecurityPolicyList](#SecurityPolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters   | object which contains security policy parameters                                                                                                                                                                                                                                 | [SecurityPolicyPropertiesParameters](#SecurityPolicyPropertiesParameters)<br/><small>Optional</small>                                                                |
 
-### <a id="SecurityPolicy_STATUS"></a>SecurityPolicy_STATUS
+### SecurityPolicy_STATUS{#SecurityPolicy_STATUS}
 
 | Property          | Description                                              | Type                                                                                                                                                    |
 |-------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -556,8 +556,8 @@ Used by: [SecurityPolicyList](#SecurityPolicyList).
 | systemData        | Read only system data                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SecurityPolicyList"></a>SecurityPolicyList
--------------------------------------------------
+SecurityPolicyList{#SecurityPolicyList}
+---------------------------------------
 
 Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/afdx.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Cdn/profiles/{profileName}/securityPolicies/{securityPolicyName}
 
@@ -567,8 +567,8 @@ Generator information: - Generated from: /cdn/resource-manager/Microsoft.Cdn/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [SecurityPolicy[]](#SecurityPolicy)<br/><small>Optional</small> |
 
-<a id="AfdCustomDomain_Spec"></a>AfdCustomDomain_Spec
------------------------------------------------------
+AfdCustomDomain_Spec{#AfdCustomDomain_Spec}
+-------------------------------------------
 
 Used by: [AfdCustomDomain](#AfdCustomDomain).
 
@@ -583,8 +583,8 @@ Used by: [AfdCustomDomain](#AfdCustomDomain).
 | preValidatedCustomDomainResourceId | Resource reference to the Azure resource where custom domain ownership was prevalidated                                                                                                                                                                                          | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                                                                                  |
 | tlsSettings                        | The configuration specifying how to enable HTTPS for the domain - using AzureFrontDoor managed certificate or user's own certificate. If not specified, enabling ssl uses AzureFrontDoor managed certificate by default.                                                         | [AFDDomainHttpsParameters](#AFDDomainHttpsParameters)<br/><small>Optional</small>                                                                                    |
 
-<a id="AfdCustomDomain_STATUS"></a>AfdCustomDomain_STATUS
----------------------------------------------------------
+AfdCustomDomain_STATUS{#AfdCustomDomain_STATUS}
+-----------------------------------------------
 
 Used by: [AfdCustomDomain](#AfdCustomDomain).
 
@@ -606,8 +606,8 @@ Used by: [AfdCustomDomain](#AfdCustomDomain).
 | type                               | Resource type.                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | validationProperties               | Values the customer needs to validate domain ownership                                                                                                                                                                   | [DomainValidationProperties_STATUS](#DomainValidationProperties_STATUS)<br/><small>Optional</small>                                                     |
 
-<a id="AfdEndpoint_Spec"></a>AfdEndpoint_Spec
----------------------------------------------
+AfdEndpoint_Spec{#AfdEndpoint_Spec}
+-----------------------------------
 
 Used by: [AfdEndpoint](#AfdEndpoint).
 
@@ -621,8 +621,8 @@ Used by: [AfdEndpoint](#AfdEndpoint).
 | owner                             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                              | Resource tags.                                                                                                                                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="AfdEndpoint_STATUS"></a>AfdEndpoint_STATUS
--------------------------------------------------
+AfdEndpoint_STATUS{#AfdEndpoint_STATUS}
+---------------------------------------
 
 Used by: [AfdEndpoint](#AfdEndpoint).
 
@@ -642,8 +642,8 @@ Used by: [AfdEndpoint](#AfdEndpoint).
 | tags                              | Resource tags.                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type.                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AfdOrigin_Spec"></a>AfdOrigin_Spec
------------------------------------------
+AfdOrigin_Spec{#AfdOrigin_Spec}
+-------------------------------
 
 Used by: [AfdOrigin](#AfdOrigin).
 
@@ -663,8 +663,8 @@ Used by: [AfdOrigin](#AfdOrigin).
 | sharedPrivateLinkResource   | The properties of the private link resource for private origin.                                                                                                                                                                                                                                                                          | [SharedPrivateLinkResourceProperties](#SharedPrivateLinkResourceProperties)<br/><small>Optional</small>                                                              |
 | weight                      | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="AfdOrigin_STATUS"></a>AfdOrigin_STATUS
----------------------------------------------
+AfdOrigin_STATUS{#AfdOrigin_STATUS}
+-----------------------------------
 
 Used by: [AfdOrigin](#AfdOrigin).
 
@@ -689,8 +689,8 @@ Used by: [AfdOrigin](#AfdOrigin).
 | type                        | Resource type.                                                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | weight                      | Weight of the origin in given origin group for load balancing. Must be between 1 and 1000                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="AfdOriginGroup_Spec"></a>AfdOriginGroup_Spec
----------------------------------------------------
+AfdOriginGroup_Spec{#AfdOriginGroup_Spec}
+-----------------------------------------
 
 Used by: [AfdOriginGroup](#AfdOriginGroup).
 
@@ -704,8 +704,8 @@ Used by: [AfdOriginGroup](#AfdOriginGroup).
 | sessionAffinityState                                  | Whether to allow session affinity on this host. Valid options are 'Enabled' or 'Disabled'                                                                                                                                                                                        | [AFDOriginGroupProperties_SessionAffinityState](#AFDOriginGroupProperties_SessionAffinityState)<br/><small>Optional</small>                                          |
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported.                                                                                | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="AfdOriginGroup_STATUS"></a>AfdOriginGroup_STATUS
--------------------------------------------------------
+AfdOriginGroup_STATUS{#AfdOriginGroup_STATUS}
+---------------------------------------------
 
 Used by: [AfdOriginGroup](#AfdOriginGroup).
 
@@ -724,8 +724,8 @@ Used by: [AfdOriginGroup](#AfdOriginGroup).
 | trafficRestorationTimeToHealedOrNewEndpointsInMinutes | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. This property is currently not supported. | int<br/><small>Optional</small>                                                                                                                         |
 | type                                                  | Resource type.                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Profile_Spec"></a>Profile_Spec
--------------------------------------
+Profile_Spec{#Profile_Spec}
+---------------------------
 
 Used by: [Profile](#Profile).
 
@@ -740,8 +740,8 @@ Used by: [Profile](#Profile).
 | sku                          | The pricing tier (defines Azure Front Door Standard or Premium or a CDN provider, feature list and rate) of the profile.                                                                                                                                                                     | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Profile_STATUS"></a>Profile_STATUS
------------------------------------------
+Profile_STATUS{#Profile_STATUS}
+-------------------------------
 
 A profile is a logical grouping of endpoints that share the same settings.
 
@@ -765,8 +765,8 @@ Used by: [Profile](#Profile).
 | tags                         | Resource tags.                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | Resource type.                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Route_Spec"></a>Route_Spec
----------------------------------
+Route_Spec{#Route_Spec}
+-----------------------
 
 Used by: [Route](#Route).
 
@@ -787,8 +787,8 @@ Used by: [Route](#Route).
 | ruleSets            | rule sets referenced by this endpoint.                                                                                                                                                                                                                                               | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small>                                                                                                |
 | supportedProtocols  | List of supported protocols for this route.                                                                                                                                                                                                                                          | [AFDEndpointProtocols[]](#AFDEndpointProtocols)<br/><small>Optional</small>                                                                                          |
 
-<a id="Route_STATUS"></a>Route_STATUS
--------------------------------------
+Route_STATUS{#Route_STATUS}
+---------------------------
 
 Used by: [Route](#Route).
 
@@ -814,8 +814,8 @@ Used by: [Route](#Route).
 | systemData          | Read only system data                                                                                                                                               | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                                                   |
 | type                | Resource type.                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                                                    |
 
-<a id="Rule_Spec"></a>Rule_Spec
--------------------------------
+Rule_Spec{#Rule_Spec}
+---------------------
 
 Used by: [Rule](#Rule).
 
@@ -829,8 +829,8 @@ Used by: [Rule](#Rule).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/RuleSet resource                 | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | ruleconditions          | A list of conditions that must be matched for the actions to be executed                                                                                                                                                                                                                         | [DeliveryRuleCondition[]](#DeliveryRuleCondition)<br/><small>Optional</small>                                                                                        |
 
-<a id="Rule_STATUS"></a>Rule_STATUS
------------------------------------
+Rule_STATUS{#Rule_STATUS}
+-------------------------
 
 Used by: [Rule](#Rule).
 
@@ -849,8 +849,8 @@ Used by: [Rule](#Rule).
 | systemData              | Read only system data                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                    | Resource type.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RuleSet_Spec"></a>RuleSet_Spec
--------------------------------------
+RuleSet_Spec{#RuleSet_Spec}
+---------------------------
 
 Used by: [RuleSet](#RuleSet).
 
@@ -860,8 +860,8 @@ Used by: [RuleSet](#RuleSet).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                  | [RuleSetOperatorSpec](#RuleSetOperatorSpec)<br/><small>Optional</small>                                                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="RuleSet_STATUS"></a>RuleSet_STATUS
------------------------------------------
+RuleSet_STATUS{#RuleSet_STATUS}
+-------------------------------
 
 Used by: [RuleSet](#RuleSet).
 
@@ -876,8 +876,8 @@ Used by: [RuleSet](#RuleSet).
 | systemData        | Read only system data                             | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Secret_Spec"></a>Secret_Spec
------------------------------------
+Secret_Spec{#Secret_Spec}
+-------------------------
 
 Used by: [Secret](#Secret).
 
@@ -888,8 +888,8 @@ Used by: [Secret](#Secret).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters   | object which contains secret parameters                                                                                                                                                                                                                                          | [SecretParameters](#SecretParameters)<br/><small>Optional</small>                                                                                                    |
 
-<a id="Secret_STATUS"></a>Secret_STATUS
----------------------------------------
+Secret_STATUS{#Secret_STATUS}
+-----------------------------
 
 Used by: [Secret](#Secret).
 
@@ -905,8 +905,8 @@ Used by: [Secret](#Secret).
 | systemData        | Read only system data                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SecurityPolicy_Spec"></a>SecurityPolicy_Spec
----------------------------------------------------
+SecurityPolicy_Spec{#SecurityPolicy_Spec}
+-----------------------------------------
 
 Used by: [SecurityPolicy](#SecurityPolicy).
 
@@ -917,8 +917,8 @@ Used by: [SecurityPolicy](#SecurityPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a cdn.azure.com/Profile resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | parameters   | object which contains security policy parameters                                                                                                                                                                                                                                 | [SecurityPolicyPropertiesParameters](#SecurityPolicyPropertiesParameters)<br/><small>Optional</small>                                                                |
 
-<a id="SecurityPolicy_STATUS"></a>SecurityPolicy_STATUS
--------------------------------------------------------
+SecurityPolicy_STATUS{#SecurityPolicy_STATUS}
+---------------------------------------------
 
 Used by: [SecurityPolicy](#SecurityPolicy).
 
@@ -934,8 +934,8 @@ Used by: [SecurityPolicy](#SecurityPolicy).
 | systemData        | Read only system data                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type.                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ActivatedResourceReference"></a>ActivatedResourceReference
------------------------------------------------------------------
+ActivatedResourceReference{#ActivatedResourceReference}
+-------------------------------------------------------
 
 Reference to another resource along with its state.
 
@@ -945,8 +945,8 @@ Used by: [Route_Spec](#Route_Spec), and [SecurityPolicyWebApplicationFirewallAss
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ActivatedResourceReference_STATUS_Profiles_AfdEndpoints_Route_SubResourceEmbedded"></a>ActivatedResourceReference_STATUS_Profiles_AfdEndpoints_Route_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ActivatedResourceReference_STATUS_Profiles_AfdEndpoints_Route_SubResourceEmbedded{#ActivatedResourceReference_STATUS_Profiles_AfdEndpoints_Route_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Reference to another resource along with its state.
 
@@ -956,8 +956,8 @@ Used by: [Route_STATUS](#Route_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="AfdCustomDomainOperatorSpec"></a>AfdCustomDomainOperatorSpec
--------------------------------------------------------------------
+AfdCustomDomainOperatorSpec{#AfdCustomDomainOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -968,8 +968,8 @@ Used by: [AfdCustomDomain_Spec](#AfdCustomDomain_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AFDDomainHttpsParameters"></a>AFDDomainHttpsParameters
--------------------------------------------------------------
+AFDDomainHttpsParameters{#AFDDomainHttpsParameters}
+---------------------------------------------------
 
 The JSON object that contains the properties to secure a domain.
 
@@ -981,8 +981,8 @@ Used by: [AfdCustomDomain_Spec](#AfdCustomDomain_Spec).
 | minimumTlsVersion | TLS protocol version that will be used for Https             | [AFDDomainHttpsParameters_MinimumTlsVersion](#AFDDomainHttpsParameters_MinimumTlsVersion)<br/><small>Optional</small> |
 | secret            | Resource reference to the secret. ie. subs/rg/profile/secret | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                                   |
 
-<a id="AFDDomainHttpsParameters_STATUS"></a>AFDDomainHttpsParameters_STATUS
----------------------------------------------------------------------------
+AFDDomainHttpsParameters_STATUS{#AFDDomainHttpsParameters_STATUS}
+-----------------------------------------------------------------
 
 The JSON object that contains the properties to secure a domain.
 
@@ -994,8 +994,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 | minimumTlsVersion | TLS protocol version that will be used for Https             | [AFDDomainHttpsParameters_MinimumTlsVersion_STATUS](#AFDDomainHttpsParameters_MinimumTlsVersion_STATUS)<br/><small>Optional</small> |
 | secret            | Resource reference to the secret. ie. subs/rg/profile/secret | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                                   |
 
-<a id="AFDDomainProperties_DeploymentStatus_STATUS"></a>AFDDomainProperties_DeploymentStatus_STATUS
----------------------------------------------------------------------------------------------------
+AFDDomainProperties_DeploymentStatus_STATUS{#AFDDomainProperties_DeploymentStatus_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 
@@ -1006,8 +1006,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="AFDDomainProperties_DomainValidationState_STATUS"></a>AFDDomainProperties_DomainValidationState_STATUS
--------------------------------------------------------------------------------------------------------------
+AFDDomainProperties_DomainValidationState_STATUS{#AFDDomainProperties_DomainValidationState_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 
@@ -1023,8 +1023,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 | "TimedOut"                  |             |
 | "Unknown"                   |             |
 
-<a id="AFDDomainProperties_ProvisioningState_STATUS"></a>AFDDomainProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------
+AFDDomainProperties_ProvisioningState_STATUS{#AFDDomainProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 
@@ -1036,8 +1036,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="AfdEndpointOperatorSpec"></a>AfdEndpointOperatorSpec
------------------------------------------------------------
+AfdEndpointOperatorSpec{#AfdEndpointOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1048,8 +1048,8 @@ Used by: [AfdEndpoint_Spec](#AfdEndpoint_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AFDEndpointProperties_DeploymentStatus_STATUS"></a>AFDEndpointProperties_DeploymentStatus_STATUS
--------------------------------------------------------------------------------------------------------
+AFDEndpointProperties_DeploymentStatus_STATUS{#AFDEndpointProperties_DeploymentStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 
@@ -1060,8 +1060,8 @@ Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="AFDEndpointProperties_EnabledState"></a>AFDEndpointProperties_EnabledState
----------------------------------------------------------------------------------
+AFDEndpointProperties_EnabledState{#AFDEndpointProperties_EnabledState}
+-----------------------------------------------------------------------
 
 Used by: [AfdEndpoint_Spec](#AfdEndpoint_Spec).
 
@@ -1070,8 +1070,8 @@ Used by: [AfdEndpoint_Spec](#AfdEndpoint_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AFDEndpointProperties_EnabledState_STATUS"></a>AFDEndpointProperties_EnabledState_STATUS
------------------------------------------------------------------------------------------------
+AFDEndpointProperties_EnabledState_STATUS{#AFDEndpointProperties_EnabledState_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 
@@ -1080,8 +1080,8 @@ Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AFDEndpointProperties_ProvisioningState_STATUS"></a>AFDEndpointProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+AFDEndpointProperties_ProvisioningState_STATUS{#AFDEndpointProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 
@@ -1093,8 +1093,8 @@ Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="AFDEndpointProtocols"></a>AFDEndpointProtocols
------------------------------------------------------
+AFDEndpointProtocols{#AFDEndpointProtocols}
+-------------------------------------------
 
 Supported protocols for the customer's endpoint.
 
@@ -1105,8 +1105,8 @@ Used by: [Route_Spec](#Route_Spec).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="AFDEndpointProtocols_STATUS"></a>AFDEndpointProtocols_STATUS
--------------------------------------------------------------------
+AFDEndpointProtocols_STATUS{#AFDEndpointProtocols_STATUS}
+---------------------------------------------------------
 
 Supported protocols for the customer's endpoint.
 
@@ -1117,68 +1117,68 @@ Used by: [Route_STATUS](#Route_STATUS).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="AfdOriginGroupOperatorSpec"></a>AfdOriginGroupOperatorSpec
------------------------------------------------------------------
-
-Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
-
-Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
-
-| Property             | Description                                                                                   | Type                                                                                                                                                                |
-|----------------------|-----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
-| secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
-
-<a id="AFDOriginGroupProperties_DeploymentStatus_STATUS"></a>AFDOriginGroupProperties_DeploymentStatus_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Failed"     |             |
-| "InProgress" |             |
-| "NotStarted" |             |
-| "Succeeded"  |             |
-
-<a id="AFDOriginGroupProperties_ProvisioningState_STATUS"></a>AFDOriginGroupProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
-
-Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Creating"  |             |
-| "Deleting"  |             |
-| "Failed"    |             |
-| "Succeeded" |             |
-| "Updating"  |             |
-
-<a id="AFDOriginGroupProperties_SessionAffinityState"></a>AFDOriginGroupProperties_SessionAffinityState
--------------------------------------------------------------------------------------------------------
-
-Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AFDOriginGroupProperties_SessionAffinityState_STATUS"></a>AFDOriginGroupProperties_SessionAffinityState_STATUS
----------------------------------------------------------------------------------------------------------------------
-
-Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AfdOriginOperatorSpec"></a>AfdOriginOperatorSpec
+AfdOriginGroupOperatorSpec{#AfdOriginGroupOperatorSpec}
 -------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
+Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
+
+| Property             | Description                                                                                   | Type                                                                                                                                                                |
+|----------------------|-----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
+| secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
+
+AFDOriginGroupProperties_DeploymentStatus_STATUS{#AFDOriginGroupProperties_DeploymentStatus_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Failed"     |             |
+| "InProgress" |             |
+| "NotStarted" |             |
+| "Succeeded"  |             |
+
+AFDOriginGroupProperties_ProvisioningState_STATUS{#AFDOriginGroupProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Creating"  |             |
+| "Deleting"  |             |
+| "Failed"    |             |
+| "Succeeded" |             |
+| "Updating"  |             |
+
+AFDOriginGroupProperties_SessionAffinityState{#AFDOriginGroupProperties_SessionAffinityState}
+---------------------------------------------------------------------------------------------
+
+Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AFDOriginGroupProperties_SessionAffinityState_STATUS{#AFDOriginGroupProperties_SessionAffinityState_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AfdOriginOperatorSpec{#AfdOriginOperatorSpec}
+---------------------------------------------
+
+Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
+
 Used by: [AfdOrigin_Spec](#AfdOrigin_Spec).
 
 | Property             | Description                                                                                   | Type                                                                                                                                                                |
@@ -1186,8 +1186,8 @@ Used by: [AfdOrigin_Spec](#AfdOrigin_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AFDOriginProperties_DeploymentStatus_STATUS"></a>AFDOriginProperties_DeploymentStatus_STATUS
----------------------------------------------------------------------------------------------------
+AFDOriginProperties_DeploymentStatus_STATUS{#AFDOriginProperties_DeploymentStatus_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 
@@ -1198,8 +1198,8 @@ Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="AFDOriginProperties_EnabledState"></a>AFDOriginProperties_EnabledState
------------------------------------------------------------------------------
+AFDOriginProperties_EnabledState{#AFDOriginProperties_EnabledState}
+-------------------------------------------------------------------
 
 Used by: [AfdOrigin_Spec](#AfdOrigin_Spec).
 
@@ -1208,8 +1208,8 @@ Used by: [AfdOrigin_Spec](#AfdOrigin_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AFDOriginProperties_EnabledState_STATUS"></a>AFDOriginProperties_EnabledState_STATUS
--------------------------------------------------------------------------------------------
+AFDOriginProperties_EnabledState_STATUS{#AFDOriginProperties_EnabledState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 
@@ -1218,8 +1218,8 @@ Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AFDOriginProperties_ProvisioningState_STATUS"></a>AFDOriginProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------
+AFDOriginProperties_ProvisioningState_STATUS{#AFDOriginProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 
@@ -1231,8 +1231,8 @@ Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="AfdRouteCacheConfiguration"></a>AfdRouteCacheConfiguration
------------------------------------------------------------------
+AfdRouteCacheConfiguration{#AfdRouteCacheConfiguration}
+-------------------------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -1244,8 +1244,8 @@ Used by: [Route_Spec](#Route_Spec).
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                          |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings. | [AfdRouteCacheConfiguration_QueryStringCachingBehavior](#AfdRouteCacheConfiguration_QueryStringCachingBehavior)<br/><small>Optional</small> |
 
-<a id="AfdRouteCacheConfiguration_STATUS"></a>AfdRouteCacheConfiguration_STATUS
--------------------------------------------------------------------------------
+AfdRouteCacheConfiguration_STATUS{#AfdRouteCacheConfiguration_STATUS}
+---------------------------------------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -1257,8 +1257,8 @@ Used by: [Route_STATUS](#Route_STATUS).
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                        |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings. | [AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS](#AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS)<br/><small>Optional</small> |
 
-<a id="AutoGeneratedDomainNameLabelScope"></a>AutoGeneratedDomainNameLabelScope
--------------------------------------------------------------------------------
+AutoGeneratedDomainNameLabelScope{#AutoGeneratedDomainNameLabelScope}
+---------------------------------------------------------------------
 
 Indicates the endpoint name reuse scope. The default value is TenantReuse.
 
@@ -1271,8 +1271,8 @@ Used by: [AfdEndpoint_Spec](#AfdEndpoint_Spec).
 | "SubscriptionReuse"  |             |
 | "TenantReuse"        |             |
 
-<a id="AutoGeneratedDomainNameLabelScope_STATUS"></a>AutoGeneratedDomainNameLabelScope_STATUS
----------------------------------------------------------------------------------------------
+AutoGeneratedDomainNameLabelScope_STATUS{#AutoGeneratedDomainNameLabelScope_STATUS}
+-----------------------------------------------------------------------------------
 
 Indicates the endpoint name reuse scope. The default value is TenantReuse.
 
@@ -1285,8 +1285,8 @@ Used by: [AfdEndpoint_STATUS](#AfdEndpoint_STATUS).
 | "SubscriptionReuse"  |             |
 | "TenantReuse"        |             |
 
-<a id="DeliveryRuleAction"></a>DeliveryRuleAction
--------------------------------------------------
+DeliveryRuleAction{#DeliveryRuleAction}
+---------------------------------------
 
 An action for the delivery rule.
 
@@ -1304,8 +1304,8 @@ Used by: [Rule_Spec](#Rule_Spec).
 | urlRewrite                 | Mutually exclusive with all other properties | [UrlRewriteAction](#UrlRewriteAction)<br/><small>Optional</small>                                                         |
 | urlSigning                 | Mutually exclusive with all other properties | [UrlSigningAction](#UrlSigningAction)<br/><small>Optional</small>                                                         |
 
-<a id="DeliveryRuleAction_STATUS"></a>DeliveryRuleAction_STATUS
----------------------------------------------------------------
+DeliveryRuleAction_STATUS{#DeliveryRuleAction_STATUS}
+-----------------------------------------------------
 
 An action for the delivery rule.
 
@@ -1323,8 +1323,8 @@ Used by: [Rule_STATUS](#Rule_STATUS).
 | urlRewrite                 | Mutually exclusive with all other properties | [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS)<br/><small>Optional</small>                                                         |
 | urlSigning                 | Mutually exclusive with all other properties | [UrlSigningAction_STATUS](#UrlSigningAction_STATUS)<br/><small>Optional</small>                                                         |
 
-<a id="DeliveryRuleCondition"></a>DeliveryRuleCondition
--------------------------------------------------------
+DeliveryRuleCondition{#DeliveryRuleCondition}
+---------------------------------------------
 
 A condition for the delivery rule.
 
@@ -1352,8 +1352,8 @@ Used by: [Rule_Spec](#Rule_Spec).
 | urlFileName      | Mutually exclusive with all other properties | [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition)<br/><small>Optional</small>           |
 | urlPath          | Mutually exclusive with all other properties | [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition)<br/><small>Optional</small>                   |
 
-<a id="DeliveryRuleCondition_STATUS"></a>DeliveryRuleCondition_STATUS
----------------------------------------------------------------------
+DeliveryRuleCondition_STATUS{#DeliveryRuleCondition_STATUS}
+-----------------------------------------------------------
 
 A condition for the delivery rule.
 
@@ -1381,8 +1381,8 @@ Used by: [Rule_STATUS](#Rule_STATUS).
 | urlFileName      | Mutually exclusive with all other properties | [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondition_STATUS)<br/><small>Optional</small>           |
 | urlPath          | Mutually exclusive with all other properties | [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STATUS)<br/><small>Optional</small>                   |
 
-<a id="DomainValidationProperties_STATUS"></a>DomainValidationProperties_STATUS
--------------------------------------------------------------------------------
+DomainValidationProperties_STATUS{#DomainValidationProperties_STATUS}
+---------------------------------------------------------------------
 
 The JSON object that contains the properties to validate a domain.
 
@@ -1393,8 +1393,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS).
 | expirationDate  | The date time that the token expires                       | string<br/><small>Optional</small> |
 | validationToken | Challenge used for DNS TXT record or file based validation | string<br/><small>Optional</small> |
 
-<a id="HealthProbeParameters"></a>HealthProbeParameters
--------------------------------------------------------
+HealthProbeParameters{#HealthProbeParameters}
+---------------------------------------------
 
 The JSON object that contains the properties to send health probes to origin.
 
@@ -1407,8 +1407,8 @@ Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
 | probeProtocol          | Protocol to use for health probe.                                                   | [HealthProbeParameters_ProbeProtocol](#HealthProbeParameters_ProbeProtocol)<br/><small>Optional</small>       |
 | probeRequestType       | The type of health probe request that is made.                                      | [HealthProbeParameters_ProbeRequestType](#HealthProbeParameters_ProbeRequestType)<br/><small>Optional</small> |
 
-<a id="HealthProbeParameters_STATUS"></a>HealthProbeParameters_STATUS
----------------------------------------------------------------------
+HealthProbeParameters_STATUS{#HealthProbeParameters_STATUS}
+-----------------------------------------------------------
 
 The JSON object that contains the properties to send health probes to origin.
 
@@ -1421,8 +1421,8 @@ Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
 | probeProtocol          | Protocol to use for health probe.                                                   | [HealthProbeParameters_ProbeProtocol_STATUS](#HealthProbeParameters_ProbeProtocol_STATUS)<br/><small>Optional</small>       |
 | probeRequestType       | The type of health probe request that is made.                                      | [HealthProbeParameters_ProbeRequestType_STATUS](#HealthProbeParameters_ProbeRequestType_STATUS)<br/><small>Optional</small> |
 
-<a id="LoadBalancingSettingsParameters"></a>LoadBalancingSettingsParameters
----------------------------------------------------------------------------
+LoadBalancingSettingsParameters{#LoadBalancingSettingsParameters}
+-----------------------------------------------------------------
 
 Round-Robin load balancing settings for a backend pool
 
@@ -1434,8 +1434,8 @@ Used by: [AfdOriginGroup_Spec](#AfdOriginGroup_Spec).
 | sampleSize                      | The number of samples to consider for load balancing decisions                           | int<br/><small>Optional</small> |
 | successfulSamplesRequired       | The number of samples within the sample period that must succeed                         | int<br/><small>Optional</small> |
 
-<a id="LoadBalancingSettingsParameters_STATUS"></a>LoadBalancingSettingsParameters_STATUS
------------------------------------------------------------------------------------------
+LoadBalancingSettingsParameters_STATUS{#LoadBalancingSettingsParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Round-Robin load balancing settings for a backend pool
 
@@ -1447,8 +1447,8 @@ Used by: [AfdOriginGroup_STATUS](#AfdOriginGroup_STATUS).
 | sampleSize                      | The number of samples to consider for load balancing decisions                           | int<br/><small>Optional</small> |
 | successfulSamplesRequired       | The number of samples within the sample period that must succeed                         | int<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -1459,8 +1459,8 @@ Used by: [Profile_Spec](#Profile_Spec).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). | [ManagedServiceIdentityType](#ManagedServiceIdentityType)<br/><small>Required</small>     |
 | userAssignedIdentities |                                                                                                  | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -1473,8 +1473,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).                              | [ManagedServiceIdentityType_STATUS](#ManagedServiceIdentityType_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities |                                                                                                                               | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>  |
 
-<a id="ProfileOperatorSpec"></a>ProfileOperatorSpec
----------------------------------------------------
+ProfileOperatorSpec{#ProfileOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1485,8 +1485,8 @@ Used by: [Profile_Spec](#Profile_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProfileProperties_ProvisioningState_STATUS"></a>ProfileProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+ProfileProperties_ProvisioningState_STATUS{#ProfileProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Profile_STATUS](#Profile_STATUS).
 
@@ -1498,8 +1498,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ProfileProperties_ResourceState_STATUS"></a>ProfileProperties_ResourceState_STATUS
------------------------------------------------------------------------------------------
+ProfileProperties_ResourceState_STATUS{#ProfileProperties_ResourceState_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Profile_STATUS](#Profile_STATUS).
 
@@ -1515,8 +1515,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 | "Migrating"              |             |
 | "PendingMigrationCommit" |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Reference to another resource.
 
@@ -1526,8 +1526,8 @@ Used by: [AfdCustomDomain_Spec](#AfdCustomDomain_Spec), [AfdCustomDomain_Spec](#
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Reference to another resource.
 
@@ -1537,8 +1537,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS), [AfdCustomDomain_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="RouteOperatorSpec"></a>RouteOperatorSpec
------------------------------------------------
+RouteOperatorSpec{#RouteOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1549,8 +1549,8 @@ Used by: [Route_Spec](#Route_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RouteProperties_DeploymentStatus_STATUS"></a>RouteProperties_DeploymentStatus_STATUS
--------------------------------------------------------------------------------------------
+RouteProperties_DeploymentStatus_STATUS{#RouteProperties_DeploymentStatus_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [Route_STATUS](#Route_STATUS).
 
@@ -1561,8 +1561,8 @@ Used by: [Route_STATUS](#Route_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="RouteProperties_EnabledState"></a>RouteProperties_EnabledState
----------------------------------------------------------------------
+RouteProperties_EnabledState{#RouteProperties_EnabledState}
+-----------------------------------------------------------
 
 Used by: [Route_Spec](#Route_Spec).
 
@@ -1571,8 +1571,8 @@ Used by: [Route_Spec](#Route_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RouteProperties_EnabledState_STATUS"></a>RouteProperties_EnabledState_STATUS
------------------------------------------------------------------------------------
+RouteProperties_EnabledState_STATUS{#RouteProperties_EnabledState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Route_STATUS](#Route_STATUS).
 
@@ -1581,50 +1581,30 @@ Used by: [Route_STATUS](#Route_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RouteProperties_ForwardingProtocol"></a>RouteProperties_ForwardingProtocol
----------------------------------------------------------------------------------
-
-Used by: [Route_Spec](#Route_Spec).
-
-| Value          | Description |
-|----------------|-------------|
-| "HttpOnly"     |             |
-| "HttpsOnly"    |             |
-| "MatchRequest" |             |
-
-<a id="RouteProperties_ForwardingProtocol_STATUS"></a>RouteProperties_ForwardingProtocol_STATUS
------------------------------------------------------------------------------------------------
-
-Used by: [Route_STATUS](#Route_STATUS).
-
-| Value          | Description |
-|----------------|-------------|
-| "HttpOnly"     |             |
-| "HttpsOnly"    |             |
-| "MatchRequest" |             |
-
-<a id="RouteProperties_HttpsRedirect"></a>RouteProperties_HttpsRedirect
+RouteProperties_ForwardingProtocol{#RouteProperties_ForwardingProtocol}
 -----------------------------------------------------------------------
 
 Used by: [Route_Spec](#Route_Spec).
 
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
+| Value          | Description |
+|----------------|-------------|
+| "HttpOnly"     |             |
+| "HttpsOnly"    |             |
+| "MatchRequest" |             |
 
-<a id="RouteProperties_HttpsRedirect_STATUS"></a>RouteProperties_HttpsRedirect_STATUS
+RouteProperties_ForwardingProtocol_STATUS{#RouteProperties_ForwardingProtocol_STATUS}
 -------------------------------------------------------------------------------------
 
 Used by: [Route_STATUS](#Route_STATUS).
 
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
+| Value          | Description |
+|----------------|-------------|
+| "HttpOnly"     |             |
+| "HttpsOnly"    |             |
+| "MatchRequest" |             |
 
-<a id="RouteProperties_LinkToDefaultDomain"></a>RouteProperties_LinkToDefaultDomain
------------------------------------------------------------------------------------
+RouteProperties_HttpsRedirect{#RouteProperties_HttpsRedirect}
+-------------------------------------------------------------
 
 Used by: [Route_Spec](#Route_Spec).
 
@@ -1633,8 +1613,8 @@ Used by: [Route_Spec](#Route_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RouteProperties_LinkToDefaultDomain_STATUS"></a>RouteProperties_LinkToDefaultDomain_STATUS
--------------------------------------------------------------------------------------------------
+RouteProperties_HttpsRedirect_STATUS{#RouteProperties_HttpsRedirect_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [Route_STATUS](#Route_STATUS).
 
@@ -1643,8 +1623,28 @@ Used by: [Route_STATUS](#Route_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RouteProperties_ProvisioningState_STATUS"></a>RouteProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+RouteProperties_LinkToDefaultDomain{#RouteProperties_LinkToDefaultDomain}
+-------------------------------------------------------------------------
+
+Used by: [Route_Spec](#Route_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+RouteProperties_LinkToDefaultDomain_STATUS{#RouteProperties_LinkToDefaultDomain_STATUS}
+---------------------------------------------------------------------------------------
+
+Used by: [Route_STATUS](#Route_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+RouteProperties_ProvisioningState_STATUS{#RouteProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Route_STATUS](#Route_STATUS).
 
@@ -1656,8 +1656,8 @@ Used by: [Route_STATUS](#Route_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RuleOperatorSpec"></a>RuleOperatorSpec
----------------------------------------------
+RuleOperatorSpec{#RuleOperatorSpec}
+-----------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1668,8 +1668,8 @@ Used by: [Rule_Spec](#Rule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RuleProperties_DeploymentStatus_STATUS"></a>RuleProperties_DeploymentStatus_STATUS
------------------------------------------------------------------------------------------
+RuleProperties_DeploymentStatus_STATUS{#RuleProperties_DeploymentStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Rule_STATUS](#Rule_STATUS).
 
@@ -1680,8 +1680,8 @@ Used by: [Rule_STATUS](#Rule_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="RuleProperties_MatchProcessingBehavior"></a>RuleProperties_MatchProcessingBehavior
------------------------------------------------------------------------------------------
+RuleProperties_MatchProcessingBehavior{#RuleProperties_MatchProcessingBehavior}
+-------------------------------------------------------------------------------
 
 Used by: [Rule_Spec](#Rule_Spec).
 
@@ -1690,8 +1690,8 @@ Used by: [Rule_Spec](#Rule_Spec).
 | "Continue" |             |
 | "Stop"     |             |
 
-<a id="RuleProperties_MatchProcessingBehavior_STATUS"></a>RuleProperties_MatchProcessingBehavior_STATUS
--------------------------------------------------------------------------------------------------------
+RuleProperties_MatchProcessingBehavior_STATUS{#RuleProperties_MatchProcessingBehavior_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [Rule_STATUS](#Rule_STATUS).
 
@@ -1700,8 +1700,8 @@ Used by: [Rule_STATUS](#Rule_STATUS).
 | "Continue" |             |
 | "Stop"     |             |
 
-<a id="RuleProperties_ProvisioningState_STATUS"></a>RuleProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------
+RuleProperties_ProvisioningState_STATUS{#RuleProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [Rule_STATUS](#Rule_STATUS).
 
@@ -1713,8 +1713,8 @@ Used by: [Rule_STATUS](#Rule_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RuleSetOperatorSpec"></a>RuleSetOperatorSpec
----------------------------------------------------
+RuleSetOperatorSpec{#RuleSetOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1725,8 +1725,8 @@ Used by: [RuleSet_Spec](#RuleSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RuleSetProperties_DeploymentStatus_STATUS"></a>RuleSetProperties_DeploymentStatus_STATUS
------------------------------------------------------------------------------------------------
+RuleSetProperties_DeploymentStatus_STATUS{#RuleSetProperties_DeploymentStatus_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [RuleSet_STATUS](#RuleSet_STATUS).
 
@@ -1737,8 +1737,8 @@ Used by: [RuleSet_STATUS](#RuleSet_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="RuleSetProperties_ProvisioningState_STATUS"></a>RuleSetProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+RuleSetProperties_ProvisioningState_STATUS{#RuleSetProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [RuleSet_STATUS](#RuleSet_STATUS).
 
@@ -1750,8 +1750,8 @@ Used by: [RuleSet_STATUS](#RuleSet_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="SecretOperatorSpec"></a>SecretOperatorSpec
--------------------------------------------------
+SecretOperatorSpec{#SecretOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1762,8 +1762,8 @@ Used by: [Secret_Spec](#Secret_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SecretParameters"></a>SecretParameters
----------------------------------------------
+SecretParameters{#SecretParameters}
+-----------------------------------
 
 Used by: [Secret_Spec](#Secret_Spec).
 
@@ -1774,8 +1774,8 @@ Used by: [Secret_Spec](#Secret_Spec).
 | managedCertificate                | Mutually exclusive with all other properties | [ManagedCertificateParameters](#ManagedCertificateParameters)<br/><small>Optional</small>                               |
 | urlSigningKey                     | Mutually exclusive with all other properties | [UrlSigningKeyParameters](#UrlSigningKeyParameters)<br/><small>Optional</small>                                         |
 
-<a id="SecretParameters_STATUS"></a>SecretParameters_STATUS
------------------------------------------------------------
+SecretParameters_STATUS{#SecretParameters_STATUS}
+-------------------------------------------------
 
 Used by: [Secret_STATUS](#Secret_STATUS).
 
@@ -1786,8 +1786,8 @@ Used by: [Secret_STATUS](#Secret_STATUS).
 | managedCertificate                | Mutually exclusive with all other properties | [ManagedCertificateParameters_STATUS](#ManagedCertificateParameters_STATUS)<br/><small>Optional</small>                               |
 | urlSigningKey                     | Mutually exclusive with all other properties | [UrlSigningKeyParameters_STATUS](#UrlSigningKeyParameters_STATUS)<br/><small>Optional</small>                                         |
 
-<a id="SecretProperties_DeploymentStatus_STATUS"></a>SecretProperties_DeploymentStatus_STATUS
----------------------------------------------------------------------------------------------
+SecretProperties_DeploymentStatus_STATUS{#SecretProperties_DeploymentStatus_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Secret_STATUS](#Secret_STATUS).
 
@@ -1798,8 +1798,8 @@ Used by: [Secret_STATUS](#Secret_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="SecretProperties_ProvisioningState_STATUS"></a>SecretProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------
+SecretProperties_ProvisioningState_STATUS{#SecretProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Secret_STATUS](#Secret_STATUS).
 
@@ -1811,8 +1811,8 @@ Used by: [Secret_STATUS](#Secret_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="SecurityPolicyOperatorSpec"></a>SecurityPolicyOperatorSpec
------------------------------------------------------------------
+SecurityPolicyOperatorSpec{#SecurityPolicyOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1823,8 +1823,8 @@ Used by: [SecurityPolicy_Spec](#SecurityPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SecurityPolicyProperties_DeploymentStatus_STATUS"></a>SecurityPolicyProperties_DeploymentStatus_STATUS
--------------------------------------------------------------------------------------------------------------
+SecurityPolicyProperties_DeploymentStatus_STATUS{#SecurityPolicyProperties_DeploymentStatus_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 
@@ -1835,8 +1835,8 @@ Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 | "NotStarted" |             |
 | "Succeeded"  |             |
 
-<a id="SecurityPolicyProperties_ProvisioningState_STATUS"></a>SecurityPolicyProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+SecurityPolicyProperties_ProvisioningState_STATUS{#SecurityPolicyProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 
@@ -1848,8 +1848,8 @@ Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="SecurityPolicyPropertiesParameters"></a>SecurityPolicyPropertiesParameters
----------------------------------------------------------------------------------
+SecurityPolicyPropertiesParameters{#SecurityPolicyPropertiesParameters}
+-----------------------------------------------------------------------
 
 Used by: [SecurityPolicy_Spec](#SecurityPolicy_Spec).
 
@@ -1857,8 +1857,8 @@ Used by: [SecurityPolicy_Spec](#SecurityPolicy_Spec).
 |------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | webApplicationFirewall | Mutually exclusive with all other properties | [SecurityPolicyWebApplicationFirewallParameters](#SecurityPolicyWebApplicationFirewallParameters)<br/><small>Optional</small> |
 
-<a id="SecurityPolicyPropertiesParameters_STATUS"></a>SecurityPolicyPropertiesParameters_STATUS
------------------------------------------------------------------------------------------------
+SecurityPolicyPropertiesParameters_STATUS{#SecurityPolicyPropertiesParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 
@@ -1866,8 +1866,8 @@ Used by: [SecurityPolicy_STATUS](#SecurityPolicy_STATUS).
 |------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | webApplicationFirewall | Mutually exclusive with all other properties | [SecurityPolicyWebApplicationFirewallParameters_STATUS](#SecurityPolicyWebApplicationFirewallParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="SharedPrivateLinkResourceProperties"></a>SharedPrivateLinkResourceProperties
------------------------------------------------------------------------------------
+SharedPrivateLinkResourceProperties{#SharedPrivateLinkResourceProperties}
+-------------------------------------------------------------------------
 
 Describes the properties of an existing Shared Private Link Resource to use when connecting to a private origin.
 
@@ -1881,8 +1881,8 @@ Used by: [AfdOrigin_Spec](#AfdOrigin_Spec).
 | requestMessage      | The request message for requesting approval of the shared private link resource.                          | string<br/><small>Optional</small>                                                                                    |
 | status              | Status of the shared private link resource. Can be Pending, Approved, Rejected, Disconnected, or Timeout. | [SharedPrivateLinkResourceProperties_Status](#SharedPrivateLinkResourceProperties_Status)<br/><small>Optional</small> |
 
-<a id="SharedPrivateLinkResourceProperties_STATUS"></a>SharedPrivateLinkResourceProperties_STATUS
--------------------------------------------------------------------------------------------------
+SharedPrivateLinkResourceProperties_STATUS{#SharedPrivateLinkResourceProperties_STATUS}
+---------------------------------------------------------------------------------------
 
 Describes the properties of an existing Shared Private Link Resource to use when connecting to a private origin.
 
@@ -1896,8 +1896,8 @@ Used by: [AfdOrigin_STATUS](#AfdOrigin_STATUS).
 | requestMessage      | The request message for requesting approval of the shared private link resource.                          | string<br/><small>Optional</small>                                                                                                  |
 | status              | Status of the shared private link resource. Can be Pending, Approved, Rejected, Disconnected, or Timeout. | [SharedPrivateLinkResourceProperties_Status_STATUS](#SharedPrivateLinkResourceProperties_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Standard_Verizon = The SKU name for a Standard Verizon CDN profile. Premium_Verizon = The SKU name for a Premium Verizon CDN profile. Custom_Verizon = The SKU name for a Custom Verizon CDN profile. Standard_Akamai = The SKU name for an Akamai CDN profile. Standard_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using GB based billing model. Standard_Microsoft = The SKU name for a Standard Microsoft CDN profile. Standard_AzureFrontDoor = The SKU name for an Azure Front Door Standard profile. Premium_AzureFrontDoor = The SKU name for an Azure Front Door Premium profile. Standard_955BandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using 95-5 peak bandwidth billing model. Standard_AvgBandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using monthly average peak bandwidth billing model. StandardPlus_ChinaCdn = The SKU name for a China CDN profile for live-streaming using GB based billing model. StandardPlus_955BandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using 95-5 peak bandwidth billing model. StandardPlus_AvgBandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using monthly average peak bandwidth billing model.
 
@@ -1907,8 +1907,8 @@ Used by: [Profile_Spec](#Profile_Spec).
 |----------|---------------------------|---------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Standard_Verizon = The SKU name for a Standard Verizon CDN profile. Premium_Verizon = The SKU name for a Premium Verizon CDN profile. Custom_Verizon = The SKU name for a Custom Verizon CDN profile. Standard_Akamai = The SKU name for an Akamai CDN profile. Standard_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using GB based billing model. Standard_Microsoft = The SKU name for a Standard Microsoft CDN profile. Standard_AzureFrontDoor = The SKU name for an Azure Front Door Standard profile. Premium_AzureFrontDoor = The SKU name for an Azure Front Door Premium profile. Standard_955BandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using 95-5 peak bandwidth billing model. Standard_AvgBandWidth_ChinaCdn = The SKU name for a China CDN profile for VOD, Web and download scenarios using monthly average peak bandwidth billing model. StandardPlus_ChinaCdn = The SKU name for a China CDN profile for live-streaming using GB based billing model. StandardPlus_955BandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using 95-5 peak bandwidth billing model. StandardPlus_AvgBandWidth_ChinaCdn = The SKU name for a China CDN live-streaming profile using monthly average peak bandwidth billing model.
 
@@ -1918,8 +1918,8 @@ Used by: [Profile_STATUS](#Profile_STATUS).
 |----------|---------------------------|-----------------------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Read only system data
 
@@ -1934,8 +1934,8 @@ Used by: [AfdCustomDomain_STATUS](#AfdCustomDomain_STATUS), [AfdEndpoint_STATUS]
 | lastModifiedBy     | An identifier for the identity that last modified the resource | string<br/><small>Optional</small>                                      |
 | lastModifiedByType | The type of identity that last modified the resource           | [IdentityType_STATUS](#IdentityType_STATUS)<br/><small>Optional</small> |
 
-<a id="AFDDomainHttpsParameters_CertificateType"></a>AFDDomainHttpsParameters_CertificateType
----------------------------------------------------------------------------------------------
+AFDDomainHttpsParameters_CertificateType{#AFDDomainHttpsParameters_CertificateType}
+-----------------------------------------------------------------------------------
 
 Used by: [AFDDomainHttpsParameters](#AFDDomainHttpsParameters).
 
@@ -1945,20 +1945,20 @@ Used by: [AFDDomainHttpsParameters](#AFDDomainHttpsParameters).
 | "CustomerCertificate"               |             |
 | "ManagedCertificate"                |             |
 
-<a id="AFDDomainHttpsParameters_CertificateType_STATUS"></a>AFDDomainHttpsParameters_CertificateType_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [AFDDomainHttpsParameters_STATUS](#AFDDomainHttpsParameters_STATUS).
-
-| Value                               | Description |
-|-------------------------------------|-------------|
-| "AzureFirstPartyManagedCertificate" |             |
-| "CustomerCertificate"               |             |
-| "ManagedCertificate"                |             |
-
-<a id="AFDDomainHttpsParameters_MinimumTlsVersion"></a>AFDDomainHttpsParameters_MinimumTlsVersion
+AFDDomainHttpsParameters_CertificateType_STATUS{#AFDDomainHttpsParameters_CertificateType_STATUS}
 -------------------------------------------------------------------------------------------------
 
+Used by: [AFDDomainHttpsParameters_STATUS](#AFDDomainHttpsParameters_STATUS).
+
+| Value                               | Description |
+|-------------------------------------|-------------|
+| "AzureFirstPartyManagedCertificate" |             |
+| "CustomerCertificate"               |             |
+| "ManagedCertificate"                |             |
+
+AFDDomainHttpsParameters_MinimumTlsVersion{#AFDDomainHttpsParameters_MinimumTlsVersion}
+---------------------------------------------------------------------------------------
+
 Used by: [AFDDomainHttpsParameters](#AFDDomainHttpsParameters).
 
 | Value   | Description |
@@ -1966,8 +1966,8 @@ Used by: [AFDDomainHttpsParameters](#AFDDomainHttpsParameters).
 | "TLS10" |             |
 | "TLS12" |             |
 
-<a id="AFDDomainHttpsParameters_MinimumTlsVersion_STATUS"></a>AFDDomainHttpsParameters_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------------
+AFDDomainHttpsParameters_MinimumTlsVersion_STATUS{#AFDDomainHttpsParameters_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [AFDDomainHttpsParameters_STATUS](#AFDDomainHttpsParameters_STATUS).
 
@@ -1976,8 +1976,8 @@ Used by: [AFDDomainHttpsParameters_STATUS](#AFDDomainHttpsParameters_STATUS).
 | "TLS10" |             |
 | "TLS12" |             |
 
-<a id="AfdRouteCacheConfiguration_QueryStringCachingBehavior"></a>AfdRouteCacheConfiguration_QueryStringCachingBehavior
------------------------------------------------------------------------------------------------------------------------
+AfdRouteCacheConfiguration_QueryStringCachingBehavior{#AfdRouteCacheConfiguration_QueryStringCachingBehavior}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [AfdRouteCacheConfiguration](#AfdRouteCacheConfiguration).
 
@@ -1988,8 +1988,8 @@ Used by: [AfdRouteCacheConfiguration](#AfdRouteCacheConfiguration).
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS"></a>AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS{#AfdRouteCacheConfiguration_QueryStringCachingBehavior_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AfdRouteCacheConfiguration_STATUS](#AfdRouteCacheConfiguration_STATUS).
 
@@ -2000,8 +2000,8 @@ Used by: [AfdRouteCacheConfiguration_STATUS](#AfdRouteCacheConfiguration_STATUS)
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="AzureFirstPartyManagedCertificateParameters"></a>AzureFirstPartyManagedCertificateParameters
----------------------------------------------------------------------------------------------------
+AzureFirstPartyManagedCertificateParameters{#AzureFirstPartyManagedCertificateParameters}
+-----------------------------------------------------------------------------------------
 
 Used by: [SecretParameters](#SecretParameters).
 
@@ -2010,8 +2010,8 @@ Used by: [SecretParameters](#SecretParameters).
 | subjectAlternativeNames | The list of SANs. | string[]<br/><small>Optional</small>                                                                                              |
 | type                    |                   | [AzureFirstPartyManagedCertificateParameters_Type](#AzureFirstPartyManagedCertificateParameters_Type)<br/><small>Required</small> |
 
-<a id="AzureFirstPartyManagedCertificateParameters_STATUS"></a>AzureFirstPartyManagedCertificateParameters_STATUS
------------------------------------------------------------------------------------------------------------------
+AzureFirstPartyManagedCertificateParameters_STATUS{#AzureFirstPartyManagedCertificateParameters_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 
@@ -2025,8 +2025,8 @@ Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 | thumbprint              | Certificate thumbprint.                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                              |
 | type                    |                                                                                                                                                                                                                                                                 | [AzureFirstPartyManagedCertificateParameters_Type_STATUS](#AzureFirstPartyManagedCertificateParameters_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="CompressionSettings"></a>CompressionSettings
----------------------------------------------------
+CompressionSettings{#CompressionSettings}
+-----------------------------------------
 
 settings for compression.
 
@@ -2037,8 +2037,8 @@ Used by: [AfdRouteCacheConfiguration](#AfdRouteCacheConfiguration).
 | contentTypesToCompress | List of content types on which compression applies. The value should be a valid MIME type.                                                                                                                                                                                                                              | string[]<br/><small>Optional</small> |
 | isCompressionEnabled   | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. | bool<br/><small>Optional</small>     |
 
-<a id="CompressionSettings_STATUS"></a>CompressionSettings_STATUS
------------------------------------------------------------------
+CompressionSettings_STATUS{#CompressionSettings_STATUS}
+-------------------------------------------------------
 
 settings for compression.
 
@@ -2049,8 +2049,8 @@ Used by: [AfdRouteCacheConfiguration_STATUS](#AfdRouteCacheConfiguration_STATUS)
 | contentTypesToCompress | List of content types on which compression applies. The value should be a valid MIME type.                                                                                                                                                                                                                              | string[]<br/><small>Optional</small> |
 | isCompressionEnabled   | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. | bool<br/><small>Optional</small>     |
 
-<a id="CustomerCertificateParameters"></a>CustomerCertificateParameters
------------------------------------------------------------------------
+CustomerCertificateParameters{#CustomerCertificateParameters}
+-------------------------------------------------------------
 
 Used by: [SecretParameters](#SecretParameters).
 
@@ -2062,8 +2062,8 @@ Used by: [SecretParameters](#SecretParameters).
 | type                    |                                                                                                                                                                                                                                                                 | [CustomerCertificateParameters_Type](#CustomerCertificateParameters_Type)<br/><small>Required</small> |
 | useLatestVersion        | Whether to use the latest version for the certificate                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                      |
 
-<a id="CustomerCertificateParameters_STATUS"></a>CustomerCertificateParameters_STATUS
--------------------------------------------------------------------------------------
+CustomerCertificateParameters_STATUS{#CustomerCertificateParameters_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 
@@ -2079,8 +2079,8 @@ Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 | type                    |                                                                                                                                                                                                                                                                 | [CustomerCertificateParameters_Type_STATUS](#CustomerCertificateParameters_Type_STATUS)<br/><small>Optional</small> |
 | useLatestVersion        | Whether to use the latest version for the certificate                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                    |
 
-<a id="DeliveryRuleCacheExpirationAction"></a>DeliveryRuleCacheExpirationAction
--------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction{#DeliveryRuleCacheExpirationAction}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2089,8 +2089,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheExpirationAction_Name](#DeliveryRuleCacheExpirationAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [CacheExpirationActionParameters](#CacheExpirationActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleCacheExpirationAction_STATUS"></a>DeliveryRuleCacheExpirationAction_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_STATUS{#DeliveryRuleCacheExpirationAction_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2099,8 +2099,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheExpirationAction_Name_STATUS](#DeliveryRuleCacheExpirationAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction"></a>DeliveryRuleCacheKeyQueryStringAction
----------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction{#DeliveryRuleCacheKeyQueryStringAction}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2109,8 +2109,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheKeyQueryStringAction_Name](#DeliveryRuleCacheKeyQueryStringAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_STATUS"></a>DeliveryRuleCacheKeyQueryStringAction_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_STATUS{#DeliveryRuleCacheKeyQueryStringAction_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2119,8 +2119,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleCacheKeyQueryStringAction_Name_STATUS](#DeliveryRuleCacheKeyQueryStringAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleClientPortCondition"></a>DeliveryRuleClientPortCondition
----------------------------------------------------------------------------
+DeliveryRuleClientPortCondition{#DeliveryRuleClientPortCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2129,8 +2129,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleClientPortCondition_Name](#DeliveryRuleClientPortCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleClientPortCondition_STATUS"></a>DeliveryRuleClientPortCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_STATUS{#DeliveryRuleClientPortCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2139,8 +2139,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleClientPortCondition_Name_STATUS](#DeliveryRuleClientPortCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleCookiesCondition"></a>DeliveryRuleCookiesCondition
----------------------------------------------------------------------
+DeliveryRuleCookiesCondition{#DeliveryRuleCookiesCondition}
+-----------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2149,8 +2149,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleCookiesCondition_Name](#DeliveryRuleCookiesCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [CookiesMatchConditionParameters](#CookiesMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleCookiesCondition_STATUS"></a>DeliveryRuleCookiesCondition_STATUS
------------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_STATUS{#DeliveryRuleCookiesCondition_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2159,8 +2159,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleCookiesCondition_Name_STATUS](#DeliveryRuleCookiesCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleHostNameCondition"></a>DeliveryRuleHostNameCondition
------------------------------------------------------------------------
+DeliveryRuleHostNameCondition{#DeliveryRuleHostNameCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2169,8 +2169,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHostNameCondition_Name](#DeliveryRuleHostNameCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [HostNameMatchConditionParameters](#HostNameMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleHostNameCondition_STATUS"></a>DeliveryRuleHostNameCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_STATUS{#DeliveryRuleHostNameCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2179,8 +2179,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHostNameCondition_Name_STATUS](#DeliveryRuleHostNameCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleHttpVersionCondition"></a>DeliveryRuleHttpVersionCondition
------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition{#DeliveryRuleHttpVersionCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2189,8 +2189,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHttpVersionCondition_Name](#DeliveryRuleHttpVersionCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleHttpVersionCondition_STATUS"></a>DeliveryRuleHttpVersionCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_STATUS{#DeliveryRuleHttpVersionCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2199,8 +2199,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleHttpVersionCondition_Name_STATUS](#DeliveryRuleHttpVersionCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleIsDeviceCondition"></a>DeliveryRuleIsDeviceCondition
------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition{#DeliveryRuleIsDeviceCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2209,8 +2209,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleIsDeviceCondition_Name](#DeliveryRuleIsDeviceCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleIsDeviceCondition_STATUS"></a>DeliveryRuleIsDeviceCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_STATUS{#DeliveryRuleIsDeviceCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2219,8 +2219,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleIsDeviceCondition_Name_STATUS](#DeliveryRuleIsDeviceCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRulePostArgsCondition"></a>DeliveryRulePostArgsCondition
------------------------------------------------------------------------
+DeliveryRulePostArgsCondition{#DeliveryRulePostArgsCondition}
+-------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2229,8 +2229,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRulePostArgsCondition_Name](#DeliveryRulePostArgsCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRulePostArgsCondition_STATUS"></a>DeliveryRulePostArgsCondition_STATUS
--------------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_STATUS{#DeliveryRulePostArgsCondition_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2239,8 +2239,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRulePostArgsCondition_Name_STATUS](#DeliveryRulePostArgsCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleQueryStringCondition"></a>DeliveryRuleQueryStringCondition
------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition{#DeliveryRuleQueryStringCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2249,8 +2249,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleQueryStringCondition_Name](#DeliveryRuleQueryStringCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleQueryStringCondition_STATUS"></a>DeliveryRuleQueryStringCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_STATUS{#DeliveryRuleQueryStringCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2259,8 +2259,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleQueryStringCondition_Name_STATUS](#DeliveryRuleQueryStringCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRemoteAddressCondition"></a>DeliveryRuleRemoteAddressCondition
----------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition{#DeliveryRuleRemoteAddressCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2269,8 +2269,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRemoteAddressCondition_Name](#DeliveryRuleRemoteAddressCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRemoteAddressCondition_STATUS"></a>DeliveryRuleRemoteAddressCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_STATUS{#DeliveryRuleRemoteAddressCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2279,8 +2279,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRemoteAddressCondition_Name_STATUS](#DeliveryRuleRemoteAddressCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestBodyCondition"></a>DeliveryRuleRequestBodyCondition
------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition{#DeliveryRuleRequestBodyCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2289,8 +2289,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestBodyCondition_Name](#DeliveryRuleRequestBodyCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestBodyCondition_STATUS"></a>DeliveryRuleRequestBodyCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_STATUS{#DeliveryRuleRequestBodyCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2299,8 +2299,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestBodyCondition_Name_STATUS](#DeliveryRuleRequestBodyCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestHeaderAction"></a>DeliveryRuleRequestHeaderAction
----------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction{#DeliveryRuleRequestHeaderAction}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2309,8 +2309,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRequestHeaderAction_Name](#DeliveryRuleRequestHeaderAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters](#HeaderActionParameters)<br/><small>Required</small>                             |
 
-<a id="DeliveryRuleRequestHeaderAction_STATUS"></a>DeliveryRuleRequestHeaderAction_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_STATUS{#DeliveryRuleRequestHeaderAction_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2319,8 +2319,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRequestHeaderAction_Name_STATUS](#DeliveryRuleRequestHeaderAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS)<br/><small>Optional</small>                             |
 
-<a id="DeliveryRuleRequestHeaderCondition"></a>DeliveryRuleRequestHeaderCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition{#DeliveryRuleRequestHeaderCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2329,8 +2329,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestHeaderCondition_Name](#DeliveryRuleRequestHeaderCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestHeaderCondition_STATUS"></a>DeliveryRuleRequestHeaderCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_STATUS{#DeliveryRuleRequestHeaderCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2339,8 +2339,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestHeaderCondition_Name_STATUS](#DeliveryRuleRequestHeaderCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestMethodCondition"></a>DeliveryRuleRequestMethodCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition{#DeliveryRuleRequestMethodCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2349,8 +2349,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestMethodCondition_Name](#DeliveryRuleRequestMethodCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestMethodCondition_STATUS"></a>DeliveryRuleRequestMethodCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_STATUS{#DeliveryRuleRequestMethodCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2359,8 +2359,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestMethodCondition_Name_STATUS](#DeliveryRuleRequestMethodCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestSchemeCondition"></a>DeliveryRuleRequestSchemeCondition
----------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition{#DeliveryRuleRequestSchemeCondition}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2369,8 +2369,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestSchemeCondition_Name](#DeliveryRuleRequestSchemeCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestSchemeCondition_STATUS"></a>DeliveryRuleRequestSchemeCondition_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_STATUS{#DeliveryRuleRequestSchemeCondition_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2379,8 +2379,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestSchemeCondition_Name_STATUS](#DeliveryRuleRequestSchemeCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleRequestUriCondition"></a>DeliveryRuleRequestUriCondition
----------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition{#DeliveryRuleRequestUriCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2389,8 +2389,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestUriCondition_Name](#DeliveryRuleRequestUriCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleRequestUriCondition_STATUS"></a>DeliveryRuleRequestUriCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_STATUS{#DeliveryRuleRequestUriCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2399,8 +2399,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleRequestUriCondition_Name_STATUS](#DeliveryRuleRequestUriCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleResponseHeaderAction"></a>DeliveryRuleResponseHeaderAction
------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction{#DeliveryRuleResponseHeaderAction}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2409,8 +2409,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleResponseHeaderAction_Name](#DeliveryRuleResponseHeaderAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters](#HeaderActionParameters)<br/><small>Required</small>                               |
 
-<a id="DeliveryRuleResponseHeaderAction_STATUS"></a>DeliveryRuleResponseHeaderAction_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_STATUS{#DeliveryRuleResponseHeaderAction_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2419,8 +2419,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleResponseHeaderAction_Name_STATUS](#DeliveryRuleResponseHeaderAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS)<br/><small>Optional</small>                               |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction"></a>DeliveryRuleRouteConfigurationOverrideAction
------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction{#DeliveryRuleRouteConfigurationOverrideAction}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2429,8 +2429,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRouteConfigurationOverrideAction_Name](#DeliveryRuleRouteConfigurationOverrideAction_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the action.        | [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrideActionParameters)<br/><small>Required</small>               |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_STATUS"></a>DeliveryRuleRouteConfigurationOverrideAction_STATUS
--------------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_STATUS{#DeliveryRuleRouteConfigurationOverrideAction_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2439,8 +2439,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS](#DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the action.        | [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfigurationOverrideActionParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="DeliveryRuleServerPortCondition"></a>DeliveryRuleServerPortCondition
----------------------------------------------------------------------------
+DeliveryRuleServerPortCondition{#DeliveryRuleServerPortCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2449,8 +2449,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleServerPortCondition_Name](#DeliveryRuleServerPortCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleServerPortCondition_STATUS"></a>DeliveryRuleServerPortCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_STATUS{#DeliveryRuleServerPortCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2459,8 +2459,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleServerPortCondition_Name_STATUS](#DeliveryRuleServerPortCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleSocketAddrCondition"></a>DeliveryRuleSocketAddrCondition
----------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition{#DeliveryRuleSocketAddrCondition}
+-----------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2469,8 +2469,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSocketAddrCondition_Name](#DeliveryRuleSocketAddrCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleSocketAddrCondition_STATUS"></a>DeliveryRuleSocketAddrCondition_STATUS
------------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_STATUS{#DeliveryRuleSocketAddrCondition_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2479,8 +2479,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSocketAddrCondition_Name_STATUS](#DeliveryRuleSocketAddrCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleSslProtocolCondition"></a>DeliveryRuleSslProtocolCondition
------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition{#DeliveryRuleSslProtocolCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2489,8 +2489,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSslProtocolCondition_Name](#DeliveryRuleSslProtocolCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleSslProtocolCondition_STATUS"></a>DeliveryRuleSslProtocolCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_STATUS{#DeliveryRuleSslProtocolCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2499,8 +2499,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleSslProtocolCondition_Name_STATUS](#DeliveryRuleSslProtocolCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlFileExtensionCondition"></a>DeliveryRuleUrlFileExtensionCondition
----------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition{#DeliveryRuleUrlFileExtensionCondition}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2509,8 +2509,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileExtensionCondition_Name](#DeliveryRuleUrlFileExtensionCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_STATUS"></a>DeliveryRuleUrlFileExtensionCondition_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_STATUS{#DeliveryRuleUrlFileExtensionCondition_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2519,8 +2519,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileExtensionCondition_Name_STATUS](#DeliveryRuleUrlFileExtensionCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlFileNameCondition"></a>DeliveryRuleUrlFileNameCondition
------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition{#DeliveryRuleUrlFileNameCondition}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2529,8 +2529,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileNameCondition_Name](#DeliveryRuleUrlFileNameCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlFileNameCondition_STATUS"></a>DeliveryRuleUrlFileNameCondition_STATUS
--------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_STATUS{#DeliveryRuleUrlFileNameCondition_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2539,8 +2539,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlFileNameCondition_Name_STATUS](#DeliveryRuleUrlFileNameCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="DeliveryRuleUrlPathCondition"></a>DeliveryRuleUrlPathCondition
----------------------------------------------------------------------
+DeliveryRuleUrlPathCondition{#DeliveryRuleUrlPathCondition}
+-----------------------------------------------------------
 
 Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 
@@ -2549,8 +2549,8 @@ Used by: [DeliveryRuleCondition](#DeliveryRuleCondition).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlPathCondition_Name](#DeliveryRuleUrlPathCondition_Name)<br/><small>Required</small> |
 | parameters | Defines the parameters for the condition.        | [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters)<br/><small>Required</small>     |
 
-<a id="DeliveryRuleUrlPathCondition_STATUS"></a>DeliveryRuleUrlPathCondition_STATUS
------------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_STATUS{#DeliveryRuleUrlPathCondition_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 
@@ -2559,8 +2559,8 @@ Used by: [DeliveryRuleCondition_STATUS](#DeliveryRuleCondition_STATUS).
 | name       | The name of the condition for the delivery rule. | [DeliveryRuleUrlPathCondition_Name_STATUS](#DeliveryRuleUrlPathCondition_Name_STATUS)<br/><small>Optional</small> |
 | parameters | Defines the parameters for the condition.        | [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS)<br/><small>Optional</small>     |
 
-<a id="HealthProbeParameters_ProbeProtocol"></a>HealthProbeParameters_ProbeProtocol
------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeProtocol{#HealthProbeParameters_ProbeProtocol}
+-------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters](#HealthProbeParameters).
 
@@ -2570,8 +2570,8 @@ Used by: [HealthProbeParameters](#HealthProbeParameters).
 | "Https"  |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeProtocol_STATUS"></a>HealthProbeParameters_ProbeProtocol_STATUS
--------------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeProtocol_STATUS{#HealthProbeParameters_ProbeProtocol_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 
@@ -2581,8 +2581,8 @@ Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 | "Https"  |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeRequestType"></a>HealthProbeParameters_ProbeRequestType
------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeRequestType{#HealthProbeParameters_ProbeRequestType}
+-------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters](#HealthProbeParameters).
 
@@ -2592,8 +2592,8 @@ Used by: [HealthProbeParameters](#HealthProbeParameters).
 | "HEAD"   |             |
 | "NotSet" |             |
 
-<a id="HealthProbeParameters_ProbeRequestType_STATUS"></a>HealthProbeParameters_ProbeRequestType_STATUS
--------------------------------------------------------------------------------------------------------
+HealthProbeParameters_ProbeRequestType_STATUS{#HealthProbeParameters_ProbeRequestType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 
@@ -2603,8 +2603,8 @@ Used by: [HealthProbeParameters_STATUS](#HealthProbeParameters_STATUS).
 | "HEAD"   |             |
 | "NotSet" |             |
 
-<a id="IdentityType_STATUS"></a>IdentityType_STATUS
----------------------------------------------------
+IdentityType_STATUS{#IdentityType_STATUS}
+-----------------------------------------
 
 The type of identity that creates/modifies resources
 
@@ -2617,8 +2617,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS), and [SystemData_STATUS](#Syste
 | "managedIdentity" |             |
 | "user"            |             |
 
-<a id="ManagedCertificateParameters"></a>ManagedCertificateParameters
----------------------------------------------------------------------
+ManagedCertificateParameters{#ManagedCertificateParameters}
+-----------------------------------------------------------
 
 Used by: [SecretParameters](#SecretParameters).
 
@@ -2626,8 +2626,8 @@ Used by: [SecretParameters](#SecretParameters).
 |----------|-------------|-----------------------------------------------------------------------------------------------------|
 | type     |             | [ManagedCertificateParameters_Type](#ManagedCertificateParameters_Type)<br/><small>Required</small> |
 
-<a id="ManagedCertificateParameters_STATUS"></a>ManagedCertificateParameters_STATUS
------------------------------------------------------------------------------------
+ManagedCertificateParameters_STATUS{#ManagedCertificateParameters_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 
@@ -2637,8 +2637,8 @@ Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 | subject        | Subject name in the certificate. | string<br/><small>Optional</small>                                                                                |
 | type           |                                  | [ManagedCertificateParameters_Type_STATUS](#ManagedCertificateParameters_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentityType"></a>ManagedServiceIdentityType
------------------------------------------------------------------
+ManagedServiceIdentityType{#ManagedServiceIdentityType}
+-------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -2651,8 +2651,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentityType_STATUS"></a>ManagedServiceIdentityType_STATUS
--------------------------------------------------------------------------------
+ManagedServiceIdentityType_STATUS{#ManagedServiceIdentityType_STATUS}
+---------------------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -2665,8 +2665,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="OriginGroupOverrideAction"></a>OriginGroupOverrideAction
----------------------------------------------------------------
+OriginGroupOverrideAction{#OriginGroupOverrideAction}
+-----------------------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2675,8 +2675,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [OriginGroupOverrideAction_Name](#OriginGroupOverrideAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParameters)<br/><small>Required</small> |
 
-<a id="OriginGroupOverrideAction_STATUS"></a>OriginGroupOverrideAction_STATUS
------------------------------------------------------------------------------
+OriginGroupOverrideAction_STATUS{#OriginGroupOverrideAction_STATUS}
+-------------------------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2685,8 +2685,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [OriginGroupOverrideAction_Name_STATUS](#OriginGroupOverrideAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="SecurityPolicyWebApplicationFirewallParameters"></a>SecurityPolicyWebApplicationFirewallParameters
----------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallParameters{#SecurityPolicyWebApplicationFirewallParameters}
+-----------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicyPropertiesParameters](#SecurityPolicyPropertiesParameters).
 
@@ -2696,8 +2696,8 @@ Used by: [SecurityPolicyPropertiesParameters](#SecurityPolicyPropertiesParameter
 | type         | The type of the Security policy to create. | [SecurityPolicyWebApplicationFirewallParameters_Type](#SecurityPolicyWebApplicationFirewallParameters_Type)<br/><small>Required</small> |
 | wafPolicy    | Resource ID.                               | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                                                     |
 
-<a id="SecurityPolicyWebApplicationFirewallParameters_STATUS"></a>SecurityPolicyWebApplicationFirewallParameters_STATUS
------------------------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallParameters_STATUS{#SecurityPolicyWebApplicationFirewallParameters_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicyPropertiesParameters_STATUS](#SecurityPolicyPropertiesParameters_STATUS).
 
@@ -2707,8 +2707,8 @@ Used by: [SecurityPolicyPropertiesParameters_STATUS](#SecurityPolicyPropertiesPa
 | type         | The type of the Security policy to create. | [SecurityPolicyWebApplicationFirewallParameters_Type_STATUS](#SecurityPolicyWebApplicationFirewallParameters_Type_STATUS)<br/><small>Optional</small> |
 | wafPolicy    | Resource ID.                               | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                                                     |
 
-<a id="SharedPrivateLinkResourceProperties_Status"></a>SharedPrivateLinkResourceProperties_Status
--------------------------------------------------------------------------------------------------
+SharedPrivateLinkResourceProperties_Status{#SharedPrivateLinkResourceProperties_Status}
+---------------------------------------------------------------------------------------
 
 Used by: [SharedPrivateLinkResourceProperties](#SharedPrivateLinkResourceProperties).
 
@@ -2720,8 +2720,8 @@ Used by: [SharedPrivateLinkResourceProperties](#SharedPrivateLinkResourcePropert
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="SharedPrivateLinkResourceProperties_Status_STATUS"></a>SharedPrivateLinkResourceProperties_Status_STATUS
----------------------------------------------------------------------------------------------------------------
+SharedPrivateLinkResourceProperties_Status_STATUS{#SharedPrivateLinkResourceProperties_Status_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [SharedPrivateLinkResourceProperties_STATUS](#SharedPrivateLinkResourceProperties_STATUS).
 
@@ -2733,8 +2733,8 @@ Used by: [SharedPrivateLinkResourceProperties_STATUS](#SharedPrivateLinkResource
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -2754,8 +2754,8 @@ Used by: [Sku](#Sku).
 | "Standard_Microsoft"                 |             |
 | "Standard_Verizon"                   |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -2775,8 +2775,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Standard_Microsoft"                 |             |
 | "Standard_Verizon"                   |             |
 
-<a id="UrlRedirectAction"></a>UrlRedirectAction
------------------------------------------------
+UrlRedirectAction{#UrlRedirectAction}
+-------------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2785,8 +2785,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlRedirectAction_Name](#UrlRedirectAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRedirectActionParameters](#UrlRedirectActionParameters)<br/><small>Required</small> |
 
-<a id="UrlRedirectAction_STATUS"></a>UrlRedirectAction_STATUS
--------------------------------------------------------------
+UrlRedirectAction_STATUS{#UrlRedirectAction_STATUS}
+---------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2795,8 +2795,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlRedirectAction_Name_STATUS](#UrlRedirectAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlRewriteAction"></a>UrlRewriteAction
----------------------------------------------
+UrlRewriteAction{#UrlRewriteAction}
+-----------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2805,8 +2805,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlRewriteAction_Name](#UrlRewriteAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRewriteActionParameters](#UrlRewriteActionParameters)<br/><small>Required</small> |
 
-<a id="UrlRewriteAction_STATUS"></a>UrlRewriteAction_STATUS
------------------------------------------------------------
+UrlRewriteAction_STATUS{#UrlRewriteAction_STATUS}
+-------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2815,8 +2815,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlRewriteAction_Name_STATUS](#UrlRewriteAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningAction"></a>UrlSigningAction
----------------------------------------------
+UrlSigningAction{#UrlSigningAction}
+-----------------------------------
 
 Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 
@@ -2825,8 +2825,8 @@ Used by: [DeliveryRuleAction](#DeliveryRuleAction).
 | name       | The name of the action for the delivery rule. | [UrlSigningAction_Name](#UrlSigningAction_Name)<br/><small>Required</small>           |
 | parameters | Defines the parameters for the action.        | [UrlSigningActionParameters](#UrlSigningActionParameters)<br/><small>Required</small> |
 
-<a id="UrlSigningAction_STATUS"></a>UrlSigningAction_STATUS
------------------------------------------------------------
+UrlSigningAction_STATUS{#UrlSigningAction_STATUS}
+-------------------------------------------------
 
 Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 
@@ -2835,8 +2835,8 @@ Used by: [DeliveryRuleAction_STATUS](#DeliveryRuleAction_STATUS).
 | name       | The name of the action for the delivery rule. | [UrlSigningAction_Name_STATUS](#UrlSigningAction_Name_STATUS)<br/><small>Optional</small>           |
 | parameters | Defines the parameters for the action.        | [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningKeyParameters"></a>UrlSigningKeyParameters
------------------------------------------------------------
+UrlSigningKeyParameters{#UrlSigningKeyParameters}
+-------------------------------------------------
 
 Used by: [SecretParameters](#SecretParameters).
 
@@ -2847,8 +2847,8 @@ Used by: [SecretParameters](#SecretParameters).
 | secretVersion | Version of the secret to be used                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                        |
 | type          |                                                                                                                                                                                                                                                       | [UrlSigningKeyParameters_Type](#UrlSigningKeyParameters_Type)<br/><small>Required</small> |
 
-<a id="UrlSigningKeyParameters_STATUS"></a>UrlSigningKeyParameters_STATUS
--------------------------------------------------------------------------
+UrlSigningKeyParameters_STATUS{#UrlSigningKeyParameters_STATUS}
+---------------------------------------------------------------
 
 Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 
@@ -2859,8 +2859,8 @@ Used by: [SecretParameters_STATUS](#SecretParameters_STATUS).
 | secretVersion | Version of the secret to be used                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                      |
 | type          |                                                                                                                                                                                                                                                       | [UrlSigningKeyParameters_Type_STATUS](#UrlSigningKeyParameters_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -2871,8 +2871,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2882,8 +2882,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureFirstPartyManagedCertificateParameters_Type"></a>AzureFirstPartyManagedCertificateParameters_Type
--------------------------------------------------------------------------------------------------------------
+AzureFirstPartyManagedCertificateParameters_Type{#AzureFirstPartyManagedCertificateParameters_Type}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AzureFirstPartyManagedCertificateParameters](#AzureFirstPartyManagedCertificateParameters).
 
@@ -2891,8 +2891,8 @@ Used by: [AzureFirstPartyManagedCertificateParameters](#AzureFirstPartyManagedCe
 |-------------------------------------|-------------|
 | "AzureFirstPartyManagedCertificate" |             |
 
-<a id="AzureFirstPartyManagedCertificateParameters_Type_STATUS"></a>AzureFirstPartyManagedCertificateParameters_Type_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AzureFirstPartyManagedCertificateParameters_Type_STATUS{#AzureFirstPartyManagedCertificateParameters_Type_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFirstPartyManagedCertificateParameters_STATUS](#AzureFirstPartyManagedCertificateParameters_STATUS).
 
@@ -2900,8 +2900,8 @@ Used by: [AzureFirstPartyManagedCertificateParameters_STATUS](#AzureFirstPartyMa
 |-------------------------------------|-------------|
 | "AzureFirstPartyManagedCertificate" |             |
 
-<a id="CacheExpirationActionParameters"></a>CacheExpirationActionParameters
----------------------------------------------------------------------------
+CacheExpirationActionParameters{#CacheExpirationActionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for the cache expiration action.
 
@@ -2914,8 +2914,8 @@ Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction)
 | cacheType     | The level at which the content needs to be cached.                                    | [CacheExpirationActionParameters_CacheType](#CacheExpirationActionParameters_CacheType)<br/><small>Required</small>         |
 | typeName      |                                                                                       | [CacheExpirationActionParameters_TypeName](#CacheExpirationActionParameters_TypeName)<br/><small>Required</small>           |
 
-<a id="CacheExpirationActionParameters_STATUS"></a>CacheExpirationActionParameters_STATUS
------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_STATUS{#CacheExpirationActionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for the cache expiration action.
 
@@ -2928,8 +2928,8 @@ Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpiration
 | cacheType     | The level at which the content needs to be cached.                                    | [CacheExpirationActionParameters_CacheType_STATUS](#CacheExpirationActionParameters_CacheType_STATUS)<br/><small>Optional</small>         |
 | typeName      |                                                                                       | [CacheExpirationActionParameters_TypeName_STATUS](#CacheExpirationActionParameters_TypeName_STATUS)<br/><small>Optional</small>           |
 
-<a id="CacheKeyQueryStringActionParameters"></a>CacheKeyQueryStringActionParameters
------------------------------------------------------------------------------------
+CacheKeyQueryStringActionParameters{#CacheKeyQueryStringActionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for the cache-key query string action.
 
@@ -2941,8 +2941,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStrin
 | queryStringBehavior | Caching behavior for the requests                         | [CacheKeyQueryStringActionParameters_QueryStringBehavior](#CacheKeyQueryStringActionParameters_QueryStringBehavior)<br/><small>Required</small> |
 | typeName            |                                                           | [CacheKeyQueryStringActionParameters_TypeName](#CacheKeyQueryStringActionParameters_TypeName)<br/><small>Required</small>                       |
 
-<a id="CacheKeyQueryStringActionParameters_STATUS"></a>CacheKeyQueryStringActionParameters_STATUS
--------------------------------------------------------------------------------------------------
+CacheKeyQueryStringActionParameters_STATUS{#CacheKeyQueryStringActionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the cache-key query string action.
 
@@ -2954,8 +2954,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQue
 | queryStringBehavior | Caching behavior for the requests                         | [CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS](#CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS)<br/><small>Optional</small> |
 | typeName            |                                                           | [CacheKeyQueryStringActionParameters_TypeName_STATUS](#CacheKeyQueryStringActionParameters_TypeName_STATUS)<br/><small>Optional</small>                       |
 
-<a id="ClientPortMatchConditionParameters"></a>ClientPortMatchConditionParameters
----------------------------------------------------------------------------------
+ClientPortMatchConditionParameters{#ClientPortMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for ClientPort match conditions
 
@@ -2969,8 +2969,8 @@ Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ClientPortMatchConditionParameters_TypeName](#ClientPortMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="ClientPortMatchConditionParameters_STATUS"></a>ClientPortMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+ClientPortMatchConditionParameters_STATUS{#ClientPortMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for ClientPort match conditions
 
@@ -2984,8 +2984,8 @@ Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ClientPortMatchConditionParameters_TypeName_STATUS](#ClientPortMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="CookiesMatchConditionParameters"></a>CookiesMatchConditionParameters
----------------------------------------------------------------------------
+CookiesMatchConditionParameters{#CookiesMatchConditionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for Cookies match conditions
 
@@ -3000,8 +3000,8 @@ Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [CookiesMatchConditionParameters_TypeName](#CookiesMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="CookiesMatchConditionParameters_STATUS"></a>CookiesMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------
+CookiesMatchConditionParameters_STATUS{#CookiesMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for Cookies match conditions
 
@@ -3016,8 +3016,8 @@ Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STA
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [CookiesMatchConditionParameters_TypeName_STATUS](#CookiesMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomerCertificateParameters_Type"></a>CustomerCertificateParameters_Type
----------------------------------------------------------------------------------
+CustomerCertificateParameters_Type{#CustomerCertificateParameters_Type}
+-----------------------------------------------------------------------
 
 Used by: [CustomerCertificateParameters](#CustomerCertificateParameters).
 
@@ -3025,8 +3025,8 @@ Used by: [CustomerCertificateParameters](#CustomerCertificateParameters).
 |-----------------------|-------------|
 | "CustomerCertificate" |             |
 
-<a id="CustomerCertificateParameters_Type_STATUS"></a>CustomerCertificateParameters_Type_STATUS
------------------------------------------------------------------------------------------------
+CustomerCertificateParameters_Type_STATUS{#CustomerCertificateParameters_Type_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [CustomerCertificateParameters_STATUS](#CustomerCertificateParameters_STATUS).
 
@@ -3034,8 +3034,8 @@ Used by: [CustomerCertificateParameters_STATUS](#CustomerCertificateParameters_S
 |-----------------------|-------------|
 | "CustomerCertificate" |             |
 
-<a id="DeliveryRuleCacheExpirationAction_Name"></a>DeliveryRuleCacheExpirationAction_Name
------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_Name{#DeliveryRuleCacheExpirationAction_Name}
+-------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction).
 
@@ -3043,8 +3043,8 @@ Used by: [DeliveryRuleCacheExpirationAction](#DeliveryRuleCacheExpirationAction)
 |-------------------|-------------|
 | "CacheExpiration" |             |
 
-<a id="DeliveryRuleCacheExpirationAction_Name_STATUS"></a>DeliveryRuleCacheExpirationAction_Name_STATUS
--------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheExpirationAction_Name_STATUS{#DeliveryRuleCacheExpirationAction_Name_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpirationAction_STATUS).
 
@@ -3052,8 +3052,8 @@ Used by: [DeliveryRuleCacheExpirationAction_STATUS](#DeliveryRuleCacheExpiration
 |-------------------|-------------|
 | "CacheExpiration" |             |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_Name"></a>DeliveryRuleCacheKeyQueryStringAction_Name
--------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_Name{#DeliveryRuleCacheKeyQueryStringAction_Name}
+---------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStringAction).
 
@@ -3061,8 +3061,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction](#DeliveryRuleCacheKeyQueryStrin
 |-----------------------|-------------|
 | "CacheKeyQueryString" |             |
 
-<a id="DeliveryRuleCacheKeyQueryStringAction_Name_STATUS"></a>DeliveryRuleCacheKeyQueryStringAction_Name_STATUS
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleCacheKeyQueryStringAction_Name_STATUS{#DeliveryRuleCacheKeyQueryStringAction_Name_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQueryStringAction_STATUS).
 
@@ -3070,8 +3070,8 @@ Used by: [DeliveryRuleCacheKeyQueryStringAction_STATUS](#DeliveryRuleCacheKeyQue
 |-----------------------|-------------|
 | "CacheKeyQueryString" |             |
 
-<a id="DeliveryRuleClientPortCondition_Name"></a>DeliveryRuleClientPortCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_Name{#DeliveryRuleClientPortCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 
@@ -3079,8 +3079,8 @@ Used by: [DeliveryRuleClientPortCondition](#DeliveryRuleClientPortCondition).
 |--------------|-------------|
 | "ClientPort" |             |
 
-<a id="DeliveryRuleClientPortCondition_Name_STATUS"></a>DeliveryRuleClientPortCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleClientPortCondition_Name_STATUS{#DeliveryRuleClientPortCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortCondition_STATUS).
 
@@ -3088,8 +3088,8 @@ Used by: [DeliveryRuleClientPortCondition_STATUS](#DeliveryRuleClientPortConditi
 |--------------|-------------|
 | "ClientPort" |             |
 
-<a id="DeliveryRuleCookiesCondition_Name"></a>DeliveryRuleCookiesCondition_Name
--------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_Name{#DeliveryRuleCookiesCondition_Name}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 
@@ -3097,8 +3097,8 @@ Used by: [DeliveryRuleCookiesCondition](#DeliveryRuleCookiesCondition).
 |-----------|-------------|
 | "Cookies" |             |
 
-<a id="DeliveryRuleCookiesCondition_Name_STATUS"></a>DeliveryRuleCookiesCondition_Name_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleCookiesCondition_Name_STATUS{#DeliveryRuleCookiesCondition_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STATUS).
 
@@ -3106,8 +3106,8 @@ Used by: [DeliveryRuleCookiesCondition_STATUS](#DeliveryRuleCookiesCondition_STA
 |-----------|-------------|
 | "Cookies" |             |
 
-<a id="DeliveryRuleHostNameCondition_Name"></a>DeliveryRuleHostNameCondition_Name
----------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_Name{#DeliveryRuleHostNameCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 
@@ -3115,8 +3115,8 @@ Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 |------------|-------------|
 | "HostName" |             |
 
-<a id="DeliveryRuleHostNameCondition_Name_STATUS"></a>DeliveryRuleHostNameCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleHostNameCondition_Name_STATUS{#DeliveryRuleHostNameCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_STATUS).
 
@@ -3124,8 +3124,8 @@ Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_S
 |------------|-------------|
 | "HostName" |             |
 
-<a id="DeliveryRuleHttpVersionCondition_Name"></a>DeliveryRuleHttpVersionCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_Name{#DeliveryRuleHttpVersionCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 
@@ -3133,8 +3133,8 @@ Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 |---------------|-------------|
 | "HttpVersion" |             |
 
-<a id="DeliveryRuleHttpVersionCondition_Name_STATUS"></a>DeliveryRuleHttpVersionCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleHttpVersionCondition_Name_STATUS{#DeliveryRuleHttpVersionCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondition_STATUS).
 
@@ -3142,8 +3142,8 @@ Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondi
 |---------------|-------------|
 | "HttpVersion" |             |
 
-<a id="DeliveryRuleIsDeviceCondition_Name"></a>DeliveryRuleIsDeviceCondition_Name
----------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_Name{#DeliveryRuleIsDeviceCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 
@@ -3151,8 +3151,8 @@ Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 |------------|-------------|
 | "IsDevice" |             |
 
-<a id="DeliveryRuleIsDeviceCondition_Name_STATUS"></a>DeliveryRuleIsDeviceCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRuleIsDeviceCondition_Name_STATUS{#DeliveryRuleIsDeviceCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_STATUS).
 
@@ -3160,8 +3160,8 @@ Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_S
 |------------|-------------|
 | "IsDevice" |             |
 
-<a id="DeliveryRulePostArgsCondition_Name"></a>DeliveryRulePostArgsCondition_Name
----------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_Name{#DeliveryRulePostArgsCondition_Name}
+-----------------------------------------------------------------------
 
 Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 
@@ -3169,8 +3169,8 @@ Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 |------------|-------------|
 | "PostArgs" |             |
 
-<a id="DeliveryRulePostArgsCondition_Name_STATUS"></a>DeliveryRulePostArgsCondition_Name_STATUS
------------------------------------------------------------------------------------------------
+DeliveryRulePostArgsCondition_Name_STATUS{#DeliveryRulePostArgsCondition_Name_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_STATUS).
 
@@ -3178,8 +3178,8 @@ Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_S
 |------------|-------------|
 | "PostArgs" |             |
 
-<a id="DeliveryRuleQueryStringCondition_Name"></a>DeliveryRuleQueryStringCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_Name{#DeliveryRuleQueryStringCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 
@@ -3187,8 +3187,8 @@ Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 |---------------|-------------|
 | "QueryString" |             |
 
-<a id="DeliveryRuleQueryStringCondition_Name_STATUS"></a>DeliveryRuleQueryStringCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleQueryStringCondition_Name_STATUS{#DeliveryRuleQueryStringCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondition_STATUS).
 
@@ -3196,8 +3196,8 @@ Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondi
 |---------------|-------------|
 | "QueryString" |             |
 
-<a id="DeliveryRuleRemoteAddressCondition_Name"></a>DeliveryRuleRemoteAddressCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_Name{#DeliveryRuleRemoteAddressCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressCondition).
 
@@ -3205,8 +3205,8 @@ Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressConditio
 |-----------------|-------------|
 | "RemoteAddress" |             |
 
-<a id="DeliveryRuleRemoteAddressCondition_Name_STATUS"></a>DeliveryRuleRemoteAddressCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRemoteAddressCondition_Name_STATUS{#DeliveryRuleRemoteAddressCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressCondition_STATUS).
 
@@ -3214,8 +3214,8 @@ Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressC
 |-----------------|-------------|
 | "RemoteAddress" |             |
 
-<a id="DeliveryRuleRequestBodyCondition_Name"></a>DeliveryRuleRequestBodyCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_Name{#DeliveryRuleRequestBodyCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 
@@ -3223,8 +3223,8 @@ Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 |---------------|-------------|
 | "RequestBody" |             |
 
-<a id="DeliveryRuleRequestBodyCondition_Name_STATUS"></a>DeliveryRuleRequestBodyCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestBodyCondition_Name_STATUS{#DeliveryRuleRequestBodyCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondition_STATUS).
 
@@ -3232,8 +3232,8 @@ Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondi
 |---------------|-------------|
 | "RequestBody" |             |
 
-<a id="DeliveryRuleRequestHeaderAction_Name"></a>DeliveryRuleRequestHeaderAction_Name
--------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_Name{#DeliveryRuleRequestHeaderAction_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction).
 
@@ -3241,8 +3241,8 @@ Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction).
 |-----------------------|-------------|
 | "ModifyRequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderAction_Name_STATUS"></a>DeliveryRuleRequestHeaderAction_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderAction_Name_STATUS{#DeliveryRuleRequestHeaderAction_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderAction_STATUS).
 
@@ -3250,8 +3250,8 @@ Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderActi
 |-----------------------|-------------|
 | "ModifyRequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderCondition_Name"></a>DeliveryRuleRequestHeaderCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_Name{#DeliveryRuleRequestHeaderCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderCondition).
 
@@ -3259,8 +3259,8 @@ Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderConditio
 |-----------------|-------------|
 | "RequestHeader" |             |
 
-<a id="DeliveryRuleRequestHeaderCondition_Name_STATUS"></a>DeliveryRuleRequestHeaderCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestHeaderCondition_Name_STATUS{#DeliveryRuleRequestHeaderCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderCondition_STATUS).
 
@@ -3268,8 +3268,8 @@ Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderC
 |-----------------|-------------|
 | "RequestHeader" |             |
 
-<a id="DeliveryRuleRequestMethodCondition_Name"></a>DeliveryRuleRequestMethodCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_Name{#DeliveryRuleRequestMethodCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodCondition).
 
@@ -3277,8 +3277,8 @@ Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodConditio
 |-----------------|-------------|
 | "RequestMethod" |             |
 
-<a id="DeliveryRuleRequestMethodCondition_Name_STATUS"></a>DeliveryRuleRequestMethodCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestMethodCondition_Name_STATUS{#DeliveryRuleRequestMethodCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodCondition_STATUS).
 
@@ -3286,8 +3286,8 @@ Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodC
 |-----------------|-------------|
 | "RequestMethod" |             |
 
-<a id="DeliveryRuleRequestSchemeCondition_Name"></a>DeliveryRuleRequestSchemeCondition_Name
--------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_Name{#DeliveryRuleRequestSchemeCondition_Name}
+---------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeCondition).
 
@@ -3295,8 +3295,8 @@ Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeConditio
 |-----------------|-------------|
 | "RequestScheme" |             |
 
-<a id="DeliveryRuleRequestSchemeCondition_Name_STATUS"></a>DeliveryRuleRequestSchemeCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------
+DeliveryRuleRequestSchemeCondition_Name_STATUS{#DeliveryRuleRequestSchemeCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeCondition_STATUS).
 
@@ -3304,8 +3304,8 @@ Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeC
 |-----------------|-------------|
 | "RequestScheme" |             |
 
-<a id="DeliveryRuleRequestUriCondition_Name"></a>DeliveryRuleRequestUriCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_Name{#DeliveryRuleRequestUriCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 
@@ -3313,8 +3313,8 @@ Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 |--------------|-------------|
 | "RequestUri" |             |
 
-<a id="DeliveryRuleRequestUriCondition_Name_STATUS"></a>DeliveryRuleRequestUriCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleRequestUriCondition_Name_STATUS{#DeliveryRuleRequestUriCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriCondition_STATUS).
 
@@ -3322,8 +3322,8 @@ Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriConditi
 |--------------|-------------|
 | "RequestUri" |             |
 
-<a id="DeliveryRuleResponseHeaderAction_Name"></a>DeliveryRuleResponseHeaderAction_Name
----------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_Name{#DeliveryRuleResponseHeaderAction_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleResponseHeaderAction](#DeliveryRuleResponseHeaderAction).
 
@@ -3331,8 +3331,8 @@ Used by: [DeliveryRuleResponseHeaderAction](#DeliveryRuleResponseHeaderAction).
 |------------------------|-------------|
 | "ModifyResponseHeader" |             |
 
-<a id="DeliveryRuleResponseHeaderAction_Name_STATUS"></a>DeliveryRuleResponseHeaderAction_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleResponseHeaderAction_Name_STATUS{#DeliveryRuleResponseHeaderAction_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleResponseHeaderAction_STATUS](#DeliveryRuleResponseHeaderAction_STATUS).
 
@@ -3340,8 +3340,8 @@ Used by: [DeliveryRuleResponseHeaderAction_STATUS](#DeliveryRuleResponseHeaderAc
 |------------------------|-------------|
 | "ModifyResponseHeader" |             |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_Name"></a>DeliveryRuleRouteConfigurationOverrideAction_Name
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_Name{#DeliveryRuleRouteConfigurationOverrideAction_Name}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfigurationOverrideAction).
 
@@ -3349,8 +3349,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfig
 |------------------------------|-------------|
 | "RouteConfigurationOverride" |             |
 
-<a id="DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS"></a>DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS
------------------------------------------------------------------------------------------------------------------------------
+DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS{#DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRouteConfigurationOverrideAction_STATUS).
 
@@ -3358,8 +3358,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRout
 |------------------------------|-------------|
 | "RouteConfigurationOverride" |             |
 
-<a id="DeliveryRuleServerPortCondition_Name"></a>DeliveryRuleServerPortCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_Name{#DeliveryRuleServerPortCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 
@@ -3367,8 +3367,8 @@ Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 |--------------|-------------|
 | "ServerPort" |             |
 
-<a id="DeliveryRuleServerPortCondition_Name_STATUS"></a>DeliveryRuleServerPortCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleServerPortCondition_Name_STATUS{#DeliveryRuleServerPortCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortCondition_STATUS).
 
@@ -3376,8 +3376,8 @@ Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortConditi
 |--------------|-------------|
 | "ServerPort" |             |
 
-<a id="DeliveryRuleSocketAddrCondition_Name"></a>DeliveryRuleSocketAddrCondition_Name
--------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_Name{#DeliveryRuleSocketAddrCondition_Name}
+---------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 
@@ -3385,8 +3385,8 @@ Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 |--------------|-------------|
 | "SocketAddr" |             |
 
-<a id="DeliveryRuleSocketAddrCondition_Name_STATUS"></a>DeliveryRuleSocketAddrCondition_Name_STATUS
----------------------------------------------------------------------------------------------------
+DeliveryRuleSocketAddrCondition_Name_STATUS{#DeliveryRuleSocketAddrCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrCondition_STATUS).
 
@@ -3394,8 +3394,8 @@ Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrConditi
 |--------------|-------------|
 | "SocketAddr" |             |
 
-<a id="DeliveryRuleSslProtocolCondition_Name"></a>DeliveryRuleSslProtocolCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_Name{#DeliveryRuleSslProtocolCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 
@@ -3403,8 +3403,8 @@ Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 |---------------|-------------|
 | "SslProtocol" |             |
 
-<a id="DeliveryRuleSslProtocolCondition_Name_STATUS"></a>DeliveryRuleSslProtocolCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleSslProtocolCondition_Name_STATUS{#DeliveryRuleSslProtocolCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondition_STATUS).
 
@@ -3412,8 +3412,8 @@ Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondi
 |---------------|-------------|
 | "SslProtocol" |             |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_Name"></a>DeliveryRuleUrlFileExtensionCondition_Name
--------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_Name{#DeliveryRuleUrlFileExtensionCondition_Name}
+---------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCondition).
 
@@ -3421,8 +3421,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCo
 |--------------------|-------------|
 | "UrlFileExtension" |             |
 
-<a id="DeliveryRuleUrlFileExtensionCondition_Name_STATUS"></a>DeliveryRuleUrlFileExtensionCondition_Name_STATUS
----------------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileExtensionCondition_Name_STATUS{#DeliveryRuleUrlFileExtensionCondition_Name_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExtensionCondition_STATUS).
 
@@ -3430,8 +3430,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExte
 |--------------------|-------------|
 | "UrlFileExtension" |             |
 
-<a id="DeliveryRuleUrlFileNameCondition_Name"></a>DeliveryRuleUrlFileNameCondition_Name
----------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_Name{#DeliveryRuleUrlFileNameCondition_Name}
+-----------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 
@@ -3439,8 +3439,8 @@ Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 |---------------|-------------|
 | "UrlFileName" |             |
 
-<a id="DeliveryRuleUrlFileNameCondition_Name_STATUS"></a>DeliveryRuleUrlFileNameCondition_Name_STATUS
------------------------------------------------------------------------------------------------------
+DeliveryRuleUrlFileNameCondition_Name_STATUS{#DeliveryRuleUrlFileNameCondition_Name_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondition_STATUS).
 
@@ -3448,8 +3448,8 @@ Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondi
 |---------------|-------------|
 | "UrlFileName" |             |
 
-<a id="DeliveryRuleUrlPathCondition_Name"></a>DeliveryRuleUrlPathCondition_Name
--------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_Name{#DeliveryRuleUrlPathCondition_Name}
+---------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 
@@ -3457,8 +3457,8 @@ Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 |-----------|-------------|
 | "UrlPath" |             |
 
-<a id="DeliveryRuleUrlPathCondition_Name_STATUS"></a>DeliveryRuleUrlPathCondition_Name_STATUS
----------------------------------------------------------------------------------------------
+DeliveryRuleUrlPathCondition_Name_STATUS{#DeliveryRuleUrlPathCondition_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STATUS).
 
@@ -3466,8 +3466,8 @@ Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STA
 |-----------|-------------|
 | "UrlPath" |             |
 
-<a id="HeaderActionParameters"></a>HeaderActionParameters
----------------------------------------------------------
+HeaderActionParameters{#HeaderActionParameters}
+-----------------------------------------------
 
 Defines the parameters for the request header action.
 
@@ -3480,8 +3480,8 @@ Used by: [DeliveryRuleRequestHeaderAction](#DeliveryRuleRequestHeaderAction), an
 | typeName     |                                | [HeaderActionParameters_TypeName](#HeaderActionParameters_TypeName)<br/><small>Required</small>         |
 | value        | Value for the specified action | string<br/><small>Optional</small>                                                                      |
 
-<a id="HeaderActionParameters_STATUS"></a>HeaderActionParameters_STATUS
------------------------------------------------------------------------
+HeaderActionParameters_STATUS{#HeaderActionParameters_STATUS}
+-------------------------------------------------------------
 
 Defines the parameters for the request header action.
 
@@ -3494,8 +3494,8 @@ Used by: [DeliveryRuleRequestHeaderAction_STATUS](#DeliveryRuleRequestHeaderActi
 | typeName     |                                | [HeaderActionParameters_TypeName_STATUS](#HeaderActionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 | value        | Value for the specified action | string<br/><small>Optional</small>                                                                                    |
 
-<a id="HostNameMatchConditionParameters"></a>HostNameMatchConditionParameters
------------------------------------------------------------------------------
+HostNameMatchConditionParameters{#HostNameMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for HostName match conditions
 
@@ -3509,8 +3509,8 @@ Used by: [DeliveryRuleHostNameCondition](#DeliveryRuleHostNameCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [HostNameMatchConditionParameters_TypeName](#HostNameMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="HostNameMatchConditionParameters_STATUS"></a>HostNameMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_STATUS{#HostNameMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for HostName match conditions
 
@@ -3524,8 +3524,8 @@ Used by: [DeliveryRuleHostNameCondition_STATUS](#DeliveryRuleHostNameCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [HostNameMatchConditionParameters_TypeName_STATUS](#HostNameMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpVersionMatchConditionParameters"></a>HttpVersionMatchConditionParameters
------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters{#HttpVersionMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for HttpVersion match conditions
 
@@ -3539,8 +3539,8 @@ Used by: [DeliveryRuleHttpVersionCondition](#DeliveryRuleHttpVersionCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [HttpVersionMatchConditionParameters_TypeName](#HttpVersionMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="HttpVersionMatchConditionParameters_STATUS"></a>HttpVersionMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_STATUS{#HttpVersionMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for HttpVersion match conditions
 
@@ -3554,8 +3554,8 @@ Used by: [DeliveryRuleHttpVersionCondition_STATUS](#DeliveryRuleHttpVersionCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [HttpVersionMatchConditionParameters_TypeName_STATUS](#HttpVersionMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="IsDeviceMatchConditionParameters"></a>IsDeviceMatchConditionParameters
------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters{#IsDeviceMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for IsDevice match conditions
 
@@ -3569,8 +3569,8 @@ Used by: [DeliveryRuleIsDeviceCondition](#DeliveryRuleIsDeviceCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                       |
 | typeName        |                                                        | [IsDeviceMatchConditionParameters_TypeName](#IsDeviceMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="IsDeviceMatchConditionParameters_STATUS"></a>IsDeviceMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_STATUS{#IsDeviceMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for IsDevice match conditions
 
@@ -3584,8 +3584,8 @@ Used by: [DeliveryRuleIsDeviceCondition_STATUS](#DeliveryRuleIsDeviceCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                       |
 | typeName        |                                                        | [IsDeviceMatchConditionParameters_TypeName_STATUS](#IsDeviceMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="ManagedCertificateParameters_Type"></a>ManagedCertificateParameters_Type
--------------------------------------------------------------------------------
+ManagedCertificateParameters_Type{#ManagedCertificateParameters_Type}
+---------------------------------------------------------------------
 
 Used by: [ManagedCertificateParameters](#ManagedCertificateParameters).
 
@@ -3593,8 +3593,8 @@ Used by: [ManagedCertificateParameters](#ManagedCertificateParameters).
 |----------------------|-------------|
 | "ManagedCertificate" |             |
 
-<a id="ManagedCertificateParameters_Type_STATUS"></a>ManagedCertificateParameters_Type_STATUS
----------------------------------------------------------------------------------------------
+ManagedCertificateParameters_Type_STATUS{#ManagedCertificateParameters_Type_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedCertificateParameters_STATUS](#ManagedCertificateParameters_STATUS).
 
@@ -3602,8 +3602,8 @@ Used by: [ManagedCertificateParameters_STATUS](#ManagedCertificateParameters_STA
 |----------------------|-------------|
 | "ManagedCertificate" |             |
 
-<a id="OriginGroupOverrideAction_Name"></a>OriginGroupOverrideAction_Name
--------------------------------------------------------------------------
+OriginGroupOverrideAction_Name{#OriginGroupOverrideAction_Name}
+---------------------------------------------------------------
 
 Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 
@@ -3611,8 +3611,8 @@ Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 |-----------------------|-------------|
 | "OriginGroupOverride" |             |
 
-<a id="OriginGroupOverrideAction_Name_STATUS"></a>OriginGroupOverrideAction_Name_STATUS
----------------------------------------------------------------------------------------
+OriginGroupOverrideAction_Name_STATUS{#OriginGroupOverrideAction_Name_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 
@@ -3620,8 +3620,8 @@ Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 |-----------------------|-------------|
 | "OriginGroupOverride" |             |
 
-<a id="OriginGroupOverrideActionParameters"></a>OriginGroupOverrideActionParameters
------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters{#OriginGroupOverrideActionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for the origin group override action.
 
@@ -3632,8 +3632,8 @@ Used by: [OriginGroupOverrideAction](#OriginGroupOverrideAction).
 | originGroup | defines the OriginGroup that would override the DefaultOriginGroup. | [ResourceReference](#ResourceReference)<br/><small>Required</small>                                                       |
 | typeName    |                                                                     | [OriginGroupOverrideActionParameters_TypeName](#OriginGroupOverrideActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="OriginGroupOverrideActionParameters_STATUS"></a>OriginGroupOverrideActionParameters_STATUS
--------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_STATUS{#OriginGroupOverrideActionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the origin group override action.
 
@@ -3644,8 +3644,8 @@ Used by: [OriginGroupOverrideAction_STATUS](#OriginGroupOverrideAction_STATUS).
 | originGroup | defines the OriginGroup that would override the DefaultOriginGroup. | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                                       |
 | typeName    |                                                                     | [OriginGroupOverrideActionParameters_TypeName_STATUS](#OriginGroupOverrideActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="PostArgsMatchConditionParameters"></a>PostArgsMatchConditionParameters
------------------------------------------------------------------------------
+PostArgsMatchConditionParameters{#PostArgsMatchConditionParameters}
+-------------------------------------------------------------------
 
 Defines the parameters for PostArgs match conditions
 
@@ -3660,8 +3660,8 @@ Used by: [DeliveryRulePostArgsCondition](#DeliveryRulePostArgsCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [PostArgsMatchConditionParameters_TypeName](#PostArgsMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="PostArgsMatchConditionParameters_STATUS"></a>PostArgsMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_STATUS{#PostArgsMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------
 
 Defines the parameters for PostArgs match conditions
 
@@ -3676,8 +3676,8 @@ Used by: [DeliveryRulePostArgsCondition_STATUS](#DeliveryRulePostArgsCondition_S
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                               |
 | typeName        |                                                        | [PostArgsMatchConditionParameters_TypeName_STATUS](#PostArgsMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="QueryStringMatchConditionParameters"></a>QueryStringMatchConditionParameters
------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters{#QueryStringMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for QueryString match conditions
 
@@ -3691,8 +3691,8 @@ Used by: [DeliveryRuleQueryStringCondition](#DeliveryRuleQueryStringCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [QueryStringMatchConditionParameters_TypeName](#QueryStringMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="QueryStringMatchConditionParameters_STATUS"></a>QueryStringMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_STATUS{#QueryStringMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for QueryString match conditions
 
@@ -3706,8 +3706,8 @@ Used by: [DeliveryRuleQueryStringCondition_STATUS](#DeliveryRuleQueryStringCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [QueryStringMatchConditionParameters_TypeName_STATUS](#QueryStringMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RemoteAddressMatchConditionParameters"></a>RemoteAddressMatchConditionParameters
----------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters{#RemoteAddressMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RemoteAddress match conditions
 
@@ -3721,8 +3721,8 @@ Used by: [DeliveryRuleRemoteAddressCondition](#DeliveryRuleRemoteAddressConditio
 | transforms      | List of transforms                                                                                                                                                                                    | [Transform[]](#Transform)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                                                                                                                                                                       | [RemoteAddressMatchConditionParameters_TypeName](#RemoteAddressMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RemoteAddressMatchConditionParameters_STATUS"></a>RemoteAddressMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_STATUS{#RemoteAddressMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RemoteAddress match conditions
 
@@ -3736,8 +3736,8 @@ Used by: [DeliveryRuleRemoteAddressCondition_STATUS](#DeliveryRuleRemoteAddressC
 | transforms      | List of transforms                                                                                                                                                                                    | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                                                                                                                                                                       | [RemoteAddressMatchConditionParameters_TypeName_STATUS](#RemoteAddressMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestBodyMatchConditionParameters"></a>RequestBodyMatchConditionParameters
------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters{#RequestBodyMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for RequestBody match conditions
 
@@ -3751,8 +3751,8 @@ Used by: [DeliveryRuleRequestBodyCondition](#DeliveryRuleRequestBodyCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [RequestBodyMatchConditionParameters_TypeName](#RequestBodyMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestBodyMatchConditionParameters_STATUS"></a>RequestBodyMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_STATUS{#RequestBodyMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for RequestBody match conditions
 
@@ -3766,8 +3766,8 @@ Used by: [DeliveryRuleRequestBodyCondition_STATUS](#DeliveryRuleRequestBodyCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [RequestBodyMatchConditionParameters_TypeName_STATUS](#RequestBodyMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestHeaderMatchConditionParameters"></a>RequestHeaderMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters{#RequestHeaderMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestHeader match conditions
 
@@ -3782,8 +3782,8 @@ Used by: [DeliveryRuleRequestHeaderCondition](#DeliveryRuleRequestHeaderConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                        | [RequestHeaderMatchConditionParameters_TypeName](#RequestHeaderMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestHeaderMatchConditionParameters_STATUS"></a>RequestHeaderMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_STATUS{#RequestHeaderMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestHeader match conditions
 
@@ -3798,8 +3798,8 @@ Used by: [DeliveryRuleRequestHeaderCondition_STATUS](#DeliveryRuleRequestHeaderC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                         |
 | typeName        |                                                        | [RequestHeaderMatchConditionParameters_TypeName_STATUS](#RequestHeaderMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RequestMethodMatchConditionParameters"></a>RequestMethodMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters{#RequestMethodMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestMethod match conditions
 
@@ -3813,8 +3813,8 @@ Used by: [DeliveryRuleRequestMethodCondition](#DeliveryRuleRequestMethodConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestMethodMatchConditionParameters_TypeName](#RequestMethodMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="RequestMethodMatchConditionParameters_STATUS"></a>RequestMethodMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters_STATUS{#RequestMethodMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestMethod match conditions
 
@@ -3828,8 +3828,8 @@ Used by: [DeliveryRuleRequestMethodCondition_STATUS](#DeliveryRuleRequestMethodC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestMethodMatchConditionParameters_TypeName_STATUS](#RequestMethodMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="RequestSchemeMatchConditionParameters"></a>RequestSchemeMatchConditionParameters
----------------------------------------------------------------------------------------
+RequestSchemeMatchConditionParameters{#RequestSchemeMatchConditionParameters}
+-----------------------------------------------------------------------------
 
 Defines the parameters for RequestScheme match conditions
 
@@ -3843,8 +3843,8 @@ Used by: [DeliveryRuleRequestSchemeCondition](#DeliveryRuleRequestSchemeConditio
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestSchemeMatchConditionParameters_TypeName](#RequestSchemeMatchConditionParameters_TypeName)<br/><small>Required</small>         |
 
-<a id="RequestSchemeMatchConditionParameters_STATUS"></a>RequestSchemeMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------
+RequestSchemeMatchConditionParameters_STATUS{#RequestSchemeMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------
 
 Defines the parameters for RequestScheme match conditions
 
@@ -3858,8 +3858,8 @@ Used by: [DeliveryRuleRequestSchemeCondition_STATUS](#DeliveryRuleRequestSchemeC
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                                 |
 | typeName        |                                                        | [RequestSchemeMatchConditionParameters_TypeName_STATUS](#RequestSchemeMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small>         |
 
-<a id="RequestUriMatchConditionParameters"></a>RequestUriMatchConditionParameters
----------------------------------------------------------------------------------
+RequestUriMatchConditionParameters{#RequestUriMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for RequestUri match conditions
 
@@ -3873,8 +3873,8 @@ Used by: [DeliveryRuleRequestUriCondition](#DeliveryRuleRequestUriCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [RequestUriMatchConditionParameters_TypeName](#RequestUriMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RequestUriMatchConditionParameters_STATUS"></a>RequestUriMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+RequestUriMatchConditionParameters_STATUS{#RequestUriMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for RequestUri match conditions
 
@@ -3888,8 +3888,8 @@ Used by: [DeliveryRuleRequestUriCondition_STATUS](#DeliveryRuleRequestUriConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [RequestUriMatchConditionParameters_TypeName_STATUS](#RequestUriMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="RouteConfigurationOverrideActionParameters"></a>RouteConfigurationOverrideActionParameters
--------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters{#RouteConfigurationOverrideActionParameters}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for the route configuration override action.
 
@@ -3901,8 +3901,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction](#DeliveryRuleRouteConfig
 | originGroupOverride | A reference to the origin group override configuration. Leave empty to use the default origin group on route.        | [OriginGroupOverride](#OriginGroupOverride)<br/><small>Optional</small>                                                                 |
 | typeName            |                                                                                                                      | [RouteConfigurationOverrideActionParameters_TypeName](#RouteConfigurationOverrideActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="RouteConfigurationOverrideActionParameters_STATUS"></a>RouteConfigurationOverrideActionParameters_STATUS
----------------------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters_STATUS{#RouteConfigurationOverrideActionParameters_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Defines the parameters for the route configuration override action.
 
@@ -3914,8 +3914,8 @@ Used by: [DeliveryRuleRouteConfigurationOverrideAction_STATUS](#DeliveryRuleRout
 | originGroupOverride | A reference to the origin group override configuration. Leave empty to use the default origin group on route.        | [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS)<br/><small>Optional</small>                                                                 |
 | typeName            |                                                                                                                      | [RouteConfigurationOverrideActionParameters_TypeName_STATUS](#RouteConfigurationOverrideActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="SecurityPolicyWebApplicationFirewallAssociation"></a>SecurityPolicyWebApplicationFirewallAssociation
------------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallAssociation{#SecurityPolicyWebApplicationFirewallAssociation}
+-------------------------------------------------------------------------------------------------
 
 settings for security policy patterns to match
 
@@ -3926,8 +3926,8 @@ Used by: [SecurityPolicyWebApplicationFirewallParameters](#SecurityPolicyWebAppl
 | domains         | List of domains. | [ActivatedResourceReference[]](#ActivatedResourceReference)<br/><small>Optional</small> |
 | patternsToMatch | List of paths    | string[]<br/><small>Optional</small>                                                    |
 
-<a id="SecurityPolicyWebApplicationFirewallAssociation_STATUS"></a>SecurityPolicyWebApplicationFirewallAssociation_STATUS
--------------------------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallAssociation_STATUS{#SecurityPolicyWebApplicationFirewallAssociation_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 settings for security policy patterns to match
 
@@ -3938,8 +3938,8 @@ Used by: [SecurityPolicyWebApplicationFirewallParameters_STATUS](#SecurityPolicy
 | domains         | List of domains. | [ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded[]](#ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded)<br/><small>Optional</small> |
 | patternsToMatch | List of paths    | string[]<br/><small>Optional</small>                                                                                                                                                          |
 
-<a id="SecurityPolicyWebApplicationFirewallParameters_Type"></a>SecurityPolicyWebApplicationFirewallParameters_Type
--------------------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallParameters_Type{#SecurityPolicyWebApplicationFirewallParameters_Type}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicyWebApplicationFirewallParameters](#SecurityPolicyWebApplicationFirewallParameters).
 
@@ -3947,8 +3947,8 @@ Used by: [SecurityPolicyWebApplicationFirewallParameters](#SecurityPolicyWebAppl
 |--------------------------|-------------|
 | "WebApplicationFirewall" |             |
 
-<a id="SecurityPolicyWebApplicationFirewallParameters_Type_STATUS"></a>SecurityPolicyWebApplicationFirewallParameters_Type_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+SecurityPolicyWebApplicationFirewallParameters_Type_STATUS{#SecurityPolicyWebApplicationFirewallParameters_Type_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [SecurityPolicyWebApplicationFirewallParameters_STATUS](#SecurityPolicyWebApplicationFirewallParameters_STATUS).
 
@@ -3956,8 +3956,8 @@ Used by: [SecurityPolicyWebApplicationFirewallParameters_STATUS](#SecurityPolicy
 |--------------------------|-------------|
 | "WebApplicationFirewall" |             |
 
-<a id="ServerPortMatchConditionParameters"></a>ServerPortMatchConditionParameters
----------------------------------------------------------------------------------
+ServerPortMatchConditionParameters{#ServerPortMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for ServerPort match conditions
 
@@ -3971,8 +3971,8 @@ Used by: [DeliveryRuleServerPortCondition](#DeliveryRuleServerPortCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ServerPortMatchConditionParameters_TypeName](#ServerPortMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="ServerPortMatchConditionParameters_STATUS"></a>ServerPortMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_STATUS{#ServerPortMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for ServerPort match conditions
 
@@ -3986,8 +3986,8 @@ Used by: [DeliveryRuleServerPortCondition_STATUS](#DeliveryRuleServerPortConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [ServerPortMatchConditionParameters_TypeName_STATUS](#ServerPortMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="SocketAddrMatchConditionParameters"></a>SocketAddrMatchConditionParameters
----------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters{#SocketAddrMatchConditionParameters}
+-----------------------------------------------------------------------
 
 Defines the parameters for SocketAddress match conditions
 
@@ -4001,8 +4001,8 @@ Used by: [DeliveryRuleSocketAddrCondition](#DeliveryRuleSocketAddrCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [SocketAddrMatchConditionParameters_TypeName](#SocketAddrMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="SocketAddrMatchConditionParameters_STATUS"></a>SocketAddrMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_STATUS{#SocketAddrMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------
 
 Defines the parameters for SocketAddress match conditions
 
@@ -4016,8 +4016,8 @@ Used by: [DeliveryRuleSocketAddrCondition_STATUS](#DeliveryRuleSocketAddrConditi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                   |
 | typeName        |                                                        | [SocketAddrMatchConditionParameters_TypeName_STATUS](#SocketAddrMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="SslProtocolMatchConditionParameters"></a>SslProtocolMatchConditionParameters
------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters{#SslProtocolMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for SslProtocol match conditions
 
@@ -4031,8 +4031,8 @@ Used by: [DeliveryRuleSslProtocolCondition](#DeliveryRuleSslProtocolCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [SslProtocolMatchConditionParameters_TypeName](#SslProtocolMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="SslProtocolMatchConditionParameters_STATUS"></a>SslProtocolMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_STATUS{#SslProtocolMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for SslProtocol match conditions
 
@@ -4046,8 +4046,8 @@ Used by: [DeliveryRuleSslProtocolCondition_STATUS](#DeliveryRuleSslProtocolCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [SslProtocolMatchConditionParameters_TypeName_STATUS](#SslProtocolMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlFileExtensionMatchConditionParameters"></a>UrlFileExtensionMatchConditionParameters
----------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters{#UrlFileExtensionMatchConditionParameters}
+-----------------------------------------------------------------------------------
 
 Defines the parameters for UrlFileExtension match conditions
 
@@ -4061,8 +4061,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition](#DeliveryRuleUrlFileExtensionCo
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                               |
 | typeName        |                                                        | [UrlFileExtensionMatchConditionParameters_TypeName](#UrlFileExtensionMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlFileExtensionMatchConditionParameters_STATUS"></a>UrlFileExtensionMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_STATUS{#UrlFileExtensionMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Defines the parameters for UrlFileExtension match conditions
 
@@ -4076,8 +4076,8 @@ Used by: [DeliveryRuleUrlFileExtensionCondition_STATUS](#DeliveryRuleUrlFileExte
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                               |
 | typeName        |                                                        | [UrlFileExtensionMatchConditionParameters_TypeName_STATUS](#UrlFileExtensionMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlFileNameMatchConditionParameters"></a>UrlFileNameMatchConditionParameters
------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters{#UrlFileNameMatchConditionParameters}
+-------------------------------------------------------------------------
 
 Defines the parameters for UrlFilename match conditions
 
@@ -4091,8 +4091,8 @@ Used by: [DeliveryRuleUrlFileNameCondition](#DeliveryRuleUrlFileNameCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [UrlFileNameMatchConditionParameters_TypeName](#UrlFileNameMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlFileNameMatchConditionParameters_STATUS"></a>UrlFileNameMatchConditionParameters_STATUS
--------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_STATUS{#UrlFileNameMatchConditionParameters_STATUS}
+---------------------------------------------------------------------------------------
 
 Defines the parameters for UrlFilename match conditions
 
@@ -4106,8 +4106,8 @@ Used by: [DeliveryRuleUrlFileNameCondition_STATUS](#DeliveryRuleUrlFileNameCondi
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                                     |
 | typeName        |                                                        | [UrlFileNameMatchConditionParameters_TypeName_STATUS](#UrlFileNameMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlPathMatchConditionParameters"></a>UrlPathMatchConditionParameters
----------------------------------------------------------------------------
+UrlPathMatchConditionParameters{#UrlPathMatchConditionParameters}
+-----------------------------------------------------------------
 
 Defines the parameters for UrlPath match conditions
 
@@ -4121,8 +4121,8 @@ Used by: [DeliveryRuleUrlPathCondition](#DeliveryRuleUrlPathCondition).
 | transforms      | List of transforms                                     | [Transform[]](#Transform)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [UrlPathMatchConditionParameters_TypeName](#UrlPathMatchConditionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlPathMatchConditionParameters_STATUS"></a>UrlPathMatchConditionParameters_STATUS
------------------------------------------------------------------------------------------
+UrlPathMatchConditionParameters_STATUS{#UrlPathMatchConditionParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Defines the parameters for UrlPath match conditions
 
@@ -4136,8 +4136,8 @@ Used by: [DeliveryRuleUrlPathCondition_STATUS](#DeliveryRuleUrlPathCondition_STA
 | transforms      | List of transforms                                     | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                                                             |
 | typeName        |                                                        | [UrlPathMatchConditionParameters_TypeName_STATUS](#UrlPathMatchConditionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlRedirectAction_Name"></a>UrlRedirectAction_Name
----------------------------------------------------------
+UrlRedirectAction_Name{#UrlRedirectAction_Name}
+-----------------------------------------------
 
 Used by: [UrlRedirectAction](#UrlRedirectAction).
 
@@ -4145,8 +4145,8 @@ Used by: [UrlRedirectAction](#UrlRedirectAction).
 |---------------|-------------|
 | "UrlRedirect" |             |
 
-<a id="UrlRedirectAction_Name_STATUS"></a>UrlRedirectAction_Name_STATUS
------------------------------------------------------------------------
+UrlRedirectAction_Name_STATUS{#UrlRedirectAction_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 
@@ -4154,8 +4154,8 @@ Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 |---------------|-------------|
 | "UrlRedirect" |             |
 
-<a id="UrlRedirectActionParameters"></a>UrlRedirectActionParameters
--------------------------------------------------------------------
+UrlRedirectActionParameters{#UrlRedirectActionParameters}
+---------------------------------------------------------
 
 Defines the parameters for the url redirect action.
 
@@ -4171,8 +4171,8 @@ Used by: [UrlRedirectAction](#UrlRedirectAction).
 | redirectType        | The redirect type the rule will use when redirecting traffic.                                                                                                                                                                                                                       | [UrlRedirectActionParameters_RedirectType](#UrlRedirectActionParameters_RedirectType)<br/><small>Required</small>               |
 | typeName            |                                                                                                                                                                                                                                                                                     | [UrlRedirectActionParameters_TypeName](#UrlRedirectActionParameters_TypeName)<br/><small>Required</small>                       |
 
-<a id="UrlRedirectActionParameters_STATUS"></a>UrlRedirectActionParameters_STATUS
----------------------------------------------------------------------------------
+UrlRedirectActionParameters_STATUS{#UrlRedirectActionParameters_STATUS}
+-----------------------------------------------------------------------
 
 Defines the parameters for the url redirect action.
 
@@ -4188,8 +4188,8 @@ Used by: [UrlRedirectAction_STATUS](#UrlRedirectAction_STATUS).
 | redirectType        | The redirect type the rule will use when redirecting traffic.                                                                                                                                                                                                                       | [UrlRedirectActionParameters_RedirectType_STATUS](#UrlRedirectActionParameters_RedirectType_STATUS)<br/><small>Optional</small>               |
 | typeName            |                                                                                                                                                                                                                                                                                     | [UrlRedirectActionParameters_TypeName_STATUS](#UrlRedirectActionParameters_TypeName_STATUS)<br/><small>Optional</small>                       |
 
-<a id="UrlRewriteAction_Name"></a>UrlRewriteAction_Name
--------------------------------------------------------
+UrlRewriteAction_Name{#UrlRewriteAction_Name}
+---------------------------------------------
 
 Used by: [UrlRewriteAction](#UrlRewriteAction).
 
@@ -4197,8 +4197,8 @@ Used by: [UrlRewriteAction](#UrlRewriteAction).
 |--------------|-------------|
 | "UrlRewrite" |             |
 
-<a id="UrlRewriteAction_Name_STATUS"></a>UrlRewriteAction_Name_STATUS
----------------------------------------------------------------------
+UrlRewriteAction_Name_STATUS{#UrlRewriteAction_Name_STATUS}
+-----------------------------------------------------------
 
 Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 
@@ -4206,8 +4206,8 @@ Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 |--------------|-------------|
 | "UrlRewrite" |             |
 
-<a id="UrlRewriteActionParameters"></a>UrlRewriteActionParameters
------------------------------------------------------------------
+UrlRewriteActionParameters{#UrlRewriteActionParameters}
+-------------------------------------------------------
 
 Defines the parameters for the url rewrite action.
 
@@ -4220,8 +4220,8 @@ Used by: [UrlRewriteAction](#UrlRewriteAction).
 | sourcePattern         | define a request URI pattern that identifies the type of requests that may be rewritten. If value is blank, all strings are matched. | string<br/><small>Required</small>                                                                      |
 | typeName              |                                                                                                                                      | [UrlRewriteActionParameters_TypeName](#UrlRewriteActionParameters_TypeName)<br/><small>Required</small> |
 
-<a id="UrlRewriteActionParameters_STATUS"></a>UrlRewriteActionParameters_STATUS
--------------------------------------------------------------------------------
+UrlRewriteActionParameters_STATUS{#UrlRewriteActionParameters_STATUS}
+---------------------------------------------------------------------
 
 Defines the parameters for the url rewrite action.
 
@@ -4234,8 +4234,8 @@ Used by: [UrlRewriteAction_STATUS](#UrlRewriteAction_STATUS).
 | sourcePattern         | define a request URI pattern that identifies the type of requests that may be rewritten. If value is blank, all strings are matched. | string<br/><small>Optional</small>                                                                                    |
 | typeName              |                                                                                                                                      | [UrlRewriteActionParameters_TypeName_STATUS](#UrlRewriteActionParameters_TypeName_STATUS)<br/><small>Optional</small> |
 
-<a id="UrlSigningAction_Name"></a>UrlSigningAction_Name
--------------------------------------------------------
+UrlSigningAction_Name{#UrlSigningAction_Name}
+---------------------------------------------
 
 Used by: [UrlSigningAction](#UrlSigningAction).
 
@@ -4243,8 +4243,8 @@ Used by: [UrlSigningAction](#UrlSigningAction).
 |--------------|-------------|
 | "UrlSigning" |             |
 
-<a id="UrlSigningAction_Name_STATUS"></a>UrlSigningAction_Name_STATUS
----------------------------------------------------------------------
+UrlSigningAction_Name_STATUS{#UrlSigningAction_Name_STATUS}
+-----------------------------------------------------------
 
 Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 
@@ -4252,8 +4252,8 @@ Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 |--------------|-------------|
 | "UrlSigning" |             |
 
-<a id="UrlSigningActionParameters"></a>UrlSigningActionParameters
------------------------------------------------------------------
+UrlSigningActionParameters{#UrlSigningActionParameters}
+-------------------------------------------------------
 
 Defines the parameters for the Url Signing action.
 
@@ -4265,8 +4265,8 @@ Used by: [UrlSigningAction](#UrlSigningAction).
 | parameterNameOverride | Defines which query string parameters in the url to be considered for expires, key id etc. | [UrlSigningParamIdentifier[]](#UrlSigningParamIdentifier)<br/><small>Optional</small>                     |
 | typeName              |                                                                                            | [UrlSigningActionParameters_TypeName](#UrlSigningActionParameters_TypeName)<br/><small>Required</small>   |
 
-<a id="UrlSigningActionParameters_STATUS"></a>UrlSigningActionParameters_STATUS
--------------------------------------------------------------------------------
+UrlSigningActionParameters_STATUS{#UrlSigningActionParameters_STATUS}
+---------------------------------------------------------------------
 
 Defines the parameters for the Url Signing action.
 
@@ -4278,8 +4278,8 @@ Used by: [UrlSigningAction_STATUS](#UrlSigningAction_STATUS).
 | parameterNameOverride | Defines which query string parameters in the url to be considered for expires, key id etc. | [UrlSigningParamIdentifier_STATUS[]](#UrlSigningParamIdentifier_STATUS)<br/><small>Optional</small>                     |
 | typeName              |                                                                                            | [UrlSigningActionParameters_TypeName_STATUS](#UrlSigningActionParameters_TypeName_STATUS)<br/><small>Optional</small>   |
 
-<a id="UrlSigningKeyParameters_Type"></a>UrlSigningKeyParameters_Type
----------------------------------------------------------------------
+UrlSigningKeyParameters_Type{#UrlSigningKeyParameters_Type}
+-----------------------------------------------------------
 
 Used by: [UrlSigningKeyParameters](#UrlSigningKeyParameters).
 
@@ -4287,8 +4287,8 @@ Used by: [UrlSigningKeyParameters](#UrlSigningKeyParameters).
 |-----------------|-------------|
 | "UrlSigningKey" |             |
 
-<a id="UrlSigningKeyParameters_Type_STATUS"></a>UrlSigningKeyParameters_Type_STATUS
------------------------------------------------------------------------------------
+UrlSigningKeyParameters_Type_STATUS{#UrlSigningKeyParameters_Type_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [UrlSigningKeyParameters_STATUS](#UrlSigningKeyParameters_STATUS).
 
@@ -4296,8 +4296,8 @@ Used by: [UrlSigningKeyParameters_STATUS](#UrlSigningKeyParameters_STATUS).
 |-----------------|-------------|
 | "UrlSigningKey" |             |
 
-<a id="ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded"></a>ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded{#ActivatedResourceReference_STATUS_Profiles_SecurityPolicy_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Reference to another resource along with its state.
 
@@ -4307,8 +4307,8 @@ Used by: [SecurityPolicyWebApplicationFirewallAssociation_STATUS](#SecurityPolic
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="CacheConfiguration"></a>CacheConfiguration
--------------------------------------------------
+CacheConfiguration{#CacheConfiguration}
+---------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -4322,8 +4322,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                          |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings.                                                       | [CacheConfiguration_QueryStringCachingBehavior](#CacheConfiguration_QueryStringCachingBehavior)<br/><small>Optional</small> |
 
-<a id="CacheConfiguration_STATUS"></a>CacheConfiguration_STATUS
----------------------------------------------------------------
+CacheConfiguration_STATUS{#CacheConfiguration_STATUS}
+-----------------------------------------------------
 
 Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
 
@@ -4337,8 +4337,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 | queryParameters            | query parameters to include or exclude (comma separated).                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                        |
 | queryStringCachingBehavior | Defines how Frontdoor caches requests that include query strings. You can ignore any query strings when caching, ignore specific query strings, cache every request with a unique URL, or cache specific query strings.                                                       | [CacheConfiguration_QueryStringCachingBehavior_STATUS](#CacheConfiguration_QueryStringCachingBehavior_STATUS)<br/><small>Optional</small> |
 
-<a id="CacheExpirationActionParameters_CacheBehavior"></a>CacheExpirationActionParameters_CacheBehavior
--------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheBehavior{#CacheExpirationActionParameters_CacheBehavior}
+---------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
@@ -4348,8 +4348,8 @@ Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 | "Override"     |             |
 | "SetIfMissing" |             |
 
-<a id="CacheExpirationActionParameters_CacheBehavior_STATUS"></a>CacheExpirationActionParameters_CacheBehavior_STATUS
----------------------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheBehavior_STATUS{#CacheExpirationActionParameters_CacheBehavior_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
 
@@ -4359,8 +4359,8 @@ Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParamete
 | "Override"     |             |
 | "SetIfMissing" |             |
 
-<a id="CacheExpirationActionParameters_CacheType"></a>CacheExpirationActionParameters_CacheType
------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheType{#CacheExpirationActionParameters_CacheType}
+-------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
@@ -4368,8 +4368,8 @@ Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 |-------|-------------|
 | "All" |             |
 
-<a id="CacheExpirationActionParameters_CacheType_STATUS"></a>CacheExpirationActionParameters_CacheType_STATUS
--------------------------------------------------------------------------------------------------------------
+CacheExpirationActionParameters_CacheType_STATUS{#CacheExpirationActionParameters_CacheType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
 
@@ -4377,188 +4377,188 @@ Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParamete
 |-------|-------------|
 | "All" |             |
 
-<a id="CacheExpirationActionParameters_TypeName"></a>CacheExpirationActionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleCacheExpirationActionParameters" |             |
-
-<a id="CacheExpirationActionParameters_TypeName_STATUS"></a>CacheExpirationActionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleCacheExpirationActionParameters" |             |
-
-<a id="CacheKeyQueryStringActionParameters_QueryStringBehavior"></a>CacheKeyQueryStringActionParameters_QueryStringBehavior
----------------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
-
-| Value        | Description |
-|--------------|-------------|
-| "Exclude"    |             |
-| "ExcludeAll" |             |
-| "Include"    |             |
-| "IncludeAll" |             |
-
-<a id="CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS"></a>CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Exclude"    |             |
-| "ExcludeAll" |             |
-| "Include"    |             |
-| "IncludeAll" |             |
-
-<a id="CacheKeyQueryStringActionParameters_TypeName"></a>CacheKeyQueryStringActionParameters_TypeName
------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
-
-| Value                                                     | Description |
-|-----------------------------------------------------------|-------------|
-| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
-
-<a id="CacheKeyQueryStringActionParameters_TypeName_STATUS"></a>CacheKeyQueryStringActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
-
-| Value                                                     | Description |
-|-----------------------------------------------------------|-------------|
-| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
-
-<a id="ClientPortMatchConditionParameters_Operator"></a>ClientPortMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="ClientPortMatchConditionParameters_Operator_STATUS"></a>ClientPortMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="ClientPortMatchConditionParameters_TypeName"></a>ClientPortMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleClientPortConditionParameters" |             |
-
-<a id="ClientPortMatchConditionParameters_TypeName_STATUS"></a>ClientPortMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleClientPortConditionParameters" |             |
-
-<a id="CookiesMatchConditionParameters_Operator"></a>CookiesMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="CookiesMatchConditionParameters_Operator_STATUS"></a>CookiesMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="CookiesMatchConditionParameters_TypeName"></a>CookiesMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
-
-| Value                                    | Description |
-|------------------------------------------|-------------|
-| "DeliveryRuleCookiesConditionParameters" |             |
-
-<a id="CookiesMatchConditionParameters_TypeName_STATUS"></a>CookiesMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
-
-| Value                                    | Description |
-|------------------------------------------|-------------|
-| "DeliveryRuleCookiesConditionParameters" |             |
-
-<a id="HeaderActionParameters_HeaderAction"></a>HeaderActionParameters_HeaderAction
+CacheExpirationActionParameters_TypeName{#CacheExpirationActionParameters_TypeName}
 -----------------------------------------------------------------------------------
 
-Used by: [HeaderActionParameters](#HeaderActionParameters).
+Used by: [CacheExpirationActionParameters](#CacheExpirationActionParameters).
 
-| Value       | Description |
-|-------------|-------------|
-| "Append"    |             |
-| "Delete"    |             |
-| "Overwrite" |             |
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleCacheExpirationActionParameters" |             |
 
-<a id="HeaderActionParameters_HeaderAction_STATUS"></a>HeaderActionParameters_HeaderAction_STATUS
+CacheExpirationActionParameters_TypeName_STATUS{#CacheExpirationActionParameters_TypeName_STATUS}
 -------------------------------------------------------------------------------------------------
 
+Used by: [CacheExpirationActionParameters_STATUS](#CacheExpirationActionParameters_STATUS).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleCacheExpirationActionParameters" |             |
+
+CacheKeyQueryStringActionParameters_QueryStringBehavior{#CacheKeyQueryStringActionParameters_QueryStringBehavior}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
+
+| Value        | Description |
+|--------------|-------------|
+| "Exclude"    |             |
+| "ExcludeAll" |             |
+| "Include"    |             |
+| "IncludeAll" |             |
+
+CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS{#CacheKeyQueryStringActionParameters_QueryStringBehavior_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Exclude"    |             |
+| "ExcludeAll" |             |
+| "Include"    |             |
+| "IncludeAll" |             |
+
+CacheKeyQueryStringActionParameters_TypeName{#CacheKeyQueryStringActionParameters_TypeName}
+-------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters](#CacheKeyQueryStringActionParameters).
+
+| Value                                                     | Description |
+|-----------------------------------------------------------|-------------|
+| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
+
+CacheKeyQueryStringActionParameters_TypeName_STATUS{#CacheKeyQueryStringActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [CacheKeyQueryStringActionParameters_STATUS](#CacheKeyQueryStringActionParameters_STATUS).
+
+| Value                                                     | Description |
+|-----------------------------------------------------------|-------------|
+| "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters" |             |
+
+ClientPortMatchConditionParameters_Operator{#ClientPortMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+ClientPortMatchConditionParameters_Operator_STATUS{#ClientPortMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+ClientPortMatchConditionParameters_TypeName{#ClientPortMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameters).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleClientPortConditionParameters" |             |
+
+ClientPortMatchConditionParameters_TypeName_STATUS{#ClientPortMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionParameters_STATUS).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleClientPortConditionParameters" |             |
+
+CookiesMatchConditionParameters_Operator{#CookiesMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+CookiesMatchConditionParameters_Operator_STATUS{#CookiesMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+CookiesMatchConditionParameters_TypeName{#CookiesMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters](#CookiesMatchConditionParameters).
+
+| Value                                    | Description |
+|------------------------------------------|-------------|
+| "DeliveryRuleCookiesConditionParameters" |             |
+
+CookiesMatchConditionParameters_TypeName_STATUS{#CookiesMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [CookiesMatchConditionParameters_STATUS](#CookiesMatchConditionParameters_STATUS).
+
+| Value                                    | Description |
+|------------------------------------------|-------------|
+| "DeliveryRuleCookiesConditionParameters" |             |
+
+HeaderActionParameters_HeaderAction{#HeaderActionParameters_HeaderAction}
+-------------------------------------------------------------------------
+
+Used by: [HeaderActionParameters](#HeaderActionParameters).
+
+| Value       | Description |
+|-------------|-------------|
+| "Append"    |             |
+| "Delete"    |             |
+| "Overwrite" |             |
+
+HeaderActionParameters_HeaderAction_STATUS{#HeaderActionParameters_HeaderAction_STATUS}
+---------------------------------------------------------------------------------------
+
 Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 
 | Value       | Description |
@@ -4567,8 +4567,8 @@ Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 | "Delete"    |             |
 | "Overwrite" |             |
 
-<a id="HeaderActionParameters_TypeName"></a>HeaderActionParameters_TypeName
----------------------------------------------------------------------------
+HeaderActionParameters_TypeName{#HeaderActionParameters_TypeName}
+-----------------------------------------------------------------
 
 Used by: [HeaderActionParameters](#HeaderActionParameters).
 
@@ -4576,8 +4576,8 @@ Used by: [HeaderActionParameters](#HeaderActionParameters).
 |--------------------------------------|-------------|
 | "DeliveryRuleHeaderActionParameters" |             |
 
-<a id="HeaderActionParameters_TypeName_STATUS"></a>HeaderActionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------
+HeaderActionParameters_TypeName_STATUS{#HeaderActionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 
@@ -4585,8 +4585,8 @@ Used by: [HeaderActionParameters_STATUS](#HeaderActionParameters_STATUS).
 |--------------------------------------|-------------|
 | "DeliveryRuleHeaderActionParameters" |             |
 
-<a id="HostNameMatchConditionParameters_Operator"></a>HostNameMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_Operator{#HostNameMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 
@@ -4603,8 +4603,8 @@ Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="HostNameMatchConditionParameters_Operator_STATUS"></a>HostNameMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_Operator_STATUS{#HostNameMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS).
 
@@ -4621,8 +4621,8 @@ Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParame
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="HostNameMatchConditionParameters_TypeName"></a>HostNameMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_TypeName{#HostNameMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 
@@ -4630,8 +4630,8 @@ Used by: [HostNameMatchConditionParameters](#HostNameMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRuleHostNameConditionParameters" |             |
 
-<a id="HostNameMatchConditionParameters_TypeName_STATUS"></a>HostNameMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+HostNameMatchConditionParameters_TypeName_STATUS{#HostNameMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParameters_STATUS).
 
@@ -4639,8 +4639,8 @@ Used by: [HostNameMatchConditionParameters_STATUS](#HostNameMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRuleHostNameConditionParameters" |             |
 
-<a id="HttpVersionMatchConditionParameters_Operator"></a>HttpVersionMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_Operator{#HttpVersionMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters).
 
@@ -4648,8 +4648,8 @@ Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParamet
 |---------|-------------|
 | "Equal" |             |
 
-<a id="HttpVersionMatchConditionParameters_Operator_STATUS"></a>HttpVersionMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_Operator_STATUS{#HttpVersionMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS).
 
@@ -4657,8 +4657,8 @@ Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchCondition
 |---------|-------------|
 | "Equal" |             |
 
-<a id="HttpVersionMatchConditionParameters_TypeName"></a>HttpVersionMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_TypeName{#HttpVersionMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParameters).
 
@@ -4666,8 +4666,8 @@ Used by: [HttpVersionMatchConditionParameters](#HttpVersionMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleHttpVersionConditionParameters" |             |
 
-<a id="HttpVersionMatchConditionParameters_TypeName_STATUS"></a>HttpVersionMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+HttpVersionMatchConditionParameters_TypeName_STATUS{#HttpVersionMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchConditionParameters_STATUS).
 
@@ -4675,8 +4675,8 @@ Used by: [HttpVersionMatchConditionParameters_STATUS](#HttpVersionMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleHttpVersionConditionParameters" |             |
 
-<a id="IsDeviceMatchConditionParameters_MatchValues"></a>IsDeviceMatchConditionParameters_MatchValues
------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_MatchValues{#IsDeviceMatchConditionParameters_MatchValues}
+-------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -4685,8 +4685,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 | "Desktop" |             |
 | "Mobile"  |             |
 
-<a id="IsDeviceMatchConditionParameters_MatchValues_STATUS"></a>IsDeviceMatchConditionParameters_MatchValues_STATUS
--------------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_MatchValues_STATUS{#IsDeviceMatchConditionParameters_MatchValues_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -4695,8 +4695,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 | "Desktop" |             |
 | "Mobile"  |             |
 
-<a id="IsDeviceMatchConditionParameters_Operator"></a>IsDeviceMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_Operator{#IsDeviceMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -4704,8 +4704,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 |---------|-------------|
 | "Equal" |             |
 
-<a id="IsDeviceMatchConditionParameters_Operator_STATUS"></a>IsDeviceMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_Operator_STATUS{#IsDeviceMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -4713,8 +4713,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 |---------|-------------|
 | "Equal" |             |
 
-<a id="IsDeviceMatchConditionParameters_TypeName"></a>IsDeviceMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_TypeName{#IsDeviceMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 
@@ -4722,8 +4722,8 @@ Used by: [IsDeviceMatchConditionParameters](#IsDeviceMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRuleIsDeviceConditionParameters" |             |
 
-<a id="IsDeviceMatchConditionParameters_TypeName_STATUS"></a>IsDeviceMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+IsDeviceMatchConditionParameters_TypeName_STATUS{#IsDeviceMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParameters_STATUS).
 
@@ -4731,8 +4731,8 @@ Used by: [IsDeviceMatchConditionParameters_STATUS](#IsDeviceMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRuleIsDeviceConditionParameters" |             |
 
-<a id="OriginGroupOverride"></a>OriginGroupOverride
----------------------------------------------------
+OriginGroupOverride{#OriginGroupOverride}
+-----------------------------------------
 
 Defines the parameters for the origin group override configuration.
 
@@ -4743,8 +4743,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 | forwardingProtocol | Protocol this rule will use when forwarding traffic to backends.             | [OriginGroupOverride_ForwardingProtocol](#OriginGroupOverride_ForwardingProtocol)<br/><small>Optional</small> |
 | originGroup        | defines the OriginGroup that would override the DefaultOriginGroup on route. | [ResourceReference](#ResourceReference)<br/><small>Optional</small>                                           |
 
-<a id="OriginGroupOverride_STATUS"></a>OriginGroupOverride_STATUS
------------------------------------------------------------------
+OriginGroupOverride_STATUS{#OriginGroupOverride_STATUS}
+-------------------------------------------------------
 
 Defines the parameters for the origin group override configuration.
 
@@ -4755,8 +4755,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 | forwardingProtocol | Protocol this rule will use when forwarding traffic to backends.             | [OriginGroupOverride_ForwardingProtocol_STATUS](#OriginGroupOverride_ForwardingProtocol_STATUS)<br/><small>Optional</small> |
 | originGroup        | defines the OriginGroup that would override the DefaultOriginGroup on route. | [ResourceReference_STATUS](#ResourceReference_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="OriginGroupOverrideActionParameters_TypeName"></a>OriginGroupOverrideActionParameters_TypeName
------------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_TypeName{#OriginGroupOverrideActionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParameters).
 
@@ -4764,8 +4764,8 @@ Used by: [OriginGroupOverrideActionParameters](#OriginGroupOverrideActionParamet
 |---------------------------------------------------|-------------|
 | "DeliveryRuleOriginGroupOverrideActionParameters" |             |
 
-<a id="OriginGroupOverrideActionParameters_TypeName_STATUS"></a>OriginGroupOverrideActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+OriginGroupOverrideActionParameters_TypeName_STATUS{#OriginGroupOverrideActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideActionParameters_STATUS).
 
@@ -4773,8 +4773,8 @@ Used by: [OriginGroupOverrideActionParameters_STATUS](#OriginGroupOverrideAction
 |---------------------------------------------------|-------------|
 | "DeliveryRuleOriginGroupOverrideActionParameters" |             |
 
-<a id="PostArgsMatchConditionParameters_Operator"></a>PostArgsMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_Operator{#PostArgsMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 
@@ -4791,8 +4791,8 @@ Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="PostArgsMatchConditionParameters_Operator_STATUS"></a>PostArgsMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_Operator_STATUS{#PostArgsMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS).
 
@@ -4809,8 +4809,8 @@ Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParame
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="PostArgsMatchConditionParameters_TypeName"></a>PostArgsMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_TypeName{#PostArgsMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 
@@ -4818,8 +4818,8 @@ Used by: [PostArgsMatchConditionParameters](#PostArgsMatchConditionParameters).
 |-------------------------------------------|-------------|
 | "DeliveryRulePostArgsConditionParameters" |             |
 
-<a id="PostArgsMatchConditionParameters_TypeName_STATUS"></a>PostArgsMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------
+PostArgsMatchConditionParameters_TypeName_STATUS{#PostArgsMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParameters_STATUS).
 
@@ -4827,8 +4827,8 @@ Used by: [PostArgsMatchConditionParameters_STATUS](#PostArgsMatchConditionParame
 |-------------------------------------------|-------------|
 | "DeliveryRulePostArgsConditionParameters" |             |
 
-<a id="QueryStringMatchConditionParameters_Operator"></a>QueryStringMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_Operator{#QueryStringMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters).
 
@@ -4845,8 +4845,8 @@ Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="QueryStringMatchConditionParameters_Operator_STATUS"></a>QueryStringMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_Operator_STATUS{#QueryStringMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS).
 
@@ -4863,8 +4863,8 @@ Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="QueryStringMatchConditionParameters_TypeName"></a>QueryStringMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_TypeName{#QueryStringMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParameters).
 
@@ -4872,8 +4872,8 @@ Used by: [QueryStringMatchConditionParameters](#QueryStringMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleQueryStringConditionParameters" |             |
 
-<a id="QueryStringMatchConditionParameters_TypeName_STATUS"></a>QueryStringMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+QueryStringMatchConditionParameters_TypeName_STATUS{#QueryStringMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchConditionParameters_STATUS).
 
@@ -4881,8 +4881,8 @@ Used by: [QueryStringMatchConditionParameters_STATUS](#QueryStringMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleQueryStringConditionParameters" |             |
 
-<a id="RemoteAddressMatchConditionParameters_Operator"></a>RemoteAddressMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_Operator{#RemoteAddressMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters).
 
@@ -4892,8 +4892,8 @@ Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionPar
 | "GeoMatch" |             |
 | "IPMatch"  |             |
 
-<a id="RemoteAddressMatchConditionParameters_Operator_STATUS"></a>RemoteAddressMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_Operator_STATUS{#RemoteAddressMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS).
 
@@ -4903,8 +4903,8 @@ Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchCondi
 | "GeoMatch" |             |
 | "IPMatch"  |             |
 
-<a id="RemoteAddressMatchConditionParameters_TypeName"></a>RemoteAddressMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_TypeName{#RemoteAddressMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionParameters).
 
@@ -4912,8 +4912,8 @@ Used by: [RemoteAddressMatchConditionParameters](#RemoteAddressMatchConditionPar
 |------------------------------------------------|-------------|
 | "DeliveryRuleRemoteAddressConditionParameters" |             |
 
-<a id="RemoteAddressMatchConditionParameters_TypeName_STATUS"></a>RemoteAddressMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
+RemoteAddressMatchConditionParameters_TypeName_STATUS{#RemoteAddressMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchConditionParameters_STATUS).
 
@@ -4921,8 +4921,8 @@ Used by: [RemoteAddressMatchConditionParameters_STATUS](#RemoteAddressMatchCondi
 |------------------------------------------------|-------------|
 | "DeliveryRuleRemoteAddressConditionParameters" |             |
 
-<a id="RequestBodyMatchConditionParameters_Operator"></a>RequestBodyMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_Operator{#RequestBodyMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters).
 
@@ -4939,8 +4939,8 @@ Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestBodyMatchConditionParameters_Operator_STATUS"></a>RequestBodyMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_Operator_STATUS{#RequestBodyMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS).
 
@@ -4957,8 +4957,8 @@ Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestBodyMatchConditionParameters_TypeName"></a>RequestBodyMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_TypeName{#RequestBodyMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParameters).
 
@@ -4966,8 +4966,8 @@ Used by: [RequestBodyMatchConditionParameters](#RequestBodyMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleRequestBodyConditionParameters" |             |
 
-<a id="RequestBodyMatchConditionParameters_TypeName_STATUS"></a>RequestBodyMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+RequestBodyMatchConditionParameters_TypeName_STATUS{#RequestBodyMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchConditionParameters_STATUS).
 
@@ -4975,8 +4975,8 @@ Used by: [RequestBodyMatchConditionParameters_STATUS](#RequestBodyMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleRequestBodyConditionParameters" |             |
 
-<a id="RequestHeaderMatchConditionParameters_Operator"></a>RequestHeaderMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_Operator{#RequestHeaderMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters).
 
@@ -4993,8 +4993,8 @@ Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionPar
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestHeaderMatchConditionParameters_Operator_STATUS"></a>RequestHeaderMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_Operator_STATUS{#RequestHeaderMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS).
 
@@ -5011,8 +5011,8 @@ Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchCondi
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="RequestHeaderMatchConditionParameters_TypeName"></a>RequestHeaderMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_TypeName{#RequestHeaderMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionParameters).
 
@@ -5020,8 +5020,8 @@ Used by: [RequestHeaderMatchConditionParameters](#RequestHeaderMatchConditionPar
 |------------------------------------------------|-------------|
 | "DeliveryRuleRequestHeaderConditionParameters" |             |
 
-<a id="RequestHeaderMatchConditionParameters_TypeName_STATUS"></a>RequestHeaderMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
+RequestHeaderMatchConditionParameters_TypeName_STATUS{#RequestHeaderMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchConditionParameters_STATUS).
 
@@ -5029,8 +5029,8 @@ Used by: [RequestHeaderMatchConditionParameters_STATUS](#RequestHeaderMatchCondi
 |------------------------------------------------|-------------|
 | "DeliveryRuleRequestHeaderConditionParameters" |             |
 
-<a id="RequestMethodMatchConditionParameters_MatchValues"></a>RequestMethodMatchConditionParameters_MatchValues
----------------------------------------------------------------------------------------------------------------
+RequestMethodMatchConditionParameters_MatchValues{#RequestMethodMatchConditionParameters_MatchValues}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
 
@@ -5044,169 +5044,169 @@ Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionPar
 | "PUT"     |             |
 | "TRACE"   |             |
 
-<a id="RequestMethodMatchConditionParameters_MatchValues_STATUS"></a>RequestMethodMatchConditionParameters_MatchValues_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "DELETE"  |             |
-| "GET"     |             |
-| "HEAD"    |             |
-| "OPTIONS" |             |
-| "POST"    |             |
-| "PUT"     |             |
-| "TRACE"   |             |
-
-<a id="RequestMethodMatchConditionParameters_Operator"></a>RequestMethodMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestMethodMatchConditionParameters_Operator_STATUS"></a>RequestMethodMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestMethodMatchConditionParameters_TypeName"></a>RequestMethodMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestMethodConditionParameters" |             |
-
-<a id="RequestMethodMatchConditionParameters_TypeName_STATUS"></a>RequestMethodMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestMethodConditionParameters" |             |
-
-<a id="RequestSchemeMatchConditionParameters_MatchValues"></a>RequestSchemeMatchConditionParameters_MatchValues
----------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "HTTP"  |             |
-| "HTTPS" |             |
-
-<a id="RequestSchemeMatchConditionParameters_MatchValues_STATUS"></a>RequestSchemeMatchConditionParameters_MatchValues_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "HTTP"  |             |
-| "HTTPS" |             |
-
-<a id="RequestSchemeMatchConditionParameters_Operator"></a>RequestSchemeMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestSchemeMatchConditionParameters_Operator_STATUS"></a>RequestSchemeMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "Equal" |             |
-
-<a id="RequestSchemeMatchConditionParameters_TypeName"></a>RequestSchemeMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestSchemeConditionParameters" |             |
-
-<a id="RequestSchemeMatchConditionParameters_TypeName_STATUS"></a>RequestSchemeMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
-
-| Value                                          | Description |
-|------------------------------------------------|-------------|
-| "DeliveryRuleRequestSchemeConditionParameters" |             |
-
-<a id="RequestUriMatchConditionParameters_Operator"></a>RequestUriMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="RequestUriMatchConditionParameters_Operator_STATUS"></a>RequestUriMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-
-<a id="RequestUriMatchConditionParameters_TypeName"></a>RequestUriMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleRequestUriConditionParameters" |             |
-
-<a id="RequestUriMatchConditionParameters_TypeName_STATUS"></a>RequestUriMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "DeliveryRuleRequestUriConditionParameters" |             |
-
-<a id="RouteConfigurationOverrideActionParameters_TypeName"></a>RouteConfigurationOverrideActionParameters_TypeName
+RequestMethodMatchConditionParameters_MatchValues_STATUS{#RequestMethodMatchConditionParameters_MatchValues_STATUS}
 -------------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "DELETE"  |             |
+| "GET"     |             |
+| "HEAD"    |             |
+| "OPTIONS" |             |
+| "POST"    |             |
+| "PUT"     |             |
+| "TRACE"   |             |
+
+RequestMethodMatchConditionParameters_Operator{#RequestMethodMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestMethodMatchConditionParameters_Operator_STATUS{#RequestMethodMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestMethodMatchConditionParameters_TypeName{#RequestMethodMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters](#RequestMethodMatchConditionParameters).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestMethodConditionParameters" |             |
+
+RequestMethodMatchConditionParameters_TypeName_STATUS{#RequestMethodMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestMethodMatchConditionParameters_STATUS](#RequestMethodMatchConditionParameters_STATUS).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestMethodConditionParameters" |             |
+
+RequestSchemeMatchConditionParameters_MatchValues{#RequestSchemeMatchConditionParameters_MatchValues}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "HTTP"  |             |
+| "HTTPS" |             |
+
+RequestSchemeMatchConditionParameters_MatchValues_STATUS{#RequestSchemeMatchConditionParameters_MatchValues_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "HTTP"  |             |
+| "HTTPS" |             |
+
+RequestSchemeMatchConditionParameters_Operator{#RequestSchemeMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestSchemeMatchConditionParameters_Operator_STATUS{#RequestSchemeMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "Equal" |             |
+
+RequestSchemeMatchConditionParameters_TypeName{#RequestSchemeMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters](#RequestSchemeMatchConditionParameters).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestSchemeConditionParameters" |             |
+
+RequestSchemeMatchConditionParameters_TypeName_STATUS{#RequestSchemeMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [RequestSchemeMatchConditionParameters_STATUS](#RequestSchemeMatchConditionParameters_STATUS).
+
+| Value                                          | Description |
+|------------------------------------------------|-------------|
+| "DeliveryRuleRequestSchemeConditionParameters" |             |
+
+RequestUriMatchConditionParameters_Operator{#RequestUriMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+RequestUriMatchConditionParameters_Operator_STATUS{#RequestUriMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+RequestUriMatchConditionParameters_TypeName{#RequestUriMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters](#RequestUriMatchConditionParameters).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleRequestUriConditionParameters" |             |
+
+RequestUriMatchConditionParameters_TypeName_STATUS{#RequestUriMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [RequestUriMatchConditionParameters_STATUS](#RequestUriMatchConditionParameters_STATUS).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "DeliveryRuleRequestUriConditionParameters" |             |
+
+RouteConfigurationOverrideActionParameters_TypeName{#RouteConfigurationOverrideActionParameters_TypeName}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrideActionParameters).
 
@@ -5214,8 +5214,8 @@ Used by: [RouteConfigurationOverrideActionParameters](#RouteConfigurationOverrid
 |----------------------------------------------------------|-------------|
 | "DeliveryRuleRouteConfigurationOverrideActionParameters" |             |
 
-<a id="RouteConfigurationOverrideActionParameters_TypeName_STATUS"></a>RouteConfigurationOverrideActionParameters_TypeName_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+RouteConfigurationOverrideActionParameters_TypeName_STATUS{#RouteConfigurationOverrideActionParameters_TypeName_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfigurationOverrideActionParameters_STATUS).
 
@@ -5223,8 +5223,8 @@ Used by: [RouteConfigurationOverrideActionParameters_STATUS](#RouteConfiguration
 |----------------------------------------------------------|-------------|
 | "DeliveryRuleRouteConfigurationOverrideActionParameters" |             |
 
-<a id="ServerPortMatchConditionParameters_Operator"></a>ServerPortMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_Operator{#ServerPortMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters).
 
@@ -5241,8 +5241,8 @@ Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameter
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="ServerPortMatchConditionParameters_Operator_STATUS"></a>ServerPortMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_Operator_STATUS{#ServerPortMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS).
 
@@ -5259,8 +5259,8 @@ Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionPa
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="ServerPortMatchConditionParameters_TypeName"></a>ServerPortMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_TypeName{#ServerPortMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameters).
 
@@ -5268,8 +5268,8 @@ Used by: [ServerPortMatchConditionParameters](#ServerPortMatchConditionParameter
 |---------------------------------------------|-------------|
 | "DeliveryRuleServerPortConditionParameters" |             |
 
-<a id="ServerPortMatchConditionParameters_TypeName_STATUS"></a>ServerPortMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
+ServerPortMatchConditionParameters_TypeName_STATUS{#ServerPortMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionParameters_STATUS).
 
@@ -5277,8 +5277,8 @@ Used by: [ServerPortMatchConditionParameters_STATUS](#ServerPortMatchConditionPa
 |---------------------------------------------|-------------|
 | "DeliveryRuleServerPortConditionParameters" |             |
 
-<a id="SocketAddrMatchConditionParameters_Operator"></a>SocketAddrMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_Operator{#SocketAddrMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters).
 
@@ -5287,8 +5287,8 @@ Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameter
 | "Any"     |             |
 | "IPMatch" |             |
 
-<a id="SocketAddrMatchConditionParameters_Operator_STATUS"></a>SocketAddrMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_Operator_STATUS{#SocketAddrMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS).
 
@@ -5297,8 +5297,8 @@ Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionPa
 | "Any"     |             |
 | "IPMatch" |             |
 
-<a id="SocketAddrMatchConditionParameters_TypeName"></a>SocketAddrMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_TypeName{#SocketAddrMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameters).
 
@@ -5306,8 +5306,8 @@ Used by: [SocketAddrMatchConditionParameters](#SocketAddrMatchConditionParameter
 |---------------------------------------------|-------------|
 | "DeliveryRuleSocketAddrConditionParameters" |             |
 
-<a id="SocketAddrMatchConditionParameters_TypeName_STATUS"></a>SocketAddrMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------
+SocketAddrMatchConditionParameters_TypeName_STATUS{#SocketAddrMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionParameters_STATUS).
 
@@ -5315,8 +5315,8 @@ Used by: [SocketAddrMatchConditionParameters_STATUS](#SocketAddrMatchConditionPa
 |---------------------------------------------|-------------|
 | "DeliveryRuleSocketAddrConditionParameters" |             |
 
-<a id="SslProtocol"></a>SslProtocol
------------------------------------
+SslProtocol{#SslProtocol}
+-------------------------
 
 The protocol of an established TLS connection.
 
@@ -5328,8 +5328,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 | "TLSv1.1" |             |
 | "TLSv1.2" |             |
 
-<a id="SslProtocol_STATUS"></a>SslProtocol_STATUS
--------------------------------------------------
+SslProtocol_STATUS{#SslProtocol_STATUS}
+---------------------------------------
 
 The protocol of an established TLS connection.
 
@@ -5341,8 +5341,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 | "TLSv1.1" |             |
 | "TLSv1.2" |             |
 
-<a id="SslProtocolMatchConditionParameters_Operator"></a>SslProtocolMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_Operator{#SslProtocolMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters).
 
@@ -5350,8 +5350,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 |---------|-------------|
 | "Equal" |             |
 
-<a id="SslProtocolMatchConditionParameters_Operator_STATUS"></a>SslProtocolMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_Operator_STATUS{#SslProtocolMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS).
 
@@ -5359,8 +5359,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 |---------|-------------|
 | "Equal" |             |
 
-<a id="SslProtocolMatchConditionParameters_TypeName"></a>SslProtocolMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_TypeName{#SslProtocolMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParameters).
 
@@ -5368,8 +5368,8 @@ Used by: [SslProtocolMatchConditionParameters](#SslProtocolMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleSslProtocolConditionParameters" |             |
 
-<a id="SslProtocolMatchConditionParameters_TypeName_STATUS"></a>SslProtocolMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+SslProtocolMatchConditionParameters_TypeName_STATUS{#SslProtocolMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchConditionParameters_STATUS).
 
@@ -5377,8 +5377,8 @@ Used by: [SslProtocolMatchConditionParameters_STATUS](#SslProtocolMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleSslProtocolConditionParameters" |             |
 
-<a id="Transform"></a>Transform
--------------------------------
+Transform{#Transform}
+---------------------
 
 Describes what transforms are applied before matching
 
@@ -5393,8 +5393,8 @@ Used by: [ClientPortMatchConditionParameters](#ClientPortMatchConditionParameter
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="Transform_STATUS"></a>Transform_STATUS
----------------------------------------------
+Transform_STATUS{#Transform_STATUS}
+-----------------------------------
 
 Describes what transforms are applied before matching
 
@@ -5409,8 +5409,8 @@ Used by: [ClientPortMatchConditionParameters_STATUS](#ClientPortMatchConditionPa
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_Operator"></a>UrlFileExtensionMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_Operator{#UrlFileExtensionMatchConditionParameters_Operator}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters).
 
@@ -5427,8 +5427,8 @@ Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchCondit
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_Operator_STATUS"></a>UrlFileExtensionMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_Operator_STATUS{#UrlFileExtensionMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS).
 
@@ -5445,8 +5445,8 @@ Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatc
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_TypeName"></a>UrlFileExtensionMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_TypeName{#UrlFileExtensionMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchConditionParameters).
 
@@ -5454,8 +5454,8 @@ Used by: [UrlFileExtensionMatchConditionParameters](#UrlFileExtensionMatchCondit
 |--------------------------------------------------------|-------------|
 | "DeliveryRuleUrlFileExtensionMatchConditionParameters" |             |
 
-<a id="UrlFileExtensionMatchConditionParameters_TypeName_STATUS"></a>UrlFileExtensionMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------------------------
+UrlFileExtensionMatchConditionParameters_TypeName_STATUS{#UrlFileExtensionMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatchConditionParameters_STATUS).
 
@@ -5463,8 +5463,8 @@ Used by: [UrlFileExtensionMatchConditionParameters_STATUS](#UrlFileExtensionMatc
 |--------------------------------------------------------|-------------|
 | "DeliveryRuleUrlFileExtensionMatchConditionParameters" |             |
 
-<a id="UrlFileNameMatchConditionParameters_Operator"></a>UrlFileNameMatchConditionParameters_Operator
------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_Operator{#UrlFileNameMatchConditionParameters_Operator}
+-------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters).
 
@@ -5481,8 +5481,8 @@ Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParamet
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileNameMatchConditionParameters_Operator_STATUS"></a>UrlFileNameMatchConditionParameters_Operator_STATUS
--------------------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_Operator_STATUS{#UrlFileNameMatchConditionParameters_Operator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS).
 
@@ -5499,8 +5499,8 @@ Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchCondition
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="UrlFileNameMatchConditionParameters_TypeName"></a>UrlFileNameMatchConditionParameters_TypeName
------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_TypeName{#UrlFileNameMatchConditionParameters_TypeName}
+-------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParameters).
 
@@ -5508,8 +5508,8 @@ Used by: [UrlFileNameMatchConditionParameters](#UrlFileNameMatchConditionParamet
 |----------------------------------------------|-------------|
 | "DeliveryRuleUrlFilenameConditionParameters" |             |
 
-<a id="UrlFileNameMatchConditionParameters_TypeName_STATUS"></a>UrlFileNameMatchConditionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------------------------
+UrlFileNameMatchConditionParameters_TypeName_STATUS{#UrlFileNameMatchConditionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchConditionParameters_STATUS).
 
@@ -5517,128 +5517,128 @@ Used by: [UrlFileNameMatchConditionParameters_STATUS](#UrlFileNameMatchCondition
 |----------------------------------------------|-------------|
 | "DeliveryRuleUrlFilenameConditionParameters" |             |
 
-<a id="UrlPathMatchConditionParameters_Operator"></a>UrlPathMatchConditionParameters_Operator
----------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-| "Wildcard"           |             |
-
-<a id="UrlPathMatchConditionParameters_Operator_STATUS"></a>UrlPathMatchConditionParameters_Operator_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
-
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
-| "Wildcard"           |             |
-
-<a id="UrlPathMatchConditionParameters_TypeName"></a>UrlPathMatchConditionParameters_TypeName
----------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleUrlPathMatchConditionParameters" |             |
-
-<a id="UrlPathMatchConditionParameters_TypeName_STATUS"></a>UrlPathMatchConditionParameters_TypeName_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
-
-| Value                                         | Description |
-|-----------------------------------------------|-------------|
-| "DeliveryRuleUrlPathMatchConditionParameters" |             |
-
-<a id="UrlRedirectActionParameters_DestinationProtocol"></a>UrlRedirectActionParameters_DestinationProtocol
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value          | Description |
-|----------------|-------------|
-| "Http"         |             |
-| "Https"        |             |
-| "MatchRequest" |             |
-
-<a id="UrlRedirectActionParameters_DestinationProtocol_STATUS"></a>UrlRedirectActionParameters_DestinationProtocol_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value          | Description |
-|----------------|-------------|
-| "Http"         |             |
-| "Https"        |             |
-| "MatchRequest" |             |
-
-<a id="UrlRedirectActionParameters_RedirectType"></a>UrlRedirectActionParameters_RedirectType
----------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value               | Description |
-|---------------------|-------------|
-| "Found"             |             |
-| "Moved"             |             |
-| "PermanentRedirect" |             |
-| "TemporaryRedirect" |             |
-
-<a id="UrlRedirectActionParameters_RedirectType_STATUS"></a>UrlRedirectActionParameters_RedirectType_STATUS
------------------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value               | Description |
-|---------------------|-------------|
-| "Found"             |             |
-| "Moved"             |             |
-| "PermanentRedirect" |             |
-| "TemporaryRedirect" |             |
-
-<a id="UrlRedirectActionParameters_TypeName"></a>UrlRedirectActionParameters_TypeName
--------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
-
-| Value                                     | Description |
-|-------------------------------------------|-------------|
-| "DeliveryRuleUrlRedirectActionParameters" |             |
-
-<a id="UrlRedirectActionParameters_TypeName_STATUS"></a>UrlRedirectActionParameters_TypeName_STATUS
----------------------------------------------------------------------------------------------------
-
-Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
-
-| Value                                     | Description |
-|-------------------------------------------|-------------|
-| "DeliveryRuleUrlRedirectActionParameters" |             |
-
-<a id="UrlRewriteActionParameters_TypeName"></a>UrlRewriteActionParameters_TypeName
+UrlPathMatchConditionParameters_Operator{#UrlPathMatchConditionParameters_Operator}
 -----------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+| "Wildcard"           |             |
+
+UrlPathMatchConditionParameters_Operator_STATUS{#UrlPathMatchConditionParameters_Operator_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+| "Wildcard"           |             |
+
+UrlPathMatchConditionParameters_TypeName{#UrlPathMatchConditionParameters_TypeName}
+-----------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters](#UrlPathMatchConditionParameters).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleUrlPathMatchConditionParameters" |             |
+
+UrlPathMatchConditionParameters_TypeName_STATUS{#UrlPathMatchConditionParameters_TypeName_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlPathMatchConditionParameters_STATUS](#UrlPathMatchConditionParameters_STATUS).
+
+| Value                                         | Description |
+|-----------------------------------------------|-------------|
+| "DeliveryRuleUrlPathMatchConditionParameters" |             |
+
+UrlRedirectActionParameters_DestinationProtocol{#UrlRedirectActionParameters_DestinationProtocol}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value          | Description |
+|----------------|-------------|
+| "Http"         |             |
+| "Https"        |             |
+| "MatchRequest" |             |
+
+UrlRedirectActionParameters_DestinationProtocol_STATUS{#UrlRedirectActionParameters_DestinationProtocol_STATUS}
+---------------------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value          | Description |
+|----------------|-------------|
+| "Http"         |             |
+| "Https"        |             |
+| "MatchRequest" |             |
+
+UrlRedirectActionParameters_RedirectType{#UrlRedirectActionParameters_RedirectType}
+-----------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value               | Description |
+|---------------------|-------------|
+| "Found"             |             |
+| "Moved"             |             |
+| "PermanentRedirect" |             |
+| "TemporaryRedirect" |             |
+
+UrlRedirectActionParameters_RedirectType_STATUS{#UrlRedirectActionParameters_RedirectType_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value               | Description |
+|---------------------|-------------|
+| "Found"             |             |
+| "Moved"             |             |
+| "PermanentRedirect" |             |
+| "TemporaryRedirect" |             |
+
+UrlRedirectActionParameters_TypeName{#UrlRedirectActionParameters_TypeName}
+---------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters](#UrlRedirectActionParameters).
+
+| Value                                     | Description |
+|-------------------------------------------|-------------|
+| "DeliveryRuleUrlRedirectActionParameters" |             |
+
+UrlRedirectActionParameters_TypeName_STATUS{#UrlRedirectActionParameters_TypeName_STATUS}
+-----------------------------------------------------------------------------------------
+
+Used by: [UrlRedirectActionParameters_STATUS](#UrlRedirectActionParameters_STATUS).
+
+| Value                                     | Description |
+|-------------------------------------------|-------------|
+| "DeliveryRuleUrlRedirectActionParameters" |             |
+
+UrlRewriteActionParameters_TypeName{#UrlRewriteActionParameters_TypeName}
+-------------------------------------------------------------------------
 
 Used by: [UrlRewriteActionParameters](#UrlRewriteActionParameters).
 
@@ -5646,8 +5646,8 @@ Used by: [UrlRewriteActionParameters](#UrlRewriteActionParameters).
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlRewriteActionParameters" |             |
 
-<a id="UrlRewriteActionParameters_TypeName_STATUS"></a>UrlRewriteActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------
+UrlRewriteActionParameters_TypeName_STATUS{#UrlRewriteActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS).
 
@@ -5655,8 +5655,8 @@ Used by: [UrlRewriteActionParameters_STATUS](#UrlRewriteActionParameters_STATUS)
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlRewriteActionParameters" |             |
 
-<a id="UrlSigningActionParameters_Algorithm"></a>UrlSigningActionParameters_Algorithm
--------------------------------------------------------------------------------------
+UrlSigningActionParameters_Algorithm{#UrlSigningActionParameters_Algorithm}
+---------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 
@@ -5664,8 +5664,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 |----------|-------------|
 | "SHA256" |             |
 
-<a id="UrlSigningActionParameters_Algorithm_STATUS"></a>UrlSigningActionParameters_Algorithm_STATUS
----------------------------------------------------------------------------------------------------
+UrlSigningActionParameters_Algorithm_STATUS{#UrlSigningActionParameters_Algorithm_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS).
 
@@ -5673,8 +5673,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 |----------|-------------|
 | "SHA256" |             |
 
-<a id="UrlSigningActionParameters_TypeName"></a>UrlSigningActionParameters_TypeName
------------------------------------------------------------------------------------
+UrlSigningActionParameters_TypeName{#UrlSigningActionParameters_TypeName}
+-------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 
@@ -5682,8 +5682,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlSigningActionParameters" |             |
 
-<a id="UrlSigningActionParameters_TypeName_STATUS"></a>UrlSigningActionParameters_TypeName_STATUS
--------------------------------------------------------------------------------------------------
+UrlSigningActionParameters_TypeName_STATUS{#UrlSigningActionParameters_TypeName_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS).
 
@@ -5691,8 +5691,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 |------------------------------------------|-------------|
 | "DeliveryRuleUrlSigningActionParameters" |             |
 
-<a id="UrlSigningParamIdentifier"></a>UrlSigningParamIdentifier
----------------------------------------------------------------
+UrlSigningParamIdentifier{#UrlSigningParamIdentifier}
+-----------------------------------------------------
 
 Defines how to identify a parameter for a specific purpose e.g. expires
 
@@ -5703,8 +5703,8 @@ Used by: [UrlSigningActionParameters](#UrlSigningActionParameters).
 | paramIndicator | Indicates the purpose of the parameter | [UrlSigningParamIdentifier_ParamIndicator](#UrlSigningParamIdentifier_ParamIndicator)<br/><small>Required</small> |
 | paramName      | Parameter name                         | string<br/><small>Required</small>                                                                                |
 
-<a id="UrlSigningParamIdentifier_STATUS"></a>UrlSigningParamIdentifier_STATUS
------------------------------------------------------------------------------
+UrlSigningParamIdentifier_STATUS{#UrlSigningParamIdentifier_STATUS}
+-------------------------------------------------------------------
 
 Defines how to identify a parameter for a specific purpose e.g. expires
 
@@ -5715,8 +5715,8 @@ Used by: [UrlSigningActionParameters_STATUS](#UrlSigningActionParameters_STATUS)
 | paramIndicator | Indicates the purpose of the parameter | [UrlSigningParamIdentifier_ParamIndicator_STATUS](#UrlSigningParamIdentifier_ParamIndicator_STATUS)<br/><small>Optional</small> |
 | paramName      | Parameter name                         | string<br/><small>Optional</small>                                                                                              |
 
-<a id="CacheConfiguration_CacheBehavior"></a>CacheConfiguration_CacheBehavior
------------------------------------------------------------------------------
+CacheConfiguration_CacheBehavior{#CacheConfiguration_CacheBehavior}
+-------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -5726,8 +5726,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "OverrideAlways"          |             |
 | "OverrideIfOriginMissing" |             |
 
-<a id="CacheConfiguration_CacheBehavior_STATUS"></a>CacheConfiguration_CacheBehavior_STATUS
--------------------------------------------------------------------------------------------
+CacheConfiguration_CacheBehavior_STATUS{#CacheConfiguration_CacheBehavior_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -5737,8 +5737,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "OverrideAlways"          |             |
 | "OverrideIfOriginMissing" |             |
 
-<a id="CacheConfiguration_IsCompressionEnabled"></a>CacheConfiguration_IsCompressionEnabled
--------------------------------------------------------------------------------------------
+CacheConfiguration_IsCompressionEnabled{#CacheConfiguration_IsCompressionEnabled}
+---------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -5747,8 +5747,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CacheConfiguration_IsCompressionEnabled_STATUS"></a>CacheConfiguration_IsCompressionEnabled_STATUS
----------------------------------------------------------------------------------------------------------
+CacheConfiguration_IsCompressionEnabled_STATUS{#CacheConfiguration_IsCompressionEnabled_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -5757,8 +5757,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CacheConfiguration_QueryStringCachingBehavior"></a>CacheConfiguration_QueryStringCachingBehavior
--------------------------------------------------------------------------------------------------------
+CacheConfiguration_QueryStringCachingBehavior{#CacheConfiguration_QueryStringCachingBehavior}
+---------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration](#CacheConfiguration).
 
@@ -5769,8 +5769,8 @@ Used by: [CacheConfiguration](#CacheConfiguration).
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="CacheConfiguration_QueryStringCachingBehavior_STATUS"></a>CacheConfiguration_QueryStringCachingBehavior_STATUS
----------------------------------------------------------------------------------------------------------------------
+CacheConfiguration_QueryStringCachingBehavior_STATUS{#CacheConfiguration_QueryStringCachingBehavior_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 
@@ -5781,8 +5781,8 @@ Used by: [CacheConfiguration_STATUS](#CacheConfiguration_STATUS).
 | "IncludeSpecifiedQueryStrings" |             |
 | "UseQueryString"               |             |
 
-<a id="OriginGroupOverride_ForwardingProtocol"></a>OriginGroupOverride_ForwardingProtocol
------------------------------------------------------------------------------------------
+OriginGroupOverride_ForwardingProtocol{#OriginGroupOverride_ForwardingProtocol}
+-------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverride](#OriginGroupOverride).
 
@@ -5792,8 +5792,8 @@ Used by: [OriginGroupOverride](#OriginGroupOverride).
 | "HttpsOnly"    |             |
 | "MatchRequest" |             |
 
-<a id="OriginGroupOverride_ForwardingProtocol_STATUS"></a>OriginGroupOverride_ForwardingProtocol_STATUS
--------------------------------------------------------------------------------------------------------
+OriginGroupOverride_ForwardingProtocol_STATUS{#OriginGroupOverride_ForwardingProtocol_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS).
 
@@ -5803,8 +5803,8 @@ Used by: [OriginGroupOverride_STATUS](#OriginGroupOverride_STATUS).
 | "HttpsOnly"    |             |
 | "MatchRequest" |             |
 
-<a id="UrlSigningParamIdentifier_ParamIndicator"></a>UrlSigningParamIdentifier_ParamIndicator
----------------------------------------------------------------------------------------------
+UrlSigningParamIdentifier_ParamIndicator{#UrlSigningParamIdentifier_ParamIndicator}
+-----------------------------------------------------------------------------------
 
 Used by: [UrlSigningParamIdentifier](#UrlSigningParamIdentifier).
 
@@ -5814,8 +5814,8 @@ Used by: [UrlSigningParamIdentifier](#UrlSigningParamIdentifier).
 | "KeyId"     |             |
 | "Signature" |             |
 
-<a id="UrlSigningParamIdentifier_ParamIndicator_STATUS"></a>UrlSigningParamIdentifier_ParamIndicator_STATUS
------------------------------------------------------------------------------------------------------------
+UrlSigningParamIdentifier_ParamIndicator_STATUS{#UrlSigningParamIdentifier_ParamIndicator_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [UrlSigningParamIdentifier_STATUS](#UrlSigningParamIdentifier_STATUS).
 

--- a/docs/hugo/content/reference/compute/v1api20200930.md
+++ b/docs/hugo/content/reference/compute/v1api20200930.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20200930
 linktitle: v1api20200930
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-09-30" |             |
 
-<a id="Disk"></a>Disk
----------------------
+Disk{#Disk}
+-----------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2020-09-30/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/disks/{diskName}
 
@@ -26,7 +26,7 @@ Used by: [DiskList](#DiskList).
 | spec                                                                                    |             | [Disk_Spec](#Disk_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Disk_STATUS](#Disk_STATUS)<br/><small>Optional</small> |
 
-### <a id="Disk_Spec"></a>Disk_Spec
+### Disk_Spec {#Disk_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -55,7 +55,7 @@ Used by: [DiskList](#DiskList).
 | tier                         | Performance tier of the disk (e.g, P4, S10) as described here: https://azure.microsoft.com/en-us/pricing/details/managed-disks/. Does not apply to Ultra disks.                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Disk_STATUS"></a>Disk_STATUS
+### Disk_STATUS{#Disk_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -93,8 +93,8 @@ Used by: [DiskList](#DiskList).
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="DiskList"></a>DiskList
------------------------------
+DiskList{#DiskList}
+-------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2020-09-30/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/disks/{diskName}
 
@@ -104,8 +104,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [Disk[]](#Disk)<br/><small>Optional</small> |
 
-<a id="Snapshot"></a>Snapshot
------------------------------
+Snapshot{#Snapshot}
+-------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2020-09-30/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/snapshots/{snapshotName}
 
@@ -118,7 +118,7 @@ Used by: [SnapshotList](#SnapshotList).
 | spec                                                                                    |             | [Snapshot_Spec](#Snapshot_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Snapshot_STATUS](#Snapshot_STATUS)<br/><small>Optional</small> |
 
-### <a id="Snapshot_Spec"></a>Snapshot_Spec
+### Snapshot_Spec {#Snapshot_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -141,7 +141,7 @@ Used by: [SnapshotList](#SnapshotList).
 | sku                          | The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot                                                                                               | [SnapshotSku](#SnapshotSku)<br/><small>Optional</small>                                                                                                              |
 | tags                         | Resource tags                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Snapshot_STATUS"></a>Snapshot_STATUS
+### Snapshot_STATUS{#Snapshot_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -170,8 +170,8 @@ Used by: [SnapshotList](#SnapshotList).
 | type                         | Resource type                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SnapshotList"></a>SnapshotList
--------------------------------------
+SnapshotList{#SnapshotList}
+---------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2020-09-30/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/snapshots/{snapshotName}
 
@@ -181,8 +181,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Snapshot[]](#Snapshot)<br/><small>Optional</small> |
 
-<a id="Disk_Spec"></a>Disk_Spec
--------------------------------
+Disk_Spec{#Disk_Spec}
+---------------------
 
 Used by: [Disk](#Disk).
 
@@ -213,8 +213,8 @@ Used by: [Disk](#Disk).
 | tier                         | Performance tier of the disk (e.g, P4, S10) as described here: https://azure.microsoft.com/en-us/pricing/details/managed-disks/. Does not apply to Ultra disks.                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                   |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Disk_STATUS"></a>Disk_STATUS
------------------------------------
+Disk_STATUS{#Disk_STATUS}
+-------------------------
 
 Disk resource.
 
@@ -256,8 +256,8 @@ Used by: [Disk](#Disk).
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="Snapshot_Spec"></a>Snapshot_Spec
----------------------------------------
+Snapshot_Spec{#Snapshot_Spec}
+-----------------------------
 
 Used by: [Snapshot](#Snapshot).
 
@@ -282,8 +282,8 @@ Used by: [Snapshot](#Snapshot).
 | sku                          | The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot                                                                                               | [SnapshotSku](#SnapshotSku)<br/><small>Optional</small>                                                                                                              |
 | tags                         | Resource tags                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Snapshot_STATUS"></a>Snapshot_STATUS
--------------------------------------------
+Snapshot_STATUS{#Snapshot_STATUS}
+---------------------------------
 
 Snapshot resource.
 
@@ -316,8 +316,8 @@ Used by: [Snapshot](#Snapshot).
 | type                         | Resource type                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Data used when creating a disk.
 
@@ -334,8 +334,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | storageAccountId        | Required if createOption is Import. The Azure Resource Manager identifier of the storage account containing the blob to import as a disk.                                                                                                           | string<br/><small>Optional</small>                                                                                                                         |
 | uploadSizeBytes         | If createOption is Upload, this is the size of the contents of the upload including the VHD footer. This value should be between 20972032 (20 MiB + 512 bytes for the VHD footer) and 35183298347520 bytes (32 TiB + 512 bytes for the VHD footer). | int<br/><small>Optional</small>                                                                                                                            |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Data used when creating a disk.
 
@@ -353,8 +353,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | storageAccountId      | Required if createOption is Import. The Azure Resource Manager identifier of the storage account containing the blob to import as a disk.                                                                                                           | string<br/><small>Optional</small>                                                                |
 | uploadSizeBytes       | If createOption is Upload, this is the size of the contents of the upload including the VHD footer. This value should be between 20972032 (20 MiB + 512 bytes for the VHD footer) and 35183298347520 bytes (32 TiB + 512 bytes for the VHD footer). | int<br/><small>Optional</small>                                                                   |
 
-<a id="DiskOperatorSpec"></a>DiskOperatorSpec
----------------------------------------------
+DiskOperatorSpec{#DiskOperatorSpec}
+-----------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -365,8 +365,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DiskProperties_HyperVGeneration"></a>DiskProperties_HyperVGeneration
----------------------------------------------------------------------------
+DiskProperties_HyperVGeneration{#DiskProperties_HyperVGeneration}
+-----------------------------------------------------------------
 
 Used by: [Disk_Spec](#Disk_Spec).
 
@@ -375,8 +375,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="DiskProperties_HyperVGeneration_STATUS"></a>DiskProperties_HyperVGeneration_STATUS
------------------------------------------------------------------------------------------
+DiskProperties_HyperVGeneration_STATUS{#DiskProperties_HyperVGeneration_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -385,8 +385,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="DiskProperties_OsType"></a>DiskProperties_OsType
--------------------------------------------------------
+DiskProperties_OsType{#DiskProperties_OsType}
+---------------------------------------------
 
 Used by: [Disk_Spec](#Disk_Spec).
 
@@ -395,8 +395,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="DiskProperties_OsType_STATUS"></a>DiskProperties_OsType_STATUS
----------------------------------------------------------------------
+DiskProperties_OsType_STATUS{#DiskProperties_OsType_STATUS}
+-----------------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -405,8 +405,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="DiskSku"></a>DiskSku
----------------------------
+DiskSku{#DiskSku}
+-----------------
 
 The disks sku name. Can be Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS.
 
@@ -416,8 +416,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 |----------|---------------|-----------------------------------------------------------|
 | name     | The sku name. | [DiskSku_Name](#DiskSku_Name)<br/><small>Optional</small> |
 
-<a id="DiskSku_STATUS"></a>DiskSku_STATUS
------------------------------------------
+DiskSku_STATUS{#DiskSku_STATUS}
+-------------------------------
 
 The disks sku name. Can be Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS.
 
@@ -428,8 +428,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | name     | The sku name. | [DiskSku_Name_STATUS](#DiskSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The sku tier. | string<br/><small>Optional</small>                                      |
 
-<a id="DiskState"></a>DiskState
--------------------------------
+DiskState{#DiskState}
+---------------------
 
 This enumerates the possible state of the disk.
 
@@ -444,8 +444,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "Reserved"      |             |
 | "Unattached"    |             |
 
-<a id="DiskState_STATUS"></a>DiskState_STATUS
----------------------------------------------
+DiskState_STATUS{#DiskState_STATUS}
+-----------------------------------
 
 This enumerates the possible state of the disk.
 
@@ -460,8 +460,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "Reserved"      |             |
 | "Unattached"    |             |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Encryption at rest settings for disk or snapshot
 
@@ -472,8 +472,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | diskEncryptionSetReference | ResourceId of the disk encryption set to use for enabling encryption at rest. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | type                       | The type of key used to encrypt the data of the disk.                         | [EncryptionType](#EncryptionType)<br/><small>Optional</small>                                                                                              |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Encryption at rest settings for disk or snapshot
 
@@ -484,8 +484,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | diskEncryptionSetId | ResourceId of the disk encryption set to use for enabling encryption at rest. | string<br/><small>Optional</small>                                          |
 | type                | The type of key used to encrypt the data of the disk.                         | [EncryptionType_STATUS](#EncryptionType_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionSettingsCollection"></a>EncryptionSettingsCollection
----------------------------------------------------------------------
+EncryptionSettingsCollection{#EncryptionSettingsCollection}
+-----------------------------------------------------------
 
 Encryption settings for disk or snapshot
 
@@ -497,8 +497,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | encryptionSettings        | A collection of encryption settings, one for each disk volume.                                                                                                                                                                                                                                       | [EncryptionSettingsElement[]](#EncryptionSettingsElement)<br/><small>Optional</small> |
 | encryptionSettingsVersion | Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption with AAD app.'1.1' corresponds to Azure Disk Encryption.                                                                                       | string<br/><small>Optional</small>                                                    |
 
-<a id="EncryptionSettingsCollection_STATUS"></a>EncryptionSettingsCollection_STATUS
------------------------------------------------------------------------------------
+EncryptionSettingsCollection_STATUS{#EncryptionSettingsCollection_STATUS}
+-------------------------------------------------------------------------
 
 Encryption settings for disk or snapshot
 
@@ -510,8 +510,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | encryptionSettings        | A collection of encryption settings, one for each disk volume.                                                                                                                                                                                                                                       | [EncryptionSettingsElement_STATUS[]](#EncryptionSettingsElement_STATUS)<br/><small>Optional</small> |
 | encryptionSettingsVersion | Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption with AAD app.'1.1' corresponds to Azure Disk Encryption.                                                                                       | string<br/><small>Optional</small>                                                                  |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -522,8 +522,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -534,8 +534,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkAccessPolicy"></a>NetworkAccessPolicy
----------------------------------------------------
+NetworkAccessPolicy{#NetworkAccessPolicy}
+-----------------------------------------
 
 Policy for accessing the disk via network.
 
@@ -547,8 +547,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | "AllowPrivate" |             |
 | "DenyAll"      |             |
 
-<a id="NetworkAccessPolicy_STATUS"></a>NetworkAccessPolicy_STATUS
------------------------------------------------------------------
+NetworkAccessPolicy_STATUS{#NetworkAccessPolicy_STATUS}
+-------------------------------------------------------
 
 Policy for accessing the disk via network.
 
@@ -560,8 +560,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "AllowPrivate" |             |
 | "DenyAll"      |             |
 
-<a id="PurchasePlan"></a>PurchasePlan
--------------------------------------
+PurchasePlan{#PurchasePlan}
+---------------------------
 
 Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 
@@ -574,8 +574,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | promotionCode | The Offer Promotion Code.                                                                                                  | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Required</small> |
 
-<a id="PurchasePlan_STATUS"></a>PurchasePlan_STATUS
----------------------------------------------------
+PurchasePlan_STATUS{#PurchasePlan_STATUS}
+-----------------------------------------
 
 Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 
@@ -588,8 +588,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | promotionCode | The Offer Promotion Code.                                                                                                  | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="ShareInfoElement_STATUS"></a>ShareInfoElement_STATUS
------------------------------------------------------------
+ShareInfoElement_STATUS{#ShareInfoElement_STATUS}
+-------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -597,8 +597,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 |----------|------------------------------------------------------------------------|------------------------------------|
 | vmUri    | A relative URI containing the ID of the VM that has the disk attached. | string<br/><small>Optional</small> |
 
-<a id="SnapshotOperatorSpec"></a>SnapshotOperatorSpec
------------------------------------------------------
+SnapshotOperatorSpec{#SnapshotOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -609,8 +609,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SnapshotProperties_HyperVGeneration"></a>SnapshotProperties_HyperVGeneration
------------------------------------------------------------------------------------
+SnapshotProperties_HyperVGeneration{#SnapshotProperties_HyperVGeneration}
+-------------------------------------------------------------------------
 
 Used by: [Snapshot_Spec](#Snapshot_Spec).
 
@@ -619,8 +619,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="SnapshotProperties_HyperVGeneration_STATUS"></a>SnapshotProperties_HyperVGeneration_STATUS
--------------------------------------------------------------------------------------------------
+SnapshotProperties_HyperVGeneration_STATUS{#SnapshotProperties_HyperVGeneration_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 
@@ -629,8 +629,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="SnapshotProperties_OsType"></a>SnapshotProperties_OsType
----------------------------------------------------------------
+SnapshotProperties_OsType{#SnapshotProperties_OsType}
+-----------------------------------------------------
 
 Used by: [Snapshot_Spec](#Snapshot_Spec).
 
@@ -639,8 +639,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="SnapshotProperties_OsType_STATUS"></a>SnapshotProperties_OsType_STATUS
------------------------------------------------------------------------------
+SnapshotProperties_OsType_STATUS{#SnapshotProperties_OsType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 
@@ -649,8 +649,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="SnapshotSku"></a>SnapshotSku
------------------------------------
+SnapshotSku{#SnapshotSku}
+-------------------------
 
 The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot
 
@@ -660,8 +660,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 |----------|---------------|-------------------------------------------------------------------|
 | name     | The sku name. | [SnapshotSku_Name](#SnapshotSku_Name)<br/><small>Optional</small> |
 
-<a id="SnapshotSku_STATUS"></a>SnapshotSku_STATUS
--------------------------------------------------
+SnapshotSku_STATUS{#SnapshotSku_STATUS}
+---------------------------------------
 
 The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot
 
@@ -672,8 +672,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | name     | The sku name. | [SnapshotSku_Name_STATUS](#SnapshotSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The sku tier. | string<br/><small>Optional</small>                                              |
 
-<a id="CreationData_CreateOption"></a>CreationData_CreateOption
----------------------------------------------------------------
+CreationData_CreateOption{#CreationData_CreateOption}
+-----------------------------------------------------
 
 Used by: [CreationData](#CreationData).
 
@@ -687,8 +687,8 @@ Used by: [CreationData](#CreationData).
 | "Restore"   |             |
 | "Upload"    |             |
 
-<a id="CreationData_CreateOption_STATUS"></a>CreationData_CreateOption_STATUS
------------------------------------------------------------------------------
+CreationData_CreateOption_STATUS{#CreationData_CreateOption_STATUS}
+-------------------------------------------------------------------
 
 Used by: [CreationData_STATUS](#CreationData_STATUS).
 
@@ -702,8 +702,8 @@ Used by: [CreationData_STATUS](#CreationData_STATUS).
 | "Restore"   |             |
 | "Upload"    |             |
 
-<a id="DiskSku_Name"></a>DiskSku_Name
--------------------------------------
+DiskSku_Name{#DiskSku_Name}
+---------------------------
 
 Used by: [DiskSku](#DiskSku).
 
@@ -714,8 +714,8 @@ Used by: [DiskSku](#DiskSku).
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="DiskSku_Name_STATUS"></a>DiskSku_Name_STATUS
----------------------------------------------------
+DiskSku_Name_STATUS{#DiskSku_Name_STATUS}
+-----------------------------------------
 
 Used by: [DiskSku_STATUS](#DiskSku_STATUS).
 
@@ -726,8 +726,8 @@ Used by: [DiskSku_STATUS](#DiskSku_STATUS).
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="EncryptionSettingsElement"></a>EncryptionSettingsElement
----------------------------------------------------------------
+EncryptionSettingsElement{#EncryptionSettingsElement}
+-----------------------------------------------------
 
 Encryption settings for one disk volume.
 
@@ -738,8 +738,8 @@ Used by: [EncryptionSettingsCollection](#EncryptionSettingsCollection).
 | diskEncryptionKey | Key Vault Secret Url and vault id of the disk encryption key                                                                                        | [KeyVaultAndSecretReference](#KeyVaultAndSecretReference)<br/><small>Optional</small> |
 | keyEncryptionKey  | Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap the disk encryption key. | [KeyVaultAndKeyReference](#KeyVaultAndKeyReference)<br/><small>Optional</small>       |
 
-<a id="EncryptionSettingsElement_STATUS"></a>EncryptionSettingsElement_STATUS
------------------------------------------------------------------------------
+EncryptionSettingsElement_STATUS{#EncryptionSettingsElement_STATUS}
+-------------------------------------------------------------------
 
 Encryption settings for one disk volume.
 
@@ -750,8 +750,8 @@ Used by: [EncryptionSettingsCollection_STATUS](#EncryptionSettingsCollection_STA
 | diskEncryptionKey | Key Vault Secret Url and vault id of the disk encryption key                                                                                        | [KeyVaultAndSecretReference_STATUS](#KeyVaultAndSecretReference_STATUS)<br/><small>Optional</small> |
 | keyEncryptionKey  | Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap the disk encryption key. | [KeyVaultAndKeyReference_STATUS](#KeyVaultAndKeyReference_STATUS)<br/><small>Optional</small>       |
 
-<a id="EncryptionType"></a>EncryptionType
------------------------------------------
+EncryptionType{#EncryptionType}
+-------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -763,8 +763,8 @@ Used by: [Encryption](#Encryption).
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 | "EncryptionAtRestWithPlatformKey"             |             |
 
-<a id="EncryptionType_STATUS"></a>EncryptionType_STATUS
--------------------------------------------------------
+EncryptionType_STATUS{#EncryptionType_STATUS}
+---------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -776,8 +776,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 | "EncryptionAtRestWithPlatformKey"             |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -787,8 +787,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -798,8 +798,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ImageDiskReference"></a>ImageDiskReference
--------------------------------------------------
+ImageDiskReference{#ImageDiskReference}
+---------------------------------------
 
 The source image used for creating the disk.
 
@@ -810,8 +810,8 @@ Used by: [CreationData](#CreationData), and [CreationData](#CreationData).
 | lun       | If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the image to use. For OS disks, this field is null. | int<br/><small>Optional</small>                                                                                                                            |
 | reference | A relative uri containing either a Platform Image Repository or user image reference.                                                                            | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="ImageDiskReference_STATUS"></a>ImageDiskReference_STATUS
----------------------------------------------------------------
+ImageDiskReference_STATUS{#ImageDiskReference_STATUS}
+-----------------------------------------------------
 
 The source image used for creating the disk.
 
@@ -822,8 +822,8 @@ Used by: [CreationData_STATUS](#CreationData_STATUS), and [CreationData_STATUS](
 | id       | A relative uri containing either a Platform Image Repository or user image reference.                                                                            | string<br/><small>Optional</small> |
 | lun      | If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the image to use. For OS disks, this field is null. | int<br/><small>Optional</small>    |
 
-<a id="SnapshotSku_Name"></a>SnapshotSku_Name
----------------------------------------------
+SnapshotSku_Name{#SnapshotSku_Name}
+-----------------------------------
 
 Used by: [SnapshotSku](#SnapshotSku).
 
@@ -833,8 +833,8 @@ Used by: [SnapshotSku](#SnapshotSku).
 | "Standard_LRS" |             |
 | "Standard_ZRS" |             |
 
-<a id="SnapshotSku_Name_STATUS"></a>SnapshotSku_Name_STATUS
------------------------------------------------------------
+SnapshotSku_Name_STATUS{#SnapshotSku_Name_STATUS}
+-------------------------------------------------
 
 Used by: [SnapshotSku_STATUS](#SnapshotSku_STATUS).
 
@@ -844,8 +844,8 @@ Used by: [SnapshotSku_STATUS](#SnapshotSku_STATUS).
 | "Standard_LRS" |             |
 | "Standard_ZRS" |             |
 
-<a id="KeyVaultAndKeyReference"></a>KeyVaultAndKeyReference
------------------------------------------------------------
+KeyVaultAndKeyReference{#KeyVaultAndKeyReference}
+-------------------------------------------------
 
 Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
 
@@ -856,8 +856,8 @@ Used by: [EncryptionSettingsElement](#EncryptionSettingsElement).
 | keyUrl      | Url pointing to a key or secret in KeyVault              | string<br/><small>Required</small>                      |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault](#SourceVault)<br/><small>Required</small> |
 
-<a id="KeyVaultAndKeyReference_STATUS"></a>KeyVaultAndKeyReference_STATUS
--------------------------------------------------------------------------
+KeyVaultAndKeyReference_STATUS{#KeyVaultAndKeyReference_STATUS}
+---------------------------------------------------------------
 
 Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
 
@@ -868,8 +868,8 @@ Used by: [EncryptionSettingsElement_STATUS](#EncryptionSettingsElement_STATUS).
 | keyUrl      | Url pointing to a key or secret in KeyVault              | string<br/><small>Optional</small>                                    |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault_STATUS](#SourceVault_STATUS)<br/><small>Optional</small> |
 
-<a id="KeyVaultAndSecretReference"></a>KeyVaultAndSecretReference
------------------------------------------------------------------
+KeyVaultAndSecretReference{#KeyVaultAndSecretReference}
+-------------------------------------------------------
 
 Key Vault Secret Url and vault id of the encryption key
 
@@ -880,8 +880,8 @@ Used by: [EncryptionSettingsElement](#EncryptionSettingsElement).
 | secretUrl   | Url pointing to a key or secret in KeyVault              | string<br/><small>Required</small>                      |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault](#SourceVault)<br/><small>Required</small> |
 
-<a id="KeyVaultAndSecretReference_STATUS"></a>KeyVaultAndSecretReference_STATUS
--------------------------------------------------------------------------------
+KeyVaultAndSecretReference_STATUS{#KeyVaultAndSecretReference_STATUS}
+---------------------------------------------------------------------
 
 Key Vault Secret Url and vault id of the encryption key
 
@@ -892,8 +892,8 @@ Used by: [EncryptionSettingsElement_STATUS](#EncryptionSettingsElement_STATUS).
 | secretUrl   | Url pointing to a key or secret in KeyVault              | string<br/><small>Optional</small>                                    |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault_STATUS](#SourceVault_STATUS)<br/><small>Optional</small> |
 
-<a id="SourceVault"></a>SourceVault
------------------------------------
+SourceVault{#SourceVault}
+-------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -903,8 +903,8 @@ Used by: [KeyVaultAndKeyReference](#KeyVaultAndKeyReference), and [KeyVaultAndSe
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SourceVault_STATUS"></a>SourceVault_STATUS
--------------------------------------------------
+SourceVault_STATUS{#SourceVault_STATUS}
+---------------------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 

--- a/docs/hugo/content/reference/compute/v1api20201201.md
+++ b/docs/hugo/content/reference/compute/v1api20201201.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20201201
 linktitle: v1api20201201
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-12-01" |             |
 
-<a id="VirtualMachine"></a>VirtualMachine
------------------------------------------
+VirtualMachine{#VirtualMachine}
+-------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}
 
@@ -26,7 +26,7 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | spec                                                                                    |             | [VirtualMachine_Spec](#VirtualMachine_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachine_STATUS](#VirtualMachine_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachine_Spec"></a>VirtualMachine_Spec
+### VirtualMachine_Spec {#VirtualMachine_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -58,7 +58,7 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | virtualMachineScaleSet  | Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. This property cannot exist along with a non-null properties.availabilitySet reference. Minimum api‐version: 2019‐03‐01                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
+### VirtualMachine_STATUS{#VirtualMachine_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                    |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -95,8 +95,8 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | vmId                    | Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineList"></a>VirtualMachineList
--------------------------------------------------
+VirtualMachineList{#VirtualMachineList}
+---------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}
 
@@ -106,8 +106,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [VirtualMachine[]](#VirtualMachine)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSet"></a>VirtualMachineScaleSet
----------------------------------------------------------
+VirtualMachineScaleSet{#VirtualMachineScaleSet}
+-----------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}
 
@@ -120,7 +120,7 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | spec                                                                                    |             | [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachineScaleSet_Spec"></a>VirtualMachineScaleSet_Spec
+### VirtualMachineScaleSet_Spec {#VirtualMachineScaleSet_Spec}
 
 | Property                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -148,7 +148,7 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage.                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="VirtualMachineScaleSet_STATUS"></a>VirtualMachineScaleSet_STATUS
+### VirtualMachineScaleSet_STATUS{#VirtualMachineScaleSet_STATUS}
 
 | Property                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                    |
 |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,8 +179,8 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage.                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                        |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSetList"></a>VirtualMachineScaleSetList
------------------------------------------------------------------
+VirtualMachineScaleSetList{#VirtualMachineScaleSetList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}
 
@@ -190,8 +190,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [VirtualMachineScaleSet[]](#VirtualMachineScaleSet)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetsExtension"></a>VirtualMachineScaleSetsExtension
------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension{#VirtualMachineScaleSetsExtension}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}
 
@@ -204,7 +204,7 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | spec                                                                                    |             | [VirtualMachineScaleSetsExtension_Spec](#VirtualMachineScaleSetsExtension_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachineScaleSetsExtension_STATUS](#VirtualMachineScaleSetsExtension_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachineScaleSetsExtension_Spec"></a>VirtualMachineScaleSetsExtension_Spec
+### VirtualMachineScaleSetsExtension_Spec {#VirtualMachineScaleSetsExtension_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -221,7 +221,7 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | type                     | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="VirtualMachineScaleSetsExtension_STATUS"></a>VirtualMachineScaleSetsExtension_STATUS
+### VirtualMachineScaleSetsExtension_STATUS{#VirtualMachineScaleSetsExtension_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -239,8 +239,8 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | type                     | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachineScaleSetsExtensionList"></a>VirtualMachineScaleSetsExtensionList
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtensionList{#VirtualMachineScaleSetsExtensionList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}
 
@@ -250,8 +250,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [VirtualMachineScaleSetsExtension[]](#VirtualMachineScaleSetsExtension)<br/><small>Optional</small> |
 
-<a id="VirtualMachinesExtension"></a>VirtualMachinesExtension
--------------------------------------------------------------
+VirtualMachinesExtension{#VirtualMachinesExtension}
+---------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}
 
@@ -264,7 +264,7 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | spec                                                                                    |             | [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachinesExtension_STATUS](#VirtualMachinesExtension_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachinesExtension_Spec"></a>VirtualMachinesExtension_Spec
+### VirtualMachinesExtension_Spec {#VirtualMachinesExtension_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -283,7 +283,7 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | type                    | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion      | Specifies the version of the script handler.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="VirtualMachinesExtension_STATUS"></a>VirtualMachinesExtension_STATUS
+### VirtualMachinesExtension_STATUS{#VirtualMachinesExtension_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -303,8 +303,8 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | type                    | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion      | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachinesExtensionList"></a>VirtualMachinesExtensionList
----------------------------------------------------------------------
+VirtualMachinesExtensionList{#VirtualMachinesExtensionList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2020-12-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}
 
@@ -314,8 +314,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [VirtualMachinesExtension[]](#VirtualMachinesExtension)<br/><small>Optional</small> |
 
-<a id="VirtualMachine_Spec"></a>VirtualMachine_Spec
----------------------------------------------------
+VirtualMachine_Spec{#VirtualMachine_Spec}
+-----------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -349,8 +349,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | virtualMachineScaleSet  | Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. This property cannot exist along with a non-null properties.availabilitySet reference. Minimum api‐version: 2019‐03‐01                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
--------------------------------------------------------
+VirtualMachine_STATUS{#VirtualMachine_STATUS}
+---------------------------------------------
 
 Describes a Virtual Machine.
 
@@ -391,8 +391,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | vmId                    | Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSet_Spec"></a>VirtualMachineScaleSet_Spec
--------------------------------------------------------------------
+VirtualMachineScaleSet_Spec{#VirtualMachineScaleSet_Spec}
+---------------------------------------------------------
 
 Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 
@@ -422,8 +422,8 @@ Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage.                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="VirtualMachineScaleSet_STATUS"></a>VirtualMachineScaleSet_STATUS
------------------------------------------------------------------------
+VirtualMachineScaleSet_STATUS{#VirtualMachineScaleSet_STATUS}
+-------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set.
 
@@ -458,8 +458,8 @@ Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage.                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                        |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSetsExtension_Spec"></a>VirtualMachineScaleSetsExtension_Spec
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension_Spec{#VirtualMachineScaleSetsExtension_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 
@@ -478,8 +478,8 @@ Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 | type                     | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VirtualMachineScaleSetsExtension_STATUS"></a>VirtualMachineScaleSetsExtension_STATUS
--------------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension_STATUS{#VirtualMachineScaleSetsExtension_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 
@@ -499,8 +499,8 @@ Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 | type                     | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachinesExtension_Spec"></a>VirtualMachinesExtension_Spec
------------------------------------------------------------------------
+VirtualMachinesExtension_Spec{#VirtualMachinesExtension_Spec}
+-------------------------------------------------------------
 
 Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 
@@ -521,8 +521,8 @@ Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 | type                    | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion      | Specifies the version of the script handler.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VirtualMachinesExtension_STATUS"></a>VirtualMachinesExtension_STATUS
----------------------------------------------------------------------------
+VirtualMachinesExtension_STATUS{#VirtualMachinesExtension_STATUS}
+-----------------------------------------------------------------
 
 Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 
@@ -544,8 +544,8 @@ Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 | type                    | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion      | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdditionalCapabilities"></a>AdditionalCapabilities
----------------------------------------------------------
+AdditionalCapabilities{#AdditionalCapabilities}
+-----------------------------------------------
 
 Enables or disables a capability on the virtual machine or virtual machine scale set.
 
@@ -555,8 +555,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | ultraSSDEnabled | The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled. | bool<br/><small>Optional</small> |
 
-<a id="AdditionalCapabilities_STATUS"></a>AdditionalCapabilities_STATUS
------------------------------------------------------------------------
+AdditionalCapabilities_STATUS{#AdditionalCapabilities_STATUS}
+-------------------------------------------------------------
 
 Enables or disables a capability on the virtual machine or virtual machine scale set.
 
@@ -566,8 +566,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | ultraSSDEnabled | The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled. | bool<br/><small>Optional</small> |
 
-<a id="AutomaticRepairsPolicy"></a>AutomaticRepairsPolicy
----------------------------------------------------------
+AutomaticRepairsPolicy{#AutomaticRepairsPolicy}
+-----------------------------------------------
 
 Specifies the configuration parameters for automatic repairs on the virtual machine scale set.
 
@@ -578,8 +578,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | enabled     | Specifies whether automatic repairs should be enabled on the virtual machine scale set. The default value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>   |
 | gracePeriod | The amount of time for which automatic repairs are suspended due to a state change on VM. The grace time starts after the state change has completed. This helps avoid premature or accidental repairs. The time duration should be specified in ISO 8601 format. The minimum allowed grace period is 30 minutes (PT30M), which is also the default value. The maximum allowed grace period is 90 minutes (PT90M). | string<br/><small>Optional</small> |
 
-<a id="AutomaticRepairsPolicy_STATUS"></a>AutomaticRepairsPolicy_STATUS
------------------------------------------------------------------------
+AutomaticRepairsPolicy_STATUS{#AutomaticRepairsPolicy_STATUS}
+-------------------------------------------------------------
 
 Specifies the configuration parameters for automatic repairs on the virtual machine scale set.
 
@@ -590,8 +590,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | enabled     | Specifies whether automatic repairs should be enabled on the virtual machine scale set. The default value is false.                                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small>   |
 | gracePeriod | The amount of time for which automatic repairs are suspended due to a state change on VM. The grace time starts after the state change has completed. This helps avoid premature or accidental repairs. The time duration should be specified in ISO 8601 format. The minimum allowed grace period is 30 minutes (PT30M), which is also the default value. The maximum allowed grace period is 90 minutes (PT90M). | string<br/><small>Optional</small> |
 
-<a id="BillingProfile"></a>BillingProfile
------------------------------------------
+BillingProfile{#BillingProfile}
+-------------------------------
 
 Specifies the billing related details of a Azure Spot VM or VMSS. Minimum api-version: 2019-03-01.
 
@@ -601,8 +601,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | maxPrice | Specifies the maximum price you are willing to pay for a Azure Spot VM/VMSS. This price is in US Dollars. This price will be compared with the current Azure Spot price for the VM size. Also, the prices are compared at the time of create/update of Azure Spot VM/VMSS and the operation will only succeed if the maxPrice is greater than the current Azure Spot price. The maxPrice will also be used for evicting a Azure Spot VM/VMSS if the current Azure Spot price goes beyond the maxPrice after creation of VM/VMSS. Possible values are: - Any decimal value greater than zero. Example: 0.01538 -1 – indicates default price to be up-to on-demand. You can set the maxPrice to -1 to indicate that the Azure Spot VM/VMSS should not be evicted for price reasons. Also, the default max price is -1 if it is not provided by you. Minimum api-version: 2019-03-01. | float64<br/><small>Optional</small> |
 
-<a id="BillingProfile_STATUS"></a>BillingProfile_STATUS
--------------------------------------------------------
+BillingProfile_STATUS{#BillingProfile_STATUS}
+---------------------------------------------
 
 Specifies the billing related details of a Azure Spot VM or VMSS. Minimum api-version: 2019-03-01.
 
@@ -612,8 +612,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | maxPrice | Specifies the maximum price you are willing to pay for a Azure Spot VM/VMSS. This price is in US Dollars. This price will be compared with the current Azure Spot price for the VM size. Also, the prices are compared at the time of create/update of Azure Spot VM/VMSS and the operation will only succeed if the maxPrice is greater than the current Azure Spot price. The maxPrice will also be used for evicting a Azure Spot VM/VMSS if the current Azure Spot price goes beyond the maxPrice after creation of VM/VMSS. Possible values are: - Any decimal value greater than zero. Example: 0.01538 -1 – indicates default price to be up-to on-demand. You can set the maxPrice to -1 to indicate that the Azure Spot VM/VMSS should not be evicted for price reasons. Also, the default max price is -1 if it is not provided by you. Minimum api-version: 2019-03-01. | float64<br/><small>Optional</small> |
 
-<a id="DiagnosticsProfile"></a>DiagnosticsProfile
--------------------------------------------------
+DiagnosticsProfile{#DiagnosticsProfile}
+---------------------------------------
 
 Specifies the boot diagnostic settings state. Minimum api-version: 2015-06-15.
 
@@ -623,8 +623,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | bootDiagnostics | Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor. | [BootDiagnostics](#BootDiagnostics)<br/><small>Optional</small> |
 
-<a id="DiagnosticsProfile_STATUS"></a>DiagnosticsProfile_STATUS
----------------------------------------------------------------
+DiagnosticsProfile_STATUS{#DiagnosticsProfile_STATUS}
+-----------------------------------------------------
 
 Specifies the boot diagnostic settings state. Minimum api-version: 2015-06-15.
 
@@ -634,8 +634,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | bootDiagnostics | Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor. | [BootDiagnostics_STATUS](#BootDiagnostics_STATUS)<br/><small>Optional</small> |
 
-<a id="EvictionPolicy"></a>EvictionPolicy
------------------------------------------
+EvictionPolicy{#EvictionPolicy}
+-------------------------------
 
 Specifies the eviction policy for the Azure Spot VM/VMSS
 
@@ -646,8 +646,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="EvictionPolicy_STATUS"></a>EvictionPolicy_STATUS
--------------------------------------------------------
+EvictionPolicy_STATUS{#EvictionPolicy_STATUS}
+---------------------------------------------
 
 Specifies the eviction policy for the Azure Spot VM/VMSS
 
@@ -658,8 +658,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -670,8 +670,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -682,8 +682,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="HardwareProfile"></a>HardwareProfile
--------------------------------------------
+HardwareProfile{#HardwareProfile}
+---------------------------------
 
 Specifies the hardware settings for the virtual machine.
 
@@ -693,8 +693,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | vmSize   | Specifies the size of the virtual machine. The enum data type is currently deprecated and will be removed by December 23rd 2023. Recommended way to get the list of available sizes is using these APIs: [List all available virtual machine sizes in an availability set](https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes) [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list) [List all available virtual machine sizes for resizing](https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes). For more information about virtual machine sizes, see [Sizes for virtual machines](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes). The available VM sizes depend on region and availability set. | string<br/><small>Optional</small> |
 
-<a id="HardwareProfile_STATUS"></a>HardwareProfile_STATUS
----------------------------------------------------------
+HardwareProfile_STATUS{#HardwareProfile_STATUS}
+-----------------------------------------------
 
 Specifies the hardware settings for the virtual machine.
 
@@ -704,8 +704,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | vmSize   | Specifies the size of the virtual machine. The enum data type is currently deprecated and will be removed by December 23rd 2023. Recommended way to get the list of available sizes is using these APIs: [List all available virtual machine sizes in an availability set](https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes) [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list) [List all available virtual machine sizes for resizing](https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes). For more information about virtual machine sizes, see [Sizes for virtual machines](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes). The available VM sizes depend on region and availability set. | [HardwareProfile_VmSize_STATUS](#HardwareProfile_VmSize_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkProfile"></a>NetworkProfile
------------------------------------------
+NetworkProfile{#NetworkProfile}
+-------------------------------
 
 Specifies the network interfaces of the virtual machine.
 
@@ -715,8 +715,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 |-------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | networkInterfaces | Specifies the list of resource Ids for the network interfaces associated with the virtual machine. | [NetworkInterfaceReference[]](#NetworkInterfaceReference)<br/><small>Optional</small> |
 
-<a id="NetworkProfile_STATUS"></a>NetworkProfile_STATUS
--------------------------------------------------------
+NetworkProfile_STATUS{#NetworkProfile_STATUS}
+---------------------------------------------
 
 Specifies the network interfaces of the virtual machine.
 
@@ -726,8 +726,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 |-------------------|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | networkInterfaces | Specifies the list of resource Ids for the network interfaces associated with the virtual machine. | [NetworkInterfaceReference_STATUS[]](#NetworkInterfaceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="OrchestrationMode"></a>OrchestrationMode
------------------------------------------------
+OrchestrationMode{#OrchestrationMode}
+-------------------------------------
 
 Specifies the orchestration mode for the virtual machine scale set.
 
@@ -738,8 +738,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | "Flexible" |             |
 | "Uniform"  |             |
 
-<a id="OrchestrationMode_STATUS"></a>OrchestrationMode_STATUS
--------------------------------------------------------------
+OrchestrationMode_STATUS{#OrchestrationMode_STATUS}
+---------------------------------------------------
 
 Specifies the orchestration mode for the virtual machine scale set.
 
@@ -750,8 +750,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | "Flexible" |             |
 | "Uniform"  |             |
 
-<a id="OSProfile"></a>OSProfile
--------------------------------
+OSProfile{#OSProfile}
+---------------------
 
 Specifies the operating system settings for the virtual machine. Some of the settings cannot be changed once VM is provisioned.
 
@@ -769,8 +769,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | secrets                     | Specifies set of certificates that should be installed onto the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | [VaultSecretGroup[]](#VaultSecretGroup)<br/><small>Optional</small>                                                                                    |
 | windowsConfiguration        | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [WindowsConfiguration](#WindowsConfiguration)<br/><small>Optional</small>                                                                              |
 
-<a id="OSProfile_STATUS"></a>OSProfile_STATUS
----------------------------------------------
+OSProfile_STATUS{#OSProfile_STATUS}
+-----------------------------------
 
 Specifies the operating system settings for the virtual machine. Some of the settings cannot be changed once VM is provisioned.
 
@@ -787,8 +787,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | secrets                     | Specifies set of certificates that should be installed onto the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | [VaultSecretGroup_STATUS[]](#VaultSecretGroup_STATUS)<br/><small>Optional</small>       |
 | windowsConfiguration        | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="Plan"></a>Plan
----------------------
+Plan{#Plan}
+-----------
 
 Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click Want to deploy programmatically, Get Started ->. Enter any required information and then click Save.
 
@@ -801,8 +801,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | promotionCode | The promotion code.                                                                                                        | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="Plan_STATUS"></a>Plan_STATUS
------------------------------------
+Plan_STATUS{#Plan_STATUS}
+-------------------------
 
 Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click Want to deploy programmatically, Get Started ->. Enter any required information and then click Save.
 
@@ -815,8 +815,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | promotionCode | The promotion code.                                                                                                        | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="Priority"></a>Priority
------------------------------
+Priority{#Priority}
+-------------------
 
 Specifies the priority for a standalone virtual machine or the virtual machines in the scale set. 'Low' enum will be deprecated in the future, please use 'Spot' as the enum to deploy Azure Spot VM/VMSS.
 
@@ -828,8 +828,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="Priority_STATUS"></a>Priority_STATUS
--------------------------------------------
+Priority_STATUS{#Priority_STATUS}
+---------------------------------
 
 Specifies the priority for a standalone virtual machine or the virtual machines in the scale set. 'Low' enum will be deprecated in the future, please use 'Spot' as the enum to deploy Azure Spot VM/VMSS.
 
@@ -841,8 +841,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleInPolicy"></a>ScaleInPolicy
----------------------------------------
+ScaleInPolicy{#ScaleInPolicy}
+-----------------------------
 
 Describes a scale-in policy for a virtual machine scale set.
 
@@ -852,8 +852,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | rules    | The rules to be followed when scaling-in a virtual machine scale set. Possible values are: Default When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. OldestVM When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. | [ScaleInPolicy_Rules[]](#ScaleInPolicy_Rules)<br/><small>Optional</small> |
 
-<a id="ScaleInPolicy_STATUS"></a>ScaleInPolicy_STATUS
------------------------------------------------------
+ScaleInPolicy_STATUS{#ScaleInPolicy_STATUS}
+-------------------------------------------
 
 Describes a scale-in policy for a virtual machine scale set.
 
@@ -863,8 +863,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | rules    | The rules to be followed when scaling-in a virtual machine scale set. Possible values are: Default When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. OldestVM When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. | [ScaleInPolicy_Rules_STATUS[]](#ScaleInPolicy_Rules_STATUS)<br/><small>Optional</small> |
 
-<a id="SecurityProfile"></a>SecurityProfile
--------------------------------------------
+SecurityProfile{#SecurityProfile}
+---------------------------------
 
 Specifies the Security profile settings for the virtual machine or virtual machine scale set.
 
@@ -876,8 +876,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | securityType     | Specifies the SecurityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings. Default: UefiSettings will not be enabled unless this property is set as TrustedLaunch.                                                                                                                                                         | [SecurityProfile_SecurityType](#SecurityProfile_SecurityType)<br/><small>Optional</small> |
 | uefiSettings     | Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01                                                                                                                                                                                                                    | [UefiSettings](#UefiSettings)<br/><small>Optional</small>                                 |
 
-<a id="SecurityProfile_STATUS"></a>SecurityProfile_STATUS
----------------------------------------------------------
+SecurityProfile_STATUS{#SecurityProfile_STATUS}
+-----------------------------------------------
 
 Specifies the Security profile settings for the virtual machine or virtual machine scale set.
 
@@ -889,8 +889,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | securityType     | Specifies the SecurityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings. Default: UefiSettings will not be enabled unless this property is set as TrustedLaunch.                                                                                                                                                         | [SecurityProfile_SecurityType_STATUS](#SecurityProfile_SecurityType_STATUS)<br/><small>Optional</small> |
 | uefiSettings     | Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01                                                                                                                                                                                                                    | [UefiSettings_STATUS](#UefiSettings_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set is currently on, you need to deallocate the VMs in the scale set before you modify the SKU name.
 
@@ -902,8 +902,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | name     | The sku name.                                                                          | string<br/><small>Optional</small> |
 | tier     | Specifies the tier of virtual machines in a scale set. Possible Values: Standard Basic | string<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set is currently on, you need to deallocate the VMs in the scale set before you modify the SKU name.
 
@@ -915,8 +915,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | name     | The sku name.                                                                          | string<br/><small>Optional</small> |
 | tier     | Specifies the tier of virtual machines in a scale set. Possible Values: Standard Basic | string<br/><small>Optional</small> |
 
-<a id="StorageProfile"></a>StorageProfile
------------------------------------------
+StorageProfile{#StorageProfile}
+-------------------------------
 
 Specifies the storage settings for the virtual machine disks.
 
@@ -928,8 +928,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.                    | [ImageReference](#ImageReference)<br/><small>Optional</small> |
 | osDisk         | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). | [OSDisk](#OSDisk)<br/><small>Optional</small>                 |
 
-<a id="StorageProfile_STATUS"></a>StorageProfile_STATUS
--------------------------------------------------------
+StorageProfile_STATUS{#StorageProfile_STATUS}
+---------------------------------------------
 
 Specifies the storage settings for the virtual machine disks.
 
@@ -941,8 +941,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.                    | [ImageReference_STATUS](#ImageReference_STATUS)<br/><small>Optional</small> |
 | osDisk         | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). | [OSDisk_STATUS](#OSDisk_STATUS)<br/><small>Optional</small>                 |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Used by: [KeyVaultKeyReference](#KeyVaultKeyReference), [KeyVaultSecretReference](#KeyVaultSecretReference), [ManagedDiskParameters](#ManagedDiskParameters), [VaultSecretGroup](#VaultSecretGroup), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec), [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetManagedDiskParameters](#VirtualMachineScaleSetManagedDiskParameters), [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNetworkConfiguration), and [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineScaleSetPublicIPAddressConfiguration).
 
@@ -950,8 +950,8 @@ Used by: [KeyVaultKeyReference](#KeyVaultKeyReference), [KeyVaultSecretReference
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Used by: [KeyVaultKeyReference_STATUS](#KeyVaultKeyReference_STATUS), [KeyVaultSecretReference_STATUS](#KeyVaultSecretReference_STATUS), [ManagedDiskParameters_STATUS](#ManagedDiskParameters_STATUS), [VaultSecretGroup_STATUS](#VaultSecretGroup_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS), [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetManagedDiskParameters_STATUS](#VirtualMachineScaleSetManagedDiskParameters_STATUS), [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScaleSetNetworkConfiguration_STATUS), and [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS).
 
@@ -959,8 +959,8 @@ Used by: [KeyVaultKeyReference_STATUS](#KeyVaultKeyReference_STATUS), [KeyVaultS
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="UpgradePolicy"></a>UpgradePolicy
----------------------------------------
+UpgradePolicy{#UpgradePolicy}
+-----------------------------
 
 Describes an upgrade policy - automatic, manual, or rolling.
 
@@ -972,8 +972,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | mode                     | Specifies the mode of an upgrade to virtual machines in the scale set. Possible values are: Manual - You control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action. Automatic - All virtual machines in the scale set are automatically updated at the same time. | [UpgradePolicy_Mode](#UpgradePolicy_Mode)<br/><small>Optional</small>             |
 | rollingUpgradePolicy     | The configuration parameters used while performing a rolling upgrade.                                                                                                                                                                                                                                                          | [RollingUpgradePolicy](#RollingUpgradePolicy)<br/><small>Optional</small>         |
 
-<a id="UpgradePolicy_STATUS"></a>UpgradePolicy_STATUS
------------------------------------------------------
+UpgradePolicy_STATUS{#UpgradePolicy_STATUS}
+-------------------------------------------
 
 Describes an upgrade policy - automatic, manual, or rolling.
 
@@ -985,8 +985,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | mode                     | Specifies the mode of an upgrade to virtual machines in the scale set. Possible values are: Manual - You control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action. Automatic - All virtual machines in the scale set are automatically updated at the same time. | [UpgradePolicy_Mode_STATUS](#UpgradePolicy_Mode_STATUS)<br/><small>Optional</small>             |
 | rollingUpgradePolicy     | The configuration parameters used while performing a rolling upgrade.                                                                                                                                                                                                                                                          | [RollingUpgradePolicy_STATUS](#RollingUpgradePolicy_STATUS)<br/><small>Optional</small>         |
 
-<a id="VirtualMachineExtension_STATUS"></a>VirtualMachineExtension_STATUS
--------------------------------------------------------------------------
+VirtualMachineExtension_STATUS{#VirtualMachineExtension_STATUS}
+---------------------------------------------------------------
 
 Describes a Virtual Machine Extension.
 
@@ -1009,8 +1009,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | type                    | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                    |
 | typeHandlerVersion      | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                    |
 
-<a id="VirtualMachineExtensionInstanceView"></a>VirtualMachineExtensionInstanceView
------------------------------------------------------------------------------------
+VirtualMachineExtensionInstanceView{#VirtualMachineExtensionInstanceView}
+-------------------------------------------------------------------------
 
 The instance view of a virtual machine extension.
 
@@ -1024,8 +1024,8 @@ Used by: [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec).
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                      |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                      |
 
-<a id="VirtualMachineExtensionInstanceView_STATUS"></a>VirtualMachineExtensionInstanceView_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineExtensionInstanceView_STATUS{#VirtualMachineExtensionInstanceView_STATUS}
+---------------------------------------------------------------------------------------
 
 The instance view of a virtual machine extension.
 
@@ -1039,8 +1039,8 @@ Used by: [VirtualMachineExtension_STATUS](#VirtualMachineExtension_STATUS), [Vir
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                                    |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                                    |
 
-<a id="VirtualMachineIdentity"></a>VirtualMachineIdentity
----------------------------------------------------------
+VirtualMachineIdentity{#VirtualMachineIdentity}
+-----------------------------------------------
 
 Identity for the virtual machine.
 
@@ -1051,8 +1051,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | type                   | The type of identity used for the virtual machine. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                                | [VirtualMachineIdentity_Type](#VirtualMachineIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="VirtualMachineIdentity_STATUS"></a>VirtualMachineIdentity_STATUS
------------------------------------------------------------------------
+VirtualMachineIdentity_STATUS{#VirtualMachineIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the virtual machine.
 
@@ -1065,8 +1065,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | type                   | The type of identity used for the virtual machine. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                                | [VirtualMachineIdentity_Type_STATUS](#VirtualMachineIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS](#VirtualMachineIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineInstanceView_STATUS"></a>VirtualMachineInstanceView_STATUS
--------------------------------------------------------------------------------
+VirtualMachineInstanceView_STATUS{#VirtualMachineInstanceView_STATUS}
+---------------------------------------------------------------------
 
 The instance view of a virtual machine.
 
@@ -1091,8 +1091,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | vmAgent                   | The VM Agent running on the virtual machine.                                                                                                                                                                                                        | [VirtualMachineAgentInstanceView_STATUS](#VirtualMachineAgentInstanceView_STATUS)<br/><small>Optional</small>                         |
 | vmHealth                  | The health status for the VM.                                                                                                                                                                                                                       | [VirtualMachineHealthStatus_STATUS](#VirtualMachineHealthStatus_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="VirtualMachineOperatorSpec"></a>VirtualMachineOperatorSpec
------------------------------------------------------------------
+VirtualMachineOperatorSpec{#VirtualMachineOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1103,8 +1103,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIdentity"></a>VirtualMachineScaleSetIdentity
--------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity{#VirtualMachineScaleSetIdentity}
+---------------------------------------------------------------
 
 Identity for the virtual machine scale set.
 
@@ -1115,8 +1115,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | type                   | The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine scale set.                                                                                                                                      | [VirtualMachineScaleSetIdentity_Type](#VirtualMachineScaleSetIdentity_Type)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small>               |
 
-<a id="VirtualMachineScaleSetIdentity_STATUS"></a>VirtualMachineScaleSetIdentity_STATUS
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_STATUS{#VirtualMachineScaleSetIdentity_STATUS}
+-----------------------------------------------------------------------------
 
 Identity for the virtual machine scale set.
 
@@ -1129,8 +1129,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | type                   | The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine scale set.                                                                                                                                      | [VirtualMachineScaleSetIdentity_Type_STATUS](#VirtualMachineScaleSetIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS](#VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetOperatorSpec"></a>VirtualMachineScaleSetOperatorSpec
----------------------------------------------------------------------------------
+VirtualMachineScaleSetOperatorSpec{#VirtualMachineScaleSetOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1141,8 +1141,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetsExtensionOperatorSpec"></a>VirtualMachineScaleSetsExtensionOperatorSpec
------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtensionOperatorSpec{#VirtualMachineScaleSetsExtensionOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1153,8 +1153,8 @@ Used by: [VirtualMachineScaleSetsExtension_Spec](#VirtualMachineScaleSetsExtensi
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetVMProfile"></a>VirtualMachineScaleSetVMProfile
----------------------------------------------------------------------------
+VirtualMachineScaleSetVMProfile{#VirtualMachineScaleSetVMProfile}
+-----------------------------------------------------------------
 
 Describes a virtual machine scale set virtual machine profile.
 
@@ -1174,8 +1174,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | securityProfile        | Specifies the Security related profile settings for the virtual machines in the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [SecurityProfile](#SecurityProfile)<br/><small>Optional</small>                                               |
 | storageProfile         | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStorageProfile)<br/><small>Optional</small>     |
 
-<a id="VirtualMachineScaleSetVMProfile_STATUS"></a>VirtualMachineScaleSetVMProfile_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetVMProfile_STATUS{#VirtualMachineScaleSetVMProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set virtual machine profile.
 
@@ -1195,8 +1195,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | securityProfile        | Specifies the Security related profile settings for the virtual machines in the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | [SecurityProfile_STATUS](#SecurityProfile_STATUS)<br/><small>Optional</small>                                               |
 | storageProfile         | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetStorageProfile_STATUS)<br/><small>Optional</small>     |
 
-<a id="VirtualMachinesExtensionOperatorSpec"></a>VirtualMachinesExtensionOperatorSpec
--------------------------------------------------------------------------------------
+VirtualMachinesExtensionOperatorSpec{#VirtualMachinesExtensionOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1207,8 +1207,8 @@ Used by: [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AutomaticOSUpgradePolicy"></a>AutomaticOSUpgradePolicy
--------------------------------------------------------------
+AutomaticOSUpgradePolicy{#AutomaticOSUpgradePolicy}
+---------------------------------------------------
 
 The configuration parameters used for performing automatic OS upgrade.
 
@@ -1219,8 +1219,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | disableAutomaticRollback | Whether OS image rollback feature should be disabled. Default value is false.                                                                                                                                                                                                                                                                                                                                                                                                   | bool<br/><small>Optional</small> |
 | enableAutomaticOSUpgrade | Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer version of the OS image becomes available. Default value is false. If this is set to true for Windows based scale sets, [enableAutomaticUpdates](https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.windowsconfiguration.enableautomaticupdates?view=azure-dotnet) is automatically set to false and cannot be set to true. | bool<br/><small>Optional</small> |
 
-<a id="AutomaticOSUpgradePolicy_STATUS"></a>AutomaticOSUpgradePolicy_STATUS
----------------------------------------------------------------------------
+AutomaticOSUpgradePolicy_STATUS{#AutomaticOSUpgradePolicy_STATUS}
+-----------------------------------------------------------------
 
 The configuration parameters used for performing automatic OS upgrade.
 
@@ -1231,8 +1231,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | disableAutomaticRollback | Whether OS image rollback feature should be disabled. Default value is false.                                                                                                                                                                                                                                                                                                                                                                                                   | bool<br/><small>Optional</small> |
 | enableAutomaticOSUpgrade | Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer version of the OS image becomes available. Default value is false. If this is set to true for Windows based scale sets, [enableAutomaticUpdates](https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.windowsconfiguration.enableautomaticupdates?view=azure-dotnet) is automatically set to false and cannot be set to true. | bool<br/><small>Optional</small> |
 
-<a id="BootDiagnostics"></a>BootDiagnostics
--------------------------------------------
+BootDiagnostics{#BootDiagnostics}
+---------------------------------
 
 Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor.
 
@@ -1243,8 +1243,8 @@ Used by: [DiagnosticsProfile](#DiagnosticsProfile).
 | enabled    | Whether boot diagnostics should be enabled on the Virtual Machine.                                                                                                             | bool<br/><small>Optional</small>   |
 | storageUri | Uri of the storage account to use for placing the console output and screenshot. If storageUri is not specified while enabling boot diagnostics, managed storage will be used. | string<br/><small>Optional</small> |
 
-<a id="BootDiagnostics_STATUS"></a>BootDiagnostics_STATUS
----------------------------------------------------------
+BootDiagnostics_STATUS{#BootDiagnostics_STATUS}
+-----------------------------------------------
 
 Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor.
 
@@ -1255,8 +1255,8 @@ Used by: [DiagnosticsProfile_STATUS](#DiagnosticsProfile_STATUS).
 | enabled    | Whether boot diagnostics should be enabled on the Virtual Machine.                                                                                                             | bool<br/><small>Optional</small>   |
 | storageUri | Uri of the storage account to use for placing the console output and screenshot. If storageUri is not specified while enabling boot diagnostics, managed storage will be used. | string<br/><small>Optional</small> |
 
-<a id="BootDiagnosticsInstanceView_STATUS"></a>BootDiagnosticsInstanceView_STATUS
----------------------------------------------------------------------------------
+BootDiagnosticsInstanceView_STATUS{#BootDiagnosticsInstanceView_STATUS}
+-----------------------------------------------------------------------
 
 The instance view of a virtual machine boot diagnostics.
 
@@ -1268,8 +1268,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | serialConsoleLogBlobUri  | The serial console log blob Uri. NOTE: This will not be set if boot diagnostics is currently enabled with managed storage.                  | string<br/><small>Optional</small>                                                  |
 | status                   | The boot diagnostics status information for the VM. NOTE: It will be set only if there are errors encountered in enabling boot diagnostics. | [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="DataDisk"></a>DataDisk
------------------------------
+DataDisk{#DataDisk}
+-------------------
 
 Describes a data disk.
 
@@ -1289,8 +1289,8 @@ Used by: [StorageProfile](#StorageProfile).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [VirtualHardDisk](#VirtualHardDisk)<br/><small>Optional</small>             |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                            |
 
-<a id="DataDisk_STATUS"></a>DataDisk_STATUS
--------------------------------------------
+DataDisk_STATUS{#DataDisk_STATUS}
+---------------------------------
 
 Describes a data disk.
 
@@ -1312,8 +1312,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [VirtualHardDisk_STATUS](#VirtualHardDisk_STATUS)<br/><small>Optional</small>             |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                          |
 
-<a id="DiskInstanceView_STATUS"></a>DiskInstanceView_STATUS
------------------------------------------------------------
+DiskInstanceView_STATUS{#DiskInstanceView_STATUS}
+-------------------------------------------------
 
 The instance view of the disk.
 
@@ -1325,8 +1325,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | name               | The disk name.                                                                     | string<br/><small>Optional</small>                                                            |
 | statuses           | The resource status information.                                                   | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>         |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -1336,8 +1336,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -1347,8 +1347,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="HardwareProfile_VmSize_STATUS"></a>HardwareProfile_VmSize_STATUS
------------------------------------------------------------------------
+HardwareProfile_VmSize_STATUS{#HardwareProfile_VmSize_STATUS}
+-------------------------------------------------------------
 
 Used by: [HardwareProfile_STATUS](#HardwareProfile_STATUS).
 
@@ -1521,8 +1521,8 @@ Used by: [HardwareProfile_STATUS](#HardwareProfile_STATUS).
 | "Standard_NV24"       |             |
 | "Standard_NV6"        |             |
 
-<a id="ImageReference"></a>ImageReference
------------------------------------------
+ImageReference{#ImageReference}
+-------------------------------
 
 Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. NOTE: Image reference publisher and offer can only be set when you create the scale set.
 
@@ -1536,8 +1536,8 @@ Used by: [StorageProfile](#StorageProfile), and [VirtualMachineScaleSetStoragePr
 | sku       | The image SKU.                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                         |
 | version   | Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available. | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ImageReference_STATUS"></a>ImageReference_STATUS
--------------------------------------------------------
+ImageReference_STATUS{#ImageReference_STATUS}
+---------------------------------------------
 
 Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. NOTE: Image reference publisher and offer can only be set when you create the scale set.
 
@@ -1552,8 +1552,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS), and [VirtualMachineSca
 | sku          | The image SKU.                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small> |
 | version      | Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available. | string<br/><small>Optional</small> |
 
-<a id="InstanceViewStatus"></a>InstanceViewStatus
--------------------------------------------------
+InstanceViewStatus{#InstanceViewStatus}
+---------------------------------------
 
 Instance view status.
 
@@ -1567,8 +1567,8 @@ Used by: [VirtualMachineExtensionInstanceView](#VirtualMachineExtensionInstanceV
 | message       | The detailed status message, including for alerts and error messages. | string<br/><small>Optional</small>                                                |
 | time          | The time of the status.                                               | string<br/><small>Optional</small>                                                |
 
-<a id="InstanceViewStatus_STATUS"></a>InstanceViewStatus_STATUS
----------------------------------------------------------------
+InstanceViewStatus_STATUS{#InstanceViewStatus_STATUS}
+-----------------------------------------------------
 
 Instance view status.
 
@@ -1582,8 +1582,8 @@ Used by: [BootDiagnosticsInstanceView_STATUS](#BootDiagnosticsInstanceView_STATU
 | message       | The detailed status message, including for alerts and error messages. | string<br/><small>Optional</small>                                                              |
 | time          | The time of the status.                                               | string<br/><small>Optional</small>                                                              |
 
-<a id="LinuxConfiguration"></a>LinuxConfiguration
--------------------------------------------------
+LinuxConfiguration{#LinuxConfiguration}
+---------------------------------------
 
 Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json) For running non-endorsed distributions, see [Information for Non-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
@@ -1596,8 +1596,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | provisionVMAgent              | Indicates whether virtual machine agent should be provisioned on the virtual machine. When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM Agent is installed on the VM so that extensions can be added to the VM later. | bool<br/><small>Optional</small>                                      |
 | ssh                           | Specifies the ssh key configuration for a Linux OS.                                                                                                                                                                                                                                          | [SshConfiguration](#SshConfiguration)<br/><small>Optional</small>     |
 
-<a id="LinuxConfiguration_STATUS"></a>LinuxConfiguration_STATUS
----------------------------------------------------------------
+LinuxConfiguration_STATUS{#LinuxConfiguration_STATUS}
+-----------------------------------------------------
 
 Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json) For running non-endorsed distributions, see [Information for Non-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
@@ -1610,8 +1610,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | provisionVMAgent              | Indicates whether virtual machine agent should be provisioned on the virtual machine. When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM Agent is installed on the VM so that extensions can be added to the VM later. | bool<br/><small>Optional</small>                                                    |
 | ssh                           | Specifies the ssh key configuration for a Linux OS.                                                                                                                                                                                                                                          | [SshConfiguration_STATUS](#SshConfiguration_STATUS)<br/><small>Optional</small>     |
 
-<a id="MaintenanceRedeployStatus_STATUS"></a>MaintenanceRedeployStatus_STATUS
------------------------------------------------------------------------------
+MaintenanceRedeployStatus_STATUS{#MaintenanceRedeployStatus_STATUS}
+-------------------------------------------------------------------
 
 Maintenance Operation Status.
 
@@ -1627,8 +1627,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | preMaintenanceWindowEndTime           | End Time for the Pre Maintenance Window.             | string<br/><small>Optional</small>                                                                                                                |
 | preMaintenanceWindowStartTime         | Start Time for the Pre Maintenance Window.           | string<br/><small>Optional</small>                                                                                                                |
 
-<a id="NetworkInterfaceReference"></a>NetworkInterfaceReference
----------------------------------------------------------------
+NetworkInterfaceReference{#NetworkInterfaceReference}
+-----------------------------------------------------
 
 Describes a network interface reference.
 
@@ -1639,8 +1639,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 | primary   | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                           |
 | reference | Resource Id                                                                                            | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceReference_STATUS"></a>NetworkInterfaceReference_STATUS
------------------------------------------------------------------------------
+NetworkInterfaceReference_STATUS{#NetworkInterfaceReference_STATUS}
+-------------------------------------------------------------------
 
 Describes a network interface reference.
 
@@ -1651,8 +1651,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | id       | Resource Id                                                                                            | string<br/><small>Optional</small> |
 | primary  | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>   |
 
-<a id="OSDisk"></a>OSDisk
--------------------------
+OSDisk{#OSDisk}
+---------------
 
 Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
 
@@ -1672,8 +1672,8 @@ Used by: [StorageProfile](#StorageProfile).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                               | [VirtualHardDisk](#VirtualHardDisk)<br/><small>Optional</small>               |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                        | bool<br/><small>Optional</small>                                              |
 
-<a id="OSDisk_STATUS"></a>OSDisk_STATUS
----------------------------------------
+OSDisk_STATUS{#OSDisk_STATUS}
+-----------------------------
 
 Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
 
@@ -1693,8 +1693,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                               | [VirtualHardDisk_STATUS](#VirtualHardDisk_STATUS)<br/><small>Optional</small>               |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                        | bool<br/><small>Optional</small>                                                            |
 
-<a id="RollingUpgradePolicy"></a>RollingUpgradePolicy
------------------------------------------------------
+RollingUpgradePolicy{#RollingUpgradePolicy}
+-------------------------------------------
 
 The configuration parameters used while performing a rolling upgrade.
 
@@ -1709,8 +1709,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | pauseTimeBetweenBatches             | The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. The default value is 0 seconds (PT0S).                                                                                                                                                                      | string<br/><small>Optional</small> |
 | prioritizeUnhealthyInstances        | Upgrade all unhealthy instances in a scale set before any healthy instances.                                                                                                                                                                                                                                                                                                         | bool<br/><small>Optional</small>   |
 
-<a id="RollingUpgradePolicy_STATUS"></a>RollingUpgradePolicy_STATUS
--------------------------------------------------------------------
+RollingUpgradePolicy_STATUS{#RollingUpgradePolicy_STATUS}
+---------------------------------------------------------
 
 The configuration parameters used while performing a rolling upgrade.
 
@@ -1725,8 +1725,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | pauseTimeBetweenBatches             | The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. The default value is 0 seconds (PT0S).                                                                                                                                                                      | string<br/><small>Optional</small> |
 | prioritizeUnhealthyInstances        | Upgrade all unhealthy instances in a scale set before any healthy instances.                                                                                                                                                                                                                                                                                                         | bool<br/><small>Optional</small>   |
 
-<a id="ScaleInPolicy_Rules"></a>ScaleInPolicy_Rules
----------------------------------------------------
+ScaleInPolicy_Rules{#ScaleInPolicy_Rules}
+-----------------------------------------
 
 Used by: [ScaleInPolicy](#ScaleInPolicy).
 
@@ -1736,8 +1736,8 @@ Used by: [ScaleInPolicy](#ScaleInPolicy).
 | "NewestVM" |             |
 | "OldestVM" |             |
 
-<a id="ScaleInPolicy_Rules_STATUS"></a>ScaleInPolicy_Rules_STATUS
------------------------------------------------------------------
+ScaleInPolicy_Rules_STATUS{#ScaleInPolicy_Rules_STATUS}
+-------------------------------------------------------
 
 Used by: [ScaleInPolicy_STATUS](#ScaleInPolicy_STATUS).
 
@@ -1747,8 +1747,8 @@ Used by: [ScaleInPolicy_STATUS](#ScaleInPolicy_STATUS).
 | "NewestVM" |             |
 | "OldestVM" |             |
 
-<a id="ScheduledEventsProfile"></a>ScheduledEventsProfile
----------------------------------------------------------
+ScheduledEventsProfile{#ScheduledEventsProfile}
+-----------------------------------------------
 
 Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 
@@ -1756,8 +1756,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 |------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | terminateNotificationProfile | Specifies Terminate Scheduled Event related configurations. | [TerminateNotificationProfile](#TerminateNotificationProfile)<br/><small>Optional</small> |
 
-<a id="ScheduledEventsProfile_STATUS"></a>ScheduledEventsProfile_STATUS
------------------------------------------------------------------------
+ScheduledEventsProfile_STATUS{#ScheduledEventsProfile_STATUS}
+-------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfile_STATUS).
 
@@ -1765,8 +1765,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 |------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | terminateNotificationProfile | Specifies Terminate Scheduled Event related configurations. | [TerminateNotificationProfile_STATUS](#TerminateNotificationProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="SecurityProfile_SecurityType"></a>SecurityProfile_SecurityType
----------------------------------------------------------------------
+SecurityProfile_SecurityType{#SecurityProfile_SecurityType}
+-----------------------------------------------------------
 
 Used by: [SecurityProfile](#SecurityProfile).
 
@@ -1774,8 +1774,8 @@ Used by: [SecurityProfile](#SecurityProfile).
 |-----------------|-------------|
 | "TrustedLaunch" |             |
 
-<a id="SecurityProfile_SecurityType_STATUS"></a>SecurityProfile_SecurityType_STATUS
------------------------------------------------------------------------------------
+SecurityProfile_SecurityType_STATUS{#SecurityProfile_SecurityType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 
@@ -1783,8 +1783,8 @@ Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 |-----------------|-------------|
 | "TrustedLaunch" |             |
 
-<a id="UefiSettings"></a>UefiSettings
--------------------------------------
+UefiSettings{#UefiSettings}
+---------------------------
 
 Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01
 
@@ -1795,8 +1795,8 @@ Used by: [SecurityProfile](#SecurityProfile).
 | secureBootEnabled | Specifies whether secure boot should be enabled on the virtual machine. Minimum api-version: 2020-12-01 | bool<br/><small>Optional</small> |
 | vTpmEnabled       | Specifies whether vTPM should be enabled on the virtual machine. Minimum api-version: 2020-12-01        | bool<br/><small>Optional</small> |
 
-<a id="UefiSettings_STATUS"></a>UefiSettings_STATUS
----------------------------------------------------
+UefiSettings_STATUS{#UefiSettings_STATUS}
+-----------------------------------------
 
 Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01
 
@@ -1807,8 +1807,8 @@ Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 | secureBootEnabled | Specifies whether secure boot should be enabled on the virtual machine. Minimum api-version: 2020-12-01 | bool<br/><small>Optional</small> |
 | vTpmEnabled       | Specifies whether vTPM should be enabled on the virtual machine. Minimum api-version: 2020-12-01        | bool<br/><small>Optional</small> |
 
-<a id="UpgradePolicy_Mode"></a>UpgradePolicy_Mode
--------------------------------------------------
+UpgradePolicy_Mode{#UpgradePolicy_Mode}
+---------------------------------------
 
 Used by: [UpgradePolicy](#UpgradePolicy).
 
@@ -1818,8 +1818,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | "Manual"    |             |
 | "Rolling"   |             |
 
-<a id="UpgradePolicy_Mode_STATUS"></a>UpgradePolicy_Mode_STATUS
----------------------------------------------------------------
+UpgradePolicy_Mode_STATUS{#UpgradePolicy_Mode_STATUS}
+-----------------------------------------------------
 
 Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 
@@ -1829,8 +1829,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | "Manual"    |             |
 | "Rolling"   |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1840,8 +1840,8 @@ Used by: [VirtualMachineIdentity](#VirtualMachineIdentity), and [VirtualMachineS
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VaultSecretGroup"></a>VaultSecretGroup
----------------------------------------------
+VaultSecretGroup{#VaultSecretGroup}
+-----------------------------------
 
 Describes a set of certificates which are all in the same Key Vault.
 
@@ -1852,8 +1852,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | sourceVault       | The relative URL of the Key Vault containing all of the certificates in VaultCertificates. | [SubResource](#SubResource)<br/><small>Optional</small>             |
 | vaultCertificates | The list of key vault references in SourceVault which contain certificates.                | [VaultCertificate[]](#VaultCertificate)<br/><small>Optional</small> |
 
-<a id="VaultSecretGroup_STATUS"></a>VaultSecretGroup_STATUS
------------------------------------------------------------
+VaultSecretGroup_STATUS{#VaultSecretGroup_STATUS}
+-------------------------------------------------
 
 Describes a set of certificates which are all in the same Key Vault.
 
@@ -1864,8 +1864,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | sourceVault       | The relative URL of the Key Vault containing all of the certificates in VaultCertificates. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>             |
 | vaultCertificates | The list of key vault references in SourceVault which contain certificates.                | [VaultCertificate_STATUS[]](#VaultCertificate_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineAgentInstanceView_STATUS"></a>VirtualMachineAgentInstanceView_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineAgentInstanceView_STATUS{#VirtualMachineAgentInstanceView_STATUS}
+-------------------------------------------------------------------------------
 
 The instance view of the VM Agent running on the virtual machine.
 
@@ -1877,8 +1877,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | statuses          | The resource status information.                     | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>                                                 |
 | vmAgentVersion    | The VM Agent full version.                           | string<br/><small>Optional</small>                                                                                                    |
 
-<a id="VirtualMachineHealthStatus_STATUS"></a>VirtualMachineHealthStatus_STATUS
--------------------------------------------------------------------------------
+VirtualMachineHealthStatus_STATUS{#VirtualMachineHealthStatus_STATUS}
+---------------------------------------------------------------------
 
 The health status of the VM.
 
@@ -1888,8 +1888,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 |----------|-------------------------------------------|-------------------------------------------------------------------------------------|
 | status   | The health status information for the VM. | [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineIdentity_Type"></a>VirtualMachineIdentity_Type
--------------------------------------------------------------------
+VirtualMachineIdentity_Type{#VirtualMachineIdentity_Type}
+---------------------------------------------------------
 
 Used by: [VirtualMachineIdentity](#VirtualMachineIdentity).
 
@@ -1900,8 +1900,8 @@ Used by: [VirtualMachineIdentity](#VirtualMachineIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineIdentity_Type_STATUS"></a>VirtualMachineIdentity_Type_STATUS
----------------------------------------------------------------------------------
+VirtualMachineIdentity_Type_STATUS{#VirtualMachineIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 
@@ -1912,8 +1912,8 @@ Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineIdentity_UserAssignedIdentities_STATUS"></a>VirtualMachineIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualMachineIdentity_UserAssignedIdentities_STATUS{#VirtualMachineIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 
@@ -1922,8 +1922,8 @@ Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineInstanceView_HyperVGeneration_STATUS"></a>VirtualMachineInstanceView_HyperVGeneration_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualMachineInstanceView_HyperVGeneration_STATUS{#VirtualMachineInstanceView_HyperVGeneration_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS).
 
@@ -1932,8 +1932,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="VirtualMachinePatchStatus_STATUS"></a>VirtualMachinePatchStatus_STATUS
------------------------------------------------------------------------------
+VirtualMachinePatchStatus_STATUS{#VirtualMachinePatchStatus_STATUS}
+-------------------------------------------------------------------
 
 The status of virtual machine patch operations.
 
@@ -1945,8 +1945,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | configurationStatuses        | The enablement status of the specified patchMode                                        | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>                   |
 | lastPatchInstallationSummary | The installation summary of the latest installation operation for the virtual machine.  | [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetExtensionProfile"></a>VirtualMachineScaleSetExtensionProfile
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtensionProfile{#VirtualMachineScaleSetExtensionProfile}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set extension profile.
 
@@ -1957,8 +1957,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | extensions           | The virtual machine scale set child extension resources.                                                                                                                                                                                                  | [VirtualMachineScaleSetExtension[]](#VirtualMachineScaleSetExtension)<br/><small>Optional</small> |
 | extensionsTimeBudget | Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). Minimum api-version: 2020-06-01 | string<br/><small>Optional</small>                                                                |
 
-<a id="VirtualMachineScaleSetExtensionProfile_STATUS"></a>VirtualMachineScaleSetExtensionProfile_STATUS
--------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtensionProfile_STATUS{#VirtualMachineScaleSetExtensionProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set extension profile.
 
@@ -1969,8 +1969,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | extensions           | The virtual machine scale set child extension resources.                                                                                                                                                                                                  | [VirtualMachineScaleSetExtension_STATUS[]](#VirtualMachineScaleSetExtension_STATUS)<br/><small>Optional</small> |
 | extensionsTimeBudget | Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). Minimum api-version: 2020-06-01 | string<br/><small>Optional</small>                                                                              |
 
-<a id="VirtualMachineScaleSetIdentity_Type"></a>VirtualMachineScaleSetIdentity_Type
------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_Type{#VirtualMachineScaleSetIdentity_Type}
+-------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity](#VirtualMachineScaleSetIdentity).
 
@@ -1981,8 +1981,8 @@ Used by: [VirtualMachineScaleSetIdentity](#VirtualMachineScaleSetIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineScaleSetIdentity_Type_STATUS"></a>VirtualMachineScaleSetIdentity_Type_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_Type_STATUS{#VirtualMachineScaleSetIdentity_Type_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity_STATUS).
 
@@ -1993,8 +1993,8 @@ Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS"></a>VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS{#VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity_STATUS).
 
@@ -2003,8 +2003,8 @@ Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkProfile"></a>VirtualMachineScaleSetNetworkProfile
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile{#VirtualMachineScaleSetNetworkProfile}
+---------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile.
 
@@ -2015,8 +2015,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | healthProbe                    | A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'. | [ApiEntityReference](#ApiEntityReference)<br/><small>Optional</small>                                                   |
 | networkInterfaceConfigurations | The list of network configurations.                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetNetworkConfiguration[]](#VirtualMachineScaleSetNetworkConfiguration)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkProfile_STATUS"></a>VirtualMachineScaleSetNetworkProfile_STATUS
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile_STATUS{#VirtualMachineScaleSetNetworkProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile.
 
@@ -2027,8 +2027,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | healthProbe                    | A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'. | [ApiEntityReference_STATUS](#ApiEntityReference_STATUS)<br/><small>Optional</small>                                                   |
 | networkInterfaceConfigurations | The list of network configurations.                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetNetworkConfiguration_STATUS[]](#VirtualMachineScaleSetNetworkConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetOSProfile"></a>VirtualMachineScaleSetOSProfile
----------------------------------------------------------------------------
+VirtualMachineScaleSetOSProfile{#VirtualMachineScaleSetOSProfile}
+-----------------------------------------------------------------
 
 Describes a virtual machine scale set OS profile.
 
@@ -2044,8 +2044,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | secrets              | Specifies set of certificates that should be installed onto the virtual machines in the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | [VaultSecretGroup[]](#VaultSecretGroup)<br/><small>Optional</small>                                                                                    |
 | windowsConfiguration | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WindowsConfiguration](#WindowsConfiguration)<br/><small>Optional</small>                                                                              |
 
-<a id="VirtualMachineScaleSetOSProfile_STATUS"></a>VirtualMachineScaleSetOSProfile_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSProfile_STATUS{#VirtualMachineScaleSetOSProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set OS profile.
 
@@ -2060,8 +2060,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | secrets              | Specifies set of certificates that should be installed onto the virtual machines in the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | [VaultSecretGroup_STATUS[]](#VaultSecretGroup_STATUS)<br/><small>Optional</small>       |
 | windowsConfiguration | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetStorageProfile"></a>VirtualMachineScaleSetStorageProfile
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetStorageProfile{#VirtualMachineScaleSetStorageProfile}
+---------------------------------------------------------------------------
 
 Describes a virtual machine scale set storage profile.
 
@@ -2073,8 +2073,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.                                      | [ImageReference](#ImageReference)<br/><small>Optional</small>                                   |
 | osDisk         | Specifies information about the operating system disk used by the virtual machines in the scale set. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). | [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk)<br/><small>Optional</small>       |
 
-<a id="VirtualMachineScaleSetStorageProfile_STATUS"></a>VirtualMachineScaleSetStorageProfile_STATUS
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetStorageProfile_STATUS{#VirtualMachineScaleSetStorageProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set storage profile.
 
@@ -2086,8 +2086,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations.                                      | [ImageReference_STATUS](#ImageReference_STATUS)<br/><small>Optional</small>                                   |
 | osDisk         | Specifies information about the operating system disk used by the virtual machines in the scale set. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). | [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS)<br/><small>Optional</small>       |
 
-<a id="WindowsConfiguration"></a>WindowsConfiguration
------------------------------------------------------
+WindowsConfiguration{#WindowsConfiguration}
+-------------------------------------------
 
 Specifies Windows operating system settings on the virtual machine.
 
@@ -2102,8 +2102,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | timeZone                  | Specifies the time zone of the virtual machine. e.g. "Pacific Standard Time". Possible values can be [TimeZoneInfo.Id](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.id?#System_TimeZoneInfo_Id) value from time zones returned by [TimeZoneInfo.GetSystemTimeZones](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.getsystemtimezones). | string<br/><small>Optional</small>                                                    |
 | winRM                     | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.                                                                                                                                                                                                                                                                                  | [WinRMConfiguration](#WinRMConfiguration)<br/><small>Optional</small>                 |
 
-<a id="WindowsConfiguration_STATUS"></a>WindowsConfiguration_STATUS
--------------------------------------------------------------------
+WindowsConfiguration_STATUS{#WindowsConfiguration_STATUS}
+---------------------------------------------------------
 
 Specifies Windows operating system settings on the virtual machine.
 
@@ -2118,8 +2118,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | timeZone                  | Specifies the time zone of the virtual machine. e.g. "Pacific Standard Time". Possible values can be [TimeZoneInfo.Id](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.id?#System_TimeZoneInfo_Id) value from time zones returned by [TimeZoneInfo.GetSystemTimeZones](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.getsystemtimezones). | string<br/><small>Optional</small>                                                                  |
 | winRM                     | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.                                                                                                                                                                                                                                                                                  | [WinRMConfiguration_STATUS](#WinRMConfiguration_STATUS)<br/><small>Optional</small>                 |
 
-<a id="AdditionalUnattendContent"></a>AdditionalUnattendContent
----------------------------------------------------------------
+AdditionalUnattendContent{#AdditionalUnattendContent}
+-----------------------------------------------------
 
 Specifies additional XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup. Contents are defined by setting name, component name, and the pass in which the content is applied.
 
@@ -2132,8 +2132,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 | passName      | The pass name. Currently, the only allowable value is OobeSystem.                                                                                                                                                                   | [AdditionalUnattendContent_PassName](#AdditionalUnattendContent_PassName)<br/><small>Optional</small>           |
 | settingName   | Specifies the name of the setting to which the content applies. Possible values are: FirstLogonCommands and AutoLogon.                                                                                                              | [AdditionalUnattendContent_SettingName](#AdditionalUnattendContent_SettingName)<br/><small>Optional</small>     |
 
-<a id="AdditionalUnattendContent_STATUS"></a>AdditionalUnattendContent_STATUS
------------------------------------------------------------------------------
+AdditionalUnattendContent_STATUS{#AdditionalUnattendContent_STATUS}
+-------------------------------------------------------------------
 
 Specifies additional XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup. Contents are defined by setting name, component name, and the pass in which the content is applied.
 
@@ -2146,8 +2146,8 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 | passName      | The pass name. Currently, the only allowable value is OobeSystem.                                                                                                                                                                   | [AdditionalUnattendContent_PassName_STATUS](#AdditionalUnattendContent_PassName_STATUS)<br/><small>Optional</small>           |
 | settingName   | Specifies the name of the setting to which the content applies. Possible values are: FirstLogonCommands and AutoLogon.                                                                                                              | [AdditionalUnattendContent_SettingName_STATUS](#AdditionalUnattendContent_SettingName_STATUS)<br/><small>Optional</small>     |
 
-<a id="ApiEntityReference"></a>ApiEntityReference
--------------------------------------------------
+ApiEntityReference{#ApiEntityReference}
+---------------------------------------
 
 The API entity reference.
 
@@ -2157,8 +2157,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The ARM resource id in the form of /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;... | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApiEntityReference_STATUS"></a>ApiEntityReference_STATUS
----------------------------------------------------------------
+ApiEntityReference_STATUS{#ApiEntityReference_STATUS}
+-----------------------------------------------------
 
 The API entity reference.
 
@@ -2168,8 +2168,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | The ARM resource id in the form of /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;... | string<br/><small>Optional</small> |
 
-<a id="AvailablePatchSummary_STATUS"></a>AvailablePatchSummary_STATUS
----------------------------------------------------------------------
+AvailablePatchSummary_STATUS{#AvailablePatchSummary_STATUS}
+-----------------------------------------------------------
 
 Describes the properties of an virtual machine instance view for available patch summary.
 
@@ -2186,48 +2186,48 @@ Used by: [VirtualMachinePatchStatus_STATUS](#VirtualMachinePatchStatus_STATUS).
 | startTime                     | The UTC timestamp when the operation began.                                                                                                                                                               | string<br/><small>Optional</small>                                                                      |
 | status                        | The overall success or failure status of the operation. It remains "InProgress" until the operation completes. At that point it will become "Unknown", "Failed", "Succeeded", or "CompletedWithWarnings." | [AvailablePatchSummary_Status_STATUS](#AvailablePatchSummary_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Caching"></a>Caching
+Caching{#Caching}
+-----------------
+
+Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+
+Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
+
+| Value       | Description |
+|-------------|-------------|
+| "None"      |             |
+| "ReadOnly"  |             |
+| "ReadWrite" |             |
+
+Caching_STATUS{#Caching_STATUS}
+-------------------------------
+
+Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+
+Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "None"      |             |
+| "ReadOnly"  |             |
+| "ReadWrite" |             |
+
+CreateOption{#CreateOption}
 ---------------------------
 
-Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
 
 Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 
 | Value       | Description |
 |-------------|-------------|
-| "None"      |             |
-| "ReadOnly"  |             |
-| "ReadWrite" |             |
+| "Attach"    |             |
+| "Empty"     |             |
+| "FromImage" |             |
 
-<a id="Caching_STATUS"></a>Caching_STATUS
+CreateOption_STATUS{#CreateOption_STATUS}
 -----------------------------------------
 
-Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
-
-Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "None"      |             |
-| "ReadOnly"  |             |
-| "ReadWrite" |             |
-
-<a id="CreateOption"></a>CreateOption
--------------------------------------
-
-Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
-
-Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
-
-| Value       | Description |
-|-------------|-------------|
-| "Attach"    |             |
-| "Empty"     |             |
-| "FromImage" |             |
-
-<a id="CreateOption_STATUS"></a>CreateOption_STATUS
----------------------------------------------------
-
 Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
 
 Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
@@ -2238,8 +2238,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [
 | "Empty"     |             |
 | "FromImage" |             |
 
-<a id="DetachOption"></a>DetachOption
--------------------------------------
+DetachOption{#DetachOption}
+---------------------------
 
 Specifies the detach behavior to be used while detaching a disk or which is already in the process of detachment from the virtual machine. Supported values: ForceDetach. detachOption: ForceDetach is applicable only for managed data disks. If a previous detachment attempt of the data disk did not complete due to an unexpected failure from the virtual machine and the disk is still not released then use force-detach as a last resort option to detach the disk forcibly from the VM. All writes might not have been flushed when using this detach behavior. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. To force-detach a data disk update toBeDetached to 'true' along with setting detachOption: 'ForceDetach'.
 
@@ -2249,8 +2249,8 @@ Used by: [DataDisk](#DataDisk).
 |---------------|-------------|
 | "ForceDetach" |             |
 
-<a id="DetachOption_STATUS"></a>DetachOption_STATUS
----------------------------------------------------
+DetachOption_STATUS{#DetachOption_STATUS}
+-----------------------------------------
 
 Specifies the detach behavior to be used while detaching a disk or which is already in the process of detachment from the virtual machine. Supported values: ForceDetach. detachOption: ForceDetach is applicable only for managed data disks. If a previous detachment attempt of the data disk did not complete due to an unexpected failure from the virtual machine and the disk is still not released then use force-detach as a last resort option to detach the disk forcibly from the VM. All writes might not have been flushed when using this detach behavior. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. To force-detach a data disk update toBeDetached to 'true' along with setting detachOption: 'ForceDetach'.
 
@@ -2260,8 +2260,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS).
 |---------------|-------------|
 | "ForceDetach" |             |
 
-<a id="DiffDiskSettings"></a>DiffDiskSettings
----------------------------------------------
+DiffDiskSettings{#DiffDiskSettings}
+-----------------------------------
 
 Describes the parameters of ephemeral disk settings that can be specified for operating system disk. NOTE: The ephemeral disk settings can only be specified for managed disk.
 
@@ -2272,8 +2272,8 @@ Used by: [OSDisk](#OSDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineSc
 | option    | Specifies the ephemeral disk settings for operating system disk.                                                                                                                                                                                                                                                                                                                                                                                               | [DiffDiskOption](#DiffDiskOption)<br/><small>Optional</small>       |
 | placement | Specifies the ephemeral disk placement for operating system disk. Possible values are: CacheDisk ResourceDisk Default: CacheDisk if one is configured for the VM size otherwise ResourceDisk is used. Refer to VM size documentation for Windows VM at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes and Linux VM at https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes to check which VM sizes exposes a cache disk. | [DiffDiskPlacement](#DiffDiskPlacement)<br/><small>Optional</small> |
 
-<a id="DiffDiskSettings_STATUS"></a>DiffDiskSettings_STATUS
------------------------------------------------------------
+DiffDiskSettings_STATUS{#DiffDiskSettings_STATUS}
+-------------------------------------------------
 
 Describes the parameters of ephemeral disk settings that can be specified for operating system disk. NOTE: The ephemeral disk settings can only be specified for managed disk.
 
@@ -2284,8 +2284,8 @@ Used by: [OSDisk_STATUS](#OSDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STAT
 | option    | Specifies the ephemeral disk settings for operating system disk.                                                                                                                                                                                                                                                                                                                                                                                               | [DiffDiskOption_STATUS](#DiffDiskOption_STATUS)<br/><small>Optional</small>       |
 | placement | Specifies the ephemeral disk placement for operating system disk. Possible values are: CacheDisk ResourceDisk Default: CacheDisk if one is configured for the VM size otherwise ResourceDisk is used. Refer to VM size documentation for Windows VM at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes and Linux VM at https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes to check which VM sizes exposes a cache disk. | [DiffDiskPlacement_STATUS](#DiffDiskPlacement_STATUS)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSettings"></a>DiskEncryptionSettings
----------------------------------------------------------
+DiskEncryptionSettings{#DiskEncryptionSettings}
+-----------------------------------------------
 
 Describes a Encryption Settings for a Disk
 
@@ -2297,8 +2297,8 @@ Used by: [OSDisk](#OSDisk).
 | enabled           | Specifies whether disk encryption should be enabled on the virtual machine.     | bool<br/><small>Optional</small>                                                |
 | keyEncryptionKey  | Specifies the location of the key encryption key in Key Vault.                  | [KeyVaultKeyReference](#KeyVaultKeyReference)<br/><small>Optional</small>       |
 
-<a id="DiskEncryptionSettings_STATUS"></a>DiskEncryptionSettings_STATUS
------------------------------------------------------------------------
+DiskEncryptionSettings_STATUS{#DiskEncryptionSettings_STATUS}
+-------------------------------------------------------------
 
 Describes a Encryption Settings for a Disk
 
@@ -2310,8 +2310,8 @@ Used by: [DiskInstanceView_STATUS](#DiskInstanceView_STATUS), and [OSDisk_STATUS
 | enabled           | Specifies whether disk encryption should be enabled on the virtual machine.     | bool<br/><small>Optional</small>                                                              |
 | keyEncryptionKey  | Specifies the location of the key encryption key in Key Vault.                  | [KeyVaultKeyReference_STATUS](#KeyVaultKeyReference_STATUS)<br/><small>Optional</small>       |
 
-<a id="InstanceViewStatus_Level"></a>InstanceViewStatus_Level
--------------------------------------------------------------
+InstanceViewStatus_Level{#InstanceViewStatus_Level}
+---------------------------------------------------
 
 Used by: [InstanceViewStatus](#InstanceViewStatus).
 
@@ -2321,8 +2321,8 @@ Used by: [InstanceViewStatus](#InstanceViewStatus).
 | "Info"    |             |
 | "Warning" |             |
 
-<a id="InstanceViewStatus_Level_STATUS"></a>InstanceViewStatus_Level_STATUS
----------------------------------------------------------------------------
+InstanceViewStatus_Level_STATUS{#InstanceViewStatus_Level_STATUS}
+-----------------------------------------------------------------
 
 Used by: [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS).
 
@@ -2332,8 +2332,8 @@ Used by: [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS).
 | "Info"    |             |
 | "Warning" |             |
 
-<a id="LastPatchInstallationSummary_STATUS"></a>LastPatchInstallationSummary_STATUS
------------------------------------------------------------------------------------
+LastPatchInstallationSummary_STATUS{#LastPatchInstallationSummary_STATUS}
+-------------------------------------------------------------------------
 
 Describes the properties of the last installed patch summary.
 
@@ -2353,8 +2353,8 @@ Used by: [VirtualMachinePatchStatus_STATUS](#VirtualMachinePatchStatus_STATUS).
 | startTime                 | The UTC timestamp when the operation began.                                                                                                                                                               | string<br/><small>Optional</small>                                                                                    |
 | status                    | The overall success or failure status of the operation. It remains "InProgress" until the operation completes. At that point it will become "Unknown", "Failed", "Succeeded", or "CompletedWithWarnings." | [LastPatchInstallationSummary_Status_STATUS](#LastPatchInstallationSummary_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="LinuxPatchSettings"></a>LinuxPatchSettings
--------------------------------------------------
+LinuxPatchSettings{#LinuxPatchSettings}
+---------------------------------------
 
 Specifies settings related to VM Guest Patching on Linux.
 
@@ -2364,8 +2364,8 @@ Used by: [LinuxConfiguration](#LinuxConfiguration).
 |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | patchMode | Specifies the mode of VM Guest Patching to IaaS virtual machine. Possible values are: ImageDefault - The virtual machine's default patching configuration is used. AutomaticByPlatform - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true | [LinuxPatchSettings_PatchMode](#LinuxPatchSettings_PatchMode)<br/><small>Optional</small> |
 
-<a id="LinuxPatchSettings_STATUS"></a>LinuxPatchSettings_STATUS
----------------------------------------------------------------
+LinuxPatchSettings_STATUS{#LinuxPatchSettings_STATUS}
+-----------------------------------------------------
 
 Specifies settings related to VM Guest Patching on Linux.
 
@@ -2375,8 +2375,8 @@ Used by: [LinuxConfiguration_STATUS](#LinuxConfiguration_STATUS).
 |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | patchMode | Specifies the mode of VM Guest Patching to IaaS virtual machine. Possible values are: ImageDefault - The virtual machine's default patching configuration is used. AutomaticByPlatform - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true | [LinuxPatchSettings_PatchMode_STATUS](#LinuxPatchSettings_PatchMode_STATUS)<br/><small>Optional</small> |
 
-<a id="MaintenanceRedeployStatus_LastOperationResultCode_STATUS"></a>MaintenanceRedeployStatus_LastOperationResultCode_STATUS
------------------------------------------------------------------------------------------------------------------------------
+MaintenanceRedeployStatus_LastOperationResultCode_STATUS{#MaintenanceRedeployStatus_LastOperationResultCode_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [MaintenanceRedeployStatus_STATUS](#MaintenanceRedeployStatus_STATUS).
 
@@ -2387,8 +2387,8 @@ Used by: [MaintenanceRedeployStatus_STATUS](#MaintenanceRedeployStatus_STATUS).
 | "None"                 |             |
 | "RetryLater"           |             |
 
-<a id="ManagedDiskParameters"></a>ManagedDiskParameters
--------------------------------------------------------
+ManagedDiskParameters{#ManagedDiskParameters}
+---------------------------------------------
 
 The parameters of a managed disk.
 
@@ -2400,8 +2400,8 @@ Used by: [DataDisk](#DataDisk), and [OSDisk](#OSDisk).
 | reference          | Resource Id                                                                                                                                                                                                                       | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | storageAccountType | Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>                                                                                      |
 
-<a id="ManagedDiskParameters_STATUS"></a>ManagedDiskParameters_STATUS
----------------------------------------------------------------------
+ManagedDiskParameters_STATUS{#ManagedDiskParameters_STATUS}
+-----------------------------------------------------------
 
 The parameters of a managed disk.
 
@@ -2413,8 +2413,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), and [OSDisk_STATUS](#OSDisk_STATUS
 | id                 | Resource Id                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                  |
 | storageAccountType | Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDisk_OsType"></a>OSDisk_OsType
----------------------------------------
+OSDisk_OsType{#OSDisk_OsType}
+-----------------------------
 
 Used by: [OSDisk](#OSDisk).
 
@@ -2423,8 +2423,8 @@ Used by: [OSDisk](#OSDisk).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSDisk_OsType_STATUS"></a>OSDisk_OsType_STATUS
------------------------------------------------------
+OSDisk_OsType_STATUS{#OSDisk_OsType_STATUS}
+-------------------------------------------
 
 Used by: [OSDisk_STATUS](#OSDisk_STATUS).
 
@@ -2433,8 +2433,8 @@ Used by: [OSDisk_STATUS](#OSDisk_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PatchSettings"></a>PatchSettings
----------------------------------------
+PatchSettings{#PatchSettings}
+-----------------------------
 
 Specifies settings related to VM Guest Patching on Windows.
 
@@ -2445,8 +2445,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 | enableHotpatching | Enables customers to patch their Azure VMs without requiring a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and 'patchMode' must be set to 'AutomaticByPlatform'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                |
 | patchMode         | Specifies the mode of VM Guest Patching to IaaS virtual machine. Possible values are: Manual - You control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false AutomaticByOS - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. AutomaticByPlatform - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true | [PatchSettings_PatchMode](#PatchSettings_PatchMode)<br/><small>Optional</small> |
 
-<a id="PatchSettings_STATUS"></a>PatchSettings_STATUS
------------------------------------------------------
+PatchSettings_STATUS{#PatchSettings_STATUS}
+-------------------------------------------
 
 Specifies settings related to VM Guest Patching on Windows.
 
@@ -2457,8 +2457,8 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 | enableHotpatching | Enables customers to patch their Azure VMs without requiring a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and 'patchMode' must be set to 'AutomaticByPlatform'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                              |
 | patchMode         | Specifies the mode of VM Guest Patching to IaaS virtual machine. Possible values are: Manual - You control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false AutomaticByOS - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. AutomaticByPlatform - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true | [PatchSettings_PatchMode_STATUS](#PatchSettings_PatchMode_STATUS)<br/><small>Optional</small> |
 
-<a id="SshConfiguration"></a>SshConfiguration
----------------------------------------------
+SshConfiguration{#SshConfiguration}
+-----------------------------------
 
 SSH configuration for Linux based VMs running on Azure
 
@@ -2468,8 +2468,8 @@ Used by: [LinuxConfiguration](#LinuxConfiguration).
 |------------|------------------------------------------------------------------------|---------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with linux based VMs. | [SshPublicKeySpec[]](#SshPublicKeySpec)<br/><small>Optional</small> |
 
-<a id="SshConfiguration_STATUS"></a>SshConfiguration_STATUS
------------------------------------------------------------
+SshConfiguration_STATUS{#SshConfiguration_STATUS}
+-------------------------------------------------
 
 SSH configuration for Linux based VMs running on Azure
 
@@ -2479,8 +2479,8 @@ Used by: [LinuxConfiguration_STATUS](#LinuxConfiguration_STATUS).
 |------------|------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with linux based VMs. | [SshPublicKey_STATUS[]](#SshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="TerminateNotificationProfile"></a>TerminateNotificationProfile
----------------------------------------------------------------------
+TerminateNotificationProfile{#TerminateNotificationProfile}
+-----------------------------------------------------------
 
 Used by: [ScheduledEventsProfile](#ScheduledEventsProfile).
 
@@ -2489,8 +2489,8 @@ Used by: [ScheduledEventsProfile](#ScheduledEventsProfile).
 | enable           | Specifies whether the Terminate Scheduled event is enabled or disabled.                                                                                                                                                                                                 | bool<br/><small>Optional</small>   |
 | notBeforeTimeout | Configurable length of time a Virtual Machine being deleted will have to potentially approve the Terminate Scheduled Event before the event is auto approved (timed out). The configuration must be specified in ISO 8601 format, the default value is 5 minutes (PT5M) | string<br/><small>Optional</small> |
 
-<a id="TerminateNotificationProfile_STATUS"></a>TerminateNotificationProfile_STATUS
------------------------------------------------------------------------------------
+TerminateNotificationProfile_STATUS{#TerminateNotificationProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ScheduledEventsProfile_STATUS](#ScheduledEventsProfile_STATUS).
 
@@ -2499,8 +2499,8 @@ Used by: [ScheduledEventsProfile_STATUS](#ScheduledEventsProfile_STATUS).
 | enable           | Specifies whether the Terminate Scheduled event is enabled or disabled.                                                                                                                                                                                                 | bool<br/><small>Optional</small>   |
 | notBeforeTimeout | Configurable length of time a Virtual Machine being deleted will have to potentially approve the Terminate Scheduled Event before the event is auto approved (timed out). The configuration must be specified in ISO 8601 format, the default value is 5 minutes (PT5M) | string<br/><small>Optional</small> |
 
-<a id="VaultCertificate"></a>VaultCertificate
----------------------------------------------
+VaultCertificate{#VaultCertificate}
+-----------------------------------
 
 Describes a single certificate reference in a Key Vault, and where the certificate should reside on the VM.
 
@@ -2511,8 +2511,8 @@ Used by: [VaultSecretGroup](#VaultSecretGroup).
 | certificateStore | For Windows VMs, specifies the certificate store on the Virtual Machine to which the certificate should be added. The specified certificate store is implicitly in the LocalMachine account. For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name &lt;UppercaseThumbprint&gt;.crt for the X509 certificate file and &lt;UppercaseThumbprint&gt;.prv for private key. Both of these files are .pem formatted.        | string<br/><small>Optional</small> |
 | certificateUrl   | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } | string<br/><small>Optional</small> |
 
-<a id="VaultCertificate_STATUS"></a>VaultCertificate_STATUS
------------------------------------------------------------
+VaultCertificate_STATUS{#VaultCertificate_STATUS}
+-------------------------------------------------
 
 Describes a single certificate reference in a Key Vault, and where the certificate should reside on the VM.
 
@@ -2523,8 +2523,8 @@ Used by: [VaultSecretGroup_STATUS](#VaultSecretGroup_STATUS).
 | certificateStore | For Windows VMs, specifies the certificate store on the Virtual Machine to which the certificate should be added. The specified certificate store is implicitly in the LocalMachine account. For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name &lt;UppercaseThumbprint&gt;.crt for the X509 certificate file and &lt;UppercaseThumbprint&gt;.prv for private key. Both of these files are .pem formatted.        | string<br/><small>Optional</small> |
 | certificateUrl   | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } | string<br/><small>Optional</small> |
 
-<a id="VirtualHardDisk"></a>VirtualHardDisk
--------------------------------------------
+VirtualHardDisk{#VirtualHardDisk}
+---------------------------------
 
 Describes the uri of a disk.
 
@@ -2534,8 +2534,8 @@ Used by: [DataDisk](#DataDisk), [DataDisk](#DataDisk), [OSDisk](#OSDisk), [OSDis
 |----------|----------------------------------------|------------------------------------|
 | uri      | Specifies the virtual hard disk's uri. | string<br/><small>Optional</small> |
 
-<a id="VirtualHardDisk_STATUS"></a>VirtualHardDisk_STATUS
----------------------------------------------------------
+VirtualHardDisk_STATUS{#VirtualHardDisk_STATUS}
+-----------------------------------------------
 
 Describes the uri of a disk.
 
@@ -2545,8 +2545,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), [DataDisk_STATUS](#DataDisk_STATUS
 |----------|----------------------------------------|------------------------------------|
 | uri      | Specifies the virtual hard disk's uri. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineExtensionHandlerInstanceView_STATUS"></a>VirtualMachineExtensionHandlerInstanceView_STATUS
----------------------------------------------------------------------------------------------------------------
+VirtualMachineExtensionHandlerInstanceView_STATUS{#VirtualMachineExtensionHandlerInstanceView_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 The instance view of a virtual machine extension handler.
 
@@ -2558,8 +2558,8 @@ Used by: [VirtualMachineAgentInstanceView_STATUS](#VirtualMachineAgentInstanceVi
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                                  |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                                  |
 
-<a id="VirtualMachineScaleSetDataDisk"></a>VirtualMachineScaleSetDataDisk
--------------------------------------------------------------------------
+VirtualMachineScaleSetDataDisk{#VirtualMachineScaleSetDataDisk}
+---------------------------------------------------------------
 
 Describes a virtual machine scale set data disk.
 
@@ -2577,8 +2577,8 @@ Used by: [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStoragePr
 | name                    | The disk name.                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                      |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                        | bool<br/><small>Optional</small>                                                                                        |
 
-<a id="VirtualMachineScaleSetDataDisk_STATUS"></a>VirtualMachineScaleSetDataDisk_STATUS
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetDataDisk_STATUS{#VirtualMachineScaleSetDataDisk_STATUS}
+-----------------------------------------------------------------------------
 
 Describes a virtual machine scale set data disk.
 
@@ -2596,8 +2596,8 @@ Used by: [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetSt
 | name                    | The disk name.                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                    |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                        | bool<br/><small>Optional</small>                                                                                                      |
 
-<a id="VirtualMachineScaleSetExtension"></a>VirtualMachineScaleSetExtension
----------------------------------------------------------------------------
+VirtualMachineScaleSetExtension{#VirtualMachineScaleSetExtension}
+-----------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set Extension.
 
@@ -2616,8 +2616,8 @@ Used by: [VirtualMachineScaleSetExtensionProfile](#VirtualMachineScaleSetExtensi
 | type                     | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                           |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="VirtualMachineScaleSetExtension_STATUS"></a>VirtualMachineScaleSetExtension_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtension_STATUS{#VirtualMachineScaleSetExtension_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set Extension.
 
@@ -2638,8 +2638,8 @@ Used by: [VirtualMachineScaleSetExtensionProfile_STATUS](#VirtualMachineScaleSet
 | type                     | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>             |
 | typeHandlerVersion       | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>             |
 
-<a id="VirtualMachineScaleSetNetworkConfiguration"></a>VirtualMachineScaleSetNetworkConfiguration
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfiguration{#VirtualMachineScaleSetNetworkConfiguration}
+---------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's network configurations.
 
@@ -2657,8 +2657,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile](#VirtualMachineScaleSetNetworkPr
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                   | Resource Id                                                                                            | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkConfiguration_STATUS"></a>VirtualMachineScaleSetNetworkConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfiguration_STATUS{#VirtualMachineScaleSetNetworkConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's network configurations.
 
@@ -2676,8 +2676,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile_STATUS](#VirtualMachineScaleSetNe
 | networkSecurityGroup        | The network security group.                                                                            | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                     |
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                          |
 
-<a id="VirtualMachineScaleSetOSDisk"></a>VirtualMachineScaleSetOSDisk
----------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk{#VirtualMachineScaleSetOSDisk}
+-----------------------------------------------------------
 
 Describes a virtual machine scale set operating system disk.
 
@@ -2696,8 +2696,8 @@ Used by: [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStoragePr
 | vhdContainers           | Specifies the container urls that are used to store operating system disks for the scale set.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                    |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                        |
 
-<a id="VirtualMachineScaleSetOSDisk_STATUS"></a>VirtualMachineScaleSetOSDisk_STATUS
------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_STATUS{#VirtualMachineScaleSetOSDisk_STATUS}
+-------------------------------------------------------------------------
 
 Describes a virtual machine scale set operating system disk.
 
@@ -2716,8 +2716,8 @@ Used by: [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetSt
 | vhdContainers           | Specifies the container urls that are used to store operating system disks for the scale set.                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                  |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                                      |
 
-<a id="WinRMConfiguration"></a>WinRMConfiguration
--------------------------------------------------
+WinRMConfiguration{#WinRMConfiguration}
+---------------------------------------
 
 Describes Windows Remote Management configuration of the VM
 
@@ -2727,8 +2727,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 |-----------|-------------------------------------------------|---------------------------------------------------------------|
 | listeners | The list of Windows Remote Management listeners | [WinRMListener[]](#WinRMListener)<br/><small>Optional</small> |
 
-<a id="WinRMConfiguration_STATUS"></a>WinRMConfiguration_STATUS
----------------------------------------------------------------
+WinRMConfiguration_STATUS{#WinRMConfiguration_STATUS}
+-----------------------------------------------------
 
 Describes Windows Remote Management configuration of the VM
 
@@ -2738,35 +2738,35 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 |-----------|-------------------------------------------------|-----------------------------------------------------------------------------|
 | listeners | The list of Windows Remote Management listeners | [WinRMListener_STATUS[]](#WinRMListener_STATUS)<br/><small>Optional</small> |
 
-<a id="AdditionalUnattendContent_ComponentName"></a>AdditionalUnattendContent_ComponentName
--------------------------------------------------------------------------------------------
-
-Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
-
-| Value                           | Description |
-|---------------------------------|-------------|
-| "Microsoft-Windows-Shell-Setup" |             |
-
-<a id="AdditionalUnattendContent_ComponentName_STATUS"></a>AdditionalUnattendContent_ComponentName_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
-
-| Value                           | Description |
-|---------------------------------|-------------|
-| "Microsoft-Windows-Shell-Setup" |             |
-
-<a id="AdditionalUnattendContent_PassName"></a>AdditionalUnattendContent_PassName
+AdditionalUnattendContent_ComponentName{#AdditionalUnattendContent_ComponentName}
 ---------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 
+| Value                           | Description |
+|---------------------------------|-------------|
+| "Microsoft-Windows-Shell-Setup" |             |
+
+AdditionalUnattendContent_ComponentName_STATUS{#AdditionalUnattendContent_ComponentName_STATUS}
+-----------------------------------------------------------------------------------------------
+
+Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
+
+| Value                           | Description |
+|---------------------------------|-------------|
+| "Microsoft-Windows-Shell-Setup" |             |
+
+AdditionalUnattendContent_PassName{#AdditionalUnattendContent_PassName}
+-----------------------------------------------------------------------
+
+Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
+
 | Value        | Description |
 |--------------|-------------|
 | "OobeSystem" |             |
 
-<a id="AdditionalUnattendContent_PassName_STATUS"></a>AdditionalUnattendContent_PassName_STATUS
------------------------------------------------------------------------------------------------
+AdditionalUnattendContent_PassName_STATUS{#AdditionalUnattendContent_PassName_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 
@@ -2774,8 +2774,8 @@ Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 |--------------|-------------|
 | "OobeSystem" |             |
 
-<a id="AdditionalUnattendContent_SettingName"></a>AdditionalUnattendContent_SettingName
----------------------------------------------------------------------------------------
+AdditionalUnattendContent_SettingName{#AdditionalUnattendContent_SettingName}
+-----------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 
@@ -2784,8 +2784,8 @@ Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 | "AutoLogon"          |             |
 | "FirstLogonCommands" |             |
 
-<a id="AdditionalUnattendContent_SettingName_STATUS"></a>AdditionalUnattendContent_SettingName_STATUS
------------------------------------------------------------------------------------------------------
+AdditionalUnattendContent_SettingName_STATUS{#AdditionalUnattendContent_SettingName_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 
@@ -2794,8 +2794,8 @@ Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 | "AutoLogon"          |             |
 | "FirstLogonCommands" |             |
 
-<a id="ApiError_STATUS"></a>ApiError_STATUS
--------------------------------------------
+ApiError_STATUS{#ApiError_STATUS}
+---------------------------------
 
 Api error.
 
@@ -2809,8 +2809,8 @@ Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS), and [Las
 | message    | The error message.                  | string<br/><small>Optional</small>                                        |
 | target     | The target of the particular error. | string<br/><small>Optional</small>                                        |
 
-<a id="AvailablePatchSummary_Status_STATUS"></a>AvailablePatchSummary_Status_STATUS
------------------------------------------------------------------------------------
+AvailablePatchSummary_Status_STATUS{#AvailablePatchSummary_Status_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS).
 
@@ -2822,8 +2822,8 @@ Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS).
 | "Succeeded"             |             |
 | "Unknown"               |             |
 
-<a id="DiffDiskOption"></a>DiffDiskOption
------------------------------------------
+DiffDiskOption{#DiffDiskOption}
+-------------------------------
 
 Specifies the ephemeral disk option for operating system disk.
 
@@ -2833,8 +2833,8 @@ Used by: [DiffDiskSettings](#DiffDiskSettings).
 |---------|-------------|
 | "Local" |             |
 
-<a id="DiffDiskOption_STATUS"></a>DiffDiskOption_STATUS
--------------------------------------------------------
+DiffDiskOption_STATUS{#DiffDiskOption_STATUS}
+---------------------------------------------
 
 Specifies the ephemeral disk option for operating system disk.
 
@@ -2844,8 +2844,8 @@ Used by: [DiffDiskSettings_STATUS](#DiffDiskSettings_STATUS).
 |---------|-------------|
 | "Local" |             |
 
-<a id="DiffDiskPlacement"></a>DiffDiskPlacement
------------------------------------------------
+DiffDiskPlacement{#DiffDiskPlacement}
+-------------------------------------
 
 Specifies the ephemeral disk placement for operating system disk. This property can be used by user in the request to choose the location i.e, cache disk or resource disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer Ephemeral OS disk size requirements for Windows VM at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements and Linux VM at https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements
 
@@ -2856,8 +2856,8 @@ Used by: [DiffDiskSettings](#DiffDiskSettings).
 | "CacheDisk"    |             |
 | "ResourceDisk" |             |
 
-<a id="DiffDiskPlacement_STATUS"></a>DiffDiskPlacement_STATUS
--------------------------------------------------------------
+DiffDiskPlacement_STATUS{#DiffDiskPlacement_STATUS}
+---------------------------------------------------
 
 Specifies the ephemeral disk placement for operating system disk. This property can be used by user in the request to choose the location i.e, cache disk or resource disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer Ephemeral OS disk size requirements for Windows VM at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements and Linux VM at https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements
 
@@ -2868,8 +2868,8 @@ Used by: [DiffDiskSettings_STATUS](#DiffDiskSettings_STATUS).
 | "CacheDisk"    |             |
 | "ResourceDisk" |             |
 
-<a id="KeyVaultKeyReference"></a>KeyVaultKeyReference
------------------------------------------------------
+KeyVaultKeyReference{#KeyVaultKeyReference}
+-------------------------------------------
 
 Describes a reference to Key Vault Key
 
@@ -2880,8 +2880,8 @@ Used by: [DiskEncryptionSettings](#DiskEncryptionSettings).
 | keyUrl      | The URL referencing a key encryption key in Key Vault. | string<br/><small>Required</small>                      |
 | sourceVault | The relative URL of the Key Vault containing the key.  | [SubResource](#SubResource)<br/><small>Required</small> |
 
-<a id="KeyVaultKeyReference_STATUS"></a>KeyVaultKeyReference_STATUS
--------------------------------------------------------------------
+KeyVaultKeyReference_STATUS{#KeyVaultKeyReference_STATUS}
+---------------------------------------------------------
 
 Describes a reference to Key Vault Key
 
@@ -2892,8 +2892,8 @@ Used by: [DiskEncryptionSettings_STATUS](#DiskEncryptionSettings_STATUS).
 | keyUrl      | The URL referencing a key encryption key in Key Vault. | string<br/><small>Optional</small>                                    |
 | sourceVault | The relative URL of the Key Vault containing the key.  | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="KeyVaultSecretReference"></a>KeyVaultSecretReference
------------------------------------------------------------
+KeyVaultSecretReference{#KeyVaultSecretReference}
+-------------------------------------------------
 
 Describes a reference to Key Vault Secret
 
@@ -2904,8 +2904,8 @@ Used by: [DiskEncryptionSettings](#DiskEncryptionSettings).
 | secretUrl   | The URL referencing a secret in a Key Vault.             | string<br/><small>Required</small>                      |
 | sourceVault | The relative URL of the Key Vault containing the secret. | [SubResource](#SubResource)<br/><small>Required</small> |
 
-<a id="KeyVaultSecretReference_STATUS"></a>KeyVaultSecretReference_STATUS
--------------------------------------------------------------------------
+KeyVaultSecretReference_STATUS{#KeyVaultSecretReference_STATUS}
+---------------------------------------------------------------
 
 Describes a reference to Key Vault Secret
 
@@ -2916,8 +2916,8 @@ Used by: [DiskEncryptionSettings_STATUS](#DiskEncryptionSettings_STATUS).
 | secretUrl   | The URL referencing a secret in a Key Vault.             | string<br/><small>Optional</small>                                    |
 | sourceVault | The relative URL of the Key Vault containing the secret. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="LastPatchInstallationSummary_Status_STATUS"></a>LastPatchInstallationSummary_Status_STATUS
--------------------------------------------------------------------------------------------------
+LastPatchInstallationSummary_Status_STATUS{#LastPatchInstallationSummary_Status_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STATUS).
 
@@ -2929,8 +2929,8 @@ Used by: [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STA
 | "Succeeded"             |             |
 | "Unknown"               |             |
 
-<a id="LinuxPatchSettings_PatchMode"></a>LinuxPatchSettings_PatchMode
----------------------------------------------------------------------
+LinuxPatchSettings_PatchMode{#LinuxPatchSettings_PatchMode}
+-----------------------------------------------------------
 
 Used by: [LinuxPatchSettings](#LinuxPatchSettings).
 
@@ -2939,8 +2939,8 @@ Used by: [LinuxPatchSettings](#LinuxPatchSettings).
 | "AutomaticByPlatform" |             |
 | "ImageDefault"        |             |
 
-<a id="LinuxPatchSettings_PatchMode_STATUS"></a>LinuxPatchSettings_PatchMode_STATUS
------------------------------------------------------------------------------------
+LinuxPatchSettings_PatchMode_STATUS{#LinuxPatchSettings_PatchMode_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
 
@@ -2949,8 +2949,8 @@ Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
 | "AutomaticByPlatform" |             |
 | "ImageDefault"        |             |
 
-<a id="PatchSettings_PatchMode"></a>PatchSettings_PatchMode
------------------------------------------------------------
+PatchSettings_PatchMode{#PatchSettings_PatchMode}
+-------------------------------------------------
 
 Used by: [PatchSettings](#PatchSettings).
 
@@ -2960,8 +2960,8 @@ Used by: [PatchSettings](#PatchSettings).
 | "AutomaticByPlatform" |             |
 | "Manual"              |             |
 
-<a id="PatchSettings_PatchMode_STATUS"></a>PatchSettings_PatchMode_STATUS
--------------------------------------------------------------------------
+PatchSettings_PatchMode_STATUS{#PatchSettings_PatchMode_STATUS}
+---------------------------------------------------------------
 
 Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
 
@@ -2971,8 +2971,8 @@ Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
 | "AutomaticByPlatform" |             |
 | "Manual"              |             |
 
-<a id="SshPublicKey_STATUS"></a>SshPublicKey_STATUS
----------------------------------------------------
+SshPublicKey_STATUS{#SshPublicKey_STATUS}
+-----------------------------------------
 
 Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
 
@@ -2983,8 +2983,8 @@ Used by: [SshConfiguration_STATUS](#SshConfiguration_STATUS).
 | keyData  | SSH public key certificate used to authenticate with the VM through ssh. The key needs to be at least 2048-bit and in ssh-rsa format. For creating ssh keys, see [Create SSH keys on Linux and Mac for Linux VMs in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json). | string<br/><small>Optional</small> |
 | path     | Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key is appended to the file. Example: /home/user/.ssh/authorized_keys                                                                                                                                                                         | string<br/><small>Optional</small> |
 
-<a id="SshPublicKeySpec"></a>SshPublicKeySpec
----------------------------------------------
+SshPublicKeySpec{#SshPublicKeySpec}
+-----------------------------------
 
 Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
 
@@ -2995,8 +2995,8 @@ Used by: [SshConfiguration](#SshConfiguration).
 | keyData  | SSH public key certificate used to authenticate with the VM through ssh. The key needs to be at least 2048-bit and in ssh-rsa format. For creating ssh keys, see [Create SSH keys on Linux and Mac for Linux VMs in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json). | string<br/><small>Optional</small> |
 | path     | Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key is appended to the file. Example: /home/user/.ssh/authorized_keys                                                                                                                                                                         | string<br/><small>Optional</small> |
 
-<a id="StorageAccountType"></a>StorageAccountType
--------------------------------------------------
+StorageAccountType{#StorageAccountType}
+---------------------------------------
 
 Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-types
 
@@ -3011,8 +3011,8 @@ Used by: [ManagedDiskParameters](#ManagedDiskParameters), and [VirtualMachineSca
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="StorageAccountType_STATUS"></a>StorageAccountType_STATUS
----------------------------------------------------------------
+StorageAccountType_STATUS{#StorageAccountType_STATUS}
+-----------------------------------------------------
 
 Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-types
 
@@ -3027,8 +3027,8 @@ Used by: [ManagedDiskParameters_STATUS](#ManagedDiskParameters_STATUS), and [Vir
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="VirtualMachineScaleSetIPConfiguration"></a>VirtualMachineScaleSetIPConfiguration
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfiguration{#VirtualMachineScaleSetIPConfiguration}
+-----------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's IP configuration.
 
@@ -3047,8 +3047,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNet
 | reference                             | Resource Id                                                                                                                                                                                                                                 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>                      |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                     | [ApiEntityReference](#ApiEntityReference)<br/><small>Optional</small>                                                                                                           |
 
-<a id="VirtualMachineScaleSetIPConfiguration_STATUS"></a>VirtualMachineScaleSetIPConfiguration_STATUS
------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfiguration_STATUS{#VirtualMachineScaleSetIPConfiguration_STATUS}
+-------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's IP configuration.
 
@@ -3067,8 +3067,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScal
 | publicIPAddressConfiguration          | The publicIPAddressConfiguration.                                                                                                                                                                                                           | [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS)<br/><small>Optional</small>                                           |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                     | [ApiEntityReference_STATUS](#ApiEntityReference_STATUS)<br/><small>Optional</small>                                                                                                           |
 
-<a id="VirtualMachineScaleSetManagedDiskParameters"></a>VirtualMachineScaleSetManagedDiskParameters
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetManagedDiskParameters{#VirtualMachineScaleSetManagedDiskParameters}
+-----------------------------------------------------------------------------------------
 
 Describes the parameters of a ScaleSet managed disk.
 
@@ -3079,8 +3079,8 @@ Used by: [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and 
 | diskEncryptionSet  | Specifies the customer managed disk encryption set resource id for the managed disk.                                                          | [SubResource](#SubResource)<br/><small>Optional</small>               |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetManagedDiskParameters_STATUS"></a>VirtualMachineScaleSetManagedDiskParameters_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetManagedDiskParameters_STATUS{#VirtualMachineScaleSetManagedDiskParameters_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Describes the parameters of a ScaleSet managed disk.
 
@@ -3091,8 +3091,8 @@ Used by: [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk
 | diskEncryptionSet  | Specifies the customer managed disk encryption set resource id for the managed disk.                                                          | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>               |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkConfigurationDnsSettings"></a>VirtualMachineScaleSetNetworkConfigurationDnsSettings
------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfigurationDnsSettings{#VirtualMachineScaleSetNetworkConfigurationDnsSettings}
+-------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -3102,8 +3102,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNet
 |------------|----------------------------------|--------------------------------------|
 | dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS"></a>VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS{#VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -3113,8 +3113,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScal
 |------------|----------------------------------|--------------------------------------|
 | dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetOSDisk_OsType"></a>VirtualMachineScaleSetOSDisk_OsType
------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_OsType{#VirtualMachineScaleSetOSDisk_OsType}
+-------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 
@@ -3123,8 +3123,8 @@ Used by: [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="VirtualMachineScaleSetOSDisk_OsType_STATUS"></a>VirtualMachineScaleSetOSDisk_OsType_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_OsType_STATUS{#VirtualMachineScaleSetOSDisk_OsType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
 
@@ -3133,8 +3133,8 @@ Used by: [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STA
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="WinRMListener"></a>WinRMListener
----------------------------------------
+WinRMListener{#WinRMListener}
+-----------------------------
 
 Describes Protocol and thumbprint of Windows Remote Management listener
 
@@ -3145,8 +3145,8 @@ Used by: [WinRMConfiguration](#WinRMConfiguration).
 | certificateUrl | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } | string<br/><small>Optional</small>                                            |
 | protocol       | Specifies the protocol of WinRM listener. Possible values are: http https                                                                                                                                                                                                                                                                                                                                                                                             | [WinRMListener_Protocol](#WinRMListener_Protocol)<br/><small>Optional</small> |
 
-<a id="WinRMListener_STATUS"></a>WinRMListener_STATUS
------------------------------------------------------
+WinRMListener_STATUS{#WinRMListener_STATUS}
+-------------------------------------------
 
 Describes Protocol and thumbprint of Windows Remote Management listener
 
@@ -3157,8 +3157,8 @@ Used by: [WinRMConfiguration_STATUS](#WinRMConfiguration_STATUS).
 | certificateUrl | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } | string<br/><small>Optional</small>                                                          |
 | protocol       | Specifies the protocol of WinRM listener. Possible values are: http https                                                                                                                                                                                                                                                                                                                                                                                             | [WinRMListener_Protocol_STATUS](#WinRMListener_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiErrorBase_STATUS"></a>ApiErrorBase_STATUS
----------------------------------------------------
+ApiErrorBase_STATUS{#ApiErrorBase_STATUS}
+-----------------------------------------
 
 Api error base.
 
@@ -3170,8 +3170,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | message  | The error message.                  | string<br/><small>Optional</small> |
 | target   | The target of the particular error. | string<br/><small>Optional</small> |
 
-<a id="InnerError_STATUS"></a>InnerError_STATUS
------------------------------------------------
+InnerError_STATUS{#InnerError_STATUS}
+-------------------------------------
 
 Inner error details.
 
@@ -3182,8 +3182,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | errordetail   | The internal error message or exception dump. | string<br/><small>Optional</small> |
 | exceptiontype | The exception type.                           | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion"></a>VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion
------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion{#VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration).
 
@@ -3192,8 +3192,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS"></a>VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS{#VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS).
 
@@ -3202,8 +3202,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfiguration"></a>VirtualMachineScaleSetPublicIPAddressConfiguration
------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfiguration{#VirtualMachineScaleSetPublicIPAddressConfiguration}
+-------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
 
@@ -3218,8 +3218,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 | publicIPAddressVersion | Available from Api-Version 2019-07-01 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default is taken as IPv4. Possible values are: 'IPv4' and 'IPv6'. | [VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion](#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion)<br/><small>Optional</small> |
 | publicIPPrefix         | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                                                                 |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS{#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
 
@@ -3234,8 +3234,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 | publicIPAddressVersion | Available from Api-Version 2019-07-01 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default is taken as IPv4. Possible values are: 'IPv4' and 'IPv6'. | [VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS](#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS)<br/><small>Optional</small> |
 | publicIPPrefix         | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                                                 |
 
-<a id="WinRMListener_Protocol"></a>WinRMListener_Protocol
----------------------------------------------------------
+WinRMListener_Protocol{#WinRMListener_Protocol}
+-----------------------------------------------
 
 Used by: [WinRMListener](#WinRMListener).
 
@@ -3244,8 +3244,8 @@ Used by: [WinRMListener](#WinRMListener).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="WinRMListener_Protocol_STATUS"></a>WinRMListener_Protocol_STATUS
------------------------------------------------------------------------
+WinRMListener_Protocol_STATUS{#WinRMListener_Protocol_STATUS}
+-------------------------------------------------------------
 
 Used by: [WinRMListener_STATUS](#WinRMListener_STATUS).
 
@@ -3254,8 +3254,8 @@ Used by: [WinRMListener_STATUS](#WinRMListener_STATUS).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="VirtualMachineScaleSetIpTag"></a>VirtualMachineScaleSetIpTag
--------------------------------------------------------------------
+VirtualMachineScaleSetIpTag{#VirtualMachineScaleSetIpTag}
+---------------------------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -3266,8 +3266,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIpTag_STATUS"></a>VirtualMachineScaleSetIpTag_STATUS
----------------------------------------------------------------------------------
+VirtualMachineScaleSetIpTag_STATUS{#VirtualMachineScaleSetIpTag_STATUS}
+-----------------------------------------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -3278,8 +3278,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMac
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings"></a>VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{#VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -3289,8 +3289,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label.The concatenation of the domain name label and vm index will be the domain name labels of the PublicIPAddress resources that will be created | string<br/><small>Required</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS{#VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -3300,8 +3300,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMac
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label.The concatenation of the domain name label and vm index will be the domain name labels of the PublicIPAddress resources that will be created | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineScaleSetPublicIPAddressConfiguration).
 
@@ -3310,8 +3310,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS).
 

--- a/docs/hugo/content/reference/compute/v1api20210701.md
+++ b/docs/hugo/content/reference/compute/v1api20210701.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20210701
 linktitle: v1api20210701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-07-01" |             |
 
-<a id="Image"></a>Image
------------------------
+Image{#Image}
+-------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2021-07-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/images/{imageName}
 
@@ -26,7 +26,7 @@ Used by: [ImageList](#ImageList).
 | spec                                                                                    |             | [Image_Spec](#Image_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Image_STATUS](#Image_STATUS)<br/><small>Optional</small> |
 
-### <a id="Image_Spec"></a>Image_Spec
+### Image_Spec {#Image_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [ImageList](#ImageList).
 | storageProfile       | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                             | [ImageStorageProfile](#ImageStorageProfile)<br/><small>Optional</small>                                                                                              |
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Image_STATUS"></a>Image_STATUS
+### Image_STATUS{#Image_STATUS}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,8 +56,8 @@ Used by: [ImageList](#ImageList).
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ImageList"></a>ImageList
--------------------------------
+ImageList{#ImageList}
+---------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2021-07-01/compute.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/images/{imageName}
 
@@ -67,8 +67,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Image[]](#Image)<br/><small>Optional</small> |
 
-<a id="Image_Spec"></a>Image_Spec
----------------------------------
+Image_Spec{#Image_Spec}
+-----------------------
 
 Used by: [Image](#Image).
 
@@ -84,8 +84,8 @@ Used by: [Image](#Image).
 | storageProfile       | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                             | [ImageStorageProfile](#ImageStorageProfile)<br/><small>Optional</small>                                                                                              |
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Image_STATUS"></a>Image_STATUS
--------------------------------------
+Image_STATUS{#Image_STATUS}
+---------------------------
 
 The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual machine. If SourceImage is provided, the destination virtual hard drive must not exist.
 
@@ -105,8 +105,8 @@ Used by: [Image](#Image).
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -117,8 +117,8 @@ Used by: [Image_Spec](#Image_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -129,8 +129,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="HyperVGenerationType"></a>HyperVGenerationType
------------------------------------------------------
+HyperVGenerationType{#HyperVGenerationType}
+-------------------------------------------
 
 Specifies the HyperVGeneration Type
 
@@ -141,8 +141,8 @@ Used by: [Image_Spec](#Image_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="HyperVGenerationType_STATUS"></a>HyperVGenerationType_STATUS
--------------------------------------------------------------------
+HyperVGenerationType_STATUS{#HyperVGenerationType_STATUS}
+---------------------------------------------------------
 
 Specifies the HyperVGeneration Type
 
@@ -153,8 +153,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="ImageOperatorSpec"></a>ImageOperatorSpec
------------------------------------------------
+ImageOperatorSpec{#ImageOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -165,8 +165,8 @@ Used by: [Image_Spec](#Image_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ImageStorageProfile"></a>ImageStorageProfile
----------------------------------------------------
+ImageStorageProfile{#ImageStorageProfile}
+-----------------------------------------
 
 Describes a storage profile.
 
@@ -178,8 +178,8 @@ Used by: [Image_Spec](#Image_Spec).
 | osDisk        | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview). | [ImageOSDisk](#ImageOSDisk)<br/><small>Optional</small>       |
 | zoneResilient | Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage (ZRS).                                                                                | bool<br/><small>Optional</small>                              |
 
-<a id="ImageStorageProfile_STATUS"></a>ImageStorageProfile_STATUS
------------------------------------------------------------------
+ImageStorageProfile_STATUS{#ImageStorageProfile_STATUS}
+-------------------------------------------------------
 
 Describes a storage profile.
 
@@ -191,8 +191,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | osDisk        | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview). | [ImageOSDisk_STATUS](#ImageOSDisk_STATUS)<br/><small>Optional</small>       |
 | zoneResilient | Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage (ZRS).                                                                                | bool<br/><small>Optional</small>                                            |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Used by: [Image_Spec](#Image_Spec), [ImageDataDisk](#ImageDataDisk), [ImageDataDisk](#ImageDataDisk), [ImageDataDisk](#ImageDataDisk), [ImageOSDisk](#ImageOSDisk), [ImageOSDisk](#ImageOSDisk), and [ImageOSDisk](#ImageOSDisk).
 
@@ -200,8 +200,8 @@ Used by: [Image_Spec](#Image_Spec), [ImageDataDisk](#ImageDataDisk), [ImageDataD
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Used by: [Image_STATUS](#Image_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageOSDisk_STATUS](#ImageOSDisk_STATUS), [ImageOSDisk_STATUS](#ImageOSDisk_STATUS), and [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 
@@ -209,8 +209,8 @@ Used by: [Image_STATUS](#Image_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_ST
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -220,8 +220,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -231,8 +231,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ImageDataDisk"></a>ImageDataDisk
----------------------------------------
+ImageDataDisk{#ImageDataDisk}
+-----------------------------
 
 Describes a data disk.
 
@@ -249,8 +249,8 @@ Used by: [ImageStorageProfile](#ImageStorageProfile).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                     |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>       |
 
-<a id="ImageDataDisk_STATUS"></a>ImageDataDisk_STATUS
------------------------------------------------------
+ImageDataDisk_STATUS{#ImageDataDisk_STATUS}
+-------------------------------------------
 
 Describes a data disk.
 
@@ -267,8 +267,8 @@ Used by: [ImageStorageProfile_STATUS](#ImageStorageProfile_STATUS).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                     |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>       |
 
-<a id="ImageOSDisk"></a>ImageOSDisk
------------------------------------
+ImageOSDisk{#ImageOSDisk}
+-------------------------
 
 Describes an Operating System disk.
 
@@ -286,8 +286,8 @@ Used by: [ImageStorageProfile](#ImageStorageProfile).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                 |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>   |
 
-<a id="ImageOSDisk_STATUS"></a>ImageOSDisk_STATUS
--------------------------------------------------
+ImageOSDisk_STATUS{#ImageOSDisk_STATUS}
+---------------------------------------
 
 Describes an Operating System disk.
 
@@ -305,8 +305,8 @@ Used by: [ImageStorageProfile_STATUS](#ImageStorageProfile_STATUS).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                 |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>   |
 
-<a id="ImageDataDisk_Caching"></a>ImageDataDisk_Caching
--------------------------------------------------------
+ImageDataDisk_Caching{#ImageDataDisk_Caching}
+---------------------------------------------
 
 Used by: [ImageDataDisk](#ImageDataDisk).
 
@@ -316,8 +316,8 @@ Used by: [ImageDataDisk](#ImageDataDisk).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageDataDisk_Caching_STATUS"></a>ImageDataDisk_Caching_STATUS
----------------------------------------------------------------------
+ImageDataDisk_Caching_STATUS{#ImageDataDisk_Caching_STATUS}
+-----------------------------------------------------------
 
 Used by: [ImageDataDisk_STATUS](#ImageDataDisk_STATUS).
 
@@ -327,8 +327,8 @@ Used by: [ImageDataDisk_STATUS](#ImageDataDisk_STATUS).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_Caching"></a>ImageOSDisk_Caching
----------------------------------------------------
+ImageOSDisk_Caching{#ImageOSDisk_Caching}
+-----------------------------------------
 
 Used by: [ImageOSDisk](#ImageOSDisk).
 
@@ -338,8 +338,8 @@ Used by: [ImageOSDisk](#ImageOSDisk).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_Caching_STATUS"></a>ImageOSDisk_Caching_STATUS
------------------------------------------------------------------
+ImageOSDisk_Caching_STATUS{#ImageOSDisk_Caching_STATUS}
+-------------------------------------------------------
 
 Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 
@@ -349,8 +349,8 @@ Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_OsState"></a>ImageOSDisk_OsState
----------------------------------------------------
+ImageOSDisk_OsState{#ImageOSDisk_OsState}
+-----------------------------------------
 
 Used by: [ImageOSDisk](#ImageOSDisk).
 
@@ -359,8 +359,8 @@ Used by: [ImageOSDisk](#ImageOSDisk).
 | "Generalized" |             |
 | "Specialized" |             |
 
-<a id="ImageOSDisk_OsState_STATUS"></a>ImageOSDisk_OsState_STATUS
------------------------------------------------------------------
+ImageOSDisk_OsState_STATUS{#ImageOSDisk_OsState_STATUS}
+-------------------------------------------------------
 
 Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 
@@ -369,8 +369,8 @@ Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 | "Generalized" |             |
 | "Specialized" |             |
 
-<a id="ImageOSDisk_OsType"></a>ImageOSDisk_OsType
--------------------------------------------------
+ImageOSDisk_OsType{#ImageOSDisk_OsType}
+---------------------------------------
 
 Used by: [ImageOSDisk](#ImageOSDisk).
 
@@ -379,8 +379,8 @@ Used by: [ImageOSDisk](#ImageOSDisk).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="ImageOSDisk_OsType_STATUS"></a>ImageOSDisk_OsType_STATUS
----------------------------------------------------------------
+ImageOSDisk_OsType_STATUS{#ImageOSDisk_OsType_STATUS}
+-----------------------------------------------------
 
 Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 
@@ -389,8 +389,8 @@ Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="StorageAccountType"></a>StorageAccountType
--------------------------------------------------
+StorageAccountType{#StorageAccountType}
+---------------------------------------
 
 Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/linux/disks-types
 
@@ -405,8 +405,8 @@ Used by: [ImageDataDisk](#ImageDataDisk), and [ImageOSDisk](#ImageOSDisk).
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="StorageAccountType_STATUS"></a>StorageAccountType_STATUS
----------------------------------------------------------------
+StorageAccountType_STATUS{#StorageAccountType_STATUS}
+-----------------------------------------------------
 
 Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/linux/disks-types
 

--- a/docs/hugo/content/reference/compute/v1api20220301.md
+++ b/docs/hugo/content/reference/compute/v1api20220301.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20220301
 linktitle: v1api20220301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-03-01" |             |
 
-<a id="Image"></a>Image
------------------------
+Image{#Image}
+-------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/image.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/images/{imageName}
 
@@ -26,7 +26,7 @@ Used by: [ImageList](#ImageList).
 | spec                                                                                    |             | [Image_Spec](#Image_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Image_STATUS](#Image_STATUS)<br/><small>Optional</small> |
 
-### <a id="Image_Spec"></a>Image_Spec
+### Image_Spec {#Image_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [ImageList](#ImageList).
 | storageProfile       | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                             | [ImageStorageProfile](#ImageStorageProfile)<br/><small>Optional</small>                                                                                              |
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Image_STATUS"></a>Image_STATUS
+### Image_STATUS{#Image_STATUS}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,8 +56,8 @@ Used by: [ImageList](#ImageList).
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ImageList"></a>ImageList
--------------------------------
+ImageList{#ImageList}
+---------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/image.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/images/{imageName}
 
@@ -67,8 +67,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Image[]](#Image)<br/><small>Optional</small> |
 
-<a id="VirtualMachine"></a>VirtualMachine
------------------------------------------
+VirtualMachine{#VirtualMachine}
+-------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachine.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}
 
@@ -81,7 +81,7 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | spec                                                                                    |             | [VirtualMachine_Spec](#VirtualMachine_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachine_STATUS](#VirtualMachine_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachine_Spec"></a>VirtualMachine_Spec
+### VirtualMachine_Spec {#VirtualMachine_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -117,7 +117,7 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | virtualMachineScaleSet  | Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. This property cannot exist along with a non-null properties.availabilitySet reference. Minimum api‐version: 2019‐03‐01                                                                                                                                                                                                                                                                                                                                                                                                                          | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
+### VirtualMachine_STATUS{#VirtualMachine_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                    |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -159,8 +159,8 @@ Used by: [VirtualMachineList](#VirtualMachineList).
 | vmId                    | Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineList"></a>VirtualMachineList
--------------------------------------------------
+VirtualMachineList{#VirtualMachineList}
+---------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachine.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}
 
@@ -170,8 +170,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [VirtualMachine[]](#VirtualMachine)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSet"></a>VirtualMachineScaleSet
----------------------------------------------------------
+VirtualMachineScaleSet{#VirtualMachineScaleSet}
+-----------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachineScaleSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}
 
@@ -184,7 +184,7 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | spec                                                                                    |             | [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachineScaleSet_Spec"></a>VirtualMachineScaleSet_Spec
+### VirtualMachineScaleSet_Spec {#VirtualMachineScaleSet_Spec}
 
 | Property                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -213,7 +213,7 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. zoneBalance property can only be set if the zones property of the scale set contains more than one zone. If there are no zones or only one zone specified, then zoneBalance property should not be set.                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="VirtualMachineScaleSet_STATUS"></a>VirtualMachineScaleSet_STATUS
+### VirtualMachineScaleSet_STATUS{#VirtualMachineScaleSet_STATUS}
 
 | Property                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                    |
 |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -246,8 +246,8 @@ Used by: [VirtualMachineScaleSetList](#VirtualMachineScaleSetList).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. zoneBalance property can only be set if the zones property of the scale set contains more than one zone. If there are no zones or only one zone specified, then zoneBalance property should not be set.                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                        |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSetList"></a>VirtualMachineScaleSetList
------------------------------------------------------------------
+VirtualMachineScaleSetList{#VirtualMachineScaleSetList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachineScaleSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}
 
@@ -257,8 +257,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [VirtualMachineScaleSet[]](#VirtualMachineScaleSet)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetsExtension"></a>VirtualMachineScaleSetsExtension
------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension{#VirtualMachineScaleSetsExtension}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachineScaleSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}
 
@@ -271,7 +271,7 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | spec                                                                                    |             | [VirtualMachineScaleSetsExtension_Spec](#VirtualMachineScaleSetsExtension_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachineScaleSetsExtension_STATUS](#VirtualMachineScaleSetsExtension_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachineScaleSetsExtension_Spec"></a>VirtualMachineScaleSetsExtension_Spec
+### VirtualMachineScaleSetsExtension_Spec {#VirtualMachineScaleSetsExtension_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -290,7 +290,7 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | type                          | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="VirtualMachineScaleSetsExtension_STATUS"></a>VirtualMachineScaleSetsExtension_STATUS
+### VirtualMachineScaleSetsExtension_STATUS{#VirtualMachineScaleSetsExtension_STATUS}
 
 | Property                      | Description                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -310,8 +310,8 @@ Used by: [VirtualMachineScaleSetsExtensionList](#VirtualMachineScaleSetsExtensio
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachineScaleSetsExtensionList"></a>VirtualMachineScaleSetsExtensionList
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtensionList{#VirtualMachineScaleSetsExtensionList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachineScaleSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}
 
@@ -321,8 +321,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [VirtualMachineScaleSetsExtension[]](#VirtualMachineScaleSetsExtension)<br/><small>Optional</small> |
 
-<a id="VirtualMachinesExtension"></a>VirtualMachinesExtension
--------------------------------------------------------------
+VirtualMachinesExtension{#VirtualMachinesExtension}
+---------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachine.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}
 
@@ -335,7 +335,7 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | spec                                                                                    |             | [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualMachinesExtension_STATUS](#VirtualMachinesExtension_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualMachinesExtension_Spec"></a>VirtualMachinesExtension_Spec
+### VirtualMachinesExtension_Spec {#VirtualMachinesExtension_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -356,7 +356,7 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | type                          | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="VirtualMachinesExtension_STATUS"></a>VirtualMachinesExtension_STATUS
+### VirtualMachinesExtension_STATUS{#VirtualMachinesExtension_STATUS}
 
 | Property                      | Description                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -378,8 +378,8 @@ Used by: [VirtualMachinesExtensionList](#VirtualMachinesExtensionList).
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachinesExtensionList"></a>VirtualMachinesExtensionList
----------------------------------------------------------------------
+VirtualMachinesExtensionList{#VirtualMachinesExtensionList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-03-01/virtualMachine.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}
 
@@ -389,8 +389,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [VirtualMachinesExtension[]](#VirtualMachinesExtension)<br/><small>Optional</small> |
 
-<a id="Image_Spec"></a>Image_Spec
----------------------------------
+Image_Spec{#Image_Spec}
+-----------------------
 
 Used by: [Image](#Image).
 
@@ -406,8 +406,8 @@ Used by: [Image](#Image).
 | storageProfile       | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                             | [ImageStorageProfile](#ImageStorageProfile)<br/><small>Optional</small>                                                                                              |
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Image_STATUS"></a>Image_STATUS
--------------------------------------
+Image_STATUS{#Image_STATUS}
+---------------------------
 
 The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual machine. If SourceImage is provided, the destination virtual hard drive must not exist.
 
@@ -427,8 +427,8 @@ Used by: [Image](#Image).
 | tags                 | Resource tags                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachine_Spec"></a>VirtualMachine_Spec
----------------------------------------------------
+VirtualMachine_Spec{#VirtualMachine_Spec}
+-----------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -466,8 +466,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | virtualMachineScaleSet  | Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. This property cannot exist along with a non-null properties.availabilitySet reference. Minimum api‐version: 2019‐03‐01                                                                                                                                                                                                                                                                                                                                                                                                                          | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
--------------------------------------------------------
+VirtualMachine_STATUS{#VirtualMachine_STATUS}
+---------------------------------------------
 
 Describes a Virtual Machine.
 
@@ -513,8 +513,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | vmId                    | Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zones                   | The virtual machine zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSet_Spec"></a>VirtualMachineScaleSet_Spec
--------------------------------------------------------------------
+VirtualMachineScaleSet_Spec{#VirtualMachineScaleSet_Spec}
+---------------------------------------------------------
 
 Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 
@@ -545,8 +545,8 @@ Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. zoneBalance property can only be set if the zones property of the scale set contains more than one zone. If there are no zones or only one zone specified, then zoneBalance property should not be set.                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="VirtualMachineScaleSet_STATUS"></a>VirtualMachineScaleSet_STATUS
------------------------------------------------------------------------
+VirtualMachineScaleSet_STATUS{#VirtualMachineScaleSet_STATUS}
+-------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set.
 
@@ -583,8 +583,8 @@ Used by: [VirtualMachineScaleSet](#VirtualMachineScaleSet).
 | zoneBalance                            | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. zoneBalance property can only be set if the zones property of the scale set contains more than one zone. If there are no zones or only one zone specified, then zoneBalance property should not be set.                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                        |
 | zones                                  | The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set                                                                                                                                                                                                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="VirtualMachineScaleSetsExtension_Spec"></a>VirtualMachineScaleSetsExtension_Spec
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension_Spec{#VirtualMachineScaleSetsExtension_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 
@@ -605,8 +605,8 @@ Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 | type                          | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VirtualMachineScaleSetsExtension_STATUS"></a>VirtualMachineScaleSetsExtension_STATUS
--------------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtension_STATUS{#VirtualMachineScaleSetsExtension_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 
@@ -628,8 +628,8 @@ Used by: [VirtualMachineScaleSetsExtension](#VirtualMachineScaleSetsExtension).
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualMachinesExtension_Spec"></a>VirtualMachinesExtension_Spec
------------------------------------------------------------------------
+VirtualMachinesExtension_Spec{#VirtualMachinesExtension_Spec}
+-------------------------------------------------------------
 
 Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 
@@ -652,8 +652,8 @@ Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 | type                          | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VirtualMachinesExtension_STATUS"></a>VirtualMachinesExtension_STATUS
----------------------------------------------------------------------------
+VirtualMachinesExtension_STATUS{#VirtualMachinesExtension_STATUS}
+-----------------------------------------------------------------
 
 Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 
@@ -677,8 +677,8 @@ Used by: [VirtualMachinesExtension](#VirtualMachinesExtension).
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdditionalCapabilities"></a>AdditionalCapabilities
----------------------------------------------------------
+AdditionalCapabilities{#AdditionalCapabilities}
+-----------------------------------------------
 
 Enables or disables a capability on the virtual machine or virtual machine scale set.
 
@@ -689,8 +689,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | hibernationEnabled | The flag that enables or disables hibernation capability on the VM.                                                                                                                                                                                                                                   | bool<br/><small>Optional</small> |
 | ultraSSDEnabled    | The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled. | bool<br/><small>Optional</small> |
 
-<a id="AdditionalCapabilities_STATUS"></a>AdditionalCapabilities_STATUS
------------------------------------------------------------------------
+AdditionalCapabilities_STATUS{#AdditionalCapabilities_STATUS}
+-------------------------------------------------------------
 
 Enables or disables a capability on the virtual machine or virtual machine scale set.
 
@@ -701,8 +701,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | hibernationEnabled | The flag that enables or disables hibernation capability on the VM.                                                                                                                                                                                                                                   | bool<br/><small>Optional</small> |
 | ultraSSDEnabled    | The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled. | bool<br/><small>Optional</small> |
 
-<a id="ApplicationProfile"></a>ApplicationProfile
--------------------------------------------------
+ApplicationProfile{#ApplicationProfile}
+---------------------------------------
 
 Contains the list of gallery applications that should be made available to the VM/VMSS
 
@@ -712,8 +712,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |---------------------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | galleryApplications | Specifies the gallery applications that should be made available to the VM/VMSS | [VMGalleryApplication[]](#VMGalleryApplication)<br/><small>Optional</small> |
 
-<a id="ApplicationProfile_STATUS"></a>ApplicationProfile_STATUS
----------------------------------------------------------------
+ApplicationProfile_STATUS{#ApplicationProfile_STATUS}
+-----------------------------------------------------
 
 Contains the list of gallery applications that should be made available to the VM/VMSS
 
@@ -723,8 +723,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |---------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | galleryApplications | Specifies the gallery applications that should be made available to the VM/VMSS | [VMGalleryApplication_STATUS[]](#VMGalleryApplication_STATUS)<br/><small>Optional</small> |
 
-<a id="AutomaticRepairsPolicy"></a>AutomaticRepairsPolicy
----------------------------------------------------------
+AutomaticRepairsPolicy{#AutomaticRepairsPolicy}
+-----------------------------------------------
 
 Specifies the configuration parameters for automatic repairs on the virtual machine scale set.
 
@@ -736,8 +736,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | gracePeriod  | The amount of time for which automatic repairs are suspended due to a state change on VM. The grace time starts after the state change has completed. This helps avoid premature or accidental repairs. The time duration should be specified in ISO 8601 format. The minimum allowed grace period is 10 minutes (PT10M), which is also the default value. The maximum allowed grace period is 90 minutes (PT90M). | string<br/><small>Optional</small>                                                                      |
 | repairAction | Type of repair action (replace, restart, reimage) that will be used for repairing unhealthy virtual machines in the scale set. Default value is replace.                                                                                                                                                                                                                                                           | [AutomaticRepairsPolicy_RepairAction](#AutomaticRepairsPolicy_RepairAction)<br/><small>Optional</small> |
 
-<a id="AutomaticRepairsPolicy_STATUS"></a>AutomaticRepairsPolicy_STATUS
------------------------------------------------------------------------
+AutomaticRepairsPolicy_STATUS{#AutomaticRepairsPolicy_STATUS}
+-------------------------------------------------------------
 
 Specifies the configuration parameters for automatic repairs on the virtual machine scale set.
 
@@ -749,8 +749,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | gracePeriod  | The amount of time for which automatic repairs are suspended due to a state change on VM. The grace time starts after the state change has completed. This helps avoid premature or accidental repairs. The time duration should be specified in ISO 8601 format. The minimum allowed grace period is 10 minutes (PT10M), which is also the default value. The maximum allowed grace period is 90 minutes (PT90M). | string<br/><small>Optional</small>                                                                                    |
 | repairAction | Type of repair action (replace, restart, reimage) that will be used for repairing unhealthy virtual machines in the scale set. Default value is replace.                                                                                                                                                                                                                                                           | [AutomaticRepairsPolicy_RepairAction_STATUS](#AutomaticRepairsPolicy_RepairAction_STATUS)<br/><small>Optional</small> |
 
-<a id="BillingProfile"></a>BillingProfile
------------------------------------------
+BillingProfile{#BillingProfile}
+-------------------------------
 
 Specifies the billing related details of a Azure Spot VM or VMSS. Minimum api-version: 2019-03-01.
 
@@ -760,8 +760,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | maxPrice | Specifies the maximum price you are willing to pay for a Azure Spot VM/VMSS. This price is in US Dollars. This price will be compared with the current Azure Spot price for the VM size. Also, the prices are compared at the time of create/update of Azure Spot VM/VMSS and the operation will only succeed if the maxPrice is greater than the current Azure Spot price. The maxPrice will also be used for evicting a Azure Spot VM/VMSS if the current Azure Spot price goes beyond the maxPrice after creation of VM/VMSS. Possible values are: - Any decimal value greater than zero. Example: 0.01538 -1 – indicates default price to be up-to on-demand. You can set the maxPrice to -1 to indicate that the Azure Spot VM/VMSS should not be evicted for price reasons. Also, the default max price is -1 if it is not provided by you. Minimum api-version: 2019-03-01. | float64<br/><small>Optional</small> |
 
-<a id="BillingProfile_STATUS"></a>BillingProfile_STATUS
--------------------------------------------------------
+BillingProfile_STATUS{#BillingProfile_STATUS}
+---------------------------------------------
 
 Specifies the billing related details of a Azure Spot VM or VMSS. Minimum api-version: 2019-03-01.
 
@@ -771,8 +771,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | maxPrice | Specifies the maximum price you are willing to pay for a Azure Spot VM/VMSS. This price is in US Dollars. This price will be compared with the current Azure Spot price for the VM size. Also, the prices are compared at the time of create/update of Azure Spot VM/VMSS and the operation will only succeed if the maxPrice is greater than the current Azure Spot price. The maxPrice will also be used for evicting a Azure Spot VM/VMSS if the current Azure Spot price goes beyond the maxPrice after creation of VM/VMSS. Possible values are: - Any decimal value greater than zero. Example: 0.01538 -1 – indicates default price to be up-to on-demand. You can set the maxPrice to -1 to indicate that the Azure Spot VM/VMSS should not be evicted for price reasons. Also, the default max price is -1 if it is not provided by you. Minimum api-version: 2019-03-01. | float64<br/><small>Optional</small> |
 
-<a id="CapacityReservationProfile"></a>CapacityReservationProfile
------------------------------------------------------------------
+CapacityReservationProfile{#CapacityReservationProfile}
+-------------------------------------------------------
 
 The parameters of a capacity reservation Profile.
 
@@ -782,8 +782,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | capacityReservationGroup | Specifies the capacity reservation group resource id that should be used for allocating the virtual machine or scaleset vm instances provided enough capacity has been reserved. Please refer to https://aka.ms/CapacityReservation for more details. | [SubResource](#SubResource)<br/><small>Optional</small> |
 
-<a id="CapacityReservationProfile_STATUS"></a>CapacityReservationProfile_STATUS
--------------------------------------------------------------------------------
+CapacityReservationProfile_STATUS{#CapacityReservationProfile_STATUS}
+---------------------------------------------------------------------
 
 The parameters of a capacity reservation Profile.
 
@@ -793,8 +793,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
 | capacityReservationGroup | Specifies the capacity reservation group resource id that should be used for allocating the virtual machine or scaleset vm instances provided enough capacity has been reserved. Please refer to https://aka.ms/CapacityReservation for more details. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="DiagnosticsProfile"></a>DiagnosticsProfile
--------------------------------------------------
+DiagnosticsProfile{#DiagnosticsProfile}
+---------------------------------------
 
 Specifies the boot diagnostic settings state. Minimum api-version: 2015-06-15.
 
@@ -804,8 +804,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | bootDiagnostics | Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. NOTE: If storageUri is being specified then ensure that the storage account is in the same region and subscription as the VM. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor. | [BootDiagnostics](#BootDiagnostics)<br/><small>Optional</small> |
 
-<a id="DiagnosticsProfile_STATUS"></a>DiagnosticsProfile_STATUS
----------------------------------------------------------------
+DiagnosticsProfile_STATUS{#DiagnosticsProfile_STATUS}
+-----------------------------------------------------
 
 Specifies the boot diagnostic settings state. Minimum api-version: 2015-06-15.
 
@@ -815,8 +815,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | bootDiagnostics | Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. NOTE: If storageUri is being specified then ensure that the storage account is in the same region and subscription as the VM. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor. | [BootDiagnostics_STATUS](#BootDiagnostics_STATUS)<br/><small>Optional</small> |
 
-<a id="EvictionPolicy"></a>EvictionPolicy
------------------------------------------
+EvictionPolicy{#EvictionPolicy}
+-------------------------------
 
 Specifies the eviction policy for the Azure Spot VM/VMSS
 
@@ -827,8 +827,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="EvictionPolicy_STATUS"></a>EvictionPolicy_STATUS
--------------------------------------------------------
+EvictionPolicy_STATUS{#EvictionPolicy_STATUS}
+---------------------------------------------
 
 Specifies the eviction policy for the Azure Spot VM/VMSS
 
@@ -839,8 +839,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -851,8 +851,8 @@ Used by: [Image_Spec](#Image_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec),
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -863,8 +863,8 @@ Used by: [Image_STATUS](#Image_STATUS), [VirtualMachine_STATUS](#VirtualMachine_
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="HardwareProfile"></a>HardwareProfile
--------------------------------------------
+HardwareProfile{#HardwareProfile}
+---------------------------------
 
 Specifies the hardware settings for the virtual machine.
 
@@ -875,8 +875,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | vmSize           | Specifies the size of the virtual machine. The enum data type is currently deprecated and will be removed by December 23rd 2023. Recommended way to get the list of available sizes is using these APIs: [List all available virtual machine sizes in an availability set](https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes) [List all available virtual machine sizes in a region](https://docs.microsoft.com/rest/api/compute/resourceskus/list) [List all available virtual machine sizes for resizing](https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes). For more information about virtual machine sizes, see [Sizes for virtual machines](https://docs.microsoft.com/azure/virtual-machines/sizes). The available VM sizes depend on region and availability set. | string<br/><small>Optional</small>                                |
 | vmSizeProperties | Specifies the properties for customizing the size of the virtual machine. Minimum api-version: 2021-07-01. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. Please follow the instructions in [VM Customization](https://aka.ms/vmcustomization) for more details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [VMSizeProperties](#VMSizeProperties)<br/><small>Optional</small> |
 
-<a id="HardwareProfile_STATUS"></a>HardwareProfile_STATUS
----------------------------------------------------------
+HardwareProfile_STATUS{#HardwareProfile_STATUS}
+-----------------------------------------------
 
 Specifies the hardware settings for the virtual machine.
 
@@ -887,8 +887,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | vmSize           | Specifies the size of the virtual machine. The enum data type is currently deprecated and will be removed by December 23rd 2023. Recommended way to get the list of available sizes is using these APIs: [List all available virtual machine sizes in an availability set](https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes) [List all available virtual machine sizes in a region](https://docs.microsoft.com/rest/api/compute/resourceskus/list) [List all available virtual machine sizes for resizing](https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes). For more information about virtual machine sizes, see [Sizes for virtual machines](https://docs.microsoft.com/azure/virtual-machines/sizes). The available VM sizes depend on region and availability set. | [HardwareProfile_VmSize_STATUS](#HardwareProfile_VmSize_STATUS)<br/><small>Optional</small> |
 | vmSizeProperties | Specifies the properties for customizing the size of the virtual machine. Minimum api-version: 2021-07-01. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. Please follow the instructions in [VM Customization](https://aka.ms/vmcustomization) for more details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [VMSizeProperties_STATUS](#VMSizeProperties_STATUS)<br/><small>Optional</small>             |
 
-<a id="HyperVGenerationType"></a>HyperVGenerationType
------------------------------------------------------
+HyperVGenerationType{#HyperVGenerationType}
+-------------------------------------------
 
 Specifies the HyperVGeneration Type
 
@@ -899,8 +899,8 @@ Used by: [Image_Spec](#Image_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="HyperVGenerationType_STATUS"></a>HyperVGenerationType_STATUS
--------------------------------------------------------------------
+HyperVGenerationType_STATUS{#HyperVGenerationType_STATUS}
+---------------------------------------------------------
 
 Specifies the HyperVGeneration Type
 
@@ -911,8 +911,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="ImageOperatorSpec"></a>ImageOperatorSpec
------------------------------------------------
+ImageOperatorSpec{#ImageOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -923,8 +923,8 @@ Used by: [Image_Spec](#Image_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ImageStorageProfile"></a>ImageStorageProfile
----------------------------------------------------
+ImageStorageProfile{#ImageStorageProfile}
+-----------------------------------------
 
 Describes a storage profile.
 
@@ -936,8 +936,8 @@ Used by: [Image_Spec](#Image_Spec).
 | osDisk        | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview). | [ImageOSDisk](#ImageOSDisk)<br/><small>Optional</small>       |
 | zoneResilient | Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage (ZRS).                                                                                | bool<br/><small>Optional</small>                              |
 
-<a id="ImageStorageProfile_STATUS"></a>ImageStorageProfile_STATUS
------------------------------------------------------------------
+ImageStorageProfile_STATUS{#ImageStorageProfile_STATUS}
+-------------------------------------------------------
 
 Describes a storage profile.
 
@@ -949,8 +949,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | osDisk        | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview). | [ImageOSDisk_STATUS](#ImageOSDisk_STATUS)<br/><small>Optional</small>       |
 | zoneResilient | Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage (ZRS).                                                                                | bool<br/><small>Optional</small>                                            |
 
-<a id="KeyVaultSecretReference"></a>KeyVaultSecretReference
------------------------------------------------------------
+KeyVaultSecretReference{#KeyVaultSecretReference}
+-------------------------------------------------
 
 Describes a reference to Key Vault Secret
 
@@ -961,8 +961,8 @@ Used by: [DiskEncryptionSettings](#DiskEncryptionSettings), [VirtualMachineScale
 | secretUrl   | The URL referencing a secret in a Key Vault.             | string<br/><small>Required</small>                      |
 | sourceVault | The relative URL of the Key Vault containing the secret. | [SubResource](#SubResource)<br/><small>Required</small> |
 
-<a id="KeyVaultSecretReference_STATUS"></a>KeyVaultSecretReference_STATUS
--------------------------------------------------------------------------
+KeyVaultSecretReference_STATUS{#KeyVaultSecretReference_STATUS}
+---------------------------------------------------------------
 
 Describes a reference to Key Vault Secret
 
@@ -973,8 +973,8 @@ Used by: [DiskEncryptionSettings_STATUS](#DiskEncryptionSettings_STATUS), [Virtu
 | secretUrl   | The URL referencing a secret in a Key Vault.             | string<br/><small>Optional</small>                                    |
 | sourceVault | The relative URL of the Key Vault containing the secret. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkProfile"></a>NetworkProfile
------------------------------------------
+NetworkProfile{#NetworkProfile}
+-------------------------------
 
 Specifies the network interfaces or the networking configuration of the virtual machine.
 
@@ -986,8 +986,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | networkInterfaceConfigurations | Specifies the networking configurations that will be used to create the virtual machine networking resources.               | [VirtualMachineNetworkInterfaceConfiguration[]](#VirtualMachineNetworkInterfaceConfiguration)<br/><small>Optional</small> |
 | networkInterfaces              | Specifies the list of resource Ids for the network interfaces associated with the virtual machine.                          | [NetworkInterfaceReference[]](#NetworkInterfaceReference)<br/><small>Optional</small>                                     |
 
-<a id="NetworkProfile_STATUS"></a>NetworkProfile_STATUS
--------------------------------------------------------
+NetworkProfile_STATUS{#NetworkProfile_STATUS}
+---------------------------------------------
 
 Specifies the network interfaces or the networking configuration of the virtual machine.
 
@@ -999,8 +999,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | networkInterfaceConfigurations | Specifies the networking configurations that will be used to create the virtual machine networking resources.               | [VirtualMachineNetworkInterfaceConfiguration_STATUS[]](#VirtualMachineNetworkInterfaceConfiguration_STATUS)<br/><small>Optional</small> |
 | networkInterfaces              | Specifies the list of resource Ids for the network interfaces associated with the virtual machine.                          | [NetworkInterfaceReference_STATUS[]](#NetworkInterfaceReference_STATUS)<br/><small>Optional</small>                                     |
 
-<a id="OrchestrationMode"></a>OrchestrationMode
------------------------------------------------
+OrchestrationMode{#OrchestrationMode}
+-------------------------------------
 
 Specifies the orchestration mode for the virtual machine scale set.
 
@@ -1011,8 +1011,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | "Flexible" |             |
 | "Uniform"  |             |
 
-<a id="OrchestrationMode_STATUS"></a>OrchestrationMode_STATUS
--------------------------------------------------------------
+OrchestrationMode_STATUS{#OrchestrationMode_STATUS}
+---------------------------------------------------
 
 Specifies the orchestration mode for the virtual machine scale set.
 
@@ -1023,8 +1023,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | "Flexible" |             |
 | "Uniform"  |             |
 
-<a id="OSProfile"></a>OSProfile
--------------------------------
+OSProfile{#OSProfile}
+---------------------
 
 Specifies the operating system settings for the virtual machine. Some of the settings cannot be changed once VM is provisioned.
 
@@ -1042,8 +1042,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | secrets                     | Specifies set of certificates that should be installed onto the virtual machine. To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | [VaultSecretGroup[]](#VaultSecretGroup)<br/><small>Optional</small>                                                                                    |
 | windowsConfiguration        | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | [WindowsConfiguration](#WindowsConfiguration)<br/><small>Optional</small>                                                                              |
 
-<a id="OSProfile_STATUS"></a>OSProfile_STATUS
----------------------------------------------
+OSProfile_STATUS{#OSProfile_STATUS}
+-----------------------------------
 
 Specifies the operating system settings for the virtual machine. Some of the settings cannot be changed once VM is provisioned.
 
@@ -1060,8 +1060,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | secrets                     | Specifies set of certificates that should be installed onto the virtual machine. To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows).                                                                                                                                                                                                                                                                         | [VaultSecretGroup_STATUS[]](#VaultSecretGroup_STATUS)<br/><small>Optional</small>       |
 | windowsConfiguration        | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="Plan"></a>Plan
----------------------
+Plan{#Plan}
+-----------
 
 Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click Want to deploy programmatically, Get Started ->. Enter any required information and then click Save.
 
@@ -1074,8 +1074,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | promotionCode | The promotion code.                                                                                                        | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="Plan_STATUS"></a>Plan_STATUS
------------------------------------
+Plan_STATUS{#Plan_STATUS}
+-------------------------
 
 Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click Want to deploy programmatically, Get Started ->. Enter any required information and then click Save.
 
@@ -1088,8 +1088,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | promotionCode | The promotion code.                                                                                                        | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="Priority"></a>Priority
------------------------------
+Priority{#Priority}
+-------------------
 
 Specifies the priority for a standalone virtual machine or the virtual machines in the scale set. 'Low' enum will be deprecated in the future, please use 'Spot' as the enum to deploy Azure Spot VM/VMSS.
 
@@ -1101,8 +1101,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="Priority_STATUS"></a>Priority_STATUS
--------------------------------------------
+Priority_STATUS{#Priority_STATUS}
+---------------------------------
 
 Specifies the priority for a standalone virtual machine or the virtual machines in the scale set. 'Low' enum will be deprecated in the future, please use 'Spot' as the enum to deploy Azure Spot VM/VMSS.
 
@@ -1114,8 +1114,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleInPolicy"></a>ScaleInPolicy
----------------------------------------
+ScaleInPolicy{#ScaleInPolicy}
+-----------------------------
 
 Describes a scale-in policy for a virtual machine scale set.
 
@@ -1126,8 +1126,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | forceDeletion | This property allows you to specify if virtual machines chosen for removal have to be force deleted when a virtual machine scale set is being scaled-in.(Feature in Preview)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                          |
 | rules         | The rules to be followed when scaling-in a virtual machine scale set. Possible values are: Default When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. OldestVM When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. | [ScaleInPolicy_Rules[]](#ScaleInPolicy_Rules)<br/><small>Optional</small> |
 
-<a id="ScaleInPolicy_STATUS"></a>ScaleInPolicy_STATUS
------------------------------------------------------
+ScaleInPolicy_STATUS{#ScaleInPolicy_STATUS}
+-------------------------------------------
 
 Describes a scale-in policy for a virtual machine scale set.
 
@@ -1138,8 +1138,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | forceDeletion | This property allows you to specify if virtual machines chosen for removal have to be force deleted when a virtual machine scale set is being scaled-in.(Feature in Preview)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                        |
 | rules         | The rules to be followed when scaling-in a virtual machine scale set. Possible values are: Default When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. OldestVM When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. | [ScaleInPolicy_Rules_STATUS[]](#ScaleInPolicy_Rules_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduledEventsProfile"></a>ScheduledEventsProfile
----------------------------------------------------------
+ScheduledEventsProfile{#ScheduledEventsProfile}
+-----------------------------------------------
 
 Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 
@@ -1147,8 +1147,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 |------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | terminateNotificationProfile | Specifies Terminate Scheduled Event related configurations. | [TerminateNotificationProfile](#TerminateNotificationProfile)<br/><small>Optional</small> |
 
-<a id="ScheduledEventsProfile_STATUS"></a>ScheduledEventsProfile_STATUS
------------------------------------------------------------------------
+ScheduledEventsProfile_STATUS{#ScheduledEventsProfile_STATUS}
+-------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfile_STATUS).
 
@@ -1156,8 +1156,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 |------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | terminateNotificationProfile | Specifies Terminate Scheduled Event related configurations. | [TerminateNotificationProfile_STATUS](#TerminateNotificationProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="SecurityProfile"></a>SecurityProfile
--------------------------------------------
+SecurityProfile{#SecurityProfile}
+---------------------------------
 
 Specifies the Security profile settings for the virtual machine or virtual machine scale set.
 
@@ -1169,8 +1169,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec), and [VirtualMachineScaleSe
 | securityType     | Specifies the SecurityType of the virtual machine. It has to be set to any specified value to enable UefiSettings. Default: UefiSettings will not be enabled unless this property is set.                                                                                                                                                             | [SecurityProfile_SecurityType](#SecurityProfile_SecurityType)<br/><small>Optional</small> |
 | uefiSettings     | Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01                                                                                                                                                                                                                    | [UefiSettings](#UefiSettings)<br/><small>Optional</small>                                 |
 
-<a id="SecurityProfile_STATUS"></a>SecurityProfile_STATUS
----------------------------------------------------------
+SecurityProfile_STATUS{#SecurityProfile_STATUS}
+-----------------------------------------------
 
 Specifies the Security profile settings for the virtual machine or virtual machine scale set.
 
@@ -1182,8 +1182,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS), and [VirtualMachineSca
 | securityType     | Specifies the SecurityType of the virtual machine. It has to be set to any specified value to enable UefiSettings. Default: UefiSettings will not be enabled unless this property is set.                                                                                                                                                             | [SecurityProfile_SecurityType_STATUS](#SecurityProfile_SecurityType_STATUS)<br/><small>Optional</small> |
 | uefiSettings     | Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01                                                                                                                                                                                                                    | [UefiSettings_STATUS](#UefiSettings_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set is currently on, you need to deallocate the VMs in the scale set before you modify the SKU name.
 
@@ -1195,8 +1195,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | name     | The sku name.                                                                          | string<br/><small>Optional</small> |
 | tier     | Specifies the tier of virtual machines in a scale set. Possible Values: Standard Basic | string<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set is currently on, you need to deallocate the VMs in the scale set before you modify the SKU name.
 
@@ -1208,8 +1208,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | name     | The sku name.                                                                          | string<br/><small>Optional</small> |
 | tier     | Specifies the tier of virtual machines in a scale set. Possible Values: Standard Basic | string<br/><small>Optional</small> |
 
-<a id="SpotRestorePolicy"></a>SpotRestorePolicy
------------------------------------------------
+SpotRestorePolicy{#SpotRestorePolicy}
+-------------------------------------
 
 Specifies the Spot-Try-Restore properties for the virtual machine scale set. With this property customer can enable or disable automatic restore of the evicted Spot VMSS VM instances opportunistically based on capacity availability and pricing constraint.
 
@@ -1220,8 +1220,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | enabled        | Enables the Spot-Try-Restore feature where evicted VMSS SPOT instances will be tried to be restored opportunistically based on capacity availability and pricing constraints | bool<br/><small>Optional</small>   |
 | restoreTimeout | Timeout value expressed as an ISO 8601 time duration after which the platform will not try to restore the VMSS SPOT instances                                                | string<br/><small>Optional</small> |
 
-<a id="SpotRestorePolicy_STATUS"></a>SpotRestorePolicy_STATUS
--------------------------------------------------------------
+SpotRestorePolicy_STATUS{#SpotRestorePolicy_STATUS}
+---------------------------------------------------
 
 Specifies the Spot-Try-Restore properties for the virtual machine scale set. With this property customer can enable or disable automatic restore of the evicted Spot VMSS VM instances opportunistically based on capacity availability and pricing constraint.
 
@@ -1232,8 +1232,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | enabled        | Enables the Spot-Try-Restore feature where evicted VMSS SPOT instances will be tried to be restored opportunistically based on capacity availability and pricing constraints | bool<br/><small>Optional</small>   |
 | restoreTimeout | Timeout value expressed as an ISO 8601 time duration after which the platform will not try to restore the VMSS SPOT instances                                                | string<br/><small>Optional</small> |
 
-<a id="StorageProfile"></a>StorageProfile
------------------------------------------
+StorageProfile{#StorageProfile}
+-------------------------------
 
 Specifies the storage settings for the virtual machine disks.
 
@@ -1245,8 +1245,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. | [ImageReference](#ImageReference)<br/><small>Optional</small> |
 | osDisk         | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).                                                      | [OSDisk](#OSDisk)<br/><small>Optional</small>                 |
 
-<a id="StorageProfile_STATUS"></a>StorageProfile_STATUS
--------------------------------------------------------
+StorageProfile_STATUS{#StorageProfile_STATUS}
+---------------------------------------------
 
 Specifies the storage settings for the virtual machine disks.
 
@@ -1258,8 +1258,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. | [ImageReference_STATUS](#ImageReference_STATUS)<br/><small>Optional</small> |
 | osDisk         | Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).                                                      | [OSDisk_STATUS](#OSDisk_STATUS)<br/><small>Optional</small>                 |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Used by: [CapacityReservationProfile](#CapacityReservationProfile), [Image_Spec](#Image_Spec), [ImageDataDisk](#ImageDataDisk), [ImageDataDisk](#ImageDataDisk), [ImageDataDisk](#ImageDataDisk), [ImageOSDisk](#ImageOSDisk), [ImageOSDisk](#ImageOSDisk), [ImageOSDisk](#ImageOSDisk), [KeyVaultKeyReference](#KeyVaultKeyReference), [KeyVaultSecretReference](#KeyVaultSecretReference), [ManagedDiskParameters](#ManagedDiskParameters), [VaultSecretGroup](#VaultSecretGroup), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachine_Spec](#VirtualMachine_Spec), [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration), [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration), [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkInterfaceIPConfiguration), [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkInterfaceIPConfiguration), [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkInterfaceIPConfiguration), [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkInterfaceIPConfiguration), [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAddressConfiguration), [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec), [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration), [VirtualMachineScaleSetManagedDiskParameters](#VirtualMachineScaleSetManagedDiskParameters), [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNetworkConfiguration), [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineScaleSetPublicIPAddressConfiguration), and [VMDiskSecurityProfile](#VMDiskSecurityProfile).
 
@@ -1267,8 +1267,8 @@ Used by: [CapacityReservationProfile](#CapacityReservationProfile), [Image_Spec]
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Used by: [CapacityReservationProfile_STATUS](#CapacityReservationProfile_STATUS), [Image_STATUS](#Image_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageOSDisk_STATUS](#ImageOSDisk_STATUS), [ImageOSDisk_STATUS](#ImageOSDisk_STATUS), [ImageOSDisk_STATUS](#ImageOSDisk_STATUS), [KeyVaultKeyReference_STATUS](#KeyVaultKeyReference_STATUS), [KeyVaultSecretReference_STATUS](#KeyVaultSecretReference_STATUS), [ManagedDiskParameters_STATUS](#ManagedDiskParameters_STATUS), [VaultSecretGroup_STATUS](#VaultSecretGroup_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachine_STATUS](#VirtualMachine_STATUS), [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNetworkInterfaceConfiguration_STATUS), [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNetworkInterfaceConfiguration_STATUS), [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineNetworkInterfaceIPConfiguration_STATUS), [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineNetworkInterfaceIPConfiguration_STATUS), [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineNetworkInterfaceIPConfiguration_STATUS), [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineNetworkInterfaceIPConfiguration_STATUS), [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS), [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS), [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS), [VirtualMachineScaleSetManagedDiskParameters_STATUS](#VirtualMachineScaleSetManagedDiskParameters_STATUS), [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScaleSetNetworkConfiguration_STATUS), [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS), and [VMDiskSecurityProfile_STATUS](#VMDiskSecurityProfile_STATUS).
 
@@ -1276,8 +1276,8 @@ Used by: [CapacityReservationProfile_STATUS](#CapacityReservationProfile_STATUS)
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="UpgradePolicy"></a>UpgradePolicy
----------------------------------------
+UpgradePolicy{#UpgradePolicy}
+-----------------------------
 
 Describes an upgrade policy - automatic, manual, or rolling.
 
@@ -1289,8 +1289,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | mode                     | Specifies the mode of an upgrade to virtual machines in the scale set. Possible values are: Manual - You control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action. Automatic - All virtual machines in the scale set are automatically updated at the same time. | [UpgradePolicy_Mode](#UpgradePolicy_Mode)<br/><small>Optional</small>             |
 | rollingUpgradePolicy     | The configuration parameters used while performing a rolling upgrade.                                                                                                                                                                                                                                                          | [RollingUpgradePolicy](#RollingUpgradePolicy)<br/><small>Optional</small>         |
 
-<a id="UpgradePolicy_STATUS"></a>UpgradePolicy_STATUS
------------------------------------------------------
+UpgradePolicy_STATUS{#UpgradePolicy_STATUS}
+-------------------------------------------
 
 Describes an upgrade policy - automatic, manual, or rolling.
 
@@ -1302,8 +1302,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | mode                     | Specifies the mode of an upgrade to virtual machines in the scale set. Possible values are: Manual - You control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action. Automatic - All virtual machines in the scale set are automatically updated at the same time. | [UpgradePolicy_Mode_STATUS](#UpgradePolicy_Mode_STATUS)<br/><small>Optional</small>             |
 | rollingUpgradePolicy     | The configuration parameters used while performing a rolling upgrade.                                                                                                                                                                                                                                                          | [RollingUpgradePolicy_STATUS](#RollingUpgradePolicy_STATUS)<br/><small>Optional</small>         |
 
-<a id="VirtualMachineExtension_STATUS"></a>VirtualMachineExtension_STATUS
--------------------------------------------------------------------------
+VirtualMachineExtension_STATUS{#VirtualMachineExtension_STATUS}
+---------------------------------------------------------------
 
 Describes a Virtual Machine Extension.
 
@@ -1328,8 +1328,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                    |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                    |
 
-<a id="VirtualMachineExtensionInstanceView"></a>VirtualMachineExtensionInstanceView
------------------------------------------------------------------------------------
+VirtualMachineExtensionInstanceView{#VirtualMachineExtensionInstanceView}
+-------------------------------------------------------------------------
 
 The instance view of a virtual machine extension.
 
@@ -1343,8 +1343,8 @@ Used by: [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec).
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                      |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                      |
 
-<a id="VirtualMachineExtensionInstanceView_STATUS"></a>VirtualMachineExtensionInstanceView_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineExtensionInstanceView_STATUS{#VirtualMachineExtensionInstanceView_STATUS}
+---------------------------------------------------------------------------------------
 
 The instance view of a virtual machine extension.
 
@@ -1358,8 +1358,8 @@ Used by: [VirtualMachineExtension_STATUS](#VirtualMachineExtension_STATUS), [Vir
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                                    |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                                    |
 
-<a id="VirtualMachineIdentity"></a>VirtualMachineIdentity
----------------------------------------------------------
+VirtualMachineIdentity{#VirtualMachineIdentity}
+-----------------------------------------------
 
 Identity for the virtual machine.
 
@@ -1370,8 +1370,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | type                   | The type of identity used for the virtual machine. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                                | [VirtualMachineIdentity_Type](#VirtualMachineIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="VirtualMachineIdentity_STATUS"></a>VirtualMachineIdentity_STATUS
------------------------------------------------------------------------
+VirtualMachineIdentity_STATUS{#VirtualMachineIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the virtual machine.
 
@@ -1384,8 +1384,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | type                   | The type of identity used for the virtual machine. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                                | [VirtualMachineIdentity_Type_STATUS](#VirtualMachineIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS](#VirtualMachineIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineInstanceView_STATUS"></a>VirtualMachineInstanceView_STATUS
--------------------------------------------------------------------------------
+VirtualMachineInstanceView_STATUS{#VirtualMachineInstanceView_STATUS}
+---------------------------------------------------------------------
 
 The instance view of a virtual machine.
 
@@ -1410,8 +1410,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | vmAgent                   | The VM Agent running on the virtual machine.                                                                                                                                                                                                        | [VirtualMachineAgentInstanceView_STATUS](#VirtualMachineAgentInstanceView_STATUS)<br/><small>Optional</small>                         |
 | vmHealth                  | The health status for the VM.                                                                                                                                                                                                                       | [VirtualMachineHealthStatus_STATUS](#VirtualMachineHealthStatus_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="VirtualMachineOperatorSpec"></a>VirtualMachineOperatorSpec
------------------------------------------------------------------
+VirtualMachineOperatorSpec{#VirtualMachineOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1422,8 +1422,8 @@ Used by: [VirtualMachine_Spec](#VirtualMachine_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIdentity"></a>VirtualMachineScaleSetIdentity
--------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity{#VirtualMachineScaleSetIdentity}
+---------------------------------------------------------------
 
 Identity for the virtual machine scale set.
 
@@ -1434,8 +1434,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | type                   | The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine scale set.                                                                                                                                      | [VirtualMachineScaleSetIdentity_Type](#VirtualMachineScaleSetIdentity_Type)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small>               |
 
-<a id="VirtualMachineScaleSetIdentity_STATUS"></a>VirtualMachineScaleSetIdentity_STATUS
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_STATUS{#VirtualMachineScaleSetIdentity_STATUS}
+-----------------------------------------------------------------------------
 
 Identity for the virtual machine scale set.
 
@@ -1448,8 +1448,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | type                   | The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine scale set.                                                                                                                                      | [VirtualMachineScaleSetIdentity_Type_STATUS](#VirtualMachineScaleSetIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS](#VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetOperatorSpec"></a>VirtualMachineScaleSetOperatorSpec
----------------------------------------------------------------------------------
+VirtualMachineScaleSetOperatorSpec{#VirtualMachineScaleSetOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1460,8 +1460,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetsExtensionOperatorSpec"></a>VirtualMachineScaleSetsExtensionOperatorSpec
------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetsExtensionOperatorSpec{#VirtualMachineScaleSetsExtensionOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1472,8 +1472,8 @@ Used by: [VirtualMachineScaleSetsExtension_Spec](#VirtualMachineScaleSetsExtensi
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetVMProfile"></a>VirtualMachineScaleSetVMProfile
----------------------------------------------------------------------------
+VirtualMachineScaleSetVMProfile{#VirtualMachineScaleSetVMProfile}
+-----------------------------------------------------------------
 
 Describes a virtual machine scale set virtual machine profile.
 
@@ -1497,8 +1497,8 @@ Used by: [VirtualMachineScaleSet_Spec](#VirtualMachineScaleSet_Spec).
 | storageProfile         | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStorageProfile)<br/><small>Optional</small>     |
 | userData               | UserData for the virtual machines in the scale set, which must be base-64 encoded. Customer should not pass any secrets in here. Minimum api-version: 2021-03-01                                                                                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                            |
 
-<a id="VirtualMachineScaleSetVMProfile_STATUS"></a>VirtualMachineScaleSetVMProfile_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetVMProfile_STATUS{#VirtualMachineScaleSetVMProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set virtual machine profile.
 
@@ -1522,8 +1522,8 @@ Used by: [VirtualMachineScaleSet_STATUS](#VirtualMachineScaleSet_STATUS).
 | storageProfile         | Specifies the storage settings for the virtual machine disks.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetStorageProfile_STATUS)<br/><small>Optional</small>     |
 | userData               | UserData for the virtual machines in the scale set, which must be base-64 encoded. Customer should not pass any secrets in here. Minimum api-version: 2021-03-01                                                                                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                          |
 
-<a id="VirtualMachinesExtensionOperatorSpec"></a>VirtualMachinesExtensionOperatorSpec
--------------------------------------------------------------------------------------
+VirtualMachinesExtensionOperatorSpec{#VirtualMachinesExtensionOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1534,8 +1534,8 @@ Used by: [VirtualMachinesExtension_Spec](#VirtualMachinesExtension_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AutomaticOSUpgradePolicy"></a>AutomaticOSUpgradePolicy
--------------------------------------------------------------
+AutomaticOSUpgradePolicy{#AutomaticOSUpgradePolicy}
+---------------------------------------------------
 
 The configuration parameters used for performing automatic OS upgrade.
 
@@ -1547,8 +1547,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | enableAutomaticOSUpgrade | Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer version of the OS image becomes available. Default value is false. If this is set to true for Windows based scale sets, [enableAutomaticUpdates](https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.windowsconfiguration.enableautomaticupdates?view=azure-dotnet) is automatically set to false and cannot be set to true. | bool<br/><small>Optional</small> |
 | useRollingUpgradePolicy  | Indicates whether rolling upgrade policy should be used during Auto OS Upgrade. Default value is false. Auto OS Upgrade will fallback to the default policy if no policy is defined on the VMSS.                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small> |
 
-<a id="AutomaticOSUpgradePolicy_STATUS"></a>AutomaticOSUpgradePolicy_STATUS
----------------------------------------------------------------------------
+AutomaticOSUpgradePolicy_STATUS{#AutomaticOSUpgradePolicy_STATUS}
+-----------------------------------------------------------------
 
 The configuration parameters used for performing automatic OS upgrade.
 
@@ -1560,8 +1560,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | enableAutomaticOSUpgrade | Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer version of the OS image becomes available. Default value is false. If this is set to true for Windows based scale sets, [enableAutomaticUpdates](https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.windowsconfiguration.enableautomaticupdates?view=azure-dotnet) is automatically set to false and cannot be set to true. | bool<br/><small>Optional</small> |
 | useRollingUpgradePolicy  | Indicates whether rolling upgrade policy should be used during Auto OS Upgrade. Default value is false. Auto OS Upgrade will fallback to the default policy if no policy is defined on the VMSS.                                                                                                                                                                                                                                                                                | bool<br/><small>Optional</small> |
 
-<a id="AutomaticRepairsPolicy_RepairAction"></a>AutomaticRepairsPolicy_RepairAction
------------------------------------------------------------------------------------
+AutomaticRepairsPolicy_RepairAction{#AutomaticRepairsPolicy_RepairAction}
+-------------------------------------------------------------------------
 
 Used by: [AutomaticRepairsPolicy](#AutomaticRepairsPolicy).
 
@@ -1571,8 +1571,8 @@ Used by: [AutomaticRepairsPolicy](#AutomaticRepairsPolicy).
 | "Replace" |             |
 | "Restart" |             |
 
-<a id="AutomaticRepairsPolicy_RepairAction_STATUS"></a>AutomaticRepairsPolicy_RepairAction_STATUS
--------------------------------------------------------------------------------------------------
+AutomaticRepairsPolicy_RepairAction_STATUS{#AutomaticRepairsPolicy_RepairAction_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [AutomaticRepairsPolicy_STATUS](#AutomaticRepairsPolicy_STATUS).
 
@@ -1582,8 +1582,8 @@ Used by: [AutomaticRepairsPolicy_STATUS](#AutomaticRepairsPolicy_STATUS).
 | "Replace" |             |
 | "Restart" |             |
 
-<a id="BootDiagnostics"></a>BootDiagnostics
--------------------------------------------
+BootDiagnostics{#BootDiagnostics}
+---------------------------------
 
 Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor.
 
@@ -1594,8 +1594,8 @@ Used by: [DiagnosticsProfile](#DiagnosticsProfile).
 | enabled    | Whether boot diagnostics should be enabled on the Virtual Machine.                                                                                                             | bool<br/><small>Optional</small>   |
 | storageUri | Uri of the storage account to use for placing the console output and screenshot. If storageUri is not specified while enabling boot diagnostics, managed storage will be used. | string<br/><small>Optional</small> |
 
-<a id="BootDiagnostics_STATUS"></a>BootDiagnostics_STATUS
----------------------------------------------------------
+BootDiagnostics_STATUS{#BootDiagnostics_STATUS}
+-----------------------------------------------
 
 Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status. You can easily view the output of your console log. Azure also enables you to see a screenshot of the VM from the hypervisor.
 
@@ -1606,8 +1606,8 @@ Used by: [DiagnosticsProfile_STATUS](#DiagnosticsProfile_STATUS).
 | enabled    | Whether boot diagnostics should be enabled on the Virtual Machine.                                                                                                             | bool<br/><small>Optional</small>   |
 | storageUri | Uri of the storage account to use for placing the console output and screenshot. If storageUri is not specified while enabling boot diagnostics, managed storage will be used. | string<br/><small>Optional</small> |
 
-<a id="BootDiagnosticsInstanceView_STATUS"></a>BootDiagnosticsInstanceView_STATUS
----------------------------------------------------------------------------------
+BootDiagnosticsInstanceView_STATUS{#BootDiagnosticsInstanceView_STATUS}
+-----------------------------------------------------------------------
 
 The instance view of a virtual machine boot diagnostics.
 
@@ -1619,8 +1619,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | serialConsoleLogBlobUri  | The serial console log blob Uri. NOTE: This will not be set if boot diagnostics is currently enabled with managed storage.                  | string<br/><small>Optional</small>                                                  |
 | status                   | The boot diagnostics status information for the VM. NOTE: It will be set only if there are errors encountered in enabling boot diagnostics. | [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="DataDisk"></a>DataDisk
------------------------------
+DataDisk{#DataDisk}
+-------------------
 
 Describes a data disk.
 
@@ -1641,8 +1641,8 @@ Used by: [StorageProfile](#StorageProfile).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [VirtualHardDisk](#VirtualHardDisk)<br/><small>Optional</small>             |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                            |
 
-<a id="DataDisk_STATUS"></a>DataDisk_STATUS
--------------------------------------------
+DataDisk_STATUS{#DataDisk_STATUS}
+---------------------------------
 
 Describes a data disk.
 
@@ -1665,8 +1665,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [VirtualHardDisk_STATUS](#VirtualHardDisk_STATUS)<br/><small>Optional</small>             |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                          |
 
-<a id="DiskInstanceView_STATUS"></a>DiskInstanceView_STATUS
------------------------------------------------------------
+DiskInstanceView_STATUS{#DiskInstanceView_STATUS}
+-------------------------------------------------
 
 The instance view of the disk.
 
@@ -1678,8 +1678,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | name               | The disk name.                                                                     | string<br/><small>Optional</small>                                                            |
 | statuses           | The resource status information.                                                   | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>         |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -1689,8 +1689,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -1700,8 +1700,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="HardwareProfile_VmSize_STATUS"></a>HardwareProfile_VmSize_STATUS
------------------------------------------------------------------------
+HardwareProfile_VmSize_STATUS{#HardwareProfile_VmSize_STATUS}
+-------------------------------------------------------------
 
 Used by: [HardwareProfile_STATUS](#HardwareProfile_STATUS).
 
@@ -1874,8 +1874,8 @@ Used by: [HardwareProfile_STATUS](#HardwareProfile_STATUS).
 | "Standard_NV24"       |             |
 | "Standard_NV6"        |             |
 
-<a id="ImageDataDisk"></a>ImageDataDisk
----------------------------------------
+ImageDataDisk{#ImageDataDisk}
+-----------------------------
 
 Describes a data disk.
 
@@ -1892,8 +1892,8 @@ Used by: [ImageStorageProfile](#ImageStorageProfile).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                     |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>       |
 
-<a id="ImageDataDisk_STATUS"></a>ImageDataDisk_STATUS
------------------------------------------------------
+ImageDataDisk_STATUS{#ImageDataDisk_STATUS}
+-------------------------------------------
 
 Describes a data disk.
 
@@ -1910,8 +1910,8 @@ Used by: [ImageStorageProfile_STATUS](#ImageStorageProfile_STATUS).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                     |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>       |
 
-<a id="ImageOSDisk"></a>ImageOSDisk
------------------------------------
+ImageOSDisk{#ImageOSDisk}
+-------------------------
 
 Describes an Operating System disk.
 
@@ -1929,8 +1929,8 @@ Used by: [ImageStorageProfile](#ImageStorageProfile).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                 |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>   |
 
-<a id="ImageOSDisk_STATUS"></a>ImageOSDisk_STATUS
--------------------------------------------------
+ImageOSDisk_STATUS{#ImageOSDisk_STATUS}
+---------------------------------------
 
 Describes an Operating System disk.
 
@@ -1948,8 +1948,8 @@ Used by: [ImageStorageProfile_STATUS](#ImageStorageProfile_STATUS).
 | snapshot           | The snapshot.                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                 |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.                                        | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>   |
 
-<a id="ImageReference"></a>ImageReference
------------------------------------------
+ImageReference{#ImageReference}
+-------------------------------
 
 Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. NOTE: Image reference publisher and offer can only be set when you create the scale set.
 
@@ -1965,8 +1965,8 @@ Used by: [StorageProfile](#StorageProfile), and [VirtualMachineScaleSetStoragePr
 | sku                     | The image SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                         |
 | version                 | Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available. Please do not use field 'version' for gallery image deployment, gallery image should always use 'id' field for deployment, to use 'latest' version of gallery image, just set '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/galleries/{galleryName}/images/{imageName}' in the 'id' field without version input. | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ImageReference_STATUS"></a>ImageReference_STATUS
--------------------------------------------------------
+ImageReference_STATUS{#ImageReference_STATUS}
+---------------------------------------------
 
 Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. NOTE: Image reference publisher and offer can only be set when you create the scale set.
 
@@ -1983,8 +1983,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS), and [VirtualMachineSca
 | sku                     | The image SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small> |
 | version                 | Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available. Please do not use field 'version' for gallery image deployment, gallery image should always use 'id' field for deployment, to use 'latest' version of gallery image, just set '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/galleries/{galleryName}/images/{imageName}' in the 'id' field without version input. | string<br/><small>Optional</small> |
 
-<a id="InstanceViewStatus"></a>InstanceViewStatus
--------------------------------------------------
+InstanceViewStatus{#InstanceViewStatus}
+---------------------------------------
 
 Instance view status.
 
@@ -1998,8 +1998,8 @@ Used by: [VirtualMachineExtensionInstanceView](#VirtualMachineExtensionInstanceV
 | message       | The detailed status message, including for alerts and error messages. | string<br/><small>Optional</small>                                                |
 | time          | The time of the status.                                               | string<br/><small>Optional</small>                                                |
 
-<a id="InstanceViewStatus_STATUS"></a>InstanceViewStatus_STATUS
----------------------------------------------------------------
+InstanceViewStatus_STATUS{#InstanceViewStatus_STATUS}
+-----------------------------------------------------
 
 Instance view status.
 
@@ -2013,8 +2013,8 @@ Used by: [BootDiagnosticsInstanceView_STATUS](#BootDiagnosticsInstanceView_STATU
 | message       | The detailed status message, including for alerts and error messages. | string<br/><small>Optional</small>                                                              |
 | time          | The time of the status.                                               | string<br/><small>Optional</small>                                                              |
 
-<a id="LinuxConfiguration"></a>LinuxConfiguration
--------------------------------------------------
+LinuxConfiguration{#LinuxConfiguration}
+---------------------------------------
 
 Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros).
 
@@ -2027,8 +2027,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | provisionVMAgent              | Indicates whether virtual machine agent should be provisioned on the virtual machine. When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM Agent is installed on the VM so that extensions can be added to the VM later. | bool<br/><small>Optional</small>                                      |
 | ssh                           | Specifies the ssh key configuration for a Linux OS.                                                                                                                                                                                                                                          | [SshConfiguration](#SshConfiguration)<br/><small>Optional</small>     |
 
-<a id="LinuxConfiguration_STATUS"></a>LinuxConfiguration_STATUS
----------------------------------------------------------------
+LinuxConfiguration_STATUS{#LinuxConfiguration_STATUS}
+-----------------------------------------------------
 
 Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros).
 
@@ -2041,8 +2041,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | provisionVMAgent              | Indicates whether virtual machine agent should be provisioned on the virtual machine. When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM Agent is installed on the VM so that extensions can be added to the VM later. | bool<br/><small>Optional</small>                                                    |
 | ssh                           | Specifies the ssh key configuration for a Linux OS.                                                                                                                                                                                                                                          | [SshConfiguration_STATUS](#SshConfiguration_STATUS)<br/><small>Optional</small>     |
 
-<a id="MaintenanceRedeployStatus_STATUS"></a>MaintenanceRedeployStatus_STATUS
------------------------------------------------------------------------------
+MaintenanceRedeployStatus_STATUS{#MaintenanceRedeployStatus_STATUS}
+-------------------------------------------------------------------
 
 Maintenance Operation Status.
 
@@ -2058,8 +2058,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | preMaintenanceWindowEndTime           | End Time for the Pre Maintenance Window.             | string<br/><small>Optional</small>                                                                                                                |
 | preMaintenanceWindowStartTime         | Start Time for the Pre Maintenance Window.           | string<br/><small>Optional</small>                                                                                                                |
 
-<a id="NetworkInterfaceReference"></a>NetworkInterfaceReference
----------------------------------------------------------------
+NetworkInterfaceReference{#NetworkInterfaceReference}
+-----------------------------------------------------
 
 Describes a network interface reference.
 
@@ -2071,8 +2071,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 | primary      | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                           |
 | reference    | Resource Id                                                                                            | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceReference_STATUS"></a>NetworkInterfaceReference_STATUS
------------------------------------------------------------------------------
+NetworkInterfaceReference_STATUS{#NetworkInterfaceReference_STATUS}
+-------------------------------------------------------------------
 
 Describes a network interface reference.
 
@@ -2084,8 +2084,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | id           | Resource Id                                                                                            | string<br/><small>Optional</small>                                                                                                              |
 | primary      | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                |
 
-<a id="NetworkProfile_NetworkApiVersion"></a>NetworkProfile_NetworkApiVersion
------------------------------------------------------------------------------
+NetworkProfile_NetworkApiVersion{#NetworkProfile_NetworkApiVersion}
+-------------------------------------------------------------------
 
 Used by: [NetworkProfile](#NetworkProfile).
 
@@ -2093,8 +2093,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 |--------------|-------------|
 | "2020-11-01" |             |
 
-<a id="NetworkProfile_NetworkApiVersion_STATUS"></a>NetworkProfile_NetworkApiVersion_STATUS
--------------------------------------------------------------------------------------------
+NetworkProfile_NetworkApiVersion_STATUS{#NetworkProfile_NetworkApiVersion_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 
@@ -2102,8 +2102,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 |--------------|-------------|
 | "2020-11-01" |             |
 
-<a id="OSDisk"></a>OSDisk
--------------------------
+OSDisk{#OSDisk}
+---------------
 
 Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).
 
@@ -2124,8 +2124,8 @@ Used by: [StorageProfile](#StorageProfile).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                               | [VirtualHardDisk](#VirtualHardDisk)<br/><small>Optional</small>               |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                        | bool<br/><small>Optional</small>                                              |
 
-<a id="OSDisk_STATUS"></a>OSDisk_STATUS
----------------------------------------
+OSDisk_STATUS{#OSDisk_STATUS}
+-----------------------------
 
 Specifies information about the operating system disk used by the virtual machine. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).
 
@@ -2146,8 +2146,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | vhd                     | The virtual hard disk.                                                                                                                                                                                                                                                                                                                                                                                                                                               | [VirtualHardDisk_STATUS](#VirtualHardDisk_STATUS)<br/><small>Optional</small>               |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                        | bool<br/><small>Optional</small>                                                            |
 
-<a id="RollingUpgradePolicy"></a>RollingUpgradePolicy
------------------------------------------------------
+RollingUpgradePolicy{#RollingUpgradePolicy}
+-------------------------------------------
 
 The configuration parameters used while performing a rolling upgrade.
 
@@ -2162,8 +2162,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | pauseTimeBetweenBatches             | The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. The default value is 0 seconds (PT0S).                                                                                                                                                                      | string<br/><small>Optional</small> |
 | prioritizeUnhealthyInstances        | Upgrade all unhealthy instances in a scale set before any healthy instances.                                                                                                                                                                                                                                                                                                         | bool<br/><small>Optional</small>   |
 
-<a id="RollingUpgradePolicy_STATUS"></a>RollingUpgradePolicy_STATUS
--------------------------------------------------------------------
+RollingUpgradePolicy_STATUS{#RollingUpgradePolicy_STATUS}
+---------------------------------------------------------
 
 The configuration parameters used while performing a rolling upgrade.
 
@@ -2178,8 +2178,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | pauseTimeBetweenBatches             | The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. The default value is 0 seconds (PT0S).                                                                                                                                                                      | string<br/><small>Optional</small> |
 | prioritizeUnhealthyInstances        | Upgrade all unhealthy instances in a scale set before any healthy instances.                                                                                                                                                                                                                                                                                                         | bool<br/><small>Optional</small>   |
 
-<a id="ScaleInPolicy_Rules"></a>ScaleInPolicy_Rules
----------------------------------------------------
+ScaleInPolicy_Rules{#ScaleInPolicy_Rules}
+-----------------------------------------
 
 Used by: [ScaleInPolicy](#ScaleInPolicy).
 
@@ -2189,8 +2189,8 @@ Used by: [ScaleInPolicy](#ScaleInPolicy).
 | "NewestVM" |             |
 | "OldestVM" |             |
 
-<a id="ScaleInPolicy_Rules_STATUS"></a>ScaleInPolicy_Rules_STATUS
------------------------------------------------------------------
+ScaleInPolicy_Rules_STATUS{#ScaleInPolicy_Rules_STATUS}
+-------------------------------------------------------
 
 Used by: [ScaleInPolicy_STATUS](#ScaleInPolicy_STATUS).
 
@@ -2200,8 +2200,8 @@ Used by: [ScaleInPolicy_STATUS](#ScaleInPolicy_STATUS).
 | "NewestVM" |             |
 | "OldestVM" |             |
 
-<a id="SecurityProfile_SecurityType"></a>SecurityProfile_SecurityType
----------------------------------------------------------------------
+SecurityProfile_SecurityType{#SecurityProfile_SecurityType}
+-----------------------------------------------------------
 
 Used by: [SecurityProfile](#SecurityProfile).
 
@@ -2210,8 +2210,8 @@ Used by: [SecurityProfile](#SecurityProfile).
 | "ConfidentialVM" |             |
 | "TrustedLaunch"  |             |
 
-<a id="SecurityProfile_SecurityType_STATUS"></a>SecurityProfile_SecurityType_STATUS
------------------------------------------------------------------------------------
+SecurityProfile_SecurityType_STATUS{#SecurityProfile_SecurityType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 
@@ -2220,8 +2220,8 @@ Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 | "ConfidentialVM" |             |
 | "TrustedLaunch"  |             |
 
-<a id="TerminateNotificationProfile"></a>TerminateNotificationProfile
----------------------------------------------------------------------
+TerminateNotificationProfile{#TerminateNotificationProfile}
+-----------------------------------------------------------
 
 Used by: [ScheduledEventsProfile](#ScheduledEventsProfile).
 
@@ -2230,8 +2230,8 @@ Used by: [ScheduledEventsProfile](#ScheduledEventsProfile).
 | enable           | Specifies whether the Terminate Scheduled event is enabled or disabled.                                                                                                                                                                                                 | bool<br/><small>Optional</small>   |
 | notBeforeTimeout | Configurable length of time a Virtual Machine being deleted will have to potentially approve the Terminate Scheduled Event before the event is auto approved (timed out). The configuration must be specified in ISO 8601 format, the default value is 5 minutes (PT5M) | string<br/><small>Optional</small> |
 
-<a id="TerminateNotificationProfile_STATUS"></a>TerminateNotificationProfile_STATUS
------------------------------------------------------------------------------------
+TerminateNotificationProfile_STATUS{#TerminateNotificationProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ScheduledEventsProfile_STATUS](#ScheduledEventsProfile_STATUS).
 
@@ -2240,8 +2240,8 @@ Used by: [ScheduledEventsProfile_STATUS](#ScheduledEventsProfile_STATUS).
 | enable           | Specifies whether the Terminate Scheduled event is enabled or disabled.                                                                                                                                                                                                 | bool<br/><small>Optional</small>   |
 | notBeforeTimeout | Configurable length of time a Virtual Machine being deleted will have to potentially approve the Terminate Scheduled Event before the event is auto approved (timed out). The configuration must be specified in ISO 8601 format, the default value is 5 minutes (PT5M) | string<br/><small>Optional</small> |
 
-<a id="UefiSettings"></a>UefiSettings
--------------------------------------
+UefiSettings{#UefiSettings}
+---------------------------
 
 Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01
 
@@ -2252,8 +2252,8 @@ Used by: [SecurityProfile](#SecurityProfile).
 | secureBootEnabled | Specifies whether secure boot should be enabled on the virtual machine. Minimum api-version: 2020-12-01 | bool<br/><small>Optional</small> |
 | vTpmEnabled       | Specifies whether vTPM should be enabled on the virtual machine. Minimum api-version: 2020-12-01        | bool<br/><small>Optional</small> |
 
-<a id="UefiSettings_STATUS"></a>UefiSettings_STATUS
----------------------------------------------------
+UefiSettings_STATUS{#UefiSettings_STATUS}
+-----------------------------------------
 
 Specifies the security settings like secure boot and vTPM used while creating the virtual machine. Minimum api-version: 2020-12-01
 
@@ -2264,8 +2264,8 @@ Used by: [SecurityProfile_STATUS](#SecurityProfile_STATUS).
 | secureBootEnabled | Specifies whether secure boot should be enabled on the virtual machine. Minimum api-version: 2020-12-01 | bool<br/><small>Optional</small> |
 | vTpmEnabled       | Specifies whether vTPM should be enabled on the virtual machine. Minimum api-version: 2020-12-01        | bool<br/><small>Optional</small> |
 
-<a id="UpgradePolicy_Mode"></a>UpgradePolicy_Mode
--------------------------------------------------
+UpgradePolicy_Mode{#UpgradePolicy_Mode}
+---------------------------------------
 
 Used by: [UpgradePolicy](#UpgradePolicy).
 
@@ -2275,8 +2275,8 @@ Used by: [UpgradePolicy](#UpgradePolicy).
 | "Manual"    |             |
 | "Rolling"   |             |
 
-<a id="UpgradePolicy_Mode_STATUS"></a>UpgradePolicy_Mode_STATUS
----------------------------------------------------------------
+UpgradePolicy_Mode_STATUS{#UpgradePolicy_Mode_STATUS}
+-----------------------------------------------------
 
 Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 
@@ -2286,8 +2286,8 @@ Used by: [UpgradePolicy_STATUS](#UpgradePolicy_STATUS).
 | "Manual"    |             |
 | "Rolling"   |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2297,8 +2297,8 @@ Used by: [VirtualMachineIdentity](#VirtualMachineIdentity), and [VirtualMachineS
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VaultSecretGroup"></a>VaultSecretGroup
----------------------------------------------
+VaultSecretGroup{#VaultSecretGroup}
+-----------------------------------
 
 Describes a set of certificates which are all in the same Key Vault.
 
@@ -2309,8 +2309,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | sourceVault       | The relative URL of the Key Vault containing all of the certificates in VaultCertificates. | [SubResource](#SubResource)<br/><small>Optional</small>             |
 | vaultCertificates | The list of key vault references in SourceVault which contain certificates.                | [VaultCertificate[]](#VaultCertificate)<br/><small>Optional</small> |
 
-<a id="VaultSecretGroup_STATUS"></a>VaultSecretGroup_STATUS
------------------------------------------------------------
+VaultSecretGroup_STATUS{#VaultSecretGroup_STATUS}
+-------------------------------------------------
 
 Describes a set of certificates which are all in the same Key Vault.
 
@@ -2321,8 +2321,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | sourceVault       | The relative URL of the Key Vault containing all of the certificates in VaultCertificates. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>             |
 | vaultCertificates | The list of key vault references in SourceVault which contain certificates.                | [VaultCertificate_STATUS[]](#VaultCertificate_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineAgentInstanceView_STATUS"></a>VirtualMachineAgentInstanceView_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineAgentInstanceView_STATUS{#VirtualMachineAgentInstanceView_STATUS}
+-------------------------------------------------------------------------------
 
 The instance view of the VM Agent running on the virtual machine.
 
@@ -2334,8 +2334,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | statuses          | The resource status information.                     | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>                                                 |
 | vmAgentVersion    | The VM Agent full version.                           | string<br/><small>Optional</small>                                                                                                    |
 
-<a id="VirtualMachineHealthStatus_STATUS"></a>VirtualMachineHealthStatus_STATUS
--------------------------------------------------------------------------------
+VirtualMachineHealthStatus_STATUS{#VirtualMachineHealthStatus_STATUS}
+---------------------------------------------------------------------
 
 The health status of the VM.
 
@@ -2345,8 +2345,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 |----------|-------------------------------------------|-------------------------------------------------------------------------------------|
 | status   | The health status information for the VM. | [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineIdentity_Type"></a>VirtualMachineIdentity_Type
--------------------------------------------------------------------
+VirtualMachineIdentity_Type{#VirtualMachineIdentity_Type}
+---------------------------------------------------------
 
 Used by: [VirtualMachineIdentity](#VirtualMachineIdentity).
 
@@ -2357,8 +2357,8 @@ Used by: [VirtualMachineIdentity](#VirtualMachineIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineIdentity_Type_STATUS"></a>VirtualMachineIdentity_Type_STATUS
----------------------------------------------------------------------------------
+VirtualMachineIdentity_Type_STATUS{#VirtualMachineIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 
@@ -2369,8 +2369,8 @@ Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineIdentity_UserAssignedIdentities_STATUS"></a>VirtualMachineIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualMachineIdentity_UserAssignedIdentities_STATUS{#VirtualMachineIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 
@@ -2379,8 +2379,8 @@ Used by: [VirtualMachineIdentity_STATUS](#VirtualMachineIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineInstanceView_HyperVGeneration_STATUS"></a>VirtualMachineInstanceView_HyperVGeneration_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualMachineInstanceView_HyperVGeneration_STATUS{#VirtualMachineInstanceView_HyperVGeneration_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS).
 
@@ -2389,8 +2389,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="VirtualMachineNetworkInterfaceConfiguration"></a>VirtualMachineNetworkInterfaceConfiguration
----------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceConfiguration{#VirtualMachineNetworkInterfaceConfiguration}
+-----------------------------------------------------------------------------------------
 
 Describes a virtual machine network interface configurations.
 
@@ -2409,8 +2409,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 | networkSecurityGroup        | The network security group.                                                                            | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                               |
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="VirtualMachineNetworkInterfaceConfiguration_STATUS"></a>VirtualMachineNetworkInterfaceConfiguration_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceConfiguration_STATUS{#VirtualMachineNetworkInterfaceConfiguration_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Describes a virtual machine network interface configurations.
 
@@ -2429,8 +2429,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | networkSecurityGroup        | The network security group.                                                                            | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                               |
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                                                    |
 
-<a id="VirtualMachinePatchStatus_STATUS"></a>VirtualMachinePatchStatus_STATUS
------------------------------------------------------------------------------
+VirtualMachinePatchStatus_STATUS{#VirtualMachinePatchStatus_STATUS}
+-------------------------------------------------------------------
 
 The status of virtual machine patch operations.
 
@@ -2442,8 +2442,8 @@ Used by: [VirtualMachineInstanceView_STATUS](#VirtualMachineInstanceView_STATUS)
 | configurationStatuses        | The enablement status of the specified patchMode                                        | [InstanceViewStatus_STATUS[]](#InstanceViewStatus_STATUS)<br/><small>Optional</small>                   |
 | lastPatchInstallationSummary | The installation summary of the latest installation operation for the virtual machine.  | [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetExtensionProfile"></a>VirtualMachineScaleSetExtensionProfile
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtensionProfile{#VirtualMachineScaleSetExtensionProfile}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set extension profile.
 
@@ -2454,8 +2454,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | extensions           | The virtual machine scale set child extension resources.                                                                                                                                                                                                  | [VirtualMachineScaleSetExtension[]](#VirtualMachineScaleSetExtension)<br/><small>Optional</small> |
 | extensionsTimeBudget | Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). Minimum api-version: 2020-06-01 | string<br/><small>Optional</small>                                                                |
 
-<a id="VirtualMachineScaleSetExtensionProfile_STATUS"></a>VirtualMachineScaleSetExtensionProfile_STATUS
--------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtensionProfile_STATUS{#VirtualMachineScaleSetExtensionProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set extension profile.
 
@@ -2466,8 +2466,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | extensions           | The virtual machine scale set child extension resources.                                                                                                                                                                                                  | [VirtualMachineScaleSetExtension_STATUS[]](#VirtualMachineScaleSetExtension_STATUS)<br/><small>Optional</small> |
 | extensionsTimeBudget | Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). Minimum api-version: 2020-06-01 | string<br/><small>Optional</small>                                                                              |
 
-<a id="VirtualMachineScaleSetHardwareProfile"></a>VirtualMachineScaleSetHardwareProfile
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetHardwareProfile{#VirtualMachineScaleSetHardwareProfile}
+-----------------------------------------------------------------------------
 
 Specifies the hardware settings for the virtual machine scale set.
 
@@ -2477,8 +2477,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | vmSizeProperties | Specifies the properties for customizing the size of the virtual machine. Minimum api-version: 2022-03-01. Please follow the instructions in [VM Customization](https://aka.ms/vmcustomization) for more details. | [VMSizeProperties](#VMSizeProperties)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetHardwareProfile_STATUS"></a>VirtualMachineScaleSetHardwareProfile_STATUS
------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetHardwareProfile_STATUS{#VirtualMachineScaleSetHardwareProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Specifies the hardware settings for the virtual machine scale set.
 
@@ -2488,8 +2488,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
 | vmSizeProperties | Specifies the properties for customizing the size of the virtual machine. Minimum api-version: 2022-03-01. Please follow the instructions in [VM Customization](https://aka.ms/vmcustomization) for more details. | [VMSizeProperties_STATUS](#VMSizeProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIdentity_Type"></a>VirtualMachineScaleSetIdentity_Type
------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_Type{#VirtualMachineScaleSetIdentity_Type}
+-------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity](#VirtualMachineScaleSetIdentity).
 
@@ -2500,8 +2500,8 @@ Used by: [VirtualMachineScaleSetIdentity](#VirtualMachineScaleSetIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineScaleSetIdentity_Type_STATUS"></a>VirtualMachineScaleSetIdentity_Type_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_Type_STATUS{#VirtualMachineScaleSetIdentity_Type_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity_STATUS).
 
@@ -2512,8 +2512,8 @@ Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS"></a>VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS{#VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity_STATUS).
 
@@ -2522,8 +2522,8 @@ Used by: [VirtualMachineScaleSetIdentity_STATUS](#VirtualMachineScaleSetIdentity
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkProfile"></a>VirtualMachineScaleSetNetworkProfile
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile{#VirtualMachineScaleSetNetworkProfile}
+---------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile.
 
@@ -2535,8 +2535,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | networkApiVersion              | specifies the Microsoft.Network API version used when creating networking resources in the Network Interface Configurations for Virtual Machine Scale Set with orchestration mode 'Flexible'                                                                                                                                                                                                                | [VirtualMachineScaleSetNetworkProfile_NetworkApiVersion](#VirtualMachineScaleSetNetworkProfile_NetworkApiVersion)<br/><small>Optional</small> |
 | networkInterfaceConfigurations | The list of network configurations.                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetNetworkConfiguration[]](#VirtualMachineScaleSetNetworkConfiguration)<br/><small>Optional</small>                       |
 
-<a id="VirtualMachineScaleSetNetworkProfile_STATUS"></a>VirtualMachineScaleSetNetworkProfile_STATUS
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile_STATUS{#VirtualMachineScaleSetNetworkProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile.
 
@@ -2548,8 +2548,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | networkApiVersion              | specifies the Microsoft.Network API version used when creating networking resources in the Network Interface Configurations for Virtual Machine Scale Set with orchestration mode 'Flexible'                                                                                                                                                                                                                | [VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS](#VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS)<br/><small>Optional</small> |
 | networkInterfaceConfigurations | The list of network configurations.                                                                                                                                                                                                                                                                                                                                                                         | [VirtualMachineScaleSetNetworkConfiguration_STATUS[]](#VirtualMachineScaleSetNetworkConfiguration_STATUS)<br/><small>Optional</small>                       |
 
-<a id="VirtualMachineScaleSetOSProfile"></a>VirtualMachineScaleSetOSProfile
----------------------------------------------------------------------------
+VirtualMachineScaleSetOSProfile{#VirtualMachineScaleSetOSProfile}
+-----------------------------------------------------------------
 
 Describes a virtual machine scale set OS profile.
 
@@ -2566,8 +2566,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | secrets                  | Specifies set of certificates that should be installed onto the virtual machines in the scale set. To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [VaultSecretGroup[]](#VaultSecretGroup)<br/><small>Optional</small>                                                                                    |
 | windowsConfiguration     | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | [WindowsConfiguration](#WindowsConfiguration)<br/><small>Optional</small>                                                                              |
 
-<a id="VirtualMachineScaleSetOSProfile_STATUS"></a>VirtualMachineScaleSetOSProfile_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSProfile_STATUS{#VirtualMachineScaleSetOSProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a virtual machine scale set OS profile.
 
@@ -2583,8 +2583,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | secrets                  | Specifies set of certificates that should be installed onto the virtual machines in the scale set. To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows).                                                                    | [VaultSecretGroup_STATUS[]](#VaultSecretGroup_STATUS)<br/><small>Optional</small>       |
 | windowsConfiguration     | Specifies Windows operating system settings on the virtual machine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetStorageProfile"></a>VirtualMachineScaleSetStorageProfile
--------------------------------------------------------------------------------------
+VirtualMachineScaleSetStorageProfile{#VirtualMachineScaleSetStorageProfile}
+---------------------------------------------------------------------------
 
 Describes a virtual machine scale set storage profile.
 
@@ -2596,8 +2596,8 @@ Used by: [VirtualMachineScaleSetVMProfile](#VirtualMachineScaleSetVMProfile).
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. | [ImageReference](#ImageReference)<br/><small>Optional</small>                                   |
 | osDisk         | Specifies information about the operating system disk used by the virtual machines in the scale set. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).                                    | [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk)<br/><small>Optional</small>       |
 
-<a id="VirtualMachineScaleSetStorageProfile_STATUS"></a>VirtualMachineScaleSetStorageProfile_STATUS
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetStorageProfile_STATUS{#VirtualMachineScaleSetStorageProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set storage profile.
 
@@ -2609,8 +2609,8 @@ Used by: [VirtualMachineScaleSetVMProfile_STATUS](#VirtualMachineScaleSetVMProfi
 | imageReference | Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This element is required when you want to use a platform image, marketplace image, or virtual machine image, but is not used in other creation operations. | [ImageReference_STATUS](#ImageReference_STATUS)<br/><small>Optional</small>                                   |
 | osDisk         | Specifies information about the operating system disk used by the virtual machines in the scale set. For more information about disks, see [About disks and VHDs for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/managed-disks-overview).                                    | [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS)<br/><small>Optional</small>       |
 
-<a id="VMGalleryApplication"></a>VMGalleryApplication
------------------------------------------------------
+VMGalleryApplication{#VMGalleryApplication}
+-------------------------------------------
 
 Specifies the required information to reference a compute gallery application version
 
@@ -2625,8 +2625,8 @@ Used by: [ApplicationProfile](#ApplicationProfile).
 | tags                            | Optional, Specifies a passthrough value for more generic context.                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 | treatFailureAsDeploymentFailure | Optional, If true, any failure for any operation in the VmApplication will fail the deployment                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                                                           |
 
-<a id="VMGalleryApplication_STATUS"></a>VMGalleryApplication_STATUS
--------------------------------------------------------------------
+VMGalleryApplication_STATUS{#VMGalleryApplication_STATUS}
+---------------------------------------------------------
 
 Specifies the required information to reference a compute gallery application version
 
@@ -2641,8 +2641,8 @@ Used by: [ApplicationProfile_STATUS](#ApplicationProfile_STATUS).
 | tags                            | Optional, Specifies a passthrough value for more generic context.                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small> |
 | treatFailureAsDeploymentFailure | Optional, If true, any failure for any operation in the VmApplication will fail the deployment                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>   |
 
-<a id="VMSizeProperties"></a>VMSizeProperties
----------------------------------------------
+VMSizeProperties{#VMSizeProperties}
+-----------------------------------
 
 Specifies VM Size Property settings on the virtual machine.
 
@@ -2653,8 +2653,8 @@ Used by: [HardwareProfile](#HardwareProfile), and [VirtualMachineScaleSetHardwar
 | vCPUsAvailable | Specifies the number of vCPUs available for the VM. When this property is not specified in the request body the default behavior is to set it to the value of vCPUs available for that VM size exposed in api response of [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resource-skus/list) .                                                    | int<br/><small>Optional</small> |
 | vCPUsPerCore   | Specifies the vCPU to physical core ratio. When this property is not specified in the request body the default behavior is set to the value of vCPUsPerCore for the VM Size exposed in api response of [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resource-skus/list) Setting this property to 1 also means that hyper-threading is disabled. | int<br/><small>Optional</small> |
 
-<a id="VMSizeProperties_STATUS"></a>VMSizeProperties_STATUS
------------------------------------------------------------
+VMSizeProperties_STATUS{#VMSizeProperties_STATUS}
+-------------------------------------------------
 
 Specifies VM Size Property settings on the virtual machine.
 
@@ -2665,8 +2665,8 @@ Used by: [HardwareProfile_STATUS](#HardwareProfile_STATUS), and [VirtualMachineS
 | vCPUsAvailable | Specifies the number of vCPUs available for the VM. When this property is not specified in the request body the default behavior is to set it to the value of vCPUs available for that VM size exposed in api response of [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resource-skus/list) .                                                    | int<br/><small>Optional</small> |
 | vCPUsPerCore   | Specifies the vCPU to physical core ratio. When this property is not specified in the request body the default behavior is set to the value of vCPUsPerCore for the VM Size exposed in api response of [List all available virtual machine sizes in a region](https://docs.microsoft.com/en-us/rest/api/compute/resource-skus/list) Setting this property to 1 also means that hyper-threading is disabled. | int<br/><small>Optional</small> |
 
-<a id="WindowsConfiguration"></a>WindowsConfiguration
------------------------------------------------------
+WindowsConfiguration{#WindowsConfiguration}
+-------------------------------------------
 
 Specifies Windows operating system settings on the virtual machine.
 
@@ -2681,8 +2681,8 @@ Used by: [OSProfile](#OSProfile), and [VirtualMachineScaleSetOSProfile](#Virtual
 | timeZone                  | Specifies the time zone of the virtual machine. e.g. "Pacific Standard Time". Possible values can be [TimeZoneInfo.Id](https://docs.microsoft.com/dotnet/api/system.timezoneinfo.id?#System_TimeZoneInfo_Id) value from time zones returned by [TimeZoneInfo.GetSystemTimeZones](https://docs.microsoft.com/dotnet/api/system.timezoneinfo.getsystemtimezones). | string<br/><small>Optional</small>                                                    |
 | winRM                     | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.                                                                                                                                                                                                                                                                      | [WinRMConfiguration](#WinRMConfiguration)<br/><small>Optional</small>                 |
 
-<a id="WindowsConfiguration_STATUS"></a>WindowsConfiguration_STATUS
--------------------------------------------------------------------
+WindowsConfiguration_STATUS{#WindowsConfiguration_STATUS}
+---------------------------------------------------------
 
 Specifies Windows operating system settings on the virtual machine.
 
@@ -2697,8 +2697,8 @@ Used by: [OSProfile_STATUS](#OSProfile_STATUS), and [VirtualMachineScaleSetOSPro
 | timeZone                  | Specifies the time zone of the virtual machine. e.g. "Pacific Standard Time". Possible values can be [TimeZoneInfo.Id](https://docs.microsoft.com/dotnet/api/system.timezoneinfo.id?#System_TimeZoneInfo_Id) value from time zones returned by [TimeZoneInfo.GetSystemTimeZones](https://docs.microsoft.com/dotnet/api/system.timezoneinfo.getsystemtimezones). | string<br/><small>Optional</small>                                                                  |
 | winRM                     | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.                                                                                                                                                                                                                                                                      | [WinRMConfiguration_STATUS](#WinRMConfiguration_STATUS)<br/><small>Optional</small>                 |
 
-<a id="AdditionalUnattendContent"></a>AdditionalUnattendContent
----------------------------------------------------------------
+AdditionalUnattendContent{#AdditionalUnattendContent}
+-----------------------------------------------------
 
 Specifies additional XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup. Contents are defined by setting name, component name, and the pass in which the content is applied.
 
@@ -2711,8 +2711,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 | passName      | The pass name. Currently, the only allowable value is OobeSystem.                                                                                                                                                                   | [AdditionalUnattendContent_PassName](#AdditionalUnattendContent_PassName)<br/><small>Optional</small>           |
 | settingName   | Specifies the name of the setting to which the content applies. Possible values are: FirstLogonCommands and AutoLogon.                                                                                                              | [AdditionalUnattendContent_SettingName](#AdditionalUnattendContent_SettingName)<br/><small>Optional</small>     |
 
-<a id="AdditionalUnattendContent_STATUS"></a>AdditionalUnattendContent_STATUS
------------------------------------------------------------------------------
+AdditionalUnattendContent_STATUS{#AdditionalUnattendContent_STATUS}
+-------------------------------------------------------------------
 
 Specifies additional XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup. Contents are defined by setting name, component name, and the pass in which the content is applied.
 
@@ -2725,8 +2725,8 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 | passName      | The pass name. Currently, the only allowable value is OobeSystem.                                                                                                                                                                   | [AdditionalUnattendContent_PassName_STATUS](#AdditionalUnattendContent_PassName_STATUS)<br/><small>Optional</small>           |
 | settingName   | Specifies the name of the setting to which the content applies. Possible values are: FirstLogonCommands and AutoLogon.                                                                                                              | [AdditionalUnattendContent_SettingName_STATUS](#AdditionalUnattendContent_SettingName_STATUS)<br/><small>Optional</small>     |
 
-<a id="ApiEntityReference"></a>ApiEntityReference
--------------------------------------------------
+ApiEntityReference{#ApiEntityReference}
+---------------------------------------
 
 The API entity reference.
 
@@ -2736,8 +2736,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The ARM resource id in the form of /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;... | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApiEntityReference_STATUS"></a>ApiEntityReference_STATUS
----------------------------------------------------------------
+ApiEntityReference_STATUS{#ApiEntityReference_STATUS}
+-----------------------------------------------------
 
 The API entity reference.
 
@@ -2747,8 +2747,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | The ARM resource id in the form of /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;... | string<br/><small>Optional</small> |
 
-<a id="AvailablePatchSummary_STATUS"></a>AvailablePatchSummary_STATUS
----------------------------------------------------------------------
+AvailablePatchSummary_STATUS{#AvailablePatchSummary_STATUS}
+-----------------------------------------------------------
 
 Describes the properties of an virtual machine instance view for available patch summary.
 
@@ -2765,48 +2765,48 @@ Used by: [VirtualMachinePatchStatus_STATUS](#VirtualMachinePatchStatus_STATUS).
 | startTime                     | The UTC timestamp when the operation began.                                                                                                                                                               | string<br/><small>Optional</small>                                                                      |
 | status                        | The overall success or failure status of the operation. It remains "InProgress" until the operation completes. At that point it will become "Unknown", "Failed", "Succeeded", or "CompletedWithWarnings." | [AvailablePatchSummary_Status_STATUS](#AvailablePatchSummary_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Caching"></a>Caching
+Caching{#Caching}
+-----------------
+
+Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+
+Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
+
+| Value       | Description |
+|-------------|-------------|
+| "None"      |             |
+| "ReadOnly"  |             |
+| "ReadWrite" |             |
+
+Caching_STATUS{#Caching_STATUS}
+-------------------------------
+
+Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+
+Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "None"      |             |
+| "ReadOnly"  |             |
+| "ReadWrite" |             |
+
+CreateOption{#CreateOption}
 ---------------------------
 
-Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
+Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
 
 Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 
 | Value       | Description |
 |-------------|-------------|
-| "None"      |             |
-| "ReadOnly"  |             |
-| "ReadWrite" |             |
+| "Attach"    |             |
+| "Empty"     |             |
+| "FromImage" |             |
 
-<a id="Caching_STATUS"></a>Caching_STATUS
+CreateOption_STATUS{#CreateOption_STATUS}
 -----------------------------------------
 
-Specifies the caching requirements. Possible values are: None ReadOnly ReadWrite Default: None for Standard storage. ReadOnly for Premium storage
-
-Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "None"      |             |
-| "ReadOnly"  |             |
-| "ReadWrite" |             |
-
-<a id="CreateOption"></a>CreateOption
--------------------------------------
-
-Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
-
-Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
-
-| Value       | Description |
-|-------------|-------------|
-| "Attach"    |             |
-| "Empty"     |             |
-| "FromImage" |             |
-
-<a id="CreateOption_STATUS"></a>CreateOption_STATUS
----------------------------------------------------
-
 Specifies how the virtual machine should be created. Possible values are: Attach \u2013 This value is used when you are using a specialized disk to create the virtual machine. FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you also use the plan element previously described.
 
 Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
@@ -2817,8 +2817,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [
 | "Empty"     |             |
 | "FromImage" |             |
 
-<a id="DeleteOption"></a>DeleteOption
--------------------------------------
+DeleteOption{#DeleteOption}
+---------------------------
 
 Specifies the behavior of the managed disk when the VM gets deleted i.e whether the managed disk is deleted or detached. Supported values: Delete If this value is used, the managed disk is deleted when VM gets deleted. Detach If this value is used, the managed disk is retained after VM gets deleted. Minimum api-version: 2021-03-01
 
@@ -2829,8 +2829,8 @@ Used by: [DataDisk](#DataDisk), [OSDisk](#OSDisk), [VirtualMachineScaleSetDataDi
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="DeleteOption_STATUS"></a>DeleteOption_STATUS
----------------------------------------------------
+DeleteOption_STATUS{#DeleteOption_STATUS}
+-----------------------------------------
 
 Specifies the behavior of the managed disk when the VM gets deleted i.e whether the managed disk is deleted or detached. Supported values: Delete If this value is used, the managed disk is deleted when VM gets deleted. Detach If this value is used, the managed disk is retained after VM gets deleted. Minimum api-version: 2021-03-01
 
@@ -2841,8 +2841,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), [OSDisk_STATUS](#OSDisk_STATUS), [
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="DetachOption"></a>DetachOption
--------------------------------------
+DetachOption{#DetachOption}
+---------------------------
 
 Specifies the detach behavior to be used while detaching a disk or which is already in the process of detachment from the virtual machine. Supported values: ForceDetach. detachOption: ForceDetach is applicable only for managed data disks. If a previous detachment attempt of the data disk did not complete due to an unexpected failure from the virtual machine and the disk is still not released then use force-detach as a last resort option to detach the disk forcibly from the VM. All writes might not have been flushed when using this detach behavior. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. To force-detach a data disk update toBeDetached to 'true' along with setting detachOption: 'ForceDetach'.
 
@@ -2852,8 +2852,8 @@ Used by: [DataDisk](#DataDisk).
 |---------------|-------------|
 | "ForceDetach" |             |
 
-<a id="DetachOption_STATUS"></a>DetachOption_STATUS
----------------------------------------------------
+DetachOption_STATUS{#DetachOption_STATUS}
+-----------------------------------------
 
 Specifies the detach behavior to be used while detaching a disk or which is already in the process of detachment from the virtual machine. Supported values: ForceDetach. detachOption: ForceDetach is applicable only for managed data disks. If a previous detachment attempt of the data disk did not complete due to an unexpected failure from the virtual machine and the disk is still not released then use force-detach as a last resort option to detach the disk forcibly from the VM. All writes might not have been flushed when using this detach behavior. This feature is still in preview mode and is not supported for VirtualMachineScaleSet. To force-detach a data disk update toBeDetached to 'true' along with setting detachOption: 'ForceDetach'.
 
@@ -2863,8 +2863,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS).
 |---------------|-------------|
 | "ForceDetach" |             |
 
-<a id="DiffDiskSettings"></a>DiffDiskSettings
----------------------------------------------
+DiffDiskSettings{#DiffDiskSettings}
+-----------------------------------
 
 Describes the parameters of ephemeral disk settings that can be specified for operating system disk. NOTE: The ephemeral disk settings can only be specified for managed disk.
 
@@ -2875,8 +2875,8 @@ Used by: [OSDisk](#OSDisk), and [VirtualMachineScaleSetOSDisk](#VirtualMachineSc
 | option    | Specifies the ephemeral disk settings for operating system disk.                                                                                                                                                                                                                                                                                                                                                                                   | [DiffDiskOption](#DiffDiskOption)<br/><small>Optional</small>       |
 | placement | Specifies the ephemeral disk placement for operating system disk. Possible values are: CacheDisk ResourceDisk Default: CacheDisk if one is configured for the VM size otherwise ResourceDisk is used. Refer to VM size documentation for Windows VM at https://docs.microsoft.com/azure/virtual-machines/windows/sizes and Linux VM at https://docs.microsoft.com/azure/virtual-machines/linux/sizes to check which VM sizes exposes a cache disk. | [DiffDiskPlacement](#DiffDiskPlacement)<br/><small>Optional</small> |
 
-<a id="DiffDiskSettings_STATUS"></a>DiffDiskSettings_STATUS
------------------------------------------------------------
+DiffDiskSettings_STATUS{#DiffDiskSettings_STATUS}
+-------------------------------------------------
 
 Describes the parameters of ephemeral disk settings that can be specified for operating system disk. NOTE: The ephemeral disk settings can only be specified for managed disk.
 
@@ -2887,8 +2887,8 @@ Used by: [OSDisk_STATUS](#OSDisk_STATUS), and [VirtualMachineScaleSetOSDisk_STAT
 | option    | Specifies the ephemeral disk settings for operating system disk.                                                                                                                                                                                                                                                                                                                                                                                   | [DiffDiskOption_STATUS](#DiffDiskOption_STATUS)<br/><small>Optional</small>       |
 | placement | Specifies the ephemeral disk placement for operating system disk. Possible values are: CacheDisk ResourceDisk Default: CacheDisk if one is configured for the VM size otherwise ResourceDisk is used. Refer to VM size documentation for Windows VM at https://docs.microsoft.com/azure/virtual-machines/windows/sizes and Linux VM at https://docs.microsoft.com/azure/virtual-machines/linux/sizes to check which VM sizes exposes a cache disk. | [DiffDiskPlacement_STATUS](#DiffDiskPlacement_STATUS)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSettings"></a>DiskEncryptionSettings
----------------------------------------------------------
+DiskEncryptionSettings{#DiskEncryptionSettings}
+-----------------------------------------------
 
 Describes a Encryption Settings for a Disk
 
@@ -2900,8 +2900,8 @@ Used by: [OSDisk](#OSDisk).
 | enabled           | Specifies whether disk encryption should be enabled on the virtual machine.     | bool<br/><small>Optional</small>                                                |
 | keyEncryptionKey  | Specifies the location of the key encryption key in Key Vault.                  | [KeyVaultKeyReference](#KeyVaultKeyReference)<br/><small>Optional</small>       |
 
-<a id="DiskEncryptionSettings_STATUS"></a>DiskEncryptionSettings_STATUS
------------------------------------------------------------------------
+DiskEncryptionSettings_STATUS{#DiskEncryptionSettings_STATUS}
+-------------------------------------------------------------
 
 Describes a Encryption Settings for a Disk
 
@@ -2913,8 +2913,8 @@ Used by: [DiskInstanceView_STATUS](#DiskInstanceView_STATUS), and [OSDisk_STATUS
 | enabled           | Specifies whether disk encryption should be enabled on the virtual machine.     | bool<br/><small>Optional</small>                                                              |
 | keyEncryptionKey  | Specifies the location of the key encryption key in Key Vault.                  | [KeyVaultKeyReference_STATUS](#KeyVaultKeyReference_STATUS)<br/><small>Optional</small>       |
 
-<a id="ImageDataDisk_Caching"></a>ImageDataDisk_Caching
--------------------------------------------------------
+ImageDataDisk_Caching{#ImageDataDisk_Caching}
+---------------------------------------------
 
 Used by: [ImageDataDisk](#ImageDataDisk).
 
@@ -2924,8 +2924,8 @@ Used by: [ImageDataDisk](#ImageDataDisk).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageDataDisk_Caching_STATUS"></a>ImageDataDisk_Caching_STATUS
----------------------------------------------------------------------
+ImageDataDisk_Caching_STATUS{#ImageDataDisk_Caching_STATUS}
+-----------------------------------------------------------
 
 Used by: [ImageDataDisk_STATUS](#ImageDataDisk_STATUS).
 
@@ -2935,8 +2935,8 @@ Used by: [ImageDataDisk_STATUS](#ImageDataDisk_STATUS).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_Caching"></a>ImageOSDisk_Caching
----------------------------------------------------
+ImageOSDisk_Caching{#ImageOSDisk_Caching}
+-----------------------------------------
 
 Used by: [ImageOSDisk](#ImageOSDisk).
 
@@ -2946,8 +2946,8 @@ Used by: [ImageOSDisk](#ImageOSDisk).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_Caching_STATUS"></a>ImageOSDisk_Caching_STATUS
------------------------------------------------------------------
+ImageOSDisk_Caching_STATUS{#ImageOSDisk_Caching_STATUS}
+-------------------------------------------------------
 
 Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 
@@ -2957,48 +2957,48 @@ Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ImageOSDisk_OsState"></a>ImageOSDisk_OsState
+ImageOSDisk_OsState{#ImageOSDisk_OsState}
+-----------------------------------------
+
+Used by: [ImageOSDisk](#ImageOSDisk).
+
+| Value         | Description |
+|---------------|-------------|
+| "Generalized" |             |
+| "Specialized" |             |
+
+ImageOSDisk_OsState_STATUS{#ImageOSDisk_OsState_STATUS}
+-------------------------------------------------------
+
+Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "Generalized" |             |
+| "Specialized" |             |
+
+ImageOSDisk_OsType{#ImageOSDisk_OsType}
+---------------------------------------
+
+Used by: [ImageOSDisk](#ImageOSDisk).
+
+| Value     | Description |
+|-----------|-------------|
+| "Linux"   |             |
+| "Windows" |             |
+
+ImageOSDisk_OsType_STATUS{#ImageOSDisk_OsType_STATUS}
+-----------------------------------------------------
+
+Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Linux"   |             |
+| "Windows" |             |
+
+InstanceViewStatus_Level{#InstanceViewStatus_Level}
 ---------------------------------------------------
-
-Used by: [ImageOSDisk](#ImageOSDisk).
-
-| Value         | Description |
-|---------------|-------------|
-| "Generalized" |             |
-| "Specialized" |             |
-
-<a id="ImageOSDisk_OsState_STATUS"></a>ImageOSDisk_OsState_STATUS
------------------------------------------------------------------
-
-Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "Generalized" |             |
-| "Specialized" |             |
-
-<a id="ImageOSDisk_OsType"></a>ImageOSDisk_OsType
--------------------------------------------------
-
-Used by: [ImageOSDisk](#ImageOSDisk).
-
-| Value     | Description |
-|-----------|-------------|
-| "Linux"   |             |
-| "Windows" |             |
-
-<a id="ImageOSDisk_OsType_STATUS"></a>ImageOSDisk_OsType_STATUS
----------------------------------------------------------------
-
-Used by: [ImageOSDisk_STATUS](#ImageOSDisk_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Linux"   |             |
-| "Windows" |             |
-
-<a id="InstanceViewStatus_Level"></a>InstanceViewStatus_Level
--------------------------------------------------------------
 
 Used by: [InstanceViewStatus](#InstanceViewStatus).
 
@@ -3008,8 +3008,8 @@ Used by: [InstanceViewStatus](#InstanceViewStatus).
 | "Info"    |             |
 | "Warning" |             |
 
-<a id="InstanceViewStatus_Level_STATUS"></a>InstanceViewStatus_Level_STATUS
----------------------------------------------------------------------------
+InstanceViewStatus_Level_STATUS{#InstanceViewStatus_Level_STATUS}
+-----------------------------------------------------------------
 
 Used by: [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS).
 
@@ -3019,8 +3019,8 @@ Used by: [InstanceViewStatus_STATUS](#InstanceViewStatus_STATUS).
 | "Info"    |             |
 | "Warning" |             |
 
-<a id="LastPatchInstallationSummary_STATUS"></a>LastPatchInstallationSummary_STATUS
------------------------------------------------------------------------------------
+LastPatchInstallationSummary_STATUS{#LastPatchInstallationSummary_STATUS}
+-------------------------------------------------------------------------
 
 Describes the properties of the last installed patch summary.
 
@@ -3040,8 +3040,8 @@ Used by: [VirtualMachinePatchStatus_STATUS](#VirtualMachinePatchStatus_STATUS).
 | startTime                 | The UTC timestamp when the operation began.                                                                                                                                                               | string<br/><small>Optional</small>                                                                                    |
 | status                    | The overall success or failure status of the operation. It remains "InProgress" until the operation completes. At that point it will become "Unknown", "Failed", "Succeeded", or "CompletedWithWarnings." | [LastPatchInstallationSummary_Status_STATUS](#LastPatchInstallationSummary_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="LinuxPatchSettings"></a>LinuxPatchSettings
--------------------------------------------------
+LinuxPatchSettings{#LinuxPatchSettings}
+---------------------------------------
 
 Specifies settings related to VM Guest Patching on Linux.
 
@@ -3053,8 +3053,8 @@ Used by: [LinuxConfiguration](#LinuxConfiguration).
 | automaticByPlatformSettings | Specifies additional settings for patch mode AutomaticByPlatform in VM Guest Patching on Linux.                                                                                                                                                                                                                                                                                                       | [LinuxVMGuestPatchAutomaticByPlatformSettings](#LinuxVMGuestPatchAutomaticByPlatformSettings)<br/><small>Optional</small> |
 | patchMode                   | Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible. Possible values are: ImageDefault - The virtual machine's default patching configuration is used. AutomaticByPlatform - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true | [LinuxPatchSettings_PatchMode](#LinuxPatchSettings_PatchMode)<br/><small>Optional</small>                                 |
 
-<a id="LinuxPatchSettings_STATUS"></a>LinuxPatchSettings_STATUS
----------------------------------------------------------------
+LinuxPatchSettings_STATUS{#LinuxPatchSettings_STATUS}
+-----------------------------------------------------
 
 Specifies settings related to VM Guest Patching on Linux.
 
@@ -3066,8 +3066,8 @@ Used by: [LinuxConfiguration_STATUS](#LinuxConfiguration_STATUS).
 | automaticByPlatformSettings | Specifies additional settings for patch mode AutomaticByPlatform in VM Guest Patching on Linux.                                                                                                                                                                                                                                                                                                       | [LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS](#LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS)<br/><small>Optional</small> |
 | patchMode                   | Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible. Possible values are: ImageDefault - The virtual machine's default patching configuration is used. AutomaticByPlatform - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true | [LinuxPatchSettings_PatchMode_STATUS](#LinuxPatchSettings_PatchMode_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="MaintenanceRedeployStatus_LastOperationResultCode_STATUS"></a>MaintenanceRedeployStatus_LastOperationResultCode_STATUS
------------------------------------------------------------------------------------------------------------------------------
+MaintenanceRedeployStatus_LastOperationResultCode_STATUS{#MaintenanceRedeployStatus_LastOperationResultCode_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [MaintenanceRedeployStatus_STATUS](#MaintenanceRedeployStatus_STATUS).
 
@@ -3078,8 +3078,8 @@ Used by: [MaintenanceRedeployStatus_STATUS](#MaintenanceRedeployStatus_STATUS).
 | "None"                 |             |
 | "RetryLater"           |             |
 
-<a id="ManagedDiskParameters"></a>ManagedDiskParameters
--------------------------------------------------------
+ManagedDiskParameters{#ManagedDiskParameters}
+---------------------------------------------
 
 The parameters of a managed disk.
 
@@ -3092,8 +3092,8 @@ Used by: [DataDisk](#DataDisk), and [OSDisk](#OSDisk).
 | securityProfile    | Specifies the security profile for the managed disk.                                                                                          | [VMDiskSecurityProfile](#VMDiskSecurityProfile)<br/><small>Optional</small>                                                                                |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>                                                                                      |
 
-<a id="ManagedDiskParameters_STATUS"></a>ManagedDiskParameters_STATUS
----------------------------------------------------------------------
+ManagedDiskParameters_STATUS{#ManagedDiskParameters_STATUS}
+-----------------------------------------------------------
 
 The parameters of a managed disk.
 
@@ -3106,8 +3106,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), and [OSDisk_STATUS](#OSDisk_STATUS
 | securityProfile    | Specifies the security profile for the managed disk.                                                                                          | [VMDiskSecurityProfile_STATUS](#VMDiskSecurityProfile_STATUS)<br/><small>Optional</small> |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>       |
 
-<a id="NetworkInterfaceReferenceProperties_DeleteOption"></a>NetworkInterfaceReferenceProperties_DeleteOption
--------------------------------------------------------------------------------------------------------------
+NetworkInterfaceReferenceProperties_DeleteOption{#NetworkInterfaceReferenceProperties_DeleteOption}
+---------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterfaceReference](#NetworkInterfaceReference).
 
@@ -3116,8 +3116,8 @@ Used by: [NetworkInterfaceReference](#NetworkInterfaceReference).
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="NetworkInterfaceReferenceProperties_DeleteOption_STATUS"></a>NetworkInterfaceReferenceProperties_DeleteOption_STATUS
----------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceReferenceProperties_DeleteOption_STATUS{#NetworkInterfaceReferenceProperties_DeleteOption_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterfaceReference_STATUS](#NetworkInterfaceReference_STATUS).
 
@@ -3126,8 +3126,8 @@ Used by: [NetworkInterfaceReference_STATUS](#NetworkInterfaceReference_STATUS).
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="OSDisk_OsType"></a>OSDisk_OsType
----------------------------------------
+OSDisk_OsType{#OSDisk_OsType}
+-----------------------------
 
 Used by: [OSDisk](#OSDisk).
 
@@ -3136,8 +3136,8 @@ Used by: [OSDisk](#OSDisk).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSDisk_OsType_STATUS"></a>OSDisk_OsType_STATUS
------------------------------------------------------
+OSDisk_OsType_STATUS{#OSDisk_OsType_STATUS}
+-------------------------------------------
 
 Used by: [OSDisk_STATUS](#OSDisk_STATUS).
 
@@ -3146,8 +3146,8 @@ Used by: [OSDisk_STATUS](#OSDisk_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PatchSettings"></a>PatchSettings
----------------------------------------
+PatchSettings{#PatchSettings}
+-----------------------------
 
 Specifies settings related to VM Guest Patching on Windows.
 
@@ -3160,8 +3160,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 | enableHotpatching           | Enables customers to patch their Azure VMs without requiring a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and 'patchMode' must be set to 'AutomaticByPlatform'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                              |
 | patchMode                   | Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible. Possible values are: Manual - You control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false AutomaticByOS - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. AutomaticByPlatform - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true | [PatchSettings_PatchMode](#PatchSettings_PatchMode)<br/><small>Optional</small>                                               |
 
-<a id="PatchSettings_STATUS"></a>PatchSettings_STATUS
------------------------------------------------------
+PatchSettings_STATUS{#PatchSettings_STATUS}
+-------------------------------------------
 
 Specifies settings related to VM Guest Patching on Windows.
 
@@ -3174,8 +3174,8 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 | enableHotpatching           | Enables customers to patch their Azure VMs without requiring a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and 'patchMode' must be set to 'AutomaticByPlatform'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                            |
 | patchMode                   | Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible. Possible values are: Manual - You control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false AutomaticByOS - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. AutomaticByPlatform - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true | [PatchSettings_PatchMode_STATUS](#PatchSettings_PatchMode_STATUS)<br/><small>Optional</small>                                               |
 
-<a id="SshConfiguration"></a>SshConfiguration
----------------------------------------------
+SshConfiguration{#SshConfiguration}
+-----------------------------------
 
 SSH configuration for Linux based VMs running on Azure
 
@@ -3185,8 +3185,8 @@ Used by: [LinuxConfiguration](#LinuxConfiguration).
 |------------|------------------------------------------------------------------------|---------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with linux based VMs. | [SshPublicKeySpec[]](#SshPublicKeySpec)<br/><small>Optional</small> |
 
-<a id="SshConfiguration_STATUS"></a>SshConfiguration_STATUS
------------------------------------------------------------
+SshConfiguration_STATUS{#SshConfiguration_STATUS}
+-------------------------------------------------
 
 SSH configuration for Linux based VMs running on Azure
 
@@ -3196,8 +3196,8 @@ Used by: [LinuxConfiguration_STATUS](#LinuxConfiguration_STATUS).
 |------------|------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with linux based VMs. | [SshPublicKey_STATUS[]](#SshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="StorageAccountType"></a>StorageAccountType
--------------------------------------------------
+StorageAccountType{#StorageAccountType}
+---------------------------------------
 
 Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/linux/disks-types
 
@@ -3213,8 +3213,8 @@ Used by: [ImageDataDisk](#ImageDataDisk), [ImageOSDisk](#ImageOSDisk), [ManagedD
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="StorageAccountType_STATUS"></a>StorageAccountType_STATUS
----------------------------------------------------------------
+StorageAccountType_STATUS{#StorageAccountType_STATUS}
+-----------------------------------------------------
 
 Specifies the storage account type for the managed disk. Managed OS disk storage account type can only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks. It cannot be used with OS Disk. Standard_LRS uses Standard HDD. StandardSSD_LRS uses Standard SSD. Premium_LRS uses Premium SSD. UltraSSD_LRS uses Ultra disk. Premium_ZRS uses Premium SSD zone redundant storage. StandardSSD_ZRS uses Standard SSD zone redundant storage. For more information regarding disks supported for Windows Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/windows/disks-types and, for Linux Virtual Machines, refer to https://docs.microsoft.com/azure/virtual-machines/linux/disks-types
 
@@ -3230,8 +3230,8 @@ Used by: [ImageDataDisk_STATUS](#ImageDataDisk_STATUS), [ImageOSDisk_STATUS](#Im
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="VaultCertificate"></a>VaultCertificate
----------------------------------------------
+VaultCertificate{#VaultCertificate}
+-----------------------------------
 
 Describes a single certificate reference in a Key Vault, and where the certificate should reside on the VM.
 
@@ -3242,8 +3242,8 @@ Used by: [VaultSecretGroup](#VaultSecretGroup).
 | certificateStore | For Windows VMs, specifies the certificate store on the Virtual Machine to which the certificate should be added. The specified certificate store is implicitly in the LocalMachine account. For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name &lt;UppercaseThumbprint&gt;.crt for the X509 certificate file and &lt;UppercaseThumbprint&gt;.prv for private key. Both of these files are .pem formatted.                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small> |
 | certificateUrl   | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows). | string<br/><small>Optional</small> |
 
-<a id="VaultCertificate_STATUS"></a>VaultCertificate_STATUS
------------------------------------------------------------
+VaultCertificate_STATUS{#VaultCertificate_STATUS}
+-------------------------------------------------
 
 Describes a single certificate reference in a Key Vault, and where the certificate should reside on the VM.
 
@@ -3254,8 +3254,8 @@ Used by: [VaultSecretGroup_STATUS](#VaultSecretGroup_STATUS).
 | certificateStore | For Windows VMs, specifies the certificate store on the Virtual Machine to which the certificate should be added. The specified certificate store is implicitly in the LocalMachine account. For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name &lt;UppercaseThumbprint&gt;.crt for the X509 certificate file and &lt;UppercaseThumbprint&gt;.prv for private key. Both of these files are .pem formatted.                                                                                                                                                                                                                                                                                                                                                                      | string<br/><small>Optional</small> |
 | certificateUrl   | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows). | string<br/><small>Optional</small> |
 
-<a id="VirtualHardDisk"></a>VirtualHardDisk
--------------------------------------------
+VirtualHardDisk{#VirtualHardDisk}
+---------------------------------
 
 Describes the uri of a disk.
 
@@ -3265,8 +3265,8 @@ Used by: [DataDisk](#DataDisk), [DataDisk](#DataDisk), [OSDisk](#OSDisk), [OSDis
 |----------|----------------------------------------|------------------------------------|
 | uri      | Specifies the virtual hard disk's uri. | string<br/><small>Optional</small> |
 
-<a id="VirtualHardDisk_STATUS"></a>VirtualHardDisk_STATUS
----------------------------------------------------------
+VirtualHardDisk_STATUS{#VirtualHardDisk_STATUS}
+-----------------------------------------------
 
 Describes the uri of a disk.
 
@@ -3276,8 +3276,8 @@ Used by: [DataDisk_STATUS](#DataDisk_STATUS), [DataDisk_STATUS](#DataDisk_STATUS
 |----------|----------------------------------------|------------------------------------|
 | uri      | Specifies the virtual hard disk's uri. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineExtensionHandlerInstanceView_STATUS"></a>VirtualMachineExtensionHandlerInstanceView_STATUS
----------------------------------------------------------------------------------------------------------------
+VirtualMachineExtensionHandlerInstanceView_STATUS{#VirtualMachineExtensionHandlerInstanceView_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 The instance view of a virtual machine extension handler.
 
@@ -3289,40 +3289,40 @@ Used by: [VirtualMachineAgentInstanceView_STATUS](#VirtualMachineAgentInstanceVi
 | type               | Specifies the type of the extension; an example is "CustomScriptExtension". | string<br/><small>Optional</small>                                                  |
 | typeHandlerVersion | Specifies the version of the script handler.                                | string<br/><small>Optional</small>                                                  |
 
-<a id="VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption"></a>VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption
--------------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration).
-
-| Value    | Description |
-|----------|-------------|
-| "Delete" |             |
-| "Detach" |             |
-
-<a id="VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption_STATUS"></a>VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNetworkInterfaceConfiguration_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "Delete" |             |
-| "Detach" |             |
-
-<a id="VirtualMachineNetworkInterfaceDnsSettingsConfiguration"></a>VirtualMachineNetworkInterfaceDnsSettingsConfiguration
--------------------------------------------------------------------------------------------------------------------------
-
-Describes a virtual machines network configuration's DNS settings.
-
-Used by: [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration).
-
-| Property   | Description                      | Type                                 |
-|------------|----------------------------------|--------------------------------------|
-| dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
-
-<a id="VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS"></a>VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS
+VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption{#VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption}
 ---------------------------------------------------------------------------------------------------------------------------------------
 
+Used by: [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration).
+
+| Value    | Description |
+|----------|-------------|
+| "Delete" |             |
+| "Detach" |             |
+
+VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption_STATUS{#VirtualMachineNetworkInterfaceConfigurationProperties_DeleteOption_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+Used by: [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNetworkInterfaceConfiguration_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "Delete" |             |
+| "Detach" |             |
+
+VirtualMachineNetworkInterfaceDnsSettingsConfiguration{#VirtualMachineNetworkInterfaceDnsSettingsConfiguration}
+---------------------------------------------------------------------------------------------------------------
+
+Describes a virtual machines network configuration's DNS settings.
+
+Used by: [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInterfaceConfiguration).
+
+| Property   | Description                      | Type                                 |
+|------------|----------------------------------|--------------------------------------|
+| dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
+
+VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS{#VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
+
 Describes a virtual machines network configuration's DNS settings.
 
 Used by: [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNetworkInterfaceConfiguration_STATUS).
@@ -3331,8 +3331,8 @@ Used by: [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNet
 |------------|----------------------------------|--------------------------------------|
 | dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
 
-<a id="VirtualMachineNetworkInterfaceIPConfiguration"></a>VirtualMachineNetworkInterfaceIPConfiguration
--------------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceIPConfiguration{#VirtualMachineNetworkInterfaceIPConfiguration}
+---------------------------------------------------------------------------------------------
 
 Describes a virtual machine network profile's IP configuration.
 
@@ -3349,8 +3349,8 @@ Used by: [VirtualMachineNetworkInterfaceConfiguration](#VirtualMachineNetworkInt
 | publicIPAddressConfiguration          | The publicIPAddressConfiguration.                                                                                                                                                                                                                         | [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAddressConfiguration)<br/><small>Optional</small>                                                                           |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                                   | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                                                         |
 
-<a id="VirtualMachineNetworkInterfaceIPConfiguration_STATUS"></a>VirtualMachineNetworkInterfaceIPConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceIPConfiguration_STATUS{#VirtualMachineNetworkInterfaceIPConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Describes a virtual machine network profile's IP configuration.
 
@@ -3367,8 +3367,8 @@ Used by: [VirtualMachineNetworkInterfaceConfiguration_STATUS](#VirtualMachineNet
 | publicIPAddressConfiguration          | The publicIPAddressConfiguration.                                                                                                                                                                                                                         | [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS)<br/><small>Optional</small>                                                                           |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                                   | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                                         |
 
-<a id="VirtualMachineScaleSetDataDisk"></a>VirtualMachineScaleSetDataDisk
--------------------------------------------------------------------------
+VirtualMachineScaleSetDataDisk{#VirtualMachineScaleSetDataDisk}
+---------------------------------------------------------------
 
 Describes a virtual machine scale set data disk.
 
@@ -3387,8 +3387,8 @@ Used by: [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStoragePr
 | name                    | The disk name.                                                                                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                      |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                        |
 
-<a id="VirtualMachineScaleSetDataDisk_STATUS"></a>VirtualMachineScaleSetDataDisk_STATUS
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetDataDisk_STATUS{#VirtualMachineScaleSetDataDisk_STATUS}
+-----------------------------------------------------------------------------
 
 Describes a virtual machine scale set data disk.
 
@@ -3407,8 +3407,8 @@ Used by: [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetSt
 | name                    | The disk name.                                                                                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                    |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                      |
 
-<a id="VirtualMachineScaleSetExtension"></a>VirtualMachineScaleSetExtension
----------------------------------------------------------------------------
+VirtualMachineScaleSetExtension{#VirtualMachineScaleSetExtension}
+-----------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set Extension.
 
@@ -3429,8 +3429,8 @@ Used by: [VirtualMachineScaleSetExtensionProfile](#VirtualMachineScaleSetExtensi
 | type                          | Specifies the type of the extension; an example is "CustomScriptExtension".                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                           |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="VirtualMachineScaleSetExtension_STATUS"></a>VirtualMachineScaleSetExtension_STATUS
------------------------------------------------------------------------------------------
+VirtualMachineScaleSetExtension_STATUS{#VirtualMachineScaleSetExtension_STATUS}
+-------------------------------------------------------------------------------
 
 Describes a Virtual Machine Scale Set Extension.
 
@@ -3453,8 +3453,8 @@ Used by: [VirtualMachineScaleSetExtensionProfile_STATUS](#VirtualMachineScaleSet
 | type                          | Resource type                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                            |
 | typeHandlerVersion            | Specifies the version of the script handler.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                            |
 
-<a id="VirtualMachineScaleSetNetworkConfiguration"></a>VirtualMachineScaleSetNetworkConfiguration
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfiguration{#VirtualMachineScaleSetNetworkConfiguration}
+---------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's network configurations.
 
@@ -3473,8 +3473,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile](#VirtualMachineScaleSetNetworkPr
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                                    |
 | reference                   | Resource Id                                                                                            | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>          |
 
-<a id="VirtualMachineScaleSetNetworkConfiguration_STATUS"></a>VirtualMachineScaleSetNetworkConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfiguration_STATUS{#VirtualMachineScaleSetNetworkConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's network configurations.
 
@@ -3493,8 +3493,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile_STATUS](#VirtualMachineScaleSetNe
 | networkSecurityGroup        | The network security group.                                                                            | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                             |
 | primary                     | Specifies the primary network interface in case the virtual machine has more than 1 network interface. | bool<br/><small>Optional</small>                                                                                                                                                  |
 
-<a id="VirtualMachineScaleSetNetworkProfile_NetworkApiVersion"></a>VirtualMachineScaleSetNetworkProfile_NetworkApiVersion
--------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile_NetworkApiVersion{#VirtualMachineScaleSetNetworkProfile_NetworkApiVersion}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetNetworkProfile](#VirtualMachineScaleSetNetworkProfile).
 
@@ -3502,8 +3502,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile](#VirtualMachineScaleSetNetworkPr
 |--------------|-------------|
 | "2020-11-01" |             |
 
-<a id="VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS"></a>VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS{#VirtualMachineScaleSetNetworkProfile_NetworkApiVersion_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetNetworkProfile_STATUS](#VirtualMachineScaleSetNetworkProfile_STATUS).
 
@@ -3511,8 +3511,8 @@ Used by: [VirtualMachineScaleSetNetworkProfile_STATUS](#VirtualMachineScaleSetNe
 |--------------|-------------|
 | "2020-11-01" |             |
 
-<a id="VirtualMachineScaleSetOSDisk"></a>VirtualMachineScaleSetOSDisk
----------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk{#VirtualMachineScaleSetOSDisk}
+-----------------------------------------------------------
 
 Describes a virtual machine scale set operating system disk.
 
@@ -3532,8 +3532,8 @@ Used by: [VirtualMachineScaleSetStorageProfile](#VirtualMachineScaleSetStoragePr
 | vhdContainers           | Specifies the container urls that are used to store operating system disks for the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                    |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                        |
 
-<a id="VirtualMachineScaleSetOSDisk_STATUS"></a>VirtualMachineScaleSetOSDisk_STATUS
------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_STATUS{#VirtualMachineScaleSetOSDisk_STATUS}
+-------------------------------------------------------------------------
 
 Describes a virtual machine scale set operating system disk.
 
@@ -3553,8 +3553,8 @@ Used by: [VirtualMachineScaleSetStorageProfile_STATUS](#VirtualMachineScaleSetSt
 | vhdContainers           | Specifies the container urls that are used to store operating system disks for the scale set.                                                                                                                                                                                                                                                                                                                                                                                                                     | string[]<br/><small>Optional</small>                                                                                                  |
 | writeAcceleratorEnabled | Specifies whether writeAccelerator should be enabled or disabled on the disk.                                                                                                                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                      |
 
-<a id="WinRMConfiguration"></a>WinRMConfiguration
--------------------------------------------------
+WinRMConfiguration{#WinRMConfiguration}
+---------------------------------------
 
 Describes Windows Remote Management configuration of the VM
 
@@ -3564,8 +3564,8 @@ Used by: [WindowsConfiguration](#WindowsConfiguration).
 |-----------|-------------------------------------------------|---------------------------------------------------------------|
 | listeners | The list of Windows Remote Management listeners | [WinRMListener[]](#WinRMListener)<br/><small>Optional</small> |
 
-<a id="WinRMConfiguration_STATUS"></a>WinRMConfiguration_STATUS
----------------------------------------------------------------
+WinRMConfiguration_STATUS{#WinRMConfiguration_STATUS}
+-----------------------------------------------------
 
 Describes Windows Remote Management configuration of the VM
 
@@ -3575,35 +3575,35 @@ Used by: [WindowsConfiguration_STATUS](#WindowsConfiguration_STATUS).
 |-----------|-------------------------------------------------|-----------------------------------------------------------------------------|
 | listeners | The list of Windows Remote Management listeners | [WinRMListener_STATUS[]](#WinRMListener_STATUS)<br/><small>Optional</small> |
 
-<a id="AdditionalUnattendContent_ComponentName"></a>AdditionalUnattendContent_ComponentName
--------------------------------------------------------------------------------------------
-
-Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
-
-| Value                           | Description |
-|---------------------------------|-------------|
-| "Microsoft-Windows-Shell-Setup" |             |
-
-<a id="AdditionalUnattendContent_ComponentName_STATUS"></a>AdditionalUnattendContent_ComponentName_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
-
-| Value                           | Description |
-|---------------------------------|-------------|
-| "Microsoft-Windows-Shell-Setup" |             |
-
-<a id="AdditionalUnattendContent_PassName"></a>AdditionalUnattendContent_PassName
+AdditionalUnattendContent_ComponentName{#AdditionalUnattendContent_ComponentName}
 ---------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 
+| Value                           | Description |
+|---------------------------------|-------------|
+| "Microsoft-Windows-Shell-Setup" |             |
+
+AdditionalUnattendContent_ComponentName_STATUS{#AdditionalUnattendContent_ComponentName_STATUS}
+-----------------------------------------------------------------------------------------------
+
+Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
+
+| Value                           | Description |
+|---------------------------------|-------------|
+| "Microsoft-Windows-Shell-Setup" |             |
+
+AdditionalUnattendContent_PassName{#AdditionalUnattendContent_PassName}
+-----------------------------------------------------------------------
+
+Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
+
 | Value        | Description |
 |--------------|-------------|
 | "OobeSystem" |             |
 
-<a id="AdditionalUnattendContent_PassName_STATUS"></a>AdditionalUnattendContent_PassName_STATUS
------------------------------------------------------------------------------------------------
+AdditionalUnattendContent_PassName_STATUS{#AdditionalUnattendContent_PassName_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 
@@ -3611,8 +3611,8 @@ Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 |--------------|-------------|
 | "OobeSystem" |             |
 
-<a id="AdditionalUnattendContent_SettingName"></a>AdditionalUnattendContent_SettingName
----------------------------------------------------------------------------------------
+AdditionalUnattendContent_SettingName{#AdditionalUnattendContent_SettingName}
+-----------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 
@@ -3621,8 +3621,8 @@ Used by: [AdditionalUnattendContent](#AdditionalUnattendContent).
 | "AutoLogon"          |             |
 | "FirstLogonCommands" |             |
 
-<a id="AdditionalUnattendContent_SettingName_STATUS"></a>AdditionalUnattendContent_SettingName_STATUS
------------------------------------------------------------------------------------------------------
+AdditionalUnattendContent_SettingName_STATUS{#AdditionalUnattendContent_SettingName_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 
@@ -3631,8 +3631,8 @@ Used by: [AdditionalUnattendContent_STATUS](#AdditionalUnattendContent_STATUS).
 | "AutoLogon"          |             |
 | "FirstLogonCommands" |             |
 
-<a id="ApiError_STATUS"></a>ApiError_STATUS
--------------------------------------------
+ApiError_STATUS{#ApiError_STATUS}
+---------------------------------
 
 Api error.
 
@@ -3646,8 +3646,8 @@ Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS), and [Las
 | message    | The error message.                  | string<br/><small>Optional</small>                                        |
 | target     | The target of the particular error. | string<br/><small>Optional</small>                                        |
 
-<a id="AvailablePatchSummary_Status_STATUS"></a>AvailablePatchSummary_Status_STATUS
------------------------------------------------------------------------------------
+AvailablePatchSummary_Status_STATUS{#AvailablePatchSummary_Status_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS).
 
@@ -3659,8 +3659,8 @@ Used by: [AvailablePatchSummary_STATUS](#AvailablePatchSummary_STATUS).
 | "Succeeded"             |             |
 | "Unknown"               |             |
 
-<a id="DiffDiskOption"></a>DiffDiskOption
------------------------------------------
+DiffDiskOption{#DiffDiskOption}
+-------------------------------
 
 Specifies the ephemeral disk option for operating system disk.
 
@@ -3670,8 +3670,8 @@ Used by: [DiffDiskSettings](#DiffDiskSettings).
 |---------|-------------|
 | "Local" |             |
 
-<a id="DiffDiskOption_STATUS"></a>DiffDiskOption_STATUS
--------------------------------------------------------
+DiffDiskOption_STATUS{#DiffDiskOption_STATUS}
+---------------------------------------------
 
 Specifies the ephemeral disk option for operating system disk.
 
@@ -3681,8 +3681,8 @@ Used by: [DiffDiskSettings_STATUS](#DiffDiskSettings_STATUS).
 |---------|-------------|
 | "Local" |             |
 
-<a id="DiffDiskPlacement"></a>DiffDiskPlacement
------------------------------------------------
+DiffDiskPlacement{#DiffDiskPlacement}
+-------------------------------------
 
 Specifies the ephemeral disk placement for operating system disk. This property can be used by user in the request to choose the location i.e, cache disk or resource disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer Ephemeral OS disk size requirements for Windows VM at https://docs.microsoft.com/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements and Linux VM at https://docs.microsoft.com/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements
 
@@ -3693,8 +3693,8 @@ Used by: [DiffDiskSettings](#DiffDiskSettings).
 | "CacheDisk"    |             |
 | "ResourceDisk" |             |
 
-<a id="DiffDiskPlacement_STATUS"></a>DiffDiskPlacement_STATUS
--------------------------------------------------------------
+DiffDiskPlacement_STATUS{#DiffDiskPlacement_STATUS}
+---------------------------------------------------
 
 Specifies the ephemeral disk placement for operating system disk. This property can be used by user in the request to choose the location i.e, cache disk or resource disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer Ephemeral OS disk size requirements for Windows VM at https://docs.microsoft.com/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements and Linux VM at https://docs.microsoft.com/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements
 
@@ -3705,8 +3705,8 @@ Used by: [DiffDiskSettings_STATUS](#DiffDiskSettings_STATUS).
 | "CacheDisk"    |             |
 | "ResourceDisk" |             |
 
-<a id="KeyVaultKeyReference"></a>KeyVaultKeyReference
------------------------------------------------------
+KeyVaultKeyReference{#KeyVaultKeyReference}
+-------------------------------------------
 
 Describes a reference to Key Vault Key
 
@@ -3717,8 +3717,8 @@ Used by: [DiskEncryptionSettings](#DiskEncryptionSettings).
 | keyUrl      | The URL referencing a key encryption key in Key Vault. | string<br/><small>Required</small>                      |
 | sourceVault | The relative URL of the Key Vault containing the key.  | [SubResource](#SubResource)<br/><small>Required</small> |
 
-<a id="KeyVaultKeyReference_STATUS"></a>KeyVaultKeyReference_STATUS
--------------------------------------------------------------------
+KeyVaultKeyReference_STATUS{#KeyVaultKeyReference_STATUS}
+---------------------------------------------------------
 
 Describes a reference to Key Vault Key
 
@@ -3729,8 +3729,8 @@ Used by: [DiskEncryptionSettings_STATUS](#DiskEncryptionSettings_STATUS).
 | keyUrl      | The URL referencing a key encryption key in Key Vault. | string<br/><small>Optional</small>                                    |
 | sourceVault | The relative URL of the Key Vault containing the key.  | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="LastPatchInstallationSummary_Status_STATUS"></a>LastPatchInstallationSummary_Status_STATUS
--------------------------------------------------------------------------------------------------
+LastPatchInstallationSummary_Status_STATUS{#LastPatchInstallationSummary_Status_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STATUS).
 
@@ -3742,27 +3742,7 @@ Used by: [LastPatchInstallationSummary_STATUS](#LastPatchInstallationSummary_STA
 | "Succeeded"             |             |
 | "Unknown"               |             |
 
-<a id="LinuxPatchSettings_AssessmentMode"></a>LinuxPatchSettings_AssessmentMode
--------------------------------------------------------------------------------
-
-Used by: [LinuxPatchSettings](#LinuxPatchSettings).
-
-| Value                 | Description |
-|-----------------------|-------------|
-| "AutomaticByPlatform" |             |
-| "ImageDefault"        |             |
-
-<a id="LinuxPatchSettings_AssessmentMode_STATUS"></a>LinuxPatchSettings_AssessmentMode_STATUS
----------------------------------------------------------------------------------------------
-
-Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
-
-| Value                 | Description |
-|-----------------------|-------------|
-| "AutomaticByPlatform" |             |
-| "ImageDefault"        |             |
-
-<a id="LinuxPatchSettings_PatchMode"></a>LinuxPatchSettings_PatchMode
+LinuxPatchSettings_AssessmentMode{#LinuxPatchSettings_AssessmentMode}
 ---------------------------------------------------------------------
 
 Used by: [LinuxPatchSettings](#LinuxPatchSettings).
@@ -3772,7 +3752,7 @@ Used by: [LinuxPatchSettings](#LinuxPatchSettings).
 | "AutomaticByPlatform" |             |
 | "ImageDefault"        |             |
 
-<a id="LinuxPatchSettings_PatchMode_STATUS"></a>LinuxPatchSettings_PatchMode_STATUS
+LinuxPatchSettings_AssessmentMode_STATUS{#LinuxPatchSettings_AssessmentMode_STATUS}
 -----------------------------------------------------------------------------------
 
 Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
@@ -3782,8 +3762,28 @@ Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
 | "AutomaticByPlatform" |             |
 | "ImageDefault"        |             |
 
-<a id="LinuxVMGuestPatchAutomaticByPlatformSettings"></a>LinuxVMGuestPatchAutomaticByPlatformSettings
------------------------------------------------------------------------------------------------------
+LinuxPatchSettings_PatchMode{#LinuxPatchSettings_PatchMode}
+-----------------------------------------------------------
+
+Used by: [LinuxPatchSettings](#LinuxPatchSettings).
+
+| Value                 | Description |
+|-----------------------|-------------|
+| "AutomaticByPlatform" |             |
+| "ImageDefault"        |             |
+
+LinuxPatchSettings_PatchMode_STATUS{#LinuxPatchSettings_PatchMode_STATUS}
+-------------------------------------------------------------------------
+
+Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
+
+| Value                 | Description |
+|-----------------------|-------------|
+| "AutomaticByPlatform" |             |
+| "ImageDefault"        |             |
+
+LinuxVMGuestPatchAutomaticByPlatformSettings{#LinuxVMGuestPatchAutomaticByPlatformSettings}
+-------------------------------------------------------------------------------------------
 
 Specifies additional settings to be applied when patch mode AutomaticByPlatform is selected in Linux patch settings.
 
@@ -3793,8 +3793,8 @@ Used by: [LinuxPatchSettings](#LinuxPatchSettings).
 |---------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rebootSetting | Specifies the reboot setting for all AutomaticByPlatform patch installation operations. | [LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting](#LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting)<br/><small>Optional</small> |
 
-<a id="LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS"></a>LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS
--------------------------------------------------------------------------------------------------------------------
+LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS{#LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Specifies additional settings to be applied when patch mode AutomaticByPlatform is selected in Linux patch settings.
 
@@ -3804,39 +3804,39 @@ Used by: [LinuxPatchSettings_STATUS](#LinuxPatchSettings_STATUS).
 |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rebootSetting | Specifies the reboot setting for all AutomaticByPlatform patch installation operations. | [LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS](#LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS)<br/><small>Optional</small> |
 
-<a id="PatchSettings_AssessmentMode"></a>PatchSettings_AssessmentMode
----------------------------------------------------------------------
-
-Used by: [PatchSettings](#PatchSettings).
-
-| Value                 | Description |
-|-----------------------|-------------|
-| "AutomaticByPlatform" |             |
-| "ImageDefault"        |             |
-
-<a id="PatchSettings_AssessmentMode_STATUS"></a>PatchSettings_AssessmentMode_STATUS
------------------------------------------------------------------------------------
-
-Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
-
-| Value                 | Description |
-|-----------------------|-------------|
-| "AutomaticByPlatform" |             |
-| "ImageDefault"        |             |
-
-<a id="PatchSettings_PatchMode"></a>PatchSettings_PatchMode
+PatchSettings_AssessmentMode{#PatchSettings_AssessmentMode}
 -----------------------------------------------------------
 
 Used by: [PatchSettings](#PatchSettings).
 
 | Value                 | Description |
 |-----------------------|-------------|
+| "AutomaticByPlatform" |             |
+| "ImageDefault"        |             |
+
+PatchSettings_AssessmentMode_STATUS{#PatchSettings_AssessmentMode_STATUS}
+-------------------------------------------------------------------------
+
+Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
+
+| Value                 | Description |
+|-----------------------|-------------|
+| "AutomaticByPlatform" |             |
+| "ImageDefault"        |             |
+
+PatchSettings_PatchMode{#PatchSettings_PatchMode}
+-------------------------------------------------
+
+Used by: [PatchSettings](#PatchSettings).
+
+| Value                 | Description |
+|-----------------------|-------------|
 | "AutomaticByOS"       |             |
 | "AutomaticByPlatform" |             |
 | "Manual"              |             |
 
-<a id="PatchSettings_PatchMode_STATUS"></a>PatchSettings_PatchMode_STATUS
--------------------------------------------------------------------------
+PatchSettings_PatchMode_STATUS{#PatchSettings_PatchMode_STATUS}
+---------------------------------------------------------------
 
 Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
 
@@ -3846,8 +3846,8 @@ Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
 | "AutomaticByPlatform" |             |
 | "Manual"              |             |
 
-<a id="SshPublicKey_STATUS"></a>SshPublicKey_STATUS
----------------------------------------------------
+SshPublicKey_STATUS{#SshPublicKey_STATUS}
+-----------------------------------------
 
 Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
 
@@ -3858,8 +3858,8 @@ Used by: [SshConfiguration_STATUS](#SshConfiguration_STATUS).
 | keyData  | SSH public key certificate used to authenticate with the VM through ssh. The key needs to be at least 2048-bit and in ssh-rsa format. For creating ssh keys, see [Create SSH keys on Linux and Mac for Linux VMs in Azure]https://docs.microsoft.com/azure/virtual-machines/linux/create-ssh-keys-detailed). | string<br/><small>Optional</small> |
 | path     | Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key is appended to the file. Example: /home/user/.ssh/authorized_keys                                                                                                                    | string<br/><small>Optional</small> |
 
-<a id="SshPublicKeySpec"></a>SshPublicKeySpec
----------------------------------------------
+SshPublicKeySpec{#SshPublicKeySpec}
+-----------------------------------
 
 Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
 
@@ -3870,8 +3870,8 @@ Used by: [SshConfiguration](#SshConfiguration).
 | keyData  | SSH public key certificate used to authenticate with the VM through ssh. The key needs to be at least 2048-bit and in ssh-rsa format. For creating ssh keys, see [Create SSH keys on Linux and Mac for Linux VMs in Azure]https://docs.microsoft.com/azure/virtual-machines/linux/create-ssh-keys-detailed). | string<br/><small>Optional</small> |
 | path     | Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key is appended to the file. Example: /home/user/.ssh/authorized_keys                                                                                                                    | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion"></a>VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion{#VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkInterfaceIPConfiguration).
 
@@ -3880,8 +3880,8 @@ Used by: [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkI
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion_STATUS"></a>VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion_STATUS{#VirtualMachineNetworkInterfaceIPConfigurationProperties_PrivateIPAddressVersion_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineNetworkInterfaceIPConfiguration_STATUS).
 
@@ -3890,8 +3890,8 @@ Used by: [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineN
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachinePublicIPAddressConfiguration"></a>VirtualMachinePublicIPAddressConfiguration
--------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfiguration{#VirtualMachinePublicIPAddressConfiguration}
+---------------------------------------------------------------------------------------
 
 Describes a virtual machines IP Configuration's PublicIPAddress configuration
 
@@ -3909,8 +3909,8 @@ Used by: [VirtualMachineNetworkInterfaceIPConfiguration](#VirtualMachineNetworkI
 | publicIPPrefix           | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                                                     |
 | sku                      | Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.                                                                                                  | [PublicIPAddressSku](#PublicIPAddressSku)<br/><small>Optional</small>                                                                                                                       |
 
-<a id="VirtualMachinePublicIPAddressConfiguration_STATUS"></a>VirtualMachinePublicIPAddressConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfiguration_STATUS{#VirtualMachinePublicIPAddressConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Describes a virtual machines IP Configuration's PublicIPAddress configuration
 
@@ -3928,8 +3928,8 @@ Used by: [VirtualMachineNetworkInterfaceIPConfiguration_STATUS](#VirtualMachineN
 | publicIPPrefix           | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                                     |
 | sku                      | Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.                                                                                                  | [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS)<br/><small>Optional</small>                                                                                                                       |
 
-<a id="VirtualMachineScaleSetIPConfiguration"></a>VirtualMachineScaleSetIPConfiguration
----------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfiguration{#VirtualMachineScaleSetIPConfiguration}
+-----------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's IP configuration.
 
@@ -3948,8 +3948,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNet
 | reference                             | Resource Id                                                                                                                                                                                                                                 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>                      |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                     | [ApiEntityReference](#ApiEntityReference)<br/><small>Optional</small>                                                                                                           |
 
-<a id="VirtualMachineScaleSetIPConfiguration_STATUS"></a>VirtualMachineScaleSetIPConfiguration_STATUS
------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfiguration_STATUS{#VirtualMachineScaleSetIPConfiguration_STATUS}
+-------------------------------------------------------------------------------------------
 
 Describes a virtual machine scale set network profile's IP configuration.
 
@@ -3968,8 +3968,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScal
 | publicIPAddressConfiguration          | The publicIPAddressConfiguration.                                                                                                                                                                                                           | [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS)<br/><small>Optional</small>                                           |
 | subnet                                | Specifies the identifier of the subnet.                                                                                                                                                                                                     | [ApiEntityReference_STATUS](#ApiEntityReference_STATUS)<br/><small>Optional</small>                                                                                                           |
 
-<a id="VirtualMachineScaleSetManagedDiskParameters"></a>VirtualMachineScaleSetManagedDiskParameters
----------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetManagedDiskParameters{#VirtualMachineScaleSetManagedDiskParameters}
+-----------------------------------------------------------------------------------------
 
 Describes the parameters of a ScaleSet managed disk.
 
@@ -3981,8 +3981,8 @@ Used by: [VirtualMachineScaleSetDataDisk](#VirtualMachineScaleSetDataDisk), and 
 | securityProfile    | Specifies the security profile for the managed disk.                                                                                          | [VMDiskSecurityProfile](#VMDiskSecurityProfile)<br/><small>Optional</small> |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType](#StorageAccountType)<br/><small>Optional</small>       |
 
-<a id="VirtualMachineScaleSetManagedDiskParameters_STATUS"></a>VirtualMachineScaleSetManagedDiskParameters_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetManagedDiskParameters_STATUS{#VirtualMachineScaleSetManagedDiskParameters_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Describes the parameters of a ScaleSet managed disk.
 
@@ -3994,8 +3994,8 @@ Used by: [VirtualMachineScaleSetDataDisk_STATUS](#VirtualMachineScaleSetDataDisk
 | securityProfile    | Specifies the security profile for the managed disk.                                                                                          | [VMDiskSecurityProfile_STATUS](#VMDiskSecurityProfile_STATUS)<br/><small>Optional</small> |
 | storageAccountType | Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk. | [StorageAccountType_STATUS](#StorageAccountType_STATUS)<br/><small>Optional</small>       |
 
-<a id="VirtualMachineScaleSetNetworkConfigurationDnsSettings"></a>VirtualMachineScaleSetNetworkConfigurationDnsSettings
------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfigurationDnsSettings{#VirtualMachineScaleSetNetworkConfigurationDnsSettings}
+-------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -4005,20 +4005,20 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNet
 |------------|----------------------------------|--------------------------------------|
 | dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS"></a>VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS
+VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS{#VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
+
+Describes a virtual machines scale sets network configuration's DNS settings.
+
+Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScaleSetNetworkConfiguration_STATUS).
+
+| Property   | Description                      | Type                                 |
+|------------|----------------------------------|--------------------------------------|
+| dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
+
+VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption{#VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption}
 -------------------------------------------------------------------------------------------------------------------------------------
 
-Describes a virtual machines scale sets network configuration's DNS settings.
-
-Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScaleSetNetworkConfiguration_STATUS).
-
-| Property   | Description                      | Type                                 |
-|------------|----------------------------------|--------------------------------------|
-| dnsServers | List of DNS servers IP addresses | string[]<br/><small>Optional</small> |
-
-<a id="VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption"></a>VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption
------------------------------------------------------------------------------------------------------------------------------------------------
-
 Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNetworkConfiguration).
 
 | Value    | Description |
@@ -4026,8 +4026,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration](#VirtualMachineScaleSetNet
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption_STATUS"></a>VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption_STATUS{#VirtualMachineScaleSetNetworkConfigurationProperties_DeleteOption_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScaleSetNetworkConfiguration_STATUS).
 
@@ -4036,8 +4036,8 @@ Used by: [VirtualMachineScaleSetNetworkConfiguration_STATUS](#VirtualMachineScal
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachineScaleSetOSDisk_OsType"></a>VirtualMachineScaleSetOSDisk_OsType
------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_OsType{#VirtualMachineScaleSetOSDisk_OsType}
+-------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 
@@ -4046,8 +4046,8 @@ Used by: [VirtualMachineScaleSetOSDisk](#VirtualMachineScaleSetOSDisk).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="VirtualMachineScaleSetOSDisk_OsType_STATUS"></a>VirtualMachineScaleSetOSDisk_OsType_STATUS
--------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetOSDisk_OsType_STATUS{#VirtualMachineScaleSetOSDisk_OsType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STATUS).
 
@@ -4056,8 +4056,8 @@ Used by: [VirtualMachineScaleSetOSDisk_STATUS](#VirtualMachineScaleSetOSDisk_STA
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="VMDiskSecurityProfile"></a>VMDiskSecurityProfile
--------------------------------------------------------
+VMDiskSecurityProfile{#VMDiskSecurityProfile}
+---------------------------------------------
 
 Specifies the security profile settings for the managed disk. NOTE: It can only be set for Confidential VMs
 
@@ -4068,8 +4068,8 @@ Used by: [ManagedDiskParameters](#ManagedDiskParameters), and [VirtualMachineSca
 | diskEncryptionSet      | Specifies the customer managed disk encryption set resource id for the managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and VMGuest blob.                                                                                           | [SubResource](#SubResource)<br/><small>Optional</small>                                                                   |
 | securityEncryptionType | Specifies the EncryptionType of the managed disk. It is set to DiskWithVMGuestState for encryption of the managed disk along with VMGuestState blob, and VMGuestStateOnly for encryption of just the VMGuestState blob. NOTE: It can be set for only Confidential VMs. | [VMDiskSecurityProfile_SecurityEncryptionType](#VMDiskSecurityProfile_SecurityEncryptionType)<br/><small>Optional</small> |
 
-<a id="VMDiskSecurityProfile_STATUS"></a>VMDiskSecurityProfile_STATUS
----------------------------------------------------------------------
+VMDiskSecurityProfile_STATUS{#VMDiskSecurityProfile_STATUS}
+-----------------------------------------------------------
 
 Specifies the security profile settings for the managed disk. NOTE: It can only be set for Confidential VMs
 
@@ -4080,8 +4080,8 @@ Used by: [ManagedDiskParameters_STATUS](#ManagedDiskParameters_STATUS), and [Vir
 | diskEncryptionSet      | Specifies the customer managed disk encryption set resource id for the managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and VMGuest blob.                                                                                           | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                   |
 | securityEncryptionType | Specifies the EncryptionType of the managed disk. It is set to DiskWithVMGuestState for encryption of the managed disk along with VMGuestState blob, and VMGuestStateOnly for encryption of just the VMGuestState blob. NOTE: It can be set for only Confidential VMs. | [VMDiskSecurityProfile_SecurityEncryptionType_STATUS](#VMDiskSecurityProfile_SecurityEncryptionType_STATUS)<br/><small>Optional</small> |
 
-<a id="WindowsVMGuestPatchAutomaticByPlatformSettings"></a>WindowsVMGuestPatchAutomaticByPlatformSettings
----------------------------------------------------------------------------------------------------------
+WindowsVMGuestPatchAutomaticByPlatformSettings{#WindowsVMGuestPatchAutomaticByPlatformSettings}
+-----------------------------------------------------------------------------------------------
 
 Specifies additional settings to be applied when patch mode AutomaticByPlatform is selected in Windows patch settings.
 
@@ -4091,8 +4091,8 @@ Used by: [PatchSettings](#PatchSettings).
 |---------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rebootSetting | Specifies the reboot setting for all AutomaticByPlatform patch installation operations. | [WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting](#WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting)<br/><small>Optional</small> |
 
-<a id="WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS"></a>WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS
------------------------------------------------------------------------------------------------------------------------
+WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS{#WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Specifies additional settings to be applied when patch mode AutomaticByPlatform is selected in Windows patch settings.
 
@@ -4102,8 +4102,8 @@ Used by: [PatchSettings_STATUS](#PatchSettings_STATUS).
 |---------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rebootSetting | Specifies the reboot setting for all AutomaticByPlatform patch installation operations. | [WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS](#WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS)<br/><small>Optional</small> |
 
-<a id="WinRMListener"></a>WinRMListener
----------------------------------------
+WinRMListener{#WinRMListener}
+-----------------------------
 
 Describes Protocol and thumbprint of Windows Remote Management listener
 
@@ -4114,8 +4114,8 @@ Used by: [WinRMConfiguration](#WinRMConfiguration).
 | certificateUrl | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows). | string<br/><small>Optional</small>                                            |
 | protocol       | Specifies the protocol of WinRM listener. Possible values are: http https                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | [WinRMListener_Protocol](#WinRMListener_Protocol)<br/><small>Optional</small> |
 
-<a id="WinRMListener_STATUS"></a>WinRMListener_STATUS
------------------------------------------------------
+WinRMListener_STATUS{#WinRMListener_STATUS}
+-------------------------------------------
 
 Describes Protocol and thumbprint of Windows Remote Management listener
 
@@ -4126,8 +4126,8 @@ Used by: [WinRMConfiguration_STATUS](#WinRMConfiguration_STATUS).
 | certificateUrl | This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: { "data":"<Base64-encoded-certificate>", "dataType":"pfx", "password":"<pfx-file-password>" } To install certificates on a virtual machine it is recommended to use the [Azure Key Vault virtual machine extension for Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-linux) or the [Azure Key Vault virtual machine extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/key-vault-windows). | string<br/><small>Optional</small>                                                          |
 | protocol       | Specifies the protocol of WinRM listener. Possible values are: http https                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | [WinRMListener_Protocol_STATUS](#WinRMListener_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiErrorBase_STATUS"></a>ApiErrorBase_STATUS
----------------------------------------------------
+ApiErrorBase_STATUS{#ApiErrorBase_STATUS}
+-----------------------------------------
 
 Api error base.
 
@@ -4139,8 +4139,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | message  | The error message.                  | string<br/><small>Optional</small> |
 | target   | The target of the particular error. | string<br/><small>Optional</small> |
 
-<a id="InnerError_STATUS"></a>InnerError_STATUS
------------------------------------------------
+InnerError_STATUS{#InnerError_STATUS}
+-------------------------------------
 
 Inner error details.
 
@@ -4151,8 +4151,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | errordetail   | The internal error message or exception dump. | string<br/><small>Optional</small> |
 | exceptiontype | The exception type.                           | string<br/><small>Optional</small> |
 
-<a id="LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting"></a>LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting
----------------------------------------------------------------------------------------------------------------------------------
+LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting{#LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [LinuxVMGuestPatchAutomaticByPlatformSettings](#LinuxVMGuestPatchAutomaticByPlatformSettings).
 
@@ -4163,8 +4163,8 @@ Used by: [LinuxVMGuestPatchAutomaticByPlatformSettings](#LinuxVMGuestPatchAutoma
 | "Never"      |             |
 | "Unknown"    |             |
 
-<a id="LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS"></a>LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS{#LinuxVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS](#LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS).
 
@@ -4175,8 +4175,8 @@ Used by: [LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS](#LinuxVMGuestPatc
 | "Never"      |             |
 | "Unknown"    |             |
 
-<a id="PublicIPAddressSku"></a>PublicIPAddressSku
--------------------------------------------------
+PublicIPAddressSku{#PublicIPAddressSku}
+---------------------------------------
 
 Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.
 
@@ -4187,8 +4187,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 | name     | Specify public IP sku name | [PublicIPAddressSku_Name](#PublicIPAddressSku_Name)<br/><small>Optional</small> |
 | tier     | Specify public IP sku tier | [PublicIPAddressSku_Tier](#PublicIPAddressSku_Tier)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSku_STATUS"></a>PublicIPAddressSku_STATUS
----------------------------------------------------------------
+PublicIPAddressSku_STATUS{#PublicIPAddressSku_STATUS}
+-----------------------------------------------------
 
 Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.
 
@@ -4199,8 +4199,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePubl
 | name     | Specify public IP sku name | [PublicIPAddressSku_Name_STATUS](#PublicIPAddressSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Specify public IP sku tier | [PublicIPAddressSku_Tier_STATUS](#PublicIPAddressSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachineIpTag"></a>VirtualMachineIpTag
----------------------------------------------------
+VirtualMachineIpTag{#VirtualMachineIpTag}
+-----------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -4211,8 +4211,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineIpTag_STATUS"></a>VirtualMachineIpTag_STATUS
------------------------------------------------------------------
+VirtualMachineIpTag_STATUS{#VirtualMachineIpTag_STATUS}
+-------------------------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -4223,8 +4223,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePubl
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption"></a>VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption
------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption{#VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAddressConfiguration).
 
@@ -4233,8 +4233,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption_STATUS"></a>VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption_STATUS{#VirtualMachinePublicIPAddressConfigurationProperties_DeleteOption_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS).
 
@@ -4243,8 +4243,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePubl
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion"></a>VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion{#VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion}
+---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAddressConfiguration).
 
@@ -4253,19 +4253,19 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS"></a>VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
-
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod"></a>VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod
+VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS{#VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS}
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod{#VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAddressConfiguration).
 
 | Value     | Description |
@@ -4273,8 +4273,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod_STATUS"></a>VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod_STATUS{#VirtualMachinePublicIPAddressConfigurationProperties_PublicIPAllocationMethod_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePublicIPAddressConfiguration_STATUS).
 
@@ -4283,8 +4283,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePubl
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="VirtualMachinePublicIPAddressDnsSettingsConfiguration"></a>VirtualMachinePublicIPAddressDnsSettingsConfiguration
------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressDnsSettingsConfiguration{#VirtualMachinePublicIPAddressDnsSettingsConfiguration}
+-------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines network configuration's DNS settings.
 
@@ -4294,8 +4294,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration](#VirtualMachinePublicIPAdd
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label prefix of the PublicIPAddress resources that will be created. The generated name label is the concatenation of the domain name label and vm network profile unique ID. | string<br/><small>Required</small> |
 
-<a id="VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS"></a>VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS{#VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines network configuration's DNS settings.
 
@@ -4305,8 +4305,8 @@ Used by: [VirtualMachinePublicIPAddressConfiguration_STATUS](#VirtualMachinePubl
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label prefix of the PublicIPAddress resources that will be created. The generated name label is the concatenation of the domain name label and vm network profile unique ID. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion"></a>VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion
------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion{#VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfiguration).
 
@@ -4315,8 +4315,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS"></a>VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS{#VirtualMachineScaleSetIPConfigurationProperties_PrivateIPAddressVersion_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetIPConfiguration_STATUS).
 
@@ -4325,8 +4325,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfiguration"></a>VirtualMachineScaleSetPublicIPAddressConfiguration
------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfiguration{#VirtualMachineScaleSetPublicIPAddressConfiguration}
+-------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
 
@@ -4343,8 +4343,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration](#VirtualMachineScaleSetIPConfig
 | publicIPPrefix         | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                                                                 |
 | sku                    | Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.                                                                                                  | [PublicIPAddressSku](#PublicIPAddressSku)<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS{#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
 
@@ -4361,8 +4361,8 @@ Used by: [VirtualMachineScaleSetIPConfiguration_STATUS](#VirtualMachineScaleSetI
 | publicIPPrefix         | The PublicIPPrefix from which to allocate publicIP addresses.                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                                                 |
 | sku                    | Describes the public IP Sku. It can only be set with OrchestrationMode as Flexible.                                                                                                  | [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS)<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="VMDiskSecurityProfile_SecurityEncryptionType"></a>VMDiskSecurityProfile_SecurityEncryptionType
------------------------------------------------------------------------------------------------------
+VMDiskSecurityProfile_SecurityEncryptionType{#VMDiskSecurityProfile_SecurityEncryptionType}
+-------------------------------------------------------------------------------------------
 
 Used by: [VMDiskSecurityProfile](#VMDiskSecurityProfile).
 
@@ -4371,8 +4371,8 @@ Used by: [VMDiskSecurityProfile](#VMDiskSecurityProfile).
 | "DiskWithVMGuestState" |             |
 | "VMGuestStateOnly"     |             |
 
-<a id="VMDiskSecurityProfile_SecurityEncryptionType_STATUS"></a>VMDiskSecurityProfile_SecurityEncryptionType_STATUS
--------------------------------------------------------------------------------------------------------------------
+VMDiskSecurityProfile_SecurityEncryptionType_STATUS{#VMDiskSecurityProfile_SecurityEncryptionType_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [VMDiskSecurityProfile_STATUS](#VMDiskSecurityProfile_STATUS).
 
@@ -4381,8 +4381,8 @@ Used by: [VMDiskSecurityProfile_STATUS](#VMDiskSecurityProfile_STATUS).
 | "DiskWithVMGuestState" |             |
 | "VMGuestStateOnly"     |             |
 
-<a id="WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting"></a>WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting
--------------------------------------------------------------------------------------------------------------------------------------
+WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting{#WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WindowsVMGuestPatchAutomaticByPlatformSettings](#WindowsVMGuestPatchAutomaticByPlatformSettings).
 
@@ -4393,8 +4393,8 @@ Used by: [WindowsVMGuestPatchAutomaticByPlatformSettings](#WindowsVMGuestPatchAu
 | "Never"      |             |
 | "Unknown"    |             |
 
-<a id="WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS"></a>WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS{#WindowsVMGuestPatchAutomaticByPlatformSettings_RebootSetting_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS](#WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS).
 
@@ -4405,8 +4405,8 @@ Used by: [WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS](#WindowsVMGuest
 | "Never"      |             |
 | "Unknown"    |             |
 
-<a id="WinRMListener_Protocol"></a>WinRMListener_Protocol
----------------------------------------------------------
+WinRMListener_Protocol{#WinRMListener_Protocol}
+-----------------------------------------------
 
 Used by: [WinRMListener](#WinRMListener).
 
@@ -4415,8 +4415,8 @@ Used by: [WinRMListener](#WinRMListener).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="WinRMListener_Protocol_STATUS"></a>WinRMListener_Protocol_STATUS
------------------------------------------------------------------------
+WinRMListener_Protocol_STATUS{#WinRMListener_Protocol_STATUS}
+-------------------------------------------------------------
 
 Used by: [WinRMListener_STATUS](#WinRMListener_STATUS).
 
@@ -4425,8 +4425,8 @@ Used by: [WinRMListener_STATUS](#WinRMListener_STATUS).
 | "Http"  |             |
 | "Https" |             |
 
-<a id="PublicIPAddressSku_Name"></a>PublicIPAddressSku_Name
------------------------------------------------------------
+PublicIPAddressSku_Name{#PublicIPAddressSku_Name}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -4435,8 +4435,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Name_STATUS"></a>PublicIPAddressSku_Name_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Name_STATUS{#PublicIPAddressSku_Name_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -4445,8 +4445,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Tier"></a>PublicIPAddressSku_Tier
------------------------------------------------------------
+PublicIPAddressSku_Tier{#PublicIPAddressSku_Tier}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -4455,8 +4455,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPAddressSku_Tier_STATUS"></a>PublicIPAddressSku_Tier_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Tier_STATUS{#PublicIPAddressSku_Tier_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -4465,8 +4465,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="VirtualMachineScaleSetIpTag"></a>VirtualMachineScaleSetIpTag
--------------------------------------------------------------------
+VirtualMachineScaleSetIpTag{#VirtualMachineScaleSetIpTag}
+---------------------------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -4477,8 +4477,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetIpTag_STATUS"></a>VirtualMachineScaleSetIpTag_STATUS
----------------------------------------------------------------------------------
+VirtualMachineScaleSetIpTag_STATUS{#VirtualMachineScaleSetIpTag_STATUS}
+-----------------------------------------------------------------------
 
 Contains the IP tag associated with the public IP address.
 
@@ -4489,8 +4489,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMac
 | ipTagType | IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | IP tag associated with the public IP. Example: SQL, Storage etc. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings"></a>VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{#VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -4500,8 +4500,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label.The concatenation of the domain name label and vm index will be the domain name labels of the PublicIPAddress resources that will be created | string<br/><small>Required</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS{#VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Describes a virtual machines scale sets network configuration's DNS settings.
 
@@ -4511,8 +4511,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMac
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | domainNameLabel | The Domain name label.The concatenation of the domain name label and vm index will be the domain name labels of the PublicIPAddress resources that will be created | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineScaleSetPublicIPAddressConfiguration).
 
@@ -4521,8 +4521,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption_STATUS{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_DeleteOption_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS).
 
@@ -4531,8 +4531,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMac
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineScaleSetPublicIPAddressConfiguration).
 
@@ -4541,8 +4541,8 @@ Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration](#VirtualMachineSca
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS"></a>VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS{#VirtualMachineScaleSetPublicIPAddressConfigurationProperties_PublicIPAddressVersion_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS](#VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS).
 

--- a/docs/hugo/content/reference/compute/v1api20220702.md
+++ b/docs/hugo/content/reference/compute/v1api20220702.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20220702
 linktitle: v1api20220702
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-07-02" |             |
 
-<a id="DiskEncryptionSet"></a>DiskEncryptionSet
------------------------------------------------
+DiskEncryptionSet{#DiskEncryptionSet}
+-------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2022-07-02/diskEncryptionSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}
 
@@ -26,7 +26,7 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | spec                                                                                    |             | [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="DiskEncryptionSet_Spec"></a>DiskEncryptionSet_Spec
+### DiskEncryptionSet_Spec {#DiskEncryptionSet_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | rotationToLatestKeyVersionEnabled | Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.                                                                                                                                                                                         | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                              | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DiskEncryptionSet_STATUS"></a>DiskEncryptionSet_STATUS
+### DiskEncryptionSet_STATUS{#DiskEncryptionSet_STATUS}
 
 | Property                          | Description                                                                                                                                                                         | Type                                                                                                                                                    |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -62,8 +62,8 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | tags                              | Resource tags                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiskEncryptionSetList"></a>DiskEncryptionSetList
--------------------------------------------------------
+DiskEncryptionSetList{#DiskEncryptionSetList}
+---------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2022-07-02/diskEncryptionSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}
 
@@ -73,8 +73,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DiskEncryptionSet[]](#DiskEncryptionSet)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSet_Spec"></a>DiskEncryptionSet_Spec
----------------------------------------------------------
+DiskEncryptionSet_Spec{#DiskEncryptionSet_Spec}
+-----------------------------------------------
 
 Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 
@@ -92,8 +92,8 @@ Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 | rotationToLatestKeyVersionEnabled | Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.                                                                                                                                                                                         | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                              | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DiskEncryptionSet_STATUS"></a>DiskEncryptionSet_STATUS
--------------------------------------------------------------
+DiskEncryptionSet_STATUS{#DiskEncryptionSet_STATUS}
+---------------------------------------------------
 
 disk encryption set resource.
 
@@ -117,8 +117,8 @@ Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 | tags                              | Resource tags                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiError_STATUS"></a>ApiError_STATUS
--------------------------------------------
+ApiError_STATUS{#ApiError_STATUS}
+---------------------------------
 
 Api error.
 
@@ -132,8 +132,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | message    | The error message.                  | string<br/><small>Optional</small>                                        |
 | target     | The target of the particular error. | string<br/><small>Optional</small>                                        |
 
-<a id="DiskEncryptionSetOperatorSpec"></a>DiskEncryptionSetOperatorSpec
------------------------------------------------------------------------
+DiskEncryptionSetOperatorSpec{#DiskEncryptionSetOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -144,8 +144,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSetType"></a>DiskEncryptionSetType
--------------------------------------------------------
+DiskEncryptionSetType{#DiskEncryptionSetType}
+---------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -157,8 +157,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | "EncryptionAtRestWithCustomerKey"             |             |
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 
-<a id="DiskEncryptionSetType_STATUS"></a>DiskEncryptionSetType_STATUS
----------------------------------------------------------------------
+DiskEncryptionSetType_STATUS{#DiskEncryptionSetType_STATUS}
+-----------------------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -170,8 +170,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | "EncryptionAtRestWithCustomerKey"             |             |
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 
-<a id="EncryptionSetIdentity"></a>EncryptionSetIdentity
--------------------------------------------------------
+EncryptionSetIdentity{#EncryptionSetIdentity}
+---------------------------------------------
 
 The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
 
@@ -182,8 +182,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | type                   | The type of Managed Identity used by the DiskEncryptionSet. Only SystemAssigned is supported for new creations. Disk Encryption Sets can be updated with Identity type None during migration of subscription to a new Azure Active Directory tenant; it will cause the encrypted resources to lose access to the keys.                                                                                 | [EncryptionSetIdentity_Type](#EncryptionSetIdentity_Type)<br/><small>Optional</small>     |
 | userAssignedIdentities | The list of user identities associated with the disk encryption set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="EncryptionSetIdentity_STATUS"></a>EncryptionSetIdentity_STATUS
----------------------------------------------------------------------
+EncryptionSetIdentity_STATUS{#EncryptionSetIdentity_STATUS}
+-----------------------------------------------------------
 
 The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
 
@@ -196,8 +196,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | type                   | The type of Managed Identity used by the DiskEncryptionSet. Only SystemAssigned is supported for new creations. Disk Encryption Sets can be updated with Identity type None during migration of subscription to a new Azure Active Directory tenant; it will cause the encrypted resources to lose access to the keys.                                                                                 | [EncryptionSetIdentity_Type_STATUS](#EncryptionSetIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the disk encryption set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]EncryptionSetIdentity_UserAssignedIdentities_STATUS](#EncryptionSetIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="KeyForDiskEncryptionSet"></a>KeyForDiskEncryptionSet
------------------------------------------------------------
+KeyForDiskEncryptionSet{#KeyForDiskEncryptionSet}
+-------------------------------------------------
 
 Key Vault Key Url to be used for server side encryption of Managed Disks and Snapshots
 
@@ -209,8 +209,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | keyUrlFromConfig | Fully versioned Key Url pointing to a key in KeyVault. Version segment of the Url is required regardless of rotationToLatestKeyVersionEnabled value.                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | sourceVault      | Resource id of the KeyVault containing the key or secret. This property is optional and cannot be used if the KeyVault subscription is not the same as the Disk Encryption Set subscription. | [SourceVault](#SourceVault)<br/><small>Optional</small>                                                                                                      |
 
-<a id="KeyForDiskEncryptionSet_STATUS"></a>KeyForDiskEncryptionSet_STATUS
--------------------------------------------------------------------------
+KeyForDiskEncryptionSet_STATUS{#KeyForDiskEncryptionSet_STATUS}
+---------------------------------------------------------------
 
 Key Vault Key Url to be used for server side encryption of Managed Disks and Snapshots
 
@@ -221,8 +221,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS), and [DiskEncrypt
 | keyUrl      | Fully versioned Key Url pointing to a key in KeyVault. Version segment of the Url is required regardless of rotationToLatestKeyVersionEnabled value.                                         | string<br/><small>Optional</small>                                    |
 | sourceVault | Resource id of the KeyVault containing the key or secret. This property is optional and cannot be used if the KeyVault subscription is not the same as the Disk Encryption Set subscription. | [SourceVault_STATUS](#SourceVault_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiErrorBase_STATUS"></a>ApiErrorBase_STATUS
----------------------------------------------------
+ApiErrorBase_STATUS{#ApiErrorBase_STATUS}
+-----------------------------------------
 
 Api error base.
 
@@ -234,8 +234,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | message  | The error message.                  | string<br/><small>Optional</small> |
 | target   | The target of the particular error. | string<br/><small>Optional</small> |
 
-<a id="EncryptionSetIdentity_Type"></a>EncryptionSetIdentity_Type
------------------------------------------------------------------
+EncryptionSetIdentity_Type{#EncryptionSetIdentity_Type}
+-------------------------------------------------------
 
 Used by: [EncryptionSetIdentity](#EncryptionSetIdentity).
 
@@ -246,8 +246,8 @@ Used by: [EncryptionSetIdentity](#EncryptionSetIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="EncryptionSetIdentity_Type_STATUS"></a>EncryptionSetIdentity_Type_STATUS
--------------------------------------------------------------------------------
+EncryptionSetIdentity_Type_STATUS{#EncryptionSetIdentity_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 
@@ -258,8 +258,8 @@ Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="EncryptionSetIdentity_UserAssignedIdentities_STATUS"></a>EncryptionSetIdentity_UserAssignedIdentities_STATUS
--------------------------------------------------------------------------------------------------------------------
+EncryptionSetIdentity_UserAssignedIdentities_STATUS{#EncryptionSetIdentity_UserAssignedIdentities_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 
@@ -268,8 +268,8 @@ Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="InnerError_STATUS"></a>InnerError_STATUS
------------------------------------------------
+InnerError_STATUS{#InnerError_STATUS}
+-------------------------------------
 
 Inner error details.
 
@@ -280,8 +280,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | errordetail   | The internal error message or exception dump. | string<br/><small>Optional</small> |
 | exceptiontype | The exception type.                           | string<br/><small>Optional</small> |
 
-<a id="SourceVault"></a>SourceVault
------------------------------------
+SourceVault{#SourceVault}
+-------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -291,8 +291,8 @@ Used by: [KeyForDiskEncryptionSet](#KeyForDiskEncryptionSet).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SourceVault_STATUS"></a>SourceVault_STATUS
--------------------------------------------------
+SourceVault_STATUS{#SourceVault_STATUS}
+---------------------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -302,8 +302,8 @@ Used by: [KeyForDiskEncryptionSet_STATUS](#KeyForDiskEncryptionSet_STATUS).
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/compute/v1api20240302.md
+++ b/docs/hugo/content/reference/compute/v1api20240302.md
@@ -5,15 +5,15 @@ title: compute.azure.com/v1api20240302
 linktitle: v1api20240302
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-03-02" |             |
 
-<a id="Disk"></a>Disk
----------------------
+Disk{#Disk}
+-----------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/disks/{diskName}
 
@@ -26,7 +26,7 @@ Used by: [DiskList](#DiskList).
 | spec                                                                                    |             | [Disk_Spec](#Disk_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Disk_STATUS](#Disk_STATUS)<br/><small>Optional</small> |
 
-### <a id="Disk_Spec"></a>Disk_Spec
+### Disk_Spec {#Disk_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -62,7 +62,7 @@ Used by: [DiskList](#DiskList).
 | tier                         | Performance tier of the disk (e.g, P4, S10) as described here: https://azure.microsoft.com/en-us/pricing/details/managed-disks/. Does not apply to Ultra disks.                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                                                                        | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="Disk_STATUS"></a>Disk_STATUS
+### Disk_STATUS{#Disk_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -110,8 +110,8 @@ Used by: [DiskList](#DiskList).
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                                                                        | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="DiskAccess"></a>DiskAccess
----------------------------------
+DiskAccess{#DiskAccess}
+-----------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/diskAccess.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskAccesses/{diskAccessName}
 
@@ -124,7 +124,7 @@ Used by: [DiskAccessList](#DiskAccessList).
 | spec                                                                                    |             | [DiskAccess_Spec](#DiskAccess_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DiskAccess_STATUS](#DiskAccess_STATUS)<br/><small>Optional</small> |
 
-### <a id="DiskAccess_Spec"></a>DiskAccess_Spec
+### DiskAccess_Spec {#DiskAccess_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -135,7 +135,7 @@ Used by: [DiskAccessList](#DiskAccessList).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags             | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DiskAccess_STATUS"></a>DiskAccess_STATUS
+### DiskAccess_STATUS{#DiskAccess_STATUS}
 
 | Property                   | Description                                                                                                                     | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -150,8 +150,8 @@ Used by: [DiskAccessList](#DiskAccessList).
 | timeCreated                | The time when the disk access was created.                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type                       | Resource type                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiskAccessList"></a>DiskAccessList
------------------------------------------
+DiskAccessList{#DiskAccessList}
+-------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/diskAccess.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskAccesses/{diskAccessName}
 
@@ -161,8 +161,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [DiskAccess[]](#DiskAccess)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSet"></a>DiskEncryptionSet
------------------------------------------------
+DiskEncryptionSet{#DiskEncryptionSet}
+-------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/diskEncryptionSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}
 
@@ -175,7 +175,7 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | spec                                                                                    |             | [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS)<br/><small>Optional</small> |
 
-### <a id="DiskEncryptionSet_Spec"></a>DiskEncryptionSet_Spec
+### DiskEncryptionSet_Spec {#DiskEncryptionSet_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -191,7 +191,7 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | rotationToLatestKeyVersionEnabled | Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.                                                                                                                                                                                         | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                              | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DiskEncryptionSet_STATUS"></a>DiskEncryptionSet_STATUS
+### DiskEncryptionSet_STATUS{#DiskEncryptionSet_STATUS}
 
 | Property                          | Description                                                                                                                                                                         | Type                                                                                                                                                    |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -211,8 +211,8 @@ Used by: [DiskEncryptionSetList](#DiskEncryptionSetList).
 | tags                              | Resource tags                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiskEncryptionSetList"></a>DiskEncryptionSetList
--------------------------------------------------------
+DiskEncryptionSetList{#DiskEncryptionSetList}
+---------------------------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/diskEncryptionSet.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}
 
@@ -222,8 +222,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DiskEncryptionSet[]](#DiskEncryptionSet)<br/><small>Optional</small> |
 
-<a id="DiskList"></a>DiskList
------------------------------
+DiskList{#DiskList}
+-------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/disk.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/disks/{diskName}
 
@@ -233,8 +233,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [Disk[]](#Disk)<br/><small>Optional</small> |
 
-<a id="Snapshot"></a>Snapshot
------------------------------
+Snapshot{#Snapshot}
+-------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/snapshot.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/snapshots/{snapshotName}
 
@@ -247,7 +247,7 @@ Used by: [SnapshotList](#SnapshotList).
 | spec                                                                                    |             | [Snapshot_Spec](#Snapshot_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Snapshot_STATUS](#Snapshot_STATUS)<br/><small>Optional</small> |
 
-### <a id="Snapshot_Spec"></a>Snapshot_Spec
+### Snapshot_Spec {#Snapshot_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -277,7 +277,7 @@ Used by: [SnapshotList](#SnapshotList).
 | supportsHibernation          | Indicates the OS on a snapshot supports hibernation.                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                         | Resource tags                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Snapshot_STATUS"></a>Snapshot_STATUS
+### Snapshot_STATUS{#Snapshot_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -314,8 +314,8 @@ Used by: [SnapshotList](#SnapshotList).
 | type                         | Resource type                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SnapshotList"></a>SnapshotList
--------------------------------------
+SnapshotList{#SnapshotList}
+---------------------------
 
 Generator information: - Generated from: /compute/resource-manager/Microsoft.Compute/DiskRP/stable/2024-03-02/snapshot.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Compute/snapshots/{snapshotName}
 
@@ -325,8 +325,8 @@ Generator information: - Generated from: /compute/resource-manager/Microsoft.Com
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Snapshot[]](#Snapshot)<br/><small>Optional</small> |
 
-<a id="Disk_Spec"></a>Disk_Spec
--------------------------------
+Disk_Spec{#Disk_Spec}
+---------------------
 
 Used by: [Disk](#Disk).
 
@@ -364,8 +364,8 @@ Used by: [Disk](#Disk).
 | tier                         | Performance tier of the disk (e.g, P4, S10) as described here: https://azure.microsoft.com/en-us/pricing/details/managed-disks/. Does not apply to Ultra disks.                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                                                                        | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="Disk_STATUS"></a>Disk_STATUS
------------------------------------
+Disk_STATUS{#Disk_STATUS}
+-------------------------
 
 Disk resource.
 
@@ -417,8 +417,8 @@ Used by: [Disk](#Disk).
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | zones                        | The Logical zone list for Disk.                                                                                                                                                                                                                                                                                                                                        | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="DiskAccess_Spec"></a>DiskAccess_Spec
--------------------------------------------
+DiskAccess_Spec{#DiskAccess_Spec}
+---------------------------------
 
 Used by: [DiskAccess](#DiskAccess).
 
@@ -431,8 +431,8 @@ Used by: [DiskAccess](#DiskAccess).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags             | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DiskAccess_STATUS"></a>DiskAccess_STATUS
------------------------------------------------
+DiskAccess_STATUS{#DiskAccess_STATUS}
+-------------------------------------
 
 disk access resource.
 
@@ -451,8 +451,8 @@ Used by: [DiskAccess](#DiskAccess).
 | timeCreated                | The time when the disk access was created.                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type                       | Resource type                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiskEncryptionSet_Spec"></a>DiskEncryptionSet_Spec
----------------------------------------------------------
+DiskEncryptionSet_Spec{#DiskEncryptionSet_Spec}
+-----------------------------------------------
 
 Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 
@@ -470,8 +470,8 @@ Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 | rotationToLatestKeyVersionEnabled | Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.                                                                                                                                                                                         | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                              | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DiskEncryptionSet_STATUS"></a>DiskEncryptionSet_STATUS
--------------------------------------------------------------
+DiskEncryptionSet_STATUS{#DiskEncryptionSet_STATUS}
+---------------------------------------------------
 
 disk encryption set resource.
 
@@ -495,8 +495,8 @@ Used by: [DiskEncryptionSet](#DiskEncryptionSet).
 | tags                              | Resource tags                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                              | Resource type                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Snapshot_Spec"></a>Snapshot_Spec
----------------------------------------
+Snapshot_Spec{#Snapshot_Spec}
+-----------------------------
 
 Used by: [Snapshot](#Snapshot).
 
@@ -528,8 +528,8 @@ Used by: [Snapshot](#Snapshot).
 | supportsHibernation          | Indicates the OS on a snapshot supports hibernation.                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                         | Resource tags                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Snapshot_STATUS"></a>Snapshot_STATUS
--------------------------------------------
+Snapshot_STATUS{#Snapshot_STATUS}
+---------------------------------
 
 Snapshot resource.
 
@@ -570,8 +570,8 @@ Used by: [Snapshot](#Snapshot).
 | type                         | Resource type                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | uniqueId                     | Unique Guid identifying the resource.                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApiError_STATUS"></a>ApiError_STATUS
--------------------------------------------
+ApiError_STATUS{#ApiError_STATUS}
+---------------------------------
 
 Api error.
 
@@ -585,8 +585,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | message    | The error message.                  | string<br/><small>Optional</small>                                        |
 | target     | The target of the particular error. | string<br/><small>Optional</small>                                        |
 
-<a id="CopyCompletionError"></a>CopyCompletionError
----------------------------------------------------
+CopyCompletionError{#CopyCompletionError}
+-----------------------------------------
 
 Indicates the error details if the background copy of a resource created via the CopyStart operation fails.
 
@@ -597,8 +597,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | errorCode    | Indicates the error code if the background copy of a resource created via the CopyStart operation fails.    | [CopyCompletionError_ErrorCode](#CopyCompletionError_ErrorCode)<br/><small>Required</small> |
 | errorMessage | Indicates the error message if the background copy of a resource created via the CopyStart operation fails. | string<br/><small>Required</small>                                                          |
 
-<a id="CopyCompletionError_STATUS"></a>CopyCompletionError_STATUS
------------------------------------------------------------------
+CopyCompletionError_STATUS{#CopyCompletionError_STATUS}
+-------------------------------------------------------
 
 Indicates the error details if the background copy of a resource created via the CopyStart operation fails.
 
@@ -609,8 +609,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | errorCode    | Indicates the error code if the background copy of a resource created via the CopyStart operation fails.    | [CopyCompletionError_ErrorCode_STATUS](#CopyCompletionError_ErrorCode_STATUS)<br/><small>Optional</small> |
 | errorMessage | Indicates the error message if the background copy of a resource created via the CopyStart operation fails. | string<br/><small>Optional</small>                                                                        |
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Data used when creating a disk.
 
@@ -631,8 +631,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | storageAccountId              | Required if createOption is Import. The Azure Resource Manager identifier of the storage account containing the blob to import as a disk.                                                                                                           | string<br/><small>Optional</small>                                                                                                                         |
 | uploadSizeBytes               | If createOption is Upload, this is the size of the contents of the upload including the VHD footer. This value should be between 20972032 (20 MiB + 512 bytes for the VHD footer) and 35183298347520 bytes (32 TiB + 512 bytes for the VHD footer). | int<br/><small>Optional</small>                                                                                                                            |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Data used when creating a disk.
 
@@ -654,8 +654,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | storageAccountId              | Required if createOption is Import. The Azure Resource Manager identifier of the storage account containing the blob to import as a disk.                                                                                                           | string<br/><small>Optional</small>                                                                                                  |
 | uploadSizeBytes               | If createOption is Upload, this is the size of the contents of the upload including the VHD footer. This value should be between 20972032 (20 MiB + 512 bytes for the VHD footer) and 35183298347520 bytes (32 TiB + 512 bytes for the VHD footer). | int<br/><small>Optional</small>                                                                                                     |
 
-<a id="DataAccessAuthMode"></a>DataAccessAuthMode
--------------------------------------------------
+DataAccessAuthMode{#DataAccessAuthMode}
+---------------------------------------
 
 Additional authentication requirements when exporting or uploading to a disk or snapshot.
 
@@ -666,8 +666,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | "AzureActiveDirectory" |             |
 | "None"                 |             |
 
-<a id="DataAccessAuthMode_STATUS"></a>DataAccessAuthMode_STATUS
----------------------------------------------------------------
+DataAccessAuthMode_STATUS{#DataAccessAuthMode_STATUS}
+-----------------------------------------------------
 
 Additional authentication requirements when exporting or uploading to a disk or snapshot.
 
@@ -678,8 +678,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "AzureActiveDirectory" |             |
 | "None"                 |             |
 
-<a id="DiskAccessOperatorSpec"></a>DiskAccessOperatorSpec
----------------------------------------------------------
+DiskAccessOperatorSpec{#DiskAccessOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -690,8 +690,8 @@ Used by: [DiskAccess_Spec](#DiskAccess_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSetOperatorSpec"></a>DiskEncryptionSetOperatorSpec
------------------------------------------------------------------------
+DiskEncryptionSetOperatorSpec{#DiskEncryptionSetOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -702,8 +702,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DiskEncryptionSetType"></a>DiskEncryptionSetType
--------------------------------------------------------
+DiskEncryptionSetType{#DiskEncryptionSetType}
+---------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -715,8 +715,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | "EncryptionAtRestWithCustomerKey"             |             |
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 
-<a id="DiskEncryptionSetType_STATUS"></a>DiskEncryptionSetType_STATUS
----------------------------------------------------------------------
+DiskEncryptionSetType_STATUS{#DiskEncryptionSetType_STATUS}
+-----------------------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -728,8 +728,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | "EncryptionAtRestWithCustomerKey"             |             |
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 
-<a id="DiskOperatorSpec"></a>DiskOperatorSpec
----------------------------------------------
+DiskOperatorSpec{#DiskOperatorSpec}
+-----------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -740,8 +740,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DiskProperties_HyperVGeneration"></a>DiskProperties_HyperVGeneration
----------------------------------------------------------------------------
+DiskProperties_HyperVGeneration{#DiskProperties_HyperVGeneration}
+-----------------------------------------------------------------
 
 Used by: [Disk_Spec](#Disk_Spec).
 
@@ -750,8 +750,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="DiskProperties_HyperVGeneration_STATUS"></a>DiskProperties_HyperVGeneration_STATUS
------------------------------------------------------------------------------------------
+DiskProperties_HyperVGeneration_STATUS{#DiskProperties_HyperVGeneration_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -760,8 +760,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="DiskProperties_OsType"></a>DiskProperties_OsType
--------------------------------------------------------
+DiskProperties_OsType{#DiskProperties_OsType}
+---------------------------------------------
 
 Used by: [Disk_Spec](#Disk_Spec).
 
@@ -770,8 +770,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="DiskProperties_OsType_STATUS"></a>DiskProperties_OsType_STATUS
----------------------------------------------------------------------
+DiskProperties_OsType_STATUS{#DiskProperties_OsType_STATUS}
+-----------------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -780,8 +780,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="DiskSecurityProfile"></a>DiskSecurityProfile
----------------------------------------------------
+DiskSecurityProfile{#DiskSecurityProfile}
+-----------------------------------------
 
 Contains the security related information for the resource.
 
@@ -792,8 +792,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | secureVMDiskEncryptionSetReference | ResourceId of the disk encryption set associated to Confidential VM supported disk encrypted with customer managed key | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityType                       | Specifies the SecurityType of the VM. Applicable for OS disks only.                                                    | [DiskSecurityType](#DiskSecurityType)<br/><small>Optional</small>                                                                                          |
 
-<a id="DiskSecurityProfile_STATUS"></a>DiskSecurityProfile_STATUS
------------------------------------------------------------------
+DiskSecurityProfile_STATUS{#DiskSecurityProfile_STATUS}
+-------------------------------------------------------
 
 Contains the security related information for the resource.
 
@@ -804,8 +804,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | secureVMDiskEncryptionSetId | ResourceId of the disk encryption set associated to Confidential VM supported disk encrypted with customer managed key | string<br/><small>Optional</small>                                              |
 | securityType                | Specifies the SecurityType of the VM. Applicable for OS disks only.                                                    | [DiskSecurityType_STATUS](#DiskSecurityType_STATUS)<br/><small>Optional</small> |
 
-<a id="DiskSku"></a>DiskSku
----------------------------
+DiskSku{#DiskSku}
+-----------------
 
 The disks sku name. Can be Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS, Premium_ZRS, StandardSSD_ZRS, or PremiumV2_LRS.
 
@@ -815,8 +815,8 @@ Used by: [Disk_Spec](#Disk_Spec).
 |----------|---------------|-----------------------------------------------------------|
 | name     | The sku name. | [DiskSku_Name](#DiskSku_Name)<br/><small>Optional</small> |
 
-<a id="DiskSku_STATUS"></a>DiskSku_STATUS
------------------------------------------
+DiskSku_STATUS{#DiskSku_STATUS}
+-------------------------------
 
 The disks sku name. Can be Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS, Premium_ZRS, StandardSSD_ZRS, or PremiumV2_LRS.
 
@@ -827,8 +827,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 | name     | The sku name. | [DiskSku_Name_STATUS](#DiskSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The sku tier. | string<br/><small>Optional</small>                                      |
 
-<a id="DiskState"></a>DiskState
--------------------------------
+DiskState{#DiskState}
+---------------------
 
 This enumerates the possible state of the disk.
 
@@ -845,8 +845,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "Reserved"        |             |
 | "Unattached"      |             |
 
-<a id="DiskState_STATUS"></a>DiskState_STATUS
----------------------------------------------
+DiskState_STATUS{#DiskState_STATUS}
+-----------------------------------
 
 This enumerates the possible state of the disk.
 
@@ -863,8 +863,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "Reserved"        |             |
 | "Unattached"      |             |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Encryption at rest settings for disk or snapshot
 
@@ -875,8 +875,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | diskEncryptionSetReference | ResourceId of the disk encryption set to use for enabling encryption at rest. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | type                       | The type of key used to encrypt the data of the disk.                         | [EncryptionType](#EncryptionType)<br/><small>Optional</small>                                                                                              |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Encryption at rest settings for disk or snapshot
 
@@ -887,8 +887,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | diskEncryptionSetId | ResourceId of the disk encryption set to use for enabling encryption at rest. | string<br/><small>Optional</small>                                          |
 | type                | The type of key used to encrypt the data of the disk.                         | [EncryptionType_STATUS](#EncryptionType_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionSetIdentity"></a>EncryptionSetIdentity
--------------------------------------------------------
+EncryptionSetIdentity{#EncryptionSetIdentity}
+---------------------------------------------
 
 The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
 
@@ -899,8 +899,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | type                   | The type of Managed Identity used by the DiskEncryptionSet. Only SystemAssigned is supported for new creations. Disk Encryption Sets can be updated with Identity type None during migration of subscription to a new Azure Active Directory tenant; it will cause the encrypted resources to lose access to the keys.                                                                                 | [EncryptionSetIdentity_Type](#EncryptionSetIdentity_Type)<br/><small>Optional</small>     |
 | userAssignedIdentities | The list of user identities associated with the disk encryption set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="EncryptionSetIdentity_STATUS"></a>EncryptionSetIdentity_STATUS
----------------------------------------------------------------------
+EncryptionSetIdentity_STATUS{#EncryptionSetIdentity_STATUS}
+-----------------------------------------------------------
 
 The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
 
@@ -913,8 +913,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS).
 | type                   | The type of Managed Identity used by the DiskEncryptionSet. Only SystemAssigned is supported for new creations. Disk Encryption Sets can be updated with Identity type None during migration of subscription to a new Azure Active Directory tenant; it will cause the encrypted resources to lose access to the keys.                                                                                 | [EncryptionSetIdentity_Type_STATUS](#EncryptionSetIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with the disk encryption set. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]EncryptionSetIdentity_UserAssignedIdentities_STATUS](#EncryptionSetIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionSettingsCollection"></a>EncryptionSettingsCollection
----------------------------------------------------------------------
+EncryptionSettingsCollection{#EncryptionSettingsCollection}
+-----------------------------------------------------------
 
 Encryption settings for disk or snapshot
 
@@ -926,8 +926,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | encryptionSettings        | A collection of encryption settings, one for each disk volume.                                                                                                                                                                                                                                       | [EncryptionSettingsElement[]](#EncryptionSettingsElement)<br/><small>Optional</small> |
 | encryptionSettingsVersion | Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption with AAD app.'1.1' corresponds to Azure Disk Encryption.                                                                                       | string<br/><small>Optional</small>                                                    |
 
-<a id="EncryptionSettingsCollection_STATUS"></a>EncryptionSettingsCollection_STATUS
------------------------------------------------------------------------------------
+EncryptionSettingsCollection_STATUS{#EncryptionSettingsCollection_STATUS}
+-------------------------------------------------------------------------
 
 Encryption settings for disk or snapshot
 
@@ -939,8 +939,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | encryptionSettings        | A collection of encryption settings, one for each disk volume.                                                                                                                                                                                                                                       | [EncryptionSettingsElement_STATUS[]](#EncryptionSettingsElement_STATUS)<br/><small>Optional</small> |
 | encryptionSettingsVersion | Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption with AAD app.'1.1' corresponds to Azure Disk Encryption.                                                                                       | string<br/><small>Optional</small>                                                                  |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -951,8 +951,8 @@ Used by: [Disk_Spec](#Disk_Spec), [DiskAccess_Spec](#DiskAccess_Spec), and [Snap
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -963,8 +963,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), [DiskAccess_STATUS](#DiskAccess_STATUS), a
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="KeyForDiskEncryptionSet"></a>KeyForDiskEncryptionSet
------------------------------------------------------------
+KeyForDiskEncryptionSet{#KeyForDiskEncryptionSet}
+-------------------------------------------------
 
 Key Vault Key Url to be used for server side encryption of Managed Disks and Snapshots
 
@@ -976,8 +976,8 @@ Used by: [DiskEncryptionSet_Spec](#DiskEncryptionSet_Spec).
 | keyUrlFromConfig | Fully versioned Key Url pointing to a key in KeyVault. Version segment of the Url is required regardless of rotationToLatestKeyVersionEnabled value.                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | sourceVault      | Resource id of the KeyVault containing the key or secret. This property is optional and cannot be used if the KeyVault subscription is not the same as the Disk Encryption Set subscription. | [SourceVault](#SourceVault)<br/><small>Optional</small>                                                                                                      |
 
-<a id="KeyForDiskEncryptionSet_STATUS"></a>KeyForDiskEncryptionSet_STATUS
--------------------------------------------------------------------------
+KeyForDiskEncryptionSet_STATUS{#KeyForDiskEncryptionSet_STATUS}
+---------------------------------------------------------------
 
 Key Vault Key Url to be used for server side encryption of Managed Disks and Snapshots
 
@@ -988,8 +988,8 @@ Used by: [DiskEncryptionSet_STATUS](#DiskEncryptionSet_STATUS), and [DiskEncrypt
 | keyUrl      | Fully versioned Key Url pointing to a key in KeyVault. Version segment of the Url is required regardless of rotationToLatestKeyVersionEnabled value.                                         | string<br/><small>Optional</small>                                    |
 | sourceVault | Resource id of the KeyVault containing the key or secret. This property is optional and cannot be used if the KeyVault subscription is not the same as the Disk Encryption Set subscription. | [SourceVault_STATUS](#SourceVault_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkAccessPolicy"></a>NetworkAccessPolicy
----------------------------------------------------
+NetworkAccessPolicy{#NetworkAccessPolicy}
+-----------------------------------------
 
 Policy for accessing the disk via network.
 
@@ -1001,8 +1001,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | "AllowPrivate" |             |
 | "DenyAll"      |             |
 
-<a id="NetworkAccessPolicy_STATUS"></a>NetworkAccessPolicy_STATUS
------------------------------------------------------------------
+NetworkAccessPolicy_STATUS{#NetworkAccessPolicy_STATUS}
+-------------------------------------------------------
 
 Policy for accessing the disk via network.
 
@@ -1014,8 +1014,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "AllowPrivate" |             |
 | "DenyAll"      |             |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -1025,8 +1025,8 @@ Used by: [DiskAccess_STATUS](#DiskAccess_STATUS).
 |----------|--------------------------------|------------------------------------|
 | id       | private endpoint connection Id | string<br/><small>Optional</small> |
 
-<a id="PropertyUpdatesInProgress_STATUS"></a>PropertyUpdatesInProgress_STATUS
------------------------------------------------------------------------------
+PropertyUpdatesInProgress_STATUS{#PropertyUpdatesInProgress_STATUS}
+-------------------------------------------------------------------
 
 Properties of the disk for which update is pending.
 
@@ -1036,8 +1036,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 |------------|------------------------------------------------------------------------------------|------------------------------------|
 | targetTier | The target performance tier of the disk if a tier change operation is in progress. | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
----------------------------------------------------
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
 
 Policy for controlling export on the disk.
 
@@ -1048,8 +1048,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
 
 Policy for controlling export on the disk.
 
@@ -1060,8 +1060,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PurchasePlan"></a>PurchasePlan
--------------------------------------
+PurchasePlan{#PurchasePlan}
+---------------------------
 
 Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 
@@ -1074,8 +1074,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | promotionCode | The Offer Promotion Code.                                                                                                  | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Required</small> |
 
-<a id="PurchasePlan_STATUS"></a>PurchasePlan_STATUS
----------------------------------------------------
+PurchasePlan_STATUS{#PurchasePlan_STATUS}
+-----------------------------------------
 
 Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 
@@ -1088,8 +1088,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | promotionCode | The Offer Promotion Code.                                                                                                  | string<br/><small>Optional</small> |
 | publisher     | The publisher ID.                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="ShareInfoElement_STATUS"></a>ShareInfoElement_STATUS
------------------------------------------------------------
+ShareInfoElement_STATUS{#ShareInfoElement_STATUS}
+-------------------------------------------------
 
 Used by: [Disk_STATUS](#Disk_STATUS).
 
@@ -1097,8 +1097,8 @@ Used by: [Disk_STATUS](#Disk_STATUS).
 |----------|------------------------------------------------------------------------|------------------------------------|
 | vmUri    | A relative URI containing the ID of the VM that has the disk attached. | string<br/><small>Optional</small> |
 
-<a id="SnapshotOperatorSpec"></a>SnapshotOperatorSpec
------------------------------------------------------
+SnapshotOperatorSpec{#SnapshotOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1109,8 +1109,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SnapshotProperties_HyperVGeneration"></a>SnapshotProperties_HyperVGeneration
------------------------------------------------------------------------------------
+SnapshotProperties_HyperVGeneration{#SnapshotProperties_HyperVGeneration}
+-------------------------------------------------------------------------
 
 Used by: [Snapshot_Spec](#Snapshot_Spec).
 
@@ -1119,8 +1119,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="SnapshotProperties_HyperVGeneration_STATUS"></a>SnapshotProperties_HyperVGeneration_STATUS
--------------------------------------------------------------------------------------------------
+SnapshotProperties_HyperVGeneration_STATUS{#SnapshotProperties_HyperVGeneration_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 
@@ -1129,8 +1129,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | "V1"  |             |
 | "V2"  |             |
 
-<a id="SnapshotProperties_OsType"></a>SnapshotProperties_OsType
----------------------------------------------------------------
+SnapshotProperties_OsType{#SnapshotProperties_OsType}
+-----------------------------------------------------
 
 Used by: [Snapshot_Spec](#Snapshot_Spec).
 
@@ -1139,8 +1139,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="SnapshotProperties_OsType_STATUS"></a>SnapshotProperties_OsType_STATUS
------------------------------------------------------------------------------
+SnapshotProperties_OsType_STATUS{#SnapshotProperties_OsType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 
@@ -1149,8 +1149,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="SnapshotSku"></a>SnapshotSku
------------------------------------
+SnapshotSku{#SnapshotSku}
+-------------------------
 
 The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot
 
@@ -1160,8 +1160,8 @@ Used by: [Snapshot_Spec](#Snapshot_Spec).
 |----------|---------------|-------------------------------------------------------------------|
 | name     | The sku name. | [SnapshotSku_Name](#SnapshotSku_Name)<br/><small>Optional</small> |
 
-<a id="SnapshotSku_STATUS"></a>SnapshotSku_STATUS
--------------------------------------------------
+SnapshotSku_STATUS{#SnapshotSku_STATUS}
+---------------------------------------
 
 The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot
 
@@ -1172,8 +1172,8 @@ Used by: [Snapshot_STATUS](#Snapshot_STATUS).
 | name     | The sku name. | [SnapshotSku_Name_STATUS](#SnapshotSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The sku tier. | string<br/><small>Optional</small>                                              |
 
-<a id="SupportedCapabilities"></a>SupportedCapabilities
--------------------------------------------------------
+SupportedCapabilities{#SupportedCapabilities}
+---------------------------------------------
 
 List of supported capabilities persisted on the disk resource for VM use.
 
@@ -1185,8 +1185,8 @@ Used by: [Disk_Spec](#Disk_Spec), and [Snapshot_Spec](#Snapshot_Spec).
 | architecture        | CPU architecture supported by an OS disk.                                                         | [SupportedCapabilities_Architecture](#SupportedCapabilities_Architecture)<br/><small>Optional</small> |
 | diskControllerTypes | The disk controllers that an OS disk supports. If set it can be SCSI or SCSI, NVME or NVME, SCSI. | string<br/><small>Optional</small>                                                                    |
 
-<a id="SupportedCapabilities_STATUS"></a>SupportedCapabilities_STATUS
----------------------------------------------------------------------
+SupportedCapabilities_STATUS{#SupportedCapabilities_STATUS}
+-----------------------------------------------------------
 
 List of supported capabilities persisted on the disk resource for VM use.
 
@@ -1198,8 +1198,8 @@ Used by: [Disk_STATUS](#Disk_STATUS), and [Snapshot_STATUS](#Snapshot_STATUS).
 | architecture        | CPU architecture supported by an OS disk.                                                         | [SupportedCapabilities_Architecture_STATUS](#SupportedCapabilities_Architecture_STATUS)<br/><small>Optional</small> |
 | diskControllerTypes | The disk controllers that an OS disk supports. If set it can be SCSI or SCSI, NVME or NVME, SCSI. | string<br/><small>Optional</small>                                                                                  |
 
-<a id="ApiErrorBase_STATUS"></a>ApiErrorBase_STATUS
----------------------------------------------------
+ApiErrorBase_STATUS{#ApiErrorBase_STATUS}
+-----------------------------------------
 
 Api error base.
 
@@ -1211,8 +1211,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | message  | The error message.                  | string<br/><small>Optional</small> |
 | target   | The target of the particular error. | string<br/><small>Optional</small> |
 
-<a id="CopyCompletionError_ErrorCode"></a>CopyCompletionError_ErrorCode
------------------------------------------------------------------------
+CopyCompletionError_ErrorCode{#CopyCompletionError_ErrorCode}
+-------------------------------------------------------------
 
 Used by: [CopyCompletionError](#CopyCompletionError).
 
@@ -1220,8 +1220,8 @@ Used by: [CopyCompletionError](#CopyCompletionError).
 |----------------------|-------------|
 | "CopySourceNotFound" |             |
 
-<a id="CopyCompletionError_ErrorCode_STATUS"></a>CopyCompletionError_ErrorCode_STATUS
--------------------------------------------------------------------------------------
+CopyCompletionError_ErrorCode_STATUS{#CopyCompletionError_ErrorCode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [CopyCompletionError_STATUS](#CopyCompletionError_STATUS).
 
@@ -1229,8 +1229,8 @@ Used by: [CopyCompletionError_STATUS](#CopyCompletionError_STATUS).
 |----------------------|-------------|
 | "CopySourceNotFound" |             |
 
-<a id="CreationData_CreateOption"></a>CreationData_CreateOption
----------------------------------------------------------------
+CreationData_CreateOption{#CreationData_CreateOption}
+-----------------------------------------------------
 
 Used by: [CreationData](#CreationData).
 
@@ -1248,8 +1248,8 @@ Used by: [CreationData](#CreationData).
 | "Upload"               |             |
 | "UploadPreparedSecure" |             |
 
-<a id="CreationData_CreateOption_STATUS"></a>CreationData_CreateOption_STATUS
------------------------------------------------------------------------------
+CreationData_CreateOption_STATUS{#CreationData_CreateOption_STATUS}
+-------------------------------------------------------------------
 
 Used by: [CreationData_STATUS](#CreationData_STATUS).
 
@@ -1267,8 +1267,8 @@ Used by: [CreationData_STATUS](#CreationData_STATUS).
 | "Upload"               |             |
 | "UploadPreparedSecure" |             |
 
-<a id="CreationData_ProvisionedBandwidthCopySpeed"></a>CreationData_ProvisionedBandwidthCopySpeed
--------------------------------------------------------------------------------------------------
+CreationData_ProvisionedBandwidthCopySpeed{#CreationData_ProvisionedBandwidthCopySpeed}
+---------------------------------------------------------------------------------------
 
 Used by: [CreationData](#CreationData).
 
@@ -1277,8 +1277,8 @@ Used by: [CreationData](#CreationData).
 | "Enhanced" |             |
 | "None"     |             |
 
-<a id="CreationData_ProvisionedBandwidthCopySpeed_STATUS"></a>CreationData_ProvisionedBandwidthCopySpeed_STATUS
----------------------------------------------------------------------------------------------------------------
+CreationData_ProvisionedBandwidthCopySpeed_STATUS{#CreationData_ProvisionedBandwidthCopySpeed_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [CreationData_STATUS](#CreationData_STATUS).
 
@@ -1287,8 +1287,8 @@ Used by: [CreationData_STATUS](#CreationData_STATUS).
 | "Enhanced" |             |
 | "None"     |             |
 
-<a id="DiskSecurityType"></a>DiskSecurityType
----------------------------------------------
+DiskSecurityType{#DiskSecurityType}
+-----------------------------------
 
 Specifies the SecurityType of the VM. Applicable for OS disks only.
 
@@ -1302,8 +1302,8 @@ Used by: [DiskSecurityProfile](#DiskSecurityProfile).
 | "ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey" |             |
 | "TrustedLaunch"                                           |             |
 
-<a id="DiskSecurityType_STATUS"></a>DiskSecurityType_STATUS
------------------------------------------------------------
+DiskSecurityType_STATUS{#DiskSecurityType_STATUS}
+-------------------------------------------------
 
 Specifies the SecurityType of the VM. Applicable for OS disks only.
 
@@ -1317,8 +1317,8 @@ Used by: [DiskSecurityProfile_STATUS](#DiskSecurityProfile_STATUS).
 | "ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey" |             |
 | "TrustedLaunch"                                           |             |
 
-<a id="DiskSku_Name"></a>DiskSku_Name
--------------------------------------
+DiskSku_Name{#DiskSku_Name}
+---------------------------
 
 Used by: [DiskSku](#DiskSku).
 
@@ -1332,8 +1332,8 @@ Used by: [DiskSku](#DiskSku).
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="DiskSku_Name_STATUS"></a>DiskSku_Name_STATUS
----------------------------------------------------
+DiskSku_Name_STATUS{#DiskSku_Name_STATUS}
+-----------------------------------------
 
 Used by: [DiskSku_STATUS](#DiskSku_STATUS).
 
@@ -1347,8 +1347,8 @@ Used by: [DiskSku_STATUS](#DiskSku_STATUS).
 | "Standard_LRS"    |             |
 | "UltraSSD_LRS"    |             |
 
-<a id="EncryptionSetIdentity_Type"></a>EncryptionSetIdentity_Type
------------------------------------------------------------------
+EncryptionSetIdentity_Type{#EncryptionSetIdentity_Type}
+-------------------------------------------------------
 
 Used by: [EncryptionSetIdentity](#EncryptionSetIdentity).
 
@@ -1359,8 +1359,8 @@ Used by: [EncryptionSetIdentity](#EncryptionSetIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="EncryptionSetIdentity_Type_STATUS"></a>EncryptionSetIdentity_Type_STATUS
--------------------------------------------------------------------------------
+EncryptionSetIdentity_Type_STATUS{#EncryptionSetIdentity_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 
@@ -1371,8 +1371,8 @@ Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="EncryptionSetIdentity_UserAssignedIdentities_STATUS"></a>EncryptionSetIdentity_UserAssignedIdentities_STATUS
--------------------------------------------------------------------------------------------------------------------
+EncryptionSetIdentity_UserAssignedIdentities_STATUS{#EncryptionSetIdentity_UserAssignedIdentities_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 
@@ -1381,8 +1381,8 @@ Used by: [EncryptionSetIdentity_STATUS](#EncryptionSetIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="EncryptionSettingsElement"></a>EncryptionSettingsElement
----------------------------------------------------------------
+EncryptionSettingsElement{#EncryptionSettingsElement}
+-----------------------------------------------------
 
 Encryption settings for one disk volume.
 
@@ -1393,8 +1393,8 @@ Used by: [EncryptionSettingsCollection](#EncryptionSettingsCollection).
 | diskEncryptionKey | Key Vault Secret Url and vault id of the disk encryption key                                                                                        | [KeyVaultAndSecretReference](#KeyVaultAndSecretReference)<br/><small>Optional</small> |
 | keyEncryptionKey  | Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap the disk encryption key. | [KeyVaultAndKeyReference](#KeyVaultAndKeyReference)<br/><small>Optional</small>       |
 
-<a id="EncryptionSettingsElement_STATUS"></a>EncryptionSettingsElement_STATUS
------------------------------------------------------------------------------
+EncryptionSettingsElement_STATUS{#EncryptionSettingsElement_STATUS}
+-------------------------------------------------------------------
 
 Encryption settings for one disk volume.
 
@@ -1405,8 +1405,8 @@ Used by: [EncryptionSettingsCollection_STATUS](#EncryptionSettingsCollection_STA
 | diskEncryptionKey | Key Vault Secret Url and vault id of the disk encryption key                                                                                        | [KeyVaultAndSecretReference_STATUS](#KeyVaultAndSecretReference_STATUS)<br/><small>Optional</small> |
 | keyEncryptionKey  | Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap the disk encryption key. | [KeyVaultAndKeyReference_STATUS](#KeyVaultAndKeyReference_STATUS)<br/><small>Optional</small>       |
 
-<a id="EncryptionType"></a>EncryptionType
------------------------------------------
+EncryptionType{#EncryptionType}
+-------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -1418,8 +1418,8 @@ Used by: [Encryption](#Encryption).
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 | "EncryptionAtRestWithPlatformKey"             |             |
 
-<a id="EncryptionType_STATUS"></a>EncryptionType_STATUS
--------------------------------------------------------
+EncryptionType_STATUS{#EncryptionType_STATUS}
+---------------------------------------------
 
 The type of key used to encrypt the data of the disk.
 
@@ -1431,8 +1431,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | "EncryptionAtRestWithPlatformAndCustomerKeys" |             |
 | "EncryptionAtRestWithPlatformKey"             |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -1442,8 +1442,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -1453,8 +1453,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ImageDiskReference"></a>ImageDiskReference
--------------------------------------------------
+ImageDiskReference{#ImageDiskReference}
+---------------------------------------
 
 The source image used for creating the disk.
 
@@ -1467,8 +1467,8 @@ Used by: [CreationData](#CreationData), and [CreationData](#CreationData).
 | reference               | A relative uri containing either a Platform Image Repository, user image, or Azure Compute Gallery image reference.                                              | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | sharedGalleryImageId    | A relative uri containing a direct shared Azure Compute Gallery image reference.                                                                                 | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ImageDiskReference_STATUS"></a>ImageDiskReference_STATUS
----------------------------------------------------------------
+ImageDiskReference_STATUS{#ImageDiskReference_STATUS}
+-----------------------------------------------------
 
 The source image used for creating the disk.
 
@@ -1481,8 +1481,8 @@ Used by: [CreationData_STATUS](#CreationData_STATUS), and [CreationData_STATUS](
 | lun                     | If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the image to use. For OS disks, this field is null. | int<br/><small>Optional</small>    |
 | sharedGalleryImageId    | A relative uri containing a direct shared Azure Compute Gallery image reference.                                                                                 | string<br/><small>Optional</small> |
 
-<a id="InnerError_STATUS"></a>InnerError_STATUS
------------------------------------------------
+InnerError_STATUS{#InnerError_STATUS}
+-------------------------------------
 
 Inner error details.
 
@@ -1493,8 +1493,8 @@ Used by: [ApiError_STATUS](#ApiError_STATUS).
 | errordetail   | The internal error message or exception dump. | string<br/><small>Optional</small> |
 | exceptiontype | The exception type.                           | string<br/><small>Optional</small> |
 
-<a id="SnapshotSku_Name"></a>SnapshotSku_Name
----------------------------------------------
+SnapshotSku_Name{#SnapshotSku_Name}
+-----------------------------------
 
 Used by: [SnapshotSku](#SnapshotSku).
 
@@ -1504,8 +1504,8 @@ Used by: [SnapshotSku](#SnapshotSku).
 | "Standard_LRS" |             |
 | "Standard_ZRS" |             |
 
-<a id="SnapshotSku_Name_STATUS"></a>SnapshotSku_Name_STATUS
------------------------------------------------------------
+SnapshotSku_Name_STATUS{#SnapshotSku_Name_STATUS}
+-------------------------------------------------
 
 Used by: [SnapshotSku_STATUS](#SnapshotSku_STATUS).
 
@@ -1515,8 +1515,8 @@ Used by: [SnapshotSku_STATUS](#SnapshotSku_STATUS).
 | "Standard_LRS" |             |
 | "Standard_ZRS" |             |
 
-<a id="SourceVault"></a>SourceVault
------------------------------------
+SourceVault{#SourceVault}
+-------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -1526,8 +1526,8 @@ Used by: [KeyForDiskEncryptionSet](#KeyForDiskEncryptionSet), [KeyVaultAndKeyRef
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SourceVault_STATUS"></a>SourceVault_STATUS
--------------------------------------------------
+SourceVault_STATUS{#SourceVault_STATUS}
+---------------------------------------
 
 The vault id is an Azure Resource Manager Resource id in the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -1537,8 +1537,8 @@ Used by: [KeyForDiskEncryptionSet_STATUS](#KeyForDiskEncryptionSet_STATUS), [Key
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="SupportedCapabilities_Architecture"></a>SupportedCapabilities_Architecture
----------------------------------------------------------------------------------
+SupportedCapabilities_Architecture{#SupportedCapabilities_Architecture}
+-----------------------------------------------------------------------
 
 Used by: [SupportedCapabilities](#SupportedCapabilities).
 
@@ -1547,8 +1547,8 @@ Used by: [SupportedCapabilities](#SupportedCapabilities).
 | "Arm64" |             |
 | "x64"   |             |
 
-<a id="SupportedCapabilities_Architecture_STATUS"></a>SupportedCapabilities_Architecture_STATUS
------------------------------------------------------------------------------------------------
+SupportedCapabilities_Architecture_STATUS{#SupportedCapabilities_Architecture_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [SupportedCapabilities_STATUS](#SupportedCapabilities_STATUS).
 
@@ -1557,8 +1557,8 @@ Used by: [SupportedCapabilities_STATUS](#SupportedCapabilities_STATUS).
 | "Arm64" |             |
 | "x64"   |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1568,8 +1568,8 @@ Used by: [EncryptionSetIdentity](#EncryptionSetIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="KeyVaultAndKeyReference"></a>KeyVaultAndKeyReference
------------------------------------------------------------
+KeyVaultAndKeyReference{#KeyVaultAndKeyReference}
+-------------------------------------------------
 
 Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
 
@@ -1580,8 +1580,8 @@ Used by: [EncryptionSettingsElement](#EncryptionSettingsElement).
 | keyUrl      | Url pointing to a key or secret in KeyVault              | string<br/><small>Required</small>                      |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault](#SourceVault)<br/><small>Required</small> |
 
-<a id="KeyVaultAndKeyReference_STATUS"></a>KeyVaultAndKeyReference_STATUS
--------------------------------------------------------------------------
+KeyVaultAndKeyReference_STATUS{#KeyVaultAndKeyReference_STATUS}
+---------------------------------------------------------------
 
 Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
 
@@ -1592,8 +1592,8 @@ Used by: [EncryptionSettingsElement_STATUS](#EncryptionSettingsElement_STATUS).
 | keyUrl      | Url pointing to a key or secret in KeyVault              | string<br/><small>Optional</small>                                    |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault_STATUS](#SourceVault_STATUS)<br/><small>Optional</small> |
 
-<a id="KeyVaultAndSecretReference"></a>KeyVaultAndSecretReference
------------------------------------------------------------------
+KeyVaultAndSecretReference{#KeyVaultAndSecretReference}
+-------------------------------------------------------
 
 Key Vault Secret Url and vault id of the encryption key
 
@@ -1604,8 +1604,8 @@ Used by: [EncryptionSettingsElement](#EncryptionSettingsElement).
 | secretUrl   | Url pointing to a key or secret in KeyVault              | string<br/><small>Required</small>                      |
 | sourceVault | Resource id of the KeyVault containing the key or secret | [SourceVault](#SourceVault)<br/><small>Required</small> |
 
-<a id="KeyVaultAndSecretReference_STATUS"></a>KeyVaultAndSecretReference_STATUS
--------------------------------------------------------------------------------
+KeyVaultAndSecretReference_STATUS{#KeyVaultAndSecretReference_STATUS}
+---------------------------------------------------------------------
 
 Key Vault Secret Url and vault id of the encryption key
 

--- a/docs/hugo/content/reference/containerinstance/v1api20211001.md
+++ b/docs/hugo/content/reference/containerinstance/v1api20211001.md
@@ -5,15 +5,15 @@ title: containerinstance.azure.com/v1api20211001
 linktitle: v1api20211001
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-10-01" |             |
 
-<a id="ContainerGroup"></a>ContainerGroup
------------------------------------------
+ContainerGroup{#ContainerGroup}
+-------------------------------
 
 Generator information: - Generated from: /containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2021-10-01/containerInstance.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerInstance/containerGroups/{containerGroupName}
 
@@ -26,7 +26,7 @@ Used by: [ContainerGroupList](#ContainerGroupList).
 | spec                                                                                    |             | [ContainerGroup_Spec](#ContainerGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ContainerGroup_STATUS](#ContainerGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="ContainerGroup_Spec"></a>ContainerGroup_Spec
+### ContainerGroup_Spec {#ContainerGroup_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,7 +50,7 @@ Used by: [ContainerGroupList](#ContainerGroupList).
 | volumes                  | The list of volumes that can be mounted by containers in this container group.                                                                                                                                                                                                               | [Volume[]](#Volume)<br/><small>Optional</small>                                                                                                                      |
 | zones                    | The zones for the container group.                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="ContainerGroup_STATUS"></a>ContainerGroup_STATUS
+### ContainerGroup_STATUS{#ContainerGroup_STATUS}
 
 | Property                 | Description                                                                                                                                      | Type                                                                                                                                                    |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -77,8 +77,8 @@ Used by: [ContainerGroupList](#ContainerGroupList).
 | volumes                  | The list of volumes that can be mounted by containers in this container group.                                                                   | [Volume_STATUS[]](#Volume_STATUS)<br/><small>Optional</small>                                                                                           |
 | zones                    | The zones for the container group.                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ContainerGroupList"></a>ContainerGroupList
--------------------------------------------------
+ContainerGroupList{#ContainerGroupList}
+---------------------------------------
 
 Generator information: - Generated from: /containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2021-10-01/containerInstance.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerInstance/containerGroups/{containerGroupName}
 
@@ -88,8 +88,8 @@ Generator information: - Generated from: /containerinstance/resource-manager/Mic
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ContainerGroup[]](#ContainerGroup)<br/><small>Optional</small> |
 
-<a id="ContainerGroup_Spec"></a>ContainerGroup_Spec
----------------------------------------------------
+ContainerGroup_Spec{#ContainerGroup_Spec}
+-----------------------------------------
 
 Used by: [ContainerGroup](#ContainerGroup).
 
@@ -115,8 +115,8 @@ Used by: [ContainerGroup](#ContainerGroup).
 | volumes                  | The list of volumes that can be mounted by containers in this container group.                                                                                                                                                                                                               | [Volume[]](#Volume)<br/><small>Optional</small>                                                                                                                      |
 | zones                    | The zones for the container group.                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="ContainerGroup_STATUS"></a>ContainerGroup_STATUS
--------------------------------------------------------
+ContainerGroup_STATUS{#ContainerGroup_STATUS}
+---------------------------------------------
 
 A container group.
 
@@ -147,8 +147,8 @@ Used by: [ContainerGroup](#ContainerGroup).
 | volumes                  | The list of volumes that can be mounted by containers in this container group.                                                                   | [Volume_STATUS[]](#Volume_STATUS)<br/><small>Optional</small>                                                                                           |
 | zones                    | The zones for the container group.                                                                                                               | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="Container"></a>Container
--------------------------------
+Container{#Container}
+---------------------
 
 A container instance.
 
@@ -166,8 +166,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | resources            | The resource requirements of the container instance.                | [ResourceRequirements](#ResourceRequirements)<br/><small>Required</small> |
 | volumeMounts         | The volume mounts available to the container instance.              | [VolumeMount[]](#VolumeMount)<br/><small>Optional</small>                 |
 
-<a id="Container_STATUS"></a>Container_STATUS
----------------------------------------------
+Container_STATUS{#Container_STATUS}
+-----------------------------------
 
 A container instance.
 
@@ -186,8 +186,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | resources            | The resource requirements of the container instance.                 | [ResourceRequirements_STATUS](#ResourceRequirements_STATUS)<br/><small>Optional</small>                         |
 | volumeMounts         | The volume mounts available to the container instance.               | [VolumeMount_STATUS[]](#VolumeMount_STATUS)<br/><small>Optional</small>                                         |
 
-<a id="ContainerGroup_Properties_InstanceView_STATUS"></a>ContainerGroup_Properties_InstanceView_STATUS
--------------------------------------------------------------------------------------------------------
+ContainerGroup_Properties_InstanceView_STATUS{#ContainerGroup_Properties_InstanceView_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 
@@ -196,8 +196,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | events   | The events of this container group.                       | [Event_STATUS[]](#Event_STATUS)<br/><small>Optional</small> |
 | state    | The state of the container group. Only valid in response. | string<br/><small>Optional</small>                          |
 
-<a id="ContainerGroup_Properties_OsType_Spec"></a>ContainerGroup_Properties_OsType_Spec
----------------------------------------------------------------------------------------
+ContainerGroup_Properties_OsType_Spec{#ContainerGroup_Properties_OsType_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 
@@ -206,19 +206,19 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="ContainerGroup_Properties_OsType_STATUS"></a>ContainerGroup_Properties_OsType_STATUS
+ContainerGroup_Properties_OsType_STATUS{#ContainerGroup_Properties_OsType_STATUS}
+---------------------------------------------------------------------------------
+
+Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Linux"   |             |
+| "Windows" |             |
+
+ContainerGroup_Properties_RestartPolicy_Spec{#ContainerGroup_Properties_RestartPolicy_Spec}
 -------------------------------------------------------------------------------------------
 
-Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Linux"   |             |
-| "Windows" |             |
-
-<a id="ContainerGroup_Properties_RestartPolicy_Spec"></a>ContainerGroup_Properties_RestartPolicy_Spec
------------------------------------------------------------------------------------------------------
-
 Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 
 | Value       | Description |
@@ -227,8 +227,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | "Never"     |             |
 | "OnFailure" |             |
 
-<a id="ContainerGroup_Properties_RestartPolicy_STATUS"></a>ContainerGroup_Properties_RestartPolicy_STATUS
----------------------------------------------------------------------------------------------------------
+ContainerGroup_Properties_RestartPolicy_STATUS{#ContainerGroup_Properties_RestartPolicy_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 
@@ -238,8 +238,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | "Never"     |             |
 | "OnFailure" |             |
 
-<a id="ContainerGroupDiagnostics"></a>ContainerGroupDiagnostics
----------------------------------------------------------------
+ContainerGroupDiagnostics{#ContainerGroupDiagnostics}
+-----------------------------------------------------
 
 Container group diagnostic information.
 
@@ -249,8 +249,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 |--------------|--------------------------------------------|-----------------------------------------------------------|
 | logAnalytics | Container group log analytics information. | [LogAnalytics](#LogAnalytics)<br/><small>Optional</small> |
 
-<a id="ContainerGroupDiagnostics_STATUS"></a>ContainerGroupDiagnostics_STATUS
------------------------------------------------------------------------------
+ContainerGroupDiagnostics_STATUS{#ContainerGroupDiagnostics_STATUS}
+-------------------------------------------------------------------
 
 Container group diagnostic information.
 
@@ -260,8 +260,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 |--------------|--------------------------------------------|-------------------------------------------------------------------------|
 | logAnalytics | Container group log analytics information. | [LogAnalytics_STATUS](#LogAnalytics_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerGroupIdentity"></a>ContainerGroupIdentity
----------------------------------------------------------
+ContainerGroupIdentity{#ContainerGroupIdentity}
+-----------------------------------------------
 
 Identity for the container group.
 
@@ -272,8 +272,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | type                   | The type of identity used for the container group. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the container group. | [ContainerGroupIdentity_Type](#ContainerGroupIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with the container group.                                                                                                                                                                                    | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ContainerGroupIdentity_STATUS"></a>ContainerGroupIdentity_STATUS
------------------------------------------------------------------------
+ContainerGroupIdentity_STATUS{#ContainerGroupIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the container group.
 
@@ -286,8 +286,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | type                   | The type of identity used for the container group. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the container group. | [ContainerGroupIdentity_Type_STATUS](#ContainerGroupIdentity_Type_STATUS)<br/><small>Optional</small>  |
 | userAssignedIdentities | The list of user identities associated with the container group.                                                                                                                                                                                    | [map[string]UserAssignedIdentities_STATUS](#UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerGroupOperatorSpec"></a>ContainerGroupOperatorSpec
------------------------------------------------------------------
+ContainerGroupOperatorSpec{#ContainerGroupOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -298,8 +298,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ContainerGroupSku"></a>ContainerGroupSku
------------------------------------------------
+ContainerGroupSku{#ContainerGroupSku}
+-------------------------------------
 
 The container group SKU.
 
@@ -310,8 +310,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | "Dedicated" |             |
 | "Standard"  |             |
 
-<a id="ContainerGroupSku_STATUS"></a>ContainerGroupSku_STATUS
--------------------------------------------------------------
+ContainerGroupSku_STATUS{#ContainerGroupSku_STATUS}
+---------------------------------------------------
 
 The container group SKU.
 
@@ -322,8 +322,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | "Dedicated" |             |
 | "Standard"  |             |
 
-<a id="ContainerGroupSubnetId"></a>ContainerGroupSubnetId
----------------------------------------------------------
+ContainerGroupSubnetId{#ContainerGroupSubnetId}
+-----------------------------------------------
 
 Container group subnet information.
 
@@ -334,8 +334,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | name      | Friendly name for the subnet.              | string<br/><small>Optional</small>                                                                                                                         |
 | reference | Resource ID of virtual network and subnet. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="ContainerGroupSubnetId_STATUS"></a>ContainerGroupSubnetId_STATUS
------------------------------------------------------------------------
+ContainerGroupSubnetId_STATUS{#ContainerGroupSubnetId_STATUS}
+-------------------------------------------------------------
 
 Container group subnet information.
 
@@ -346,8 +346,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | id       | Resource ID of virtual network and subnet. | string<br/><small>Optional</small> |
 | name     | Friendly name for the subnet.              | string<br/><small>Optional</small> |
 
-<a id="DnsConfiguration"></a>DnsConfiguration
----------------------------------------------
+DnsConfiguration{#DnsConfiguration}
+-----------------------------------
 
 DNS configuration for the container group.
 
@@ -359,8 +359,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | options       | The DNS options for the container group.                           | string<br/><small>Optional</small>   |
 | searchDomains | The DNS search domains for hostname lookup in the container group. | string<br/><small>Optional</small>   |
 
-<a id="DnsConfiguration_STATUS"></a>DnsConfiguration_STATUS
------------------------------------------------------------
+DnsConfiguration_STATUS{#DnsConfiguration_STATUS}
+-------------------------------------------------
 
 DNS configuration for the container group.
 
@@ -372,8 +372,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | options       | The DNS options for the container group.                           | string<br/><small>Optional</small>   |
 | searchDomains | The DNS search domains for hostname lookup in the container group. | string<br/><small>Optional</small>   |
 
-<a id="EncryptionProperties"></a>EncryptionProperties
------------------------------------------------------
+EncryptionProperties{#EncryptionProperties}
+-------------------------------------------
 
 The container group encryption properties.
 
@@ -385,8 +385,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | keyVersion   | The encryption key version. | string<br/><small>Required</small> |
 | vaultBaseUrl | The keyvault base url.      | string<br/><small>Required</small> |
 
-<a id="EncryptionProperties_STATUS"></a>EncryptionProperties_STATUS
--------------------------------------------------------------------
+EncryptionProperties_STATUS{#EncryptionProperties_STATUS}
+---------------------------------------------------------
 
 The container group encryption properties.
 
@@ -398,8 +398,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | keyVersion   | The encryption key version. | string<br/><small>Optional</small> |
 | vaultBaseUrl | The keyvault base url.      | string<br/><small>Optional</small> |
 
-<a id="ImageRegistryCredential"></a>ImageRegistryCredential
------------------------------------------------------------
+ImageRegistryCredential{#ImageRegistryCredential}
+-------------------------------------------------
 
 Image registry credential.
 
@@ -413,8 +413,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | server      | The Docker image registry server without a protocol such as "http" and "https". | string<br/><small>Required</small>                                                                                                                     |
 | username    | The username for the private registry.                                          | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ImageRegistryCredential_STATUS"></a>ImageRegistryCredential_STATUS
--------------------------------------------------------------------------
+ImageRegistryCredential_STATUS{#ImageRegistryCredential_STATUS}
+---------------------------------------------------------------
 
 Image registry credential.
 
@@ -427,8 +427,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | server      | The Docker image registry server without a protocol such as "http" and "https". | string<br/><small>Optional</small> |
 | username    | The username for the private registry.                                          | string<br/><small>Optional</small> |
 
-<a id="InitContainerDefinition"></a>InitContainerDefinition
------------------------------------------------------------
+InitContainerDefinition{#InitContainerDefinition}
+-------------------------------------------------
 
 The init container definition.
 
@@ -442,8 +442,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | name                 | The name for the init container.                               | string<br/><small>Required</small>                                        |
 | volumeMounts         | The volume mounts available to the init container.             | [VolumeMount[]](#VolumeMount)<br/><small>Optional</small>                 |
 
-<a id="InitContainerDefinition_STATUS"></a>InitContainerDefinition_STATUS
--------------------------------------------------------------------------
+InitContainerDefinition_STATUS{#InitContainerDefinition_STATUS}
+---------------------------------------------------------------
 
 The init container definition.
 
@@ -458,8 +458,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | name                 | The name for the init container.                                 | string<br/><small>Optional</small>                                                                                                          |
 | volumeMounts         | The volume mounts available to the init container.               | [VolumeMount_STATUS[]](#VolumeMount_STATUS)<br/><small>Optional</small>                                                                     |
 
-<a id="IpAddress"></a>IpAddress
--------------------------------
+IpAddress{#IpAddress}
+---------------------
 
 IP address for the container group.
 
@@ -473,8 +473,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | ports                             | The list of ports exposed on the container group.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [Port[]](#Port)<br/><small>Required</small>                                                                             |
 | type                              | Specifies if the IP is exposed to the public internet or private VNET.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [IpAddress_Type](#IpAddress_Type)<br/><small>Required</small>                                                           |
 
-<a id="IpAddress_STATUS"></a>IpAddress_STATUS
----------------------------------------------
+IpAddress_STATUS{#IpAddress_STATUS}
+-----------------------------------
 
 IP address for the container group.
 
@@ -489,8 +489,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | ports                             | The list of ports exposed on the container group.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [Port_STATUS[]](#Port_STATUS)<br/><small>Optional</small>                                                                             |
 | type                              | Specifies if the IP is exposed to the public internet or private VNET.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [IpAddress_Type_STATUS](#IpAddress_Type_STATUS)<br/><small>Optional</small>                                                           |
 
-<a id="Volume"></a>Volume
--------------------------
+Volume{#Volume}
+---------------
 
 The properties of the volume.
 
@@ -504,8 +504,8 @@ Used by: [ContainerGroup_Spec](#ContainerGroup_Spec).
 | name      | The name of the volume.     | string<br/><small>Required</small>                              |
 | secret    | The secret volume.          | map[string]string<br/><small>Optional</small>                   |
 
-<a id="Volume_STATUS"></a>Volume_STATUS
----------------------------------------
+Volume_STATUS{#Volume_STATUS}
+-----------------------------
 
 The properties of the volume.
 
@@ -519,8 +519,8 @@ Used by: [ContainerGroup_STATUS](#ContainerGroup_STATUS).
 | name      | The name of the volume.     | string<br/><small>Optional</small>                                            |
 | secret    | The secret volume.          | map[string]string<br/><small>Optional</small>                                 |
 
-<a id="AzureFileVolume"></a>AzureFileVolume
--------------------------------------------
+AzureFileVolume{#AzureFileVolume}
+---------------------------------
 
 The properties of the Azure File volume. Azure File shares are mounted as volumes.
 
@@ -533,8 +533,8 @@ Used by: [Volume](#Volume).
 | storageAccountKey  | The storage account access key used to access the Azure File share.                 | string<br/><small>Optional</small> |
 | storageAccountName | The name of the storage account that contains the Azure File share.                 | string<br/><small>Required</small> |
 
-<a id="AzureFileVolume_STATUS"></a>AzureFileVolume_STATUS
----------------------------------------------------------
+AzureFileVolume_STATUS{#AzureFileVolume_STATUS}
+-----------------------------------------------
 
 The properties of the Azure File volume. Azure File shares are mounted as volumes.
 
@@ -547,8 +547,8 @@ Used by: [Volume_STATUS](#Volume_STATUS).
 | storageAccountKey  | The storage account access key used to access the Azure File share.                 | string<br/><small>Optional</small> |
 | storageAccountName | The name of the storage account that contains the Azure File share.                 | string<br/><small>Optional</small> |
 
-<a id="ContainerGroupIdentity_Type"></a>ContainerGroupIdentity_Type
--------------------------------------------------------------------
+ContainerGroupIdentity_Type{#ContainerGroupIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ContainerGroupIdentity](#ContainerGroupIdentity).
 
@@ -559,8 +559,8 @@ Used by: [ContainerGroupIdentity](#ContainerGroupIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ContainerGroupIdentity_Type_STATUS"></a>ContainerGroupIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ContainerGroupIdentity_Type_STATUS{#ContainerGroupIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ContainerGroupIdentity_STATUS](#ContainerGroupIdentity_STATUS).
 
@@ -571,8 +571,8 @@ Used by: [ContainerGroupIdentity_STATUS](#ContainerGroupIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ContainerPort"></a>ContainerPort
----------------------------------------
+ContainerPort{#ContainerPort}
+-----------------------------
 
 The port exposed on the container instance.
 
@@ -583,8 +583,8 @@ Used by: [Container](#Container).
 | port     | The port number exposed within the container group. | int<br/><small>Required</small>                                               |
 | protocol | The protocol associated with the port.              | [ContainerPort_Protocol](#ContainerPort_Protocol)<br/><small>Optional</small> |
 
-<a id="ContainerPort_STATUS"></a>ContainerPort_STATUS
------------------------------------------------------
+ContainerPort_STATUS{#ContainerPort_STATUS}
+-------------------------------------------
 
 The port exposed on the container instance.
 
@@ -595,8 +595,8 @@ Used by: [Container_STATUS](#Container_STATUS).
 | port     | The port number exposed within the container group. | int<br/><small>Optional</small>                                                             |
 | protocol | The protocol associated with the port.              | [ContainerPort_Protocol_STATUS](#ContainerPort_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerProbe"></a>ContainerProbe
------------------------------------------
+ContainerProbe{#ContainerProbe}
+-------------------------------
 
 The container probe, for liveness or readiness
 
@@ -612,8 +612,8 @@ Used by: [Container](#Container), and [Container](#Container).
 | successThreshold    | The success threshold.         | int<br/><small>Optional</small>                                   |
 | timeoutSeconds      | The timeout seconds.           | int<br/><small>Optional</small>                                   |
 
-<a id="ContainerProbe_STATUS"></a>ContainerProbe_STATUS
--------------------------------------------------------
+ContainerProbe_STATUS{#ContainerProbe_STATUS}
+---------------------------------------------
 
 The container probe, for liveness or readiness
 
@@ -629,8 +629,8 @@ Used by: [Container_STATUS](#Container_STATUS), and [Container_STATUS](#Containe
 | successThreshold    | The success threshold.         | int<br/><small>Optional</small>                                                 |
 | timeoutSeconds      | The timeout seconds.           | int<br/><small>Optional</small>                                                 |
 
-<a id="ContainerProperties_InstanceView_STATUS"></a>ContainerProperties_InstanceView_STATUS
--------------------------------------------------------------------------------------------
+ContainerProperties_InstanceView_STATUS{#ContainerProperties_InstanceView_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [Container_STATUS](#Container_STATUS).
 
@@ -641,8 +641,8 @@ Used by: [Container_STATUS](#Container_STATUS).
 | previousState | Previous container instance state.                                  | [ContainerState_STATUS](#ContainerState_STATUS)<br/><small>Optional</small> |
 | restartCount  | The number of times that the container instance has been restarted. | int<br/><small>Optional</small>                                             |
 
-<a id="EnvironmentVariable"></a>EnvironmentVariable
----------------------------------------------------
+EnvironmentVariable{#EnvironmentVariable}
+-----------------------------------------
 
 The environment variable to set within the container instance.
 
@@ -654,8 +654,8 @@ Used by: [Container](#Container), and [InitContainerDefinition](#InitContainerDe
 | secureValue | The value of the secure environment variable. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | value       | The value of the environment variable.        | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="EnvironmentVariable_STATUS"></a>EnvironmentVariable_STATUS
------------------------------------------------------------------
+EnvironmentVariable_STATUS{#EnvironmentVariable_STATUS}
+-------------------------------------------------------
 
 The environment variable to set within the container instance.
 
@@ -666,8 +666,8 @@ Used by: [Container_STATUS](#Container_STATUS), and [InitContainerDefinition_STA
 | name     | The name of the environment variable.  | string<br/><small>Optional</small> |
 | value    | The value of the environment variable. | string<br/><small>Optional</small> |
 
-<a id="Event_STATUS"></a>Event_STATUS
--------------------------------------
+Event_STATUS{#Event_STATUS}
+---------------------------
 
 A container group or container instance event.
 
@@ -682,8 +682,8 @@ Used by: [ContainerGroup_Properties_InstanceView_STATUS](#ContainerGroup_Propert
 | name           | The event name.                             | string<br/><small>Optional</small> |
 | type           | The event type.                             | string<br/><small>Optional</small> |
 
-<a id="GitRepoVolume"></a>GitRepoVolume
----------------------------------------
+GitRepoVolume{#GitRepoVolume}
+-----------------------------
 
 Represents a volume that is populated with the contents of a git repository
 
@@ -695,8 +695,8 @@ Used by: [Volume](#Volume).
 | repository | Repository URL                                                                                                                                                                                                                                | string<br/><small>Required</small> |
 | revision   | Commit hash for the specified revision.                                                                                                                                                                                                       | string<br/><small>Optional</small> |
 
-<a id="GitRepoVolume_STATUS"></a>GitRepoVolume_STATUS
------------------------------------------------------
+GitRepoVolume_STATUS{#GitRepoVolume_STATUS}
+-------------------------------------------
 
 Represents a volume that is populated with the contents of a git repository
 
@@ -708,8 +708,8 @@ Used by: [Volume_STATUS](#Volume_STATUS).
 | repository | Repository URL                                                                                                                                                                                                                                | string<br/><small>Optional</small> |
 | revision   | Commit hash for the specified revision.                                                                                                                                                                                                       | string<br/><small>Optional</small> |
 
-<a id="InitContainerPropertiesDefinition_InstanceView_STATUS"></a>InitContainerPropertiesDefinition_InstanceView_STATUS
------------------------------------------------------------------------------------------------------------------------
+InitContainerPropertiesDefinition_InstanceView_STATUS{#InitContainerPropertiesDefinition_InstanceView_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [InitContainerDefinition_STATUS](#InitContainerDefinition_STATUS).
 
@@ -720,8 +720,8 @@ Used by: [InitContainerDefinition_STATUS](#InitContainerDefinition_STATUS).
 | previousState | The previous state of the init container.                       | [ContainerState_STATUS](#ContainerState_STATUS)<br/><small>Optional</small> |
 | restartCount  | The number of times that the init container has been restarted. | int<br/><small>Optional</small>                                             |
 
-<a id="IpAddress_AutoGeneratedDomainNameLabelScope"></a>IpAddress_AutoGeneratedDomainNameLabelScope
----------------------------------------------------------------------------------------------------
+IpAddress_AutoGeneratedDomainNameLabelScope{#IpAddress_AutoGeneratedDomainNameLabelScope}
+-----------------------------------------------------------------------------------------
 
 Used by: [IpAddress](#IpAddress).
 
@@ -733,8 +733,8 @@ Used by: [IpAddress](#IpAddress).
 | "TenantReuse"        |             |
 | "Unsecure"           |             |
 
-<a id="IpAddress_AutoGeneratedDomainNameLabelScope_STATUS"></a>IpAddress_AutoGeneratedDomainNameLabelScope_STATUS
------------------------------------------------------------------------------------------------------------------
+IpAddress_AutoGeneratedDomainNameLabelScope_STATUS{#IpAddress_AutoGeneratedDomainNameLabelScope_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [IpAddress_STATUS](#IpAddress_STATUS).
 
@@ -746,8 +746,8 @@ Used by: [IpAddress_STATUS](#IpAddress_STATUS).
 | "TenantReuse"        |             |
 | "Unsecure"           |             |
 
-<a id="IpAddress_Type"></a>IpAddress_Type
------------------------------------------
+IpAddress_Type{#IpAddress_Type}
+-------------------------------
 
 Used by: [IpAddress](#IpAddress).
 
@@ -756,8 +756,8 @@ Used by: [IpAddress](#IpAddress).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="IpAddress_Type_STATUS"></a>IpAddress_Type_STATUS
--------------------------------------------------------
+IpAddress_Type_STATUS{#IpAddress_Type_STATUS}
+---------------------------------------------
 
 Used by: [IpAddress_STATUS](#IpAddress_STATUS).
 
@@ -766,8 +766,8 @@ Used by: [IpAddress_STATUS](#IpAddress_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="LogAnalytics"></a>LogAnalytics
--------------------------------------
+LogAnalytics{#LogAnalytics}
+---------------------------
 
 Container group log analytics information.
 
@@ -781,8 +781,8 @@ Used by: [ContainerGroupDiagnostics](#ContainerGroupDiagnostics).
 | workspaceKey               | The workspace key for log analytics         | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small>     |
 | workspaceResourceReference | The workspace resource id for log analytics | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="LogAnalytics_STATUS"></a>LogAnalytics_STATUS
----------------------------------------------------
+LogAnalytics_STATUS{#LogAnalytics_STATUS}
+-----------------------------------------
 
 Container group log analytics information.
 
@@ -794,8 +794,8 @@ Used by: [ContainerGroupDiagnostics_STATUS](#ContainerGroupDiagnostics_STATUS).
 | metadata    | Metadata for log analytics.        | map[string]string<br/><small>Optional</small>                                           |
 | workspaceId | The workspace id for log analytics | string<br/><small>Optional</small>                                                      |
 
-<a id="Port"></a>Port
----------------------
+Port{#Port}
+-----------
 
 The port exposed on the container group.
 
@@ -806,8 +806,8 @@ Used by: [IpAddress](#IpAddress).
 | port     | The port number.                       | int<br/><small>Required</small>                             |
 | protocol | The protocol associated with the port. | [Port_Protocol](#Port_Protocol)<br/><small>Optional</small> |
 
-<a id="Port_STATUS"></a>Port_STATUS
------------------------------------
+Port_STATUS{#Port_STATUS}
+-------------------------
 
 The port exposed on the container group.
 
@@ -818,8 +818,8 @@ Used by: [IpAddress_STATUS](#IpAddress_STATUS).
 | port     | The port number.                       | int<br/><small>Optional</small>                                           |
 | protocol | The protocol associated with the port. | [Port_Protocol_STATUS](#Port_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceRequirements"></a>ResourceRequirements
------------------------------------------------------
+ResourceRequirements{#ResourceRequirements}
+-------------------------------------------
 
 The resource requirements.
 
@@ -830,8 +830,8 @@ Used by: [Container](#Container).
 | limits   | The resource limits of this container instance.   | [ResourceLimits](#ResourceLimits)<br/><small>Optional</small>     |
 | requests | The resource requests of this container instance. | [ResourceRequests](#ResourceRequests)<br/><small>Required</small> |
 
-<a id="ResourceRequirements_STATUS"></a>ResourceRequirements_STATUS
--------------------------------------------------------------------
+ResourceRequirements_STATUS{#ResourceRequirements_STATUS}
+---------------------------------------------------------
 
 The resource requirements.
 
@@ -842,8 +842,8 @@ Used by: [Container_STATUS](#Container_STATUS).
 | limits   | The resource limits of this container instance.   | [ResourceLimits_STATUS](#ResourceLimits_STATUS)<br/><small>Optional</small>     |
 | requests | The resource requests of this container instance. | [ResourceRequests_STATUS](#ResourceRequests_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentities_STATUS"></a>UserAssignedIdentities_STATUS
------------------------------------------------------------------------
+UserAssignedIdentities_STATUS{#UserAssignedIdentities_STATUS}
+-------------------------------------------------------------
 
 The list of user identities associated with the container group. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
 
@@ -854,8 +854,8 @@ Used by: [ContainerGroupIdentity_STATUS](#ContainerGroupIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -865,8 +865,8 @@ Used by: [ContainerGroupIdentity](#ContainerGroupIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VolumeMount"></a>VolumeMount
------------------------------------
+VolumeMount{#VolumeMount}
+-------------------------
 
 The properties of the volume mount.
 
@@ -878,8 +878,8 @@ Used by: [Container](#Container), and [InitContainerDefinition](#InitContainerDe
 | name      | The name of the volume mount.                                                                 | string<br/><small>Required</small> |
 | readOnly  | The flag indicating whether the volume mount is read-only.                                    | bool<br/><small>Optional</small>   |
 
-<a id="VolumeMount_STATUS"></a>VolumeMount_STATUS
--------------------------------------------------
+VolumeMount_STATUS{#VolumeMount_STATUS}
+---------------------------------------
 
 The properties of the volume mount.
 
@@ -891,8 +891,8 @@ Used by: [Container_STATUS](#Container_STATUS), and [InitContainerDefinition_STA
 | name      | The name of the volume mount.                                                                 | string<br/><small>Optional</small> |
 | readOnly  | The flag indicating whether the volume mount is read-only.                                    | bool<br/><small>Optional</small>   |
 
-<a id="ContainerExec"></a>ContainerExec
----------------------------------------
+ContainerExec{#ContainerExec}
+-----------------------------
 
 The container execution command, for liveness or readiness probe
 
@@ -902,8 +902,8 @@ Used by: [ContainerProbe](#ContainerProbe).
 |----------|-----------------------------------------------|--------------------------------------|
 | command  | The commands to execute within the container. | string[]<br/><small>Optional</small> |
 
-<a id="ContainerExec_STATUS"></a>ContainerExec_STATUS
------------------------------------------------------
+ContainerExec_STATUS{#ContainerExec_STATUS}
+-------------------------------------------
 
 The container execution command, for liveness or readiness probe
 
@@ -913,8 +913,8 @@ Used by: [ContainerProbe_STATUS](#ContainerProbe_STATUS).
 |----------|-----------------------------------------------|--------------------------------------|
 | command  | The commands to execute within the container. | string[]<br/><small>Optional</small> |
 
-<a id="ContainerHttpGet"></a>ContainerHttpGet
----------------------------------------------
+ContainerHttpGet{#ContainerHttpGet}
+-----------------------------------
 
 The container Http Get settings, for liveness or readiness probe
 
@@ -927,8 +927,8 @@ Used by: [ContainerProbe](#ContainerProbe).
 | port        | The port number to probe. | int<br/><small>Required</small>                                                 |
 | scheme      | The scheme.               | [ContainerHttpGet_Scheme](#ContainerHttpGet_Scheme)<br/><small>Optional</small> |
 
-<a id="ContainerHttpGet_STATUS"></a>ContainerHttpGet_STATUS
------------------------------------------------------------
+ContainerHttpGet_STATUS{#ContainerHttpGet_STATUS}
+-------------------------------------------------
 
 The container Http Get settings, for liveness or readiness probe
 
@@ -941,8 +941,8 @@ Used by: [ContainerProbe_STATUS](#ContainerProbe_STATUS).
 | port        | The port number to probe. | int<br/><small>Optional</small>                                                               |
 | scheme      | The scheme.               | [ContainerHttpGet_Scheme_STATUS](#ContainerHttpGet_Scheme_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerPort_Protocol"></a>ContainerPort_Protocol
----------------------------------------------------------
+ContainerPort_Protocol{#ContainerPort_Protocol}
+-----------------------------------------------
 
 Used by: [ContainerPort](#ContainerPort).
 
@@ -951,8 +951,8 @@ Used by: [ContainerPort](#ContainerPort).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ContainerPort_Protocol_STATUS"></a>ContainerPort_Protocol_STATUS
------------------------------------------------------------------------
+ContainerPort_Protocol_STATUS{#ContainerPort_Protocol_STATUS}
+-------------------------------------------------------------
 
 Used by: [ContainerPort_STATUS](#ContainerPort_STATUS).
 
@@ -961,8 +961,8 @@ Used by: [ContainerPort_STATUS](#ContainerPort_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ContainerState_STATUS"></a>ContainerState_STATUS
--------------------------------------------------------
+ContainerState_STATUS{#ContainerState_STATUS}
+---------------------------------------------
 
 The container instance state.
 
@@ -976,8 +976,8 @@ Used by: [ContainerProperties_InstanceView_STATUS](#ContainerProperties_Instance
 | startTime    | The date-time when the container instance state started.                             | string<br/><small>Optional</small> |
 | state        | The state of the container instance.                                                 | string<br/><small>Optional</small> |
 
-<a id="LogAnalytics_LogType"></a>LogAnalytics_LogType
------------------------------------------------------
+LogAnalytics_LogType{#LogAnalytics_LogType}
+-------------------------------------------
 
 Used by: [LogAnalytics](#LogAnalytics).
 
@@ -986,8 +986,8 @@ Used by: [LogAnalytics](#LogAnalytics).
 | "ContainerInsights"     |             |
 | "ContainerInstanceLogs" |             |
 
-<a id="LogAnalytics_LogType_STATUS"></a>LogAnalytics_LogType_STATUS
--------------------------------------------------------------------
+LogAnalytics_LogType_STATUS{#LogAnalytics_LogType_STATUS}
+---------------------------------------------------------
 
 Used by: [LogAnalytics_STATUS](#LogAnalytics_STATUS).
 
@@ -996,8 +996,8 @@ Used by: [LogAnalytics_STATUS](#LogAnalytics_STATUS).
 | "ContainerInsights"     |             |
 | "ContainerInstanceLogs" |             |
 
-<a id="Port_Protocol"></a>Port_Protocol
----------------------------------------
+Port_Protocol{#Port_Protocol}
+-----------------------------
 
 Used by: [Port](#Port).
 
@@ -1006,8 +1006,8 @@ Used by: [Port](#Port).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="Port_Protocol_STATUS"></a>Port_Protocol_STATUS
------------------------------------------------------
+Port_Protocol_STATUS{#Port_Protocol_STATUS}
+-------------------------------------------
 
 Used by: [Port_STATUS](#Port_STATUS).
 
@@ -1016,8 +1016,8 @@ Used by: [Port_STATUS](#Port_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ResourceLimits"></a>ResourceLimits
------------------------------------------
+ResourceLimits{#ResourceLimits}
+-------------------------------
 
 The resource limits.
 
@@ -1029,8 +1029,8 @@ Used by: [ResourceRequirements](#ResourceRequirements).
 | gpu        | The GPU limit of this container instance.          | [GpuResource](#GpuResource)<br/><small>Optional</small> |
 | memoryInGB | The memory limit in GB of this container instance. | float64<br/><small>Optional</small>                     |
 
-<a id="ResourceLimits_STATUS"></a>ResourceLimits_STATUS
--------------------------------------------------------
+ResourceLimits_STATUS{#ResourceLimits_STATUS}
+---------------------------------------------
 
 The resource limits.
 
@@ -1042,8 +1042,8 @@ Used by: [ResourceRequirements_STATUS](#ResourceRequirements_STATUS).
 | gpu        | The GPU limit of this container instance.          | [GpuResource_STATUS](#GpuResource_STATUS)<br/><small>Optional</small> |
 | memoryInGB | The memory limit in GB of this container instance. | float64<br/><small>Optional</small>                                   |
 
-<a id="ResourceRequests"></a>ResourceRequests
----------------------------------------------
+ResourceRequests{#ResourceRequests}
+-----------------------------------
 
 The resource requests.
 
@@ -1055,8 +1055,8 @@ Used by: [ResourceRequirements](#ResourceRequirements).
 | gpu        | The GPU request of this container instance.          | [GpuResource](#GpuResource)<br/><small>Optional</small> |
 | memoryInGB | The memory request in GB of this container instance. | float64<br/><small>Required</small>                     |
 
-<a id="ResourceRequests_STATUS"></a>ResourceRequests_STATUS
------------------------------------------------------------
+ResourceRequests_STATUS{#ResourceRequests_STATUS}
+-------------------------------------------------
 
 The resource requests.
 
@@ -1068,8 +1068,8 @@ Used by: [ResourceRequirements_STATUS](#ResourceRequirements_STATUS).
 | gpu        | The GPU request of this container instance.          | [GpuResource_STATUS](#GpuResource_STATUS)<br/><small>Optional</small> |
 | memoryInGB | The memory request in GB of this container instance. | float64<br/><small>Optional</small>                                   |
 
-<a id="ContainerHttpGet_Scheme"></a>ContainerHttpGet_Scheme
------------------------------------------------------------
+ContainerHttpGet_Scheme{#ContainerHttpGet_Scheme}
+-------------------------------------------------
 
 Used by: [ContainerHttpGet](#ContainerHttpGet).
 
@@ -1078,8 +1078,8 @@ Used by: [ContainerHttpGet](#ContainerHttpGet).
 | "http"  |             |
 | "https" |             |
 
-<a id="ContainerHttpGet_Scheme_STATUS"></a>ContainerHttpGet_Scheme_STATUS
--------------------------------------------------------------------------
+ContainerHttpGet_Scheme_STATUS{#ContainerHttpGet_Scheme_STATUS}
+---------------------------------------------------------------
 
 Used by: [ContainerHttpGet_STATUS](#ContainerHttpGet_STATUS).
 
@@ -1088,8 +1088,8 @@ Used by: [ContainerHttpGet_STATUS](#ContainerHttpGet_STATUS).
 | "http"  |             |
 | "https" |             |
 
-<a id="GpuResource"></a>GpuResource
------------------------------------
+GpuResource{#GpuResource}
+-------------------------
 
 The GPU resource.
 
@@ -1100,8 +1100,8 @@ Used by: [ResourceLimits](#ResourceLimits), and [ResourceRequests](#ResourceRequ
 | count    | The count of the GPU resource. | int<br/><small>Required</small>                                 |
 | sku      | The SKU of the GPU resource.   | [GpuResource_Sku](#GpuResource_Sku)<br/><small>Required</small> |
 
-<a id="GpuResource_STATUS"></a>GpuResource_STATUS
--------------------------------------------------
+GpuResource_STATUS{#GpuResource_STATUS}
+---------------------------------------
 
 The GPU resource.
 
@@ -1112,8 +1112,8 @@ Used by: [ResourceLimits_STATUS](#ResourceLimits_STATUS), and [ResourceRequests_
 | count    | The count of the GPU resource. | int<br/><small>Optional</small>                                               |
 | sku      | The SKU of the GPU resource.   | [GpuResource_Sku_STATUS](#GpuResource_Sku_STATUS)<br/><small>Optional</small> |
 
-<a id="HttpHeader"></a>HttpHeader
----------------------------------
+HttpHeader{#HttpHeader}
+-----------------------
 
 The HTTP header.
 
@@ -1124,8 +1124,8 @@ Used by: [ContainerHttpGet](#ContainerHttpGet).
 | name     | The header name.  | string<br/><small>Optional</small> |
 | value    | The header value. | string<br/><small>Optional</small> |
 
-<a id="HttpHeader_STATUS"></a>HttpHeader_STATUS
------------------------------------------------
+HttpHeader_STATUS{#HttpHeader_STATUS}
+-------------------------------------
 
 The HTTP header.
 
@@ -1136,8 +1136,8 @@ Used by: [ContainerHttpGet_STATUS](#ContainerHttpGet_STATUS).
 | name     | The header name.  | string<br/><small>Optional</small> |
 | value    | The header value. | string<br/><small>Optional</small> |
 
-<a id="GpuResource_Sku"></a>GpuResource_Sku
--------------------------------------------
+GpuResource_Sku{#GpuResource_Sku}
+---------------------------------
 
 Used by: [GpuResource](#GpuResource).
 
@@ -1147,8 +1147,8 @@ Used by: [GpuResource](#GpuResource).
 | "P100" |             |
 | "V100" |             |
 
-<a id="GpuResource_Sku_STATUS"></a>GpuResource_Sku_STATUS
----------------------------------------------------------
+GpuResource_Sku_STATUS{#GpuResource_Sku_STATUS}
+-----------------------------------------------
 
 Used by: [GpuResource_STATUS](#GpuResource_STATUS).
 

--- a/docs/hugo/content/reference/containerregistry/v1api20210901.md
+++ b/docs/hugo/content/reference/containerregistry/v1api20210901.md
@@ -5,15 +5,15 @@ title: containerregistry.azure.com/v1api20210901
 linktitle: v1api20210901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-09-01" |             |
 
-<a id="Registry"></a>Registry
------------------------------
+Registry{#Registry}
+-------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2021-09-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}
 
@@ -26,7 +26,7 @@ Used by: [RegistryList](#RegistryList).
 | spec                                                                                    |             | [Registry_Spec](#Registry_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Registry_STATUS](#Registry_STATUS)<br/><small>Optional</small> |
 
-### <a id="Registry_Spec"></a>Registry_Spec
+### Registry_Spec {#Registry_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ Used by: [RegistryList](#RegistryList).
 | tags                     | The tags of the resource.                                                                                                                                                                                                                                                                    | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy           | Whether or not zone redundancy is enabled for this container registry                                                                                                                                                                                                                        | [RegistryProperties_ZoneRedundancy](#RegistryProperties_ZoneRedundancy)<br/><small>Optional</small>                                                                  |
 
-### <a id="Registry_STATUS"></a>Registry_STATUS
+### Registry_STATUS{#Registry_STATUS}
 
 | Property                   | Description                                                                            | Type                                                                                                                                                    |
 |----------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -74,8 +74,8 @@ Used by: [RegistryList](#RegistryList).
 | type                       | The type of the resource.                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy             | Whether or not zone redundancy is enabled for this container registry                  | [RegistryProperties_ZoneRedundancy_STATUS](#RegistryProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="RegistryList"></a>RegistryList
--------------------------------------
+RegistryList{#RegistryList}
+---------------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2021-09-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}
 
@@ -85,8 +85,8 @@ Generator information: - Generated from: /containerregistry/resource-manager/Mic
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Registry[]](#Registry)<br/><small>Optional</small> |
 
-<a id="Registry_Spec"></a>Registry_Spec
----------------------------------------
+Registry_Spec{#Registry_Spec}
+-----------------------------
 
 Used by: [Registry](#Registry).
 
@@ -108,8 +108,8 @@ Used by: [Registry](#Registry).
 | tags                     | The tags of the resource.                                                                                                                                                                                                                                                                    | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy           | Whether or not zone redundancy is enabled for this container registry                                                                                                                                                                                                                        | [RegistryProperties_ZoneRedundancy](#RegistryProperties_ZoneRedundancy)<br/><small>Optional</small>                                                                  |
 
-<a id="Registry_STATUS"></a>Registry_STATUS
--------------------------------------------
+Registry_STATUS{#Registry_STATUS}
+---------------------------------
 
 An object that represents a container registry.
 
@@ -141,8 +141,8 @@ Used by: [Registry](#Registry).
 | type                       | The type of the resource.                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy             | Whether or not zone redundancy is enabled for this container registry                  | [RegistryProperties_ZoneRedundancy_STATUS](#RegistryProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="EncryptionProperty"></a>EncryptionProperty
--------------------------------------------------
+EncryptionProperty{#EncryptionProperty}
+---------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
 
@@ -151,8 +151,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | keyVaultProperties | Key vault properties.                                                      | [KeyVaultProperties](#KeyVaultProperties)<br/><small>Optional</small>               |
 | status             | Indicates whether or not the encryption is enabled for container registry. | [EncryptionProperty_Status](#EncryptionProperty_Status)<br/><small>Optional</small> |
 
-<a id="EncryptionProperty_STATUS"></a>EncryptionProperty_STATUS
----------------------------------------------------------------
+EncryptionProperty_STATUS{#EncryptionProperty_STATUS}
+-----------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -161,8 +161,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | keyVaultProperties | Key vault properties.                                                      | [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS)<br/><small>Optional</small>               |
 | status             | Indicates whether or not the encryption is enabled for container registry. | [EncryptionProperty_Status_STATUS](#EncryptionProperty_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityProperties"></a>IdentityProperties
--------------------------------------------------
+IdentityProperties{#IdentityProperties}
+---------------------------------------
 
 Managed identity for the resource.
 
@@ -175,8 +175,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | type                   | The identity type.                                                                                                                                                                                                                                                                                                                                                           | [IdentityProperties_Type](#IdentityProperties_Type)<br/><small>Optional</small>           |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="IdentityProperties_STATUS"></a>IdentityProperties_STATUS
----------------------------------------------------------------
+IdentityProperties_STATUS{#IdentityProperties_STATUS}
+-----------------------------------------------------
 
 Managed identity for the resource.
 
@@ -189,8 +189,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | type                   | The identity type.                                                                                                                                                                                                                                                                                                                                                           | [IdentityProperties_Type_STATUS](#IdentityProperties_Type_STATUS)<br/><small>Optional</small>          |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentityProperties_STATUS](#UserIdentityProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 The network rule set for a container registry.
 
@@ -201,8 +201,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | defaultAction | The default action of allow or deny when no other rules match. | [NetworkRuleSet_DefaultAction](#NetworkRuleSet_DefaultAction)<br/><small>Required</small> |
 | ipRules       | The IP ACL rules.                                              | [IPRule[]](#IPRule)<br/><small>Optional</small>                                           |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 The network rule set for a container registry.
 
@@ -213,8 +213,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | defaultAction | The default action of allow or deny when no other rules match. | [NetworkRuleSet_DefaultAction_STATUS](#NetworkRuleSet_DefaultAction_STATUS)<br/><small>Optional</small> |
 | ipRules       | The IP ACL rules.                                              | [IPRule_STATUS[]](#IPRule_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="Policies"></a>Policies
------------------------------
+Policies{#Policies}
+-------------------
 
 The policies for a container registry.
 
@@ -227,8 +227,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | retentionPolicy  | The retention policy for a container registry.     | [RetentionPolicy](#RetentionPolicy)<br/><small>Optional</small>   |
 | trustPolicy      | The content trust policy for a container registry. | [TrustPolicy](#TrustPolicy)<br/><small>Optional</small>           |
 
-<a id="Policies_STATUS"></a>Policies_STATUS
--------------------------------------------
+Policies_STATUS{#Policies_STATUS}
+---------------------------------
 
 The policies for a container registry.
 
@@ -241,8 +241,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | retentionPolicy  | The retention policy for a container registry.     | [RetentionPolicy_STATUS](#RetentionPolicy_STATUS)<br/><small>Optional</small>   |
 | trustPolicy      | The content trust policy for a container registry. | [TrustPolicy_STATUS](#TrustPolicy_STATUS)<br/><small>Optional</small>           |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 An object that represents a private endpoint connection for a container registry.
 
@@ -252,8 +252,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 |----------|------------------|------------------------------------|
 | id       | The resource ID. | string<br/><small>Optional</small> |
 
-<a id="RegistryOperatorSpec"></a>RegistryOperatorSpec
------------------------------------------------------
+RegistryOperatorSpec{#RegistryOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -264,8 +264,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RegistryProperties_NetworkRuleBypassOptions"></a>RegistryProperties_NetworkRuleBypassOptions
----------------------------------------------------------------------------------------------------
+RegistryProperties_NetworkRuleBypassOptions{#RegistryProperties_NetworkRuleBypassOptions}
+-----------------------------------------------------------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
 
@@ -274,8 +274,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="RegistryProperties_NetworkRuleBypassOptions_STATUS"></a>RegistryProperties_NetworkRuleBypassOptions_STATUS
------------------------------------------------------------------------------------------------------------------
+RegistryProperties_NetworkRuleBypassOptions_STATUS{#RegistryProperties_NetworkRuleBypassOptions_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -284,8 +284,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="RegistryProperties_ProvisioningState_STATUS"></a>RegistryProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------
+RegistryProperties_ProvisioningState_STATUS{#RegistryProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -298,27 +298,7 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RegistryProperties_PublicNetworkAccess"></a>RegistryProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------
-
-Used by: [Registry_Spec](#Registry_Spec).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="RegistryProperties_PublicNetworkAccess_STATUS"></a>RegistryProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [Registry_STATUS](#Registry_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="RegistryProperties_ZoneRedundancy"></a>RegistryProperties_ZoneRedundancy
+RegistryProperties_PublicNetworkAccess{#RegistryProperties_PublicNetworkAccess}
 -------------------------------------------------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
@@ -328,7 +308,7 @@ Used by: [Registry_Spec](#Registry_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RegistryProperties_ZoneRedundancy_STATUS"></a>RegistryProperties_ZoneRedundancy_STATUS
+RegistryProperties_PublicNetworkAccess_STATUS{#RegistryProperties_PublicNetworkAccess_STATUS}
 ---------------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
@@ -338,8 +318,28 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+RegistryProperties_ZoneRedundancy{#RegistryProperties_ZoneRedundancy}
+---------------------------------------------------------------------
+
+Used by: [Registry_Spec](#Registry_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+RegistryProperties_ZoneRedundancy_STATUS{#RegistryProperties_ZoneRedundancy_STATUS}
+-----------------------------------------------------------------------------------
+
+Used by: [Registry_STATUS](#Registry_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+Sku{#Sku}
+---------
 
 The SKU of a container registry.
 
@@ -349,8 +349,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 |----------|-------------------------------------------------------------------------|---------------------------------------------------|
 | name     | The SKU name of the container registry. Required for registry creation. | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The SKU of a container registry.
 
@@ -361,8 +361,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | name     | The SKU name of the container registry. Required for registry creation. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The SKU tier based on the SKU name.                                     | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Status_STATUS"></a>Status_STATUS
----------------------------------------
+Status_STATUS{#Status_STATUS}
+-----------------------------
 
 The status of an Azure resource at the time the operation was called.
 
@@ -374,8 +374,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | message       | The detailed message for the status, including alerts and error messages. | string<br/><small>Optional</small> |
 | timestamp     | The timestamp when the status was changed to the current value.           | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -390,8 +390,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionProperty_Status"></a>EncryptionProperty_Status
----------------------------------------------------------------
+EncryptionProperty_Status{#EncryptionProperty_Status}
+-----------------------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -400,8 +400,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="EncryptionProperty_Status_STATUS"></a>EncryptionProperty_Status_STATUS
------------------------------------------------------------------------------
+EncryptionProperty_Status_STATUS{#EncryptionProperty_Status_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -410,8 +410,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="ExportPolicy"></a>ExportPolicy
--------------------------------------
+ExportPolicy{#ExportPolicy}
+---------------------------
 
 The export policy for a container registry.
 
@@ -421,8 +421,8 @@ Used by: [Policies](#Policies).
 |----------|----------------------------------------------------------------|-------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [ExportPolicy_Status](#ExportPolicy_Status)<br/><small>Optional</small> |
 
-<a id="ExportPolicy_STATUS"></a>ExportPolicy_STATUS
----------------------------------------------------
+ExportPolicy_STATUS{#ExportPolicy_STATUS}
+-----------------------------------------
 
 The export policy for a container registry.
 
@@ -432,8 +432,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 |----------|----------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [ExportPolicy_Status_STATUS](#ExportPolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityProperties_Type"></a>IdentityProperties_Type
------------------------------------------------------------
+IdentityProperties_Type{#IdentityProperties_Type}
+-------------------------------------------------
 
 Used by: [IdentityProperties](#IdentityProperties).
 
@@ -444,8 +444,8 @@ Used by: [IdentityProperties](#IdentityProperties).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="IdentityProperties_Type_STATUS"></a>IdentityProperties_Type_STATUS
--------------------------------------------------------------------------
+IdentityProperties_Type_STATUS{#IdentityProperties_Type_STATUS}
+---------------------------------------------------------------
 
 Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 
@@ -456,8 +456,8 @@ Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -468,8 +468,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action](#IPRule_Action)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Required</small>                          |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -480,8 +480,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action_STATUS](#IPRule_Action_STATUS)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small>                                        |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -490,8 +490,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | identity      | The client id of the identity which will be used to access key vault. | string<br/><small>Optional</small> |
 | keyIdentifier | Key vault uri to access the encryption key.                           | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -503,8 +503,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | lastKeyRotationTimestamp | Timestamp of the last successful key rotation.                                                                | string<br/><small>Optional</small> |
 | versionedKeyIdentifier   | The fully qualified key identifier that includes the version of the key that is actually used for encryption. | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -513,8 +513,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -523,8 +523,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="QuarantinePolicy"></a>QuarantinePolicy
----------------------------------------------
+QuarantinePolicy{#QuarantinePolicy}
+-----------------------------------
 
 The quarantine policy for a container registry.
 
@@ -534,8 +534,8 @@ Used by: [Policies](#Policies).
 |----------|----------------------------------------------------------------|---------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [QuarantinePolicy_Status](#QuarantinePolicy_Status)<br/><small>Optional</small> |
 
-<a id="QuarantinePolicy_STATUS"></a>QuarantinePolicy_STATUS
------------------------------------------------------------
+QuarantinePolicy_STATUS{#QuarantinePolicy_STATUS}
+-------------------------------------------------
 
 The quarantine policy for a container registry.
 
@@ -545,8 +545,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 |----------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [QuarantinePolicy_Status_STATUS](#QuarantinePolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="RetentionPolicy"></a>RetentionPolicy
--------------------------------------------
+RetentionPolicy{#RetentionPolicy}
+---------------------------------
 
 The retention policy for a container registry.
 
@@ -557,8 +557,8 @@ Used by: [Policies](#Policies).
 | days     | The number of days to retain an untagged manifest after which it gets purged. | int<br/><small>Optional</small>                                               |
 | status   | The value that indicates whether the policy is enabled or not.                | [RetentionPolicy_Status](#RetentionPolicy_Status)<br/><small>Optional</small> |
 
-<a id="RetentionPolicy_STATUS"></a>RetentionPolicy_STATUS
----------------------------------------------------------
+RetentionPolicy_STATUS{#RetentionPolicy_STATUS}
+-----------------------------------------------
 
 The retention policy for a container registry.
 
@@ -570,8 +570,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 | lastUpdatedTime | The timestamp when the policy was last updated.                               | string<br/><small>Optional</small>                                                          |
 | status          | The value that indicates whether the policy is enabled or not.                | [RetentionPolicy_Status_STATUS](#RetentionPolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -582,8 +582,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -594,8 +594,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -606,7 +606,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -618,20 +630,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="TrustPolicy"></a>TrustPolicy
------------------------------------
+TrustPolicy{#TrustPolicy}
+-------------------------
 
 The content trust policy for a container registry.
 
@@ -642,8 +642,8 @@ Used by: [Policies](#Policies).
 | status   | The value that indicates whether the policy is enabled or not. | [TrustPolicy_Status](#TrustPolicy_Status)<br/><small>Optional</small> |
 | type     | The type of trust policy.                                      | [TrustPolicy_Type](#TrustPolicy_Type)<br/><small>Optional</small>     |
 
-<a id="TrustPolicy_STATUS"></a>TrustPolicy_STATUS
--------------------------------------------------
+TrustPolicy_STATUS{#TrustPolicy_STATUS}
+---------------------------------------
 
 The content trust policy for a container registry.
 
@@ -654,8 +654,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 | status   | The value that indicates whether the policy is enabled or not. | [TrustPolicy_Status_STATUS](#TrustPolicy_Status_STATUS)<br/><small>Optional</small> |
 | type     | The type of trust policy.                                      | [TrustPolicy_Type_STATUS](#TrustPolicy_Type_STATUS)<br/><small>Optional</small>     |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -665,8 +665,8 @@ Used by: [IdentityProperties](#IdentityProperties).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentityProperties_STATUS"></a>UserIdentityProperties_STATUS
------------------------------------------------------------------------
+UserIdentityProperties_STATUS{#UserIdentityProperties_STATUS}
+-------------------------------------------------------------
 
 Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 
@@ -675,8 +675,8 @@ Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ExportPolicy_Status"></a>ExportPolicy_Status
----------------------------------------------------
+ExportPolicy_Status{#ExportPolicy_Status}
+-----------------------------------------
 
 Used by: [ExportPolicy](#ExportPolicy).
 
@@ -685,8 +685,8 @@ Used by: [ExportPolicy](#ExportPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="ExportPolicy_Status_STATUS"></a>ExportPolicy_Status_STATUS
------------------------------------------------------------------
+ExportPolicy_Status_STATUS{#ExportPolicy_Status_STATUS}
+-------------------------------------------------------
 
 Used by: [ExportPolicy_STATUS](#ExportPolicy_STATUS).
 
@@ -695,8 +695,8 @@ Used by: [ExportPolicy_STATUS](#ExportPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="IPRule_Action"></a>IPRule_Action
----------------------------------------
+IPRule_Action{#IPRule_Action}
+-----------------------------
 
 Used by: [IPRule](#IPRule).
 
@@ -704,8 +704,8 @@ Used by: [IPRule](#IPRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="IPRule_Action_STATUS"></a>IPRule_Action_STATUS
------------------------------------------------------
+IPRule_Action_STATUS{#IPRule_Action_STATUS}
+-------------------------------------------
 
 Used by: [IPRule_STATUS](#IPRule_STATUS).
 
@@ -713,8 +713,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="QuarantinePolicy_Status"></a>QuarantinePolicy_Status
------------------------------------------------------------
+QuarantinePolicy_Status{#QuarantinePolicy_Status}
+-------------------------------------------------
 
 Used by: [QuarantinePolicy](#QuarantinePolicy).
 
@@ -723,8 +723,8 @@ Used by: [QuarantinePolicy](#QuarantinePolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="QuarantinePolicy_Status_STATUS"></a>QuarantinePolicy_Status_STATUS
--------------------------------------------------------------------------
+QuarantinePolicy_Status_STATUS{#QuarantinePolicy_Status_STATUS}
+---------------------------------------------------------------
 
 Used by: [QuarantinePolicy_STATUS](#QuarantinePolicy_STATUS).
 
@@ -733,8 +733,8 @@ Used by: [QuarantinePolicy_STATUS](#QuarantinePolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="RetentionPolicy_Status"></a>RetentionPolicy_Status
----------------------------------------------------------
+RetentionPolicy_Status{#RetentionPolicy_Status}
+-----------------------------------------------
 
 Used by: [RetentionPolicy](#RetentionPolicy).
 
@@ -743,8 +743,8 @@ Used by: [RetentionPolicy](#RetentionPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="RetentionPolicy_Status_STATUS"></a>RetentionPolicy_Status_STATUS
------------------------------------------------------------------------
+RetentionPolicy_Status_STATUS{#RetentionPolicy_Status_STATUS}
+-------------------------------------------------------------
 
 Used by: [RetentionPolicy_STATUS](#RetentionPolicy_STATUS).
 
@@ -753,8 +753,8 @@ Used by: [RetentionPolicy_STATUS](#RetentionPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Status"></a>TrustPolicy_Status
--------------------------------------------------
+TrustPolicy_Status{#TrustPolicy_Status}
+---------------------------------------
 
 Used by: [TrustPolicy](#TrustPolicy).
 
@@ -763,8 +763,8 @@ Used by: [TrustPolicy](#TrustPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Status_STATUS"></a>TrustPolicy_Status_STATUS
----------------------------------------------------------------
+TrustPolicy_Status_STATUS{#TrustPolicy_Status_STATUS}
+-----------------------------------------------------
 
 Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 
@@ -773,8 +773,8 @@ Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Type"></a>TrustPolicy_Type
----------------------------------------------
+TrustPolicy_Type{#TrustPolicy_Type}
+-----------------------------------
 
 Used by: [TrustPolicy](#TrustPolicy).
 
@@ -782,8 +782,8 @@ Used by: [TrustPolicy](#TrustPolicy).
 |----------|-------------|
 | "Notary" |             |
 
-<a id="TrustPolicy_Type_STATUS"></a>TrustPolicy_Type_STATUS
------------------------------------------------------------
+TrustPolicy_Type_STATUS{#TrustPolicy_Type_STATUS}
+-------------------------------------------------
 
 Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 

--- a/docs/hugo/content/reference/containerregistry/v1api20230701.md
+++ b/docs/hugo/content/reference/containerregistry/v1api20230701.md
@@ -5,15 +5,15 @@ title: containerregistry.azure.com/v1api20230701
 linktitle: v1api20230701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-07-01" |             |
 
-<a id="Registry"></a>Registry
------------------------------
+Registry{#Registry}
+-------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2023-07-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}
 
@@ -26,7 +26,7 @@ Used by: [RegistryList](#RegistryList).
 | spec                                                                                    |             | [Registry_Spec](#Registry_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Registry_STATUS](#Registry_STATUS)<br/><small>Optional</small> |
 
-### <a id="Registry_Spec"></a>Registry_Spec
+### Registry_Spec {#Registry_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ Used by: [RegistryList](#RegistryList).
 | tags                     | The tags of the resource.                                                                                                                                                                                                                                                                    | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy           | Whether or not zone redundancy is enabled for this container registry                                                                                                                                                                                                                        | [RegistryProperties_ZoneRedundancy](#RegistryProperties_ZoneRedundancy)<br/><small>Optional</small>                                                                  |
 
-### <a id="Registry_STATUS"></a>Registry_STATUS
+### Registry_STATUS{#Registry_STATUS}
 
 | Property                   | Description                                                                            | Type                                                                                                                                                    |
 |----------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -74,8 +74,8 @@ Used by: [RegistryList](#RegistryList).
 | type                       | The type of the resource.                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy             | Whether or not zone redundancy is enabled for this container registry                  | [RegistryProperties_ZoneRedundancy_STATUS](#RegistryProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="RegistryList"></a>RegistryList
--------------------------------------
+RegistryList{#RegistryList}
+---------------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2023-07-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}
 
@@ -85,8 +85,8 @@ Generator information: - Generated from: /containerregistry/resource-manager/Mic
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Registry[]](#Registry)<br/><small>Optional</small> |
 
-<a id="RegistryReplication"></a>RegistryReplication
----------------------------------------------------
+RegistryReplication{#RegistryReplication}
+-----------------------------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2023-07-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}/replications/{replicationName}
 
@@ -99,7 +99,7 @@ Used by: [RegistryReplicationList](#RegistryReplicationList).
 | spec                                                                                    |             | [RegistryReplication_Spec](#RegistryReplication_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RegistryReplication_STATUS](#RegistryReplication_STATUS)<br/><small>Optional</small> |
 
-### <a id="RegistryReplication_Spec"></a>RegistryReplication_Spec
+### RegistryReplication_Spec {#RegistryReplication_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [RegistryReplicationList](#RegistryReplicationList).
 | tags                  | The tags of the resource.                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy        | Whether or not zone redundancy is enabled for this container registry replication                                                                                                                                                                                                               | [ReplicationProperties_ZoneRedundancy](#ReplicationProperties_ZoneRedundancy)<br/><small>Optional</small>                                                            |
 
-### <a id="RegistryReplication_STATUS"></a>RegistryReplication_STATUS
+### RegistryReplication_STATUS{#RegistryReplication_STATUS}
 
 | Property              | Description                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -127,8 +127,8 @@ Used by: [RegistryReplicationList](#RegistryReplicationList).
 | type                  | The type of the resource.                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy        | Whether or not zone redundancy is enabled for this container registry replication                                                                                                                                        | [ReplicationProperties_ZoneRedundancy_STATUS](#ReplicationProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="RegistryReplicationList"></a>RegistryReplicationList
------------------------------------------------------------
+RegistryReplicationList{#RegistryReplicationList}
+-------------------------------------------------
 
 Generator information: - Generated from: /containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2023-07-01/containerregistry.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{registryName}/replications/{replicationName}
 
@@ -138,8 +138,8 @@ Generator information: - Generated from: /containerregistry/resource-manager/Mic
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                           |
 | items                                                                               |             | [RegistryReplication[]](#RegistryReplication)<br/><small>Optional</small> |
 
-<a id="Registry_Spec"></a>Registry_Spec
----------------------------------------
+Registry_Spec{#Registry_Spec}
+-----------------------------
 
 Used by: [Registry](#Registry).
 
@@ -161,8 +161,8 @@ Used by: [Registry](#Registry).
 | tags                     | The tags of the resource.                                                                                                                                                                                                                                                                    | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy           | Whether or not zone redundancy is enabled for this container registry                                                                                                                                                                                                                        | [RegistryProperties_ZoneRedundancy](#RegistryProperties_ZoneRedundancy)<br/><small>Optional</small>                                                                  |
 
-<a id="Registry_STATUS"></a>Registry_STATUS
--------------------------------------------
+Registry_STATUS{#Registry_STATUS}
+---------------------------------
 
 An object that represents a container registry.
 
@@ -194,8 +194,8 @@ Used by: [Registry](#Registry).
 | type                       | The type of the resource.                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy             | Whether or not zone redundancy is enabled for this container registry                  | [RegistryProperties_ZoneRedundancy_STATUS](#RegistryProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="RegistryReplication_Spec"></a>RegistryReplication_Spec
--------------------------------------------------------------
+RegistryReplication_Spec{#RegistryReplication_Spec}
+---------------------------------------------------
 
 Used by: [RegistryReplication](#RegistryReplication).
 
@@ -209,8 +209,8 @@ Used by: [RegistryReplication](#RegistryReplication).
 | tags                  | The tags of the resource.                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundancy        | Whether or not zone redundancy is enabled for this container registry replication                                                                                                                                                                                                               | [ReplicationProperties_ZoneRedundancy](#ReplicationProperties_ZoneRedundancy)<br/><small>Optional</small>                                                            |
 
-<a id="RegistryReplication_STATUS"></a>RegistryReplication_STATUS
------------------------------------------------------------------
+RegistryReplication_STATUS{#RegistryReplication_STATUS}
+-------------------------------------------------------
 
 Used by: [RegistryReplication](#RegistryReplication).
 
@@ -228,8 +228,8 @@ Used by: [RegistryReplication](#RegistryReplication).
 | type                  | The type of the resource.                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundancy        | Whether or not zone redundancy is enabled for this container registry replication                                                                                                                                        | [ReplicationProperties_ZoneRedundancy_STATUS](#ReplicationProperties_ZoneRedundancy_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="EncryptionProperty"></a>EncryptionProperty
--------------------------------------------------
+EncryptionProperty{#EncryptionProperty}
+---------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
 
@@ -238,8 +238,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | keyVaultProperties | Key vault properties.                                                      | [KeyVaultProperties](#KeyVaultProperties)<br/><small>Optional</small>               |
 | status             | Indicates whether or not the encryption is enabled for container registry. | [EncryptionProperty_Status](#EncryptionProperty_Status)<br/><small>Optional</small> |
 
-<a id="EncryptionProperty_STATUS"></a>EncryptionProperty_STATUS
----------------------------------------------------------------
+EncryptionProperty_STATUS{#EncryptionProperty_STATUS}
+-----------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -248,8 +248,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | keyVaultProperties | Key vault properties.                                                      | [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS)<br/><small>Optional</small>               |
 | status             | Indicates whether or not the encryption is enabled for container registry. | [EncryptionProperty_Status_STATUS](#EncryptionProperty_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityProperties"></a>IdentityProperties
--------------------------------------------------
+IdentityProperties{#IdentityProperties}
+---------------------------------------
 
 Managed identity for the resource.
 
@@ -260,8 +260,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | type                   | The identity type.                                                                                                                                                                                                                                                                                                                                                           | [IdentityProperties_Type](#IdentityProperties_Type)<br/><small>Optional</small>           |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="IdentityProperties_STATUS"></a>IdentityProperties_STATUS
----------------------------------------------------------------
+IdentityProperties_STATUS{#IdentityProperties_STATUS}
+-----------------------------------------------------
 
 Managed identity for the resource.
 
@@ -274,8 +274,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | type                   | The identity type.                                                                                                                                                                                                                                                                                                                                                           | [IdentityProperties_Type_STATUS](#IdentityProperties_Type_STATUS)<br/><small>Optional</small>          |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace; providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentityProperties_STATUS](#UserIdentityProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 The network rule set for a container registry.
 
@@ -286,8 +286,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | defaultAction | The default action of allow or deny when no other rules match. | [NetworkRuleSet_DefaultAction](#NetworkRuleSet_DefaultAction)<br/><small>Required</small> |
 | ipRules       | The IP ACL rules.                                              | [IPRule[]](#IPRule)<br/><small>Optional</small>                                           |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 The network rule set for a container registry.
 
@@ -298,8 +298,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | defaultAction | The default action of allow or deny when no other rules match. | [NetworkRuleSet_DefaultAction_STATUS](#NetworkRuleSet_DefaultAction_STATUS)<br/><small>Optional</small> |
 | ipRules       | The IP ACL rules.                                              | [IPRule_STATUS[]](#IPRule_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="Policies"></a>Policies
------------------------------
+Policies{#Policies}
+-------------------
 
 The policies for a container registry.
 
@@ -312,8 +312,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | retentionPolicy  | The retention policy for a container registry.     | [RetentionPolicy](#RetentionPolicy)<br/><small>Optional</small>   |
 | trustPolicy      | The content trust policy for a container registry. | [TrustPolicy](#TrustPolicy)<br/><small>Optional</small>           |
 
-<a id="Policies_STATUS"></a>Policies_STATUS
--------------------------------------------
+Policies_STATUS{#Policies_STATUS}
+---------------------------------
 
 The policies for a container registry.
 
@@ -326,8 +326,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | retentionPolicy  | The retention policy for a container registry.     | [RetentionPolicy_STATUS](#RetentionPolicy_STATUS)<br/><small>Optional</small>   |
 | trustPolicy      | The content trust policy for a container registry. | [TrustPolicy_STATUS](#TrustPolicy_STATUS)<br/><small>Optional</small>           |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 An object that represents a private endpoint connection for a container registry.
 
@@ -337,8 +337,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 |----------|------------------|------------------------------------|
 | id       | The resource ID. | string<br/><small>Optional</small> |
 
-<a id="RegistryOperatorSpec"></a>RegistryOperatorSpec
------------------------------------------------------
+RegistryOperatorSpec{#RegistryOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -349,8 +349,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RegistryProperties_NetworkRuleBypassOptions"></a>RegistryProperties_NetworkRuleBypassOptions
----------------------------------------------------------------------------------------------------
+RegistryProperties_NetworkRuleBypassOptions{#RegistryProperties_NetworkRuleBypassOptions}
+-----------------------------------------------------------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
 
@@ -359,8 +359,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="RegistryProperties_NetworkRuleBypassOptions_STATUS"></a>RegistryProperties_NetworkRuleBypassOptions_STATUS
------------------------------------------------------------------------------------------------------------------
+RegistryProperties_NetworkRuleBypassOptions_STATUS{#RegistryProperties_NetworkRuleBypassOptions_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -369,8 +369,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="RegistryProperties_ProvisioningState_STATUS"></a>RegistryProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------
+RegistryProperties_ProvisioningState_STATUS{#RegistryProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
 
@@ -383,27 +383,7 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="RegistryProperties_PublicNetworkAccess"></a>RegistryProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------
-
-Used by: [Registry_Spec](#Registry_Spec).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="RegistryProperties_PublicNetworkAccess_STATUS"></a>RegistryProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [Registry_STATUS](#Registry_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="RegistryProperties_ZoneRedundancy"></a>RegistryProperties_ZoneRedundancy
+RegistryProperties_PublicNetworkAccess{#RegistryProperties_PublicNetworkAccess}
 -------------------------------------------------------------------------------
 
 Used by: [Registry_Spec](#Registry_Spec).
@@ -413,7 +393,7 @@ Used by: [Registry_Spec](#Registry_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RegistryProperties_ZoneRedundancy_STATUS"></a>RegistryProperties_ZoneRedundancy_STATUS
+RegistryProperties_PublicNetworkAccess_STATUS{#RegistryProperties_PublicNetworkAccess_STATUS}
 ---------------------------------------------------------------------------------------------
 
 Used by: [Registry_STATUS](#Registry_STATUS).
@@ -423,8 +403,28 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="RegistryReplicationOperatorSpec"></a>RegistryReplicationOperatorSpec
----------------------------------------------------------------------------
+RegistryProperties_ZoneRedundancy{#RegistryProperties_ZoneRedundancy}
+---------------------------------------------------------------------
+
+Used by: [Registry_Spec](#Registry_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+RegistryProperties_ZoneRedundancy_STATUS{#RegistryProperties_ZoneRedundancy_STATUS}
+-----------------------------------------------------------------------------------
+
+Used by: [Registry_STATUS](#Registry_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+RegistryReplicationOperatorSpec{#RegistryReplicationOperatorSpec}
+-----------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -435,8 +435,8 @@ Used by: [RegistryReplication_Spec](#RegistryReplication_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ReplicationProperties_ProvisioningState_STATUS"></a>ReplicationProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+ReplicationProperties_ProvisioningState_STATUS{#ReplicationProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [RegistryReplication_STATUS](#RegistryReplication_STATUS).
 
@@ -449,8 +449,8 @@ Used by: [RegistryReplication_STATUS](#RegistryReplication_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ReplicationProperties_ZoneRedundancy"></a>ReplicationProperties_ZoneRedundancy
--------------------------------------------------------------------------------------
+ReplicationProperties_ZoneRedundancy{#ReplicationProperties_ZoneRedundancy}
+---------------------------------------------------------------------------
 
 Used by: [RegistryReplication_Spec](#RegistryReplication_Spec).
 
@@ -459,8 +459,8 @@ Used by: [RegistryReplication_Spec](#RegistryReplication_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ReplicationProperties_ZoneRedundancy_STATUS"></a>ReplicationProperties_ZoneRedundancy_STATUS
----------------------------------------------------------------------------------------------------
+ReplicationProperties_ZoneRedundancy_STATUS{#ReplicationProperties_ZoneRedundancy_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [RegistryReplication_STATUS](#RegistryReplication_STATUS).
 
@@ -469,8 +469,8 @@ Used by: [RegistryReplication_STATUS](#RegistryReplication_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The SKU of a container registry.
 
@@ -480,8 +480,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 |----------|-------------------------------------------------------------------------|---------------------------------------------------|
 | name     | The SKU name of the container registry. Required for registry creation. | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The SKU of a container registry.
 
@@ -492,8 +492,8 @@ Used by: [Registry_STATUS](#Registry_STATUS).
 | name     | The SKU name of the container registry. Required for registry creation. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The SKU tier based on the SKU name.                                     | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Status_STATUS"></a>Status_STATUS
----------------------------------------
+Status_STATUS{#Status_STATUS}
+-----------------------------
 
 The status of an Azure resource at the time the operation was called.
 
@@ -505,8 +505,8 @@ Used by: [Registry_STATUS](#Registry_STATUS), and [RegistryReplication_STATUS](#
 | message       | The detailed message for the status, including alerts and error messages. | string<br/><small>Optional</small> |
 | timestamp     | The timestamp when the status was changed to the current value.           | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -521,8 +521,8 @@ Used by: [Registry_STATUS](#Registry_STATUS), and [RegistryReplication_STATUS](#
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionProperty_Status"></a>EncryptionProperty_Status
----------------------------------------------------------------
+EncryptionProperty_Status{#EncryptionProperty_Status}
+-----------------------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -531,8 +531,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="EncryptionProperty_Status_STATUS"></a>EncryptionProperty_Status_STATUS
------------------------------------------------------------------------------
+EncryptionProperty_Status_STATUS{#EncryptionProperty_Status_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -541,8 +541,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="ExportPolicy"></a>ExportPolicy
--------------------------------------
+ExportPolicy{#ExportPolicy}
+---------------------------
 
 The export policy for a container registry.
 
@@ -552,8 +552,8 @@ Used by: [Policies](#Policies).
 |----------|----------------------------------------------------------------|-------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [ExportPolicy_Status](#ExportPolicy_Status)<br/><small>Optional</small> |
 
-<a id="ExportPolicy_STATUS"></a>ExportPolicy_STATUS
----------------------------------------------------
+ExportPolicy_STATUS{#ExportPolicy_STATUS}
+-----------------------------------------
 
 The export policy for a container registry.
 
@@ -563,8 +563,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 |----------|----------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [ExportPolicy_Status_STATUS](#ExportPolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityProperties_Type"></a>IdentityProperties_Type
------------------------------------------------------------
+IdentityProperties_Type{#IdentityProperties_Type}
+-------------------------------------------------
 
 Used by: [IdentityProperties](#IdentityProperties).
 
@@ -575,8 +575,8 @@ Used by: [IdentityProperties](#IdentityProperties).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="IdentityProperties_Type_STATUS"></a>IdentityProperties_Type_STATUS
--------------------------------------------------------------------------
+IdentityProperties_Type_STATUS{#IdentityProperties_Type_STATUS}
+---------------------------------------------------------------
 
 Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 
@@ -587,8 +587,8 @@ Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -599,8 +599,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action](#IPRule_Action)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Required</small>                          |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -611,8 +611,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action_STATUS](#IPRule_Action_STATUS)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small>                                        |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -622,8 +622,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | identityFromConfig | The client id of the identity which will be used to access key vault. | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | keyIdentifier      | Key vault uri to access the encryption key.                           | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -635,8 +635,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | lastKeyRotationTimestamp | Timestamp of the last successful key rotation.                                                                | string<br/><small>Optional</small> |
 | versionedKeyIdentifier   | The fully qualified key identifier that includes the version of the key that is actually used for encryption. | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -645,8 +645,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -655,8 +655,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="QuarantinePolicy"></a>QuarantinePolicy
----------------------------------------------
+QuarantinePolicy{#QuarantinePolicy}
+-----------------------------------
 
 The quarantine policy for a container registry.
 
@@ -666,8 +666,8 @@ Used by: [Policies](#Policies).
 |----------|----------------------------------------------------------------|---------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [QuarantinePolicy_Status](#QuarantinePolicy_Status)<br/><small>Optional</small> |
 
-<a id="QuarantinePolicy_STATUS"></a>QuarantinePolicy_STATUS
------------------------------------------------------------
+QuarantinePolicy_STATUS{#QuarantinePolicy_STATUS}
+-------------------------------------------------
 
 The quarantine policy for a container registry.
 
@@ -677,8 +677,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 |----------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | status   | The value that indicates whether the policy is enabled or not. | [QuarantinePolicy_Status_STATUS](#QuarantinePolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="RetentionPolicy"></a>RetentionPolicy
--------------------------------------------
+RetentionPolicy{#RetentionPolicy}
+---------------------------------
 
 The retention policy for a container registry.
 
@@ -689,8 +689,8 @@ Used by: [Policies](#Policies).
 | days     | The number of days to retain an untagged manifest after which it gets purged. | int<br/><small>Optional</small>                                               |
 | status   | The value that indicates whether the policy is enabled or not.                | [RetentionPolicy_Status](#RetentionPolicy_Status)<br/><small>Optional</small> |
 
-<a id="RetentionPolicy_STATUS"></a>RetentionPolicy_STATUS
----------------------------------------------------------
+RetentionPolicy_STATUS{#RetentionPolicy_STATUS}
+-----------------------------------------------
 
 The retention policy for a container registry.
 
@@ -702,8 +702,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 | lastUpdatedTime | The timestamp when the policy was last updated.                               | string<br/><small>Optional</small>                                                          |
 | status          | The value that indicates whether the policy is enabled or not.                | [RetentionPolicy_Status_STATUS](#RetentionPolicy_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -714,8 +714,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -726,8 +726,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -738,7 +738,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -750,20 +762,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="TrustPolicy"></a>TrustPolicy
------------------------------------
+TrustPolicy{#TrustPolicy}
+-------------------------
 
 The content trust policy for a container registry.
 
@@ -774,8 +774,8 @@ Used by: [Policies](#Policies).
 | status   | The value that indicates whether the policy is enabled or not. | [TrustPolicy_Status](#TrustPolicy_Status)<br/><small>Optional</small> |
 | type     | The type of trust policy.                                      | [TrustPolicy_Type](#TrustPolicy_Type)<br/><small>Optional</small>     |
 
-<a id="TrustPolicy_STATUS"></a>TrustPolicy_STATUS
--------------------------------------------------
+TrustPolicy_STATUS{#TrustPolicy_STATUS}
+---------------------------------------
 
 The content trust policy for a container registry.
 
@@ -786,8 +786,8 @@ Used by: [Policies_STATUS](#Policies_STATUS).
 | status   | The value that indicates whether the policy is enabled or not. | [TrustPolicy_Status_STATUS](#TrustPolicy_Status_STATUS)<br/><small>Optional</small> |
 | type     | The type of trust policy.                                      | [TrustPolicy_Type_STATUS](#TrustPolicy_Type_STATUS)<br/><small>Optional</small>     |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -797,8 +797,8 @@ Used by: [IdentityProperties](#IdentityProperties).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentityProperties_STATUS"></a>UserIdentityProperties_STATUS
------------------------------------------------------------------------
+UserIdentityProperties_STATUS{#UserIdentityProperties_STATUS}
+-------------------------------------------------------------
 
 Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 
@@ -807,8 +807,8 @@ Used by: [IdentityProperties_STATUS](#IdentityProperties_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ExportPolicy_Status"></a>ExportPolicy_Status
----------------------------------------------------
+ExportPolicy_Status{#ExportPolicy_Status}
+-----------------------------------------
 
 Used by: [ExportPolicy](#ExportPolicy).
 
@@ -817,8 +817,8 @@ Used by: [ExportPolicy](#ExportPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="ExportPolicy_Status_STATUS"></a>ExportPolicy_Status_STATUS
------------------------------------------------------------------
+ExportPolicy_Status_STATUS{#ExportPolicy_Status_STATUS}
+-------------------------------------------------------
 
 Used by: [ExportPolicy_STATUS](#ExportPolicy_STATUS).
 
@@ -827,8 +827,8 @@ Used by: [ExportPolicy_STATUS](#ExportPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="IPRule_Action"></a>IPRule_Action
----------------------------------------
+IPRule_Action{#IPRule_Action}
+-----------------------------
 
 Used by: [IPRule](#IPRule).
 
@@ -836,8 +836,8 @@ Used by: [IPRule](#IPRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="IPRule_Action_STATUS"></a>IPRule_Action_STATUS
------------------------------------------------------
+IPRule_Action_STATUS{#IPRule_Action_STATUS}
+-------------------------------------------
 
 Used by: [IPRule_STATUS](#IPRule_STATUS).
 
@@ -845,8 +845,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="QuarantinePolicy_Status"></a>QuarantinePolicy_Status
------------------------------------------------------------
+QuarantinePolicy_Status{#QuarantinePolicy_Status}
+-------------------------------------------------
 
 Used by: [QuarantinePolicy](#QuarantinePolicy).
 
@@ -855,8 +855,8 @@ Used by: [QuarantinePolicy](#QuarantinePolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="QuarantinePolicy_Status_STATUS"></a>QuarantinePolicy_Status_STATUS
--------------------------------------------------------------------------
+QuarantinePolicy_Status_STATUS{#QuarantinePolicy_Status_STATUS}
+---------------------------------------------------------------
 
 Used by: [QuarantinePolicy_STATUS](#QuarantinePolicy_STATUS).
 
@@ -865,8 +865,8 @@ Used by: [QuarantinePolicy_STATUS](#QuarantinePolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="RetentionPolicy_Status"></a>RetentionPolicy_Status
----------------------------------------------------------
+RetentionPolicy_Status{#RetentionPolicy_Status}
+-----------------------------------------------
 
 Used by: [RetentionPolicy](#RetentionPolicy).
 
@@ -875,8 +875,8 @@ Used by: [RetentionPolicy](#RetentionPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="RetentionPolicy_Status_STATUS"></a>RetentionPolicy_Status_STATUS
------------------------------------------------------------------------
+RetentionPolicy_Status_STATUS{#RetentionPolicy_Status_STATUS}
+-------------------------------------------------------------
 
 Used by: [RetentionPolicy_STATUS](#RetentionPolicy_STATUS).
 
@@ -885,8 +885,8 @@ Used by: [RetentionPolicy_STATUS](#RetentionPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Status"></a>TrustPolicy_Status
--------------------------------------------------
+TrustPolicy_Status{#TrustPolicy_Status}
+---------------------------------------
 
 Used by: [TrustPolicy](#TrustPolicy).
 
@@ -895,8 +895,8 @@ Used by: [TrustPolicy](#TrustPolicy).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Status_STATUS"></a>TrustPolicy_Status_STATUS
----------------------------------------------------------------
+TrustPolicy_Status_STATUS{#TrustPolicy_Status_STATUS}
+-----------------------------------------------------
 
 Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 
@@ -905,8 +905,8 @@ Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="TrustPolicy_Type"></a>TrustPolicy_Type
----------------------------------------------
+TrustPolicy_Type{#TrustPolicy_Type}
+-----------------------------------
 
 Used by: [TrustPolicy](#TrustPolicy).
 
@@ -914,8 +914,8 @@ Used by: [TrustPolicy](#TrustPolicy).
 |----------|-------------|
 | "Notary" |             |
 
-<a id="TrustPolicy_Type_STATUS"></a>TrustPolicy_Type_STATUS
------------------------------------------------------------
+TrustPolicy_Type_STATUS{#TrustPolicy_Type_STATUS}
+-------------------------------------------------
 
 Used by: [TrustPolicy_STATUS](#TrustPolicy_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20210501.md
+++ b/docs/hugo/content/reference/containerservice/v1api20210501.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20210501
 linktitle: v1api20210501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-05-01" |             |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Used by: [ManagedClusterList](#ManagedClusterList).
 
@@ -24,7 +24,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -59,7 +59,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | tags                         |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | windowsProfile               |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                | Description                        | Type                                                                                                                                                    |
 |-------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,8 +101,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | type                    |                                    | string<br/><small>Optional</small>                                                                                                                      |
 | windowsProfile          |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 | Property                                                                            | Description | Type                                                            |
 |-------------------------------------------------------------------------------------|-------------|-----------------------------------------------------------------|
@@ -110,8 +110,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2021-05-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -124,7 +124,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -165,7 +165,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vmSize                        | VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | vnetSubnetIDReference         | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -210,8 +210,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vmSize                    | VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | vnetSubnetID              | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2021-05-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -221,8 +221,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -259,8 +259,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | tags                         |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | windowsProfile               |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -304,8 +304,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | type                    |                                    | string<br/><small>Optional</small>                                                                                                                      |
 | windowsProfile          |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -348,8 +348,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vmSize                        | VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | vnetSubnetIDReference         | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -396,8 +396,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vmSize                    | VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | vnetSubnetID              | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -406,8 +406,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -416,8 +416,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -426,8 +426,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -436,8 +436,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -445,8 +445,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|------------------------------------|
 | maxSurge |             | string<br/><small>Optional</small> |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -454,8 +454,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|-------------|------------------------------------|
 | maxSurge |             | string<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -464,8 +464,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername |             | string<br/><small>Required</small>                                                                |
 | ssh           |             | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -474,8 +474,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername |             | string<br/><small>Optional</small>                                                                              |
 | ssh           |             | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -492,8 +492,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | podCidr             |             | string<br/><small>Optional</small>                                                                                            |
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                            |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -510,13 +510,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | podCidr             |             | string<br/><small>Optional</small>                                                                                                          |
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                                          |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -525,8 +525,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | string<br/><small>Optional</small>                                        |
 | type     |             | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -535,56 +535,37 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | string<br/><small>Optional</small>                                                      |
 | type     |             | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Property              | Description | Type                                 |
-|-----------------------|-------------|--------------------------------------|
-| allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
-| containerLogMaxFiles  |             | int<br/><small>Optional</small>      |
-| containerLogMaxSizeMB |             | int<br/><small>Optional</small>      |
-| cpuCfsQuota           |             | bool<br/><small>Optional</small>     |
-| cpuCfsQuotaPeriod     |             | string<br/><small>Optional</small>   |
-| cpuManagerPolicy      |             | string<br/><small>Optional</small>   |
-| failSwapOn            |             | bool<br/><small>Optional</small>     |
-| imageGcHighThreshold  |             | int<br/><small>Optional</small>      |
-| imageGcLowThreshold   |             | int<br/><small>Optional</small>      |
-| podMaxPids            |             | int<br/><small>Optional</small>      |
-| topologyManagerPolicy |             | string<br/><small>Optional</small>   |
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
 -----------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Property              | Description | Type                                 |
 |-----------------------|-------------|--------------------------------------|
 | allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
@@ -599,8 +580,27 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            |             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy |             | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
 -------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Property              | Description | Type                                 |
+|-----------------------|-------------|--------------------------------------|
+| allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
+| containerLogMaxFiles  |             | int<br/><small>Optional</small>      |
+| containerLogMaxSizeMB |             | int<br/><small>Optional</small>      |
+| cpuCfsQuota           |             | bool<br/><small>Optional</small>     |
+| cpuCfsQuotaPeriod     |             | string<br/><small>Optional</small>   |
+| cpuManagerPolicy      |             | string<br/><small>Optional</small>   |
+| failSwapOn            |             | bool<br/><small>Optional</small>     |
+| imageGcHighThreshold  |             | int<br/><small>Optional</small>      |
+| imageGcLowThreshold   |             | int<br/><small>Optional</small>      |
+| podMaxPids            |             | int<br/><small>Optional</small>      |
+| topologyManagerPolicy |             | string<br/><small>Optional</small>   |
+
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -609,8 +609,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -619,8 +619,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -631,8 +631,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -643,8 +643,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -658,8 +658,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -673,8 +673,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -683,8 +683,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   |             | map[string]string<br/><small>Optional</small> |
 | enabled  |             | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -694,8 +694,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  |             | bool<br/><small>Optional</small>                                                        |
 | identity |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -736,8 +736,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | vmSize                        |             | string<br/><small>Optional</small>                                                                                                                         |
 | vnetSubnetIDReference         |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -781,8 +781,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | vmSize                    |             | string<br/><small>Optional</small>                                                              |
 | vnetSubnetID              |             | string<br/><small>Optional</small>                                                              |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -793,8 +793,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | enablePrivateClusterPublicFQDN |             | bool<br/><small>Optional</small>     |
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -805,8 +805,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enablePrivateClusterPublicFQDN |             | bool<br/><small>Optional</small>     |
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -814,8 +814,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------|
 | upgradeChannel |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -823,8 +823,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | upgradeChannel |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -835,8 +835,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    |             | string[]<br/><small>Optional</small> |
 | trustedCa  |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -847,8 +847,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy    |             | string[]<br/><small>Optional</small> |
 | trustedCa  |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -857,8 +857,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   |             | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities |             | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -869,8 +869,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   |             | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities |             | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -882,8 +882,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -894,8 +894,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -906,8 +906,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -931,8 +931,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage    |             | string<br/><small>Optional</small>                                                                                                      |
 | skip-nodes-with-system-pods      |             | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -956,8 +956,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage    |             | string<br/><small>Optional</small>                                                                                                                    |
 | skip-nodes-with-system-pods      |             | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -968,8 +968,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -978,8 +978,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId |             | string<br/><small>Required</small>                                                                                                                     |
 | secret   |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -987,8 +987,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|------------------------------------|
 | clientId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -997,8 +997,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1007,8 +1007,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1019,8 +1019,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | enableCSIProxy |             | bool<br/><small>Optional</small>                                                                                                                       |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1030,38 +1030,38 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enableCSIProxy |             | bool<br/><small>Optional</small>                                                                                                |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSDiskType_STATUS{#OSDiskType_STATUS}
+-------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Value        | Description |
 |--------------|-------------|
 | "CBLMariner" |             |
 | "Ubuntu"     |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
--------------------------------------
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1070,8 +1070,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "CBLMariner" |             |
 | "Ubuntu"     |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1080,8 +1080,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1090,8 +1090,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1099,8 +1099,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------|-------------------------------------------------------------------------------|
 | code     |             | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1112,8 +1112,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers |             | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            |             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1126,8 +1126,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      |             | string[]<br/><small>Optional</small> |
 | type                 |             | string<br/><small>Optional</small>   |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1136,8 +1136,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1146,8 +1146,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1156,8 +1156,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1166,8 +1166,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIdentity](#ManagedClusterPodIdentity).
 
@@ -1177,8 +1177,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          |             | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonProfile_STATUS](#ManagedClusterAddonProfile_STATUS), and [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -1188,59 +1188,59 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   |             | string<br/><small>Optional</small> |
 | resourceId |             | string<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku"></a>ContainerServiceNetworkProfile_LoadBalancerSku
+ContainerServiceNetworkProfile_LoadBalancerSku{#ContainerServiceNetworkProfile_LoadBalancerSku}
+-----------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value      | Description |
+|------------|-------------|
+| "basic"    |             |
+| "standard" |             |
+
+ContainerServiceNetworkProfile_LoadBalancerSku_STATUS{#ContainerServiceNetworkProfile_LoadBalancerSku_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "basic"    |             |
+| "standard" |             |
+
+ContainerServiceNetworkProfile_NetworkMode{#ContainerServiceNetworkProfile_NetworkMode}
+---------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+ContainerServiceNetworkProfile_NetworkMode_STATUS{#ContainerServiceNetworkProfile_NetworkMode_STATUS}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+ContainerServiceNetworkProfile_NetworkPlugin{#ContainerServiceNetworkProfile_NetworkPlugin}
+-------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value     | Description |
+|-----------|-------------|
+| "azure"   |             |
+| "kubenet" |             |
+
+ContainerServiceNetworkProfile_NetworkPlugin_STATUS{#ContainerServiceNetworkProfile_NetworkPlugin_STATUS}
 ---------------------------------------------------------------------------------------------------------
 
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value      | Description |
-|------------|-------------|
-| "basic"    |             |
-| "standard" |             |
-
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku_STATUS"></a>ContainerServiceNetworkProfile_LoadBalancerSku_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "basic"    |             |
-| "standard" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkMode"></a>ContainerServiceNetworkProfile_NetworkMode
--------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkMode_STATUS
----------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPlugin"></a>ContainerServiceNetworkProfile_NetworkPlugin
------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value     | Description |
-|-----------|-------------|
-| "azure"   |             |
-| "kubenet" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPlugin_STATUS"></a>ContainerServiceNetworkProfile_NetworkPlugin_STATUS
--------------------------------------------------------------------------------------------------------------------
-
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
 | Value     | Description |
@@ -1248,8 +1248,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "azure"   |             |
 | "kubenet" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPolicy"></a>ContainerServiceNetworkProfile_NetworkPolicy
------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkPolicy{#ContainerServiceNetworkProfile_NetworkPolicy}
+-------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1258,8 +1258,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "azure"  |             |
 | "calico" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPolicy_STATUS"></a>ContainerServiceNetworkProfile_NetworkPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkPolicy_STATUS{#ContainerServiceNetworkProfile_NetworkPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1268,8 +1268,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "azure"  |             |
 | "calico" |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
----------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1278,8 +1278,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "loadBalancer"       |             |
 | "userDefinedRouting" |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1288,8 +1288,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "loadBalancer"       |             |
 | "userDefinedRouting" |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 
@@ -1297,8 +1297,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------|---------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STATUS).
 
@@ -1306,8 +1306,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 Used by: [ExtendedLocation](#ExtendedLocation).
 
@@ -1315,8 +1315,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 
@@ -1324,8 +1324,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -1337,8 +1337,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -1350,8 +1350,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -1361,8 +1361,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -1372,8 +1372,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -1382,8 +1382,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    |             | string<br/><small>Optional</small> |
 | principalId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1396,8 +1396,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes     |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small> |
 | outboundIPs            |             | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1410,8 +1410,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes     |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small> |
 | outboundIPs            |             | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -1420,8 +1420,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -1432,8 +1432,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            |             | string<br/><small>Required</small>                                        |
 | namespace       |             | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -1446,8 +1446,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |             | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState |             | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -1457,8 +1457,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace |             | string<br/><small>Required</small>            |
 | podLabels |             | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -1468,8 +1468,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace |             | string<br/><small>Optional</small>            |
 | podLabels |             | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander"></a>ManagedClusterProperties_AutoScalerProfile_Expander
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander{#ManagedClusterProperties_AutoScalerProfile_Expander}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_AutoScalerProfile).
 
@@ -1480,8 +1480,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_Expander_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander_STATUS{#ManagedClusterProperties_AutoScalerProfile_Expander_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProperties_AutoScalerProfile_STATUS).
 
@@ -1492,8 +1492,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
 
 Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 
@@ -1501,8 +1501,8 @@ Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 |---------|-------------|
 | "Basic" |             |
 
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 
@@ -1510,8 +1510,8 @@ Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 |---------|-------------|
 | "Basic" |             |
 
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
 
 Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 
@@ -1520,8 +1520,8 @@ Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 | "Free" |             |
 | "Paid" |             |
 
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 
@@ -1530,8 +1530,8 @@ Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 | "Free" |             |
 | "Paid" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
----------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -1540,8 +1540,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -1550,8 +1550,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -1560,8 +1560,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Used by: [LinuxOSConfig](#LinuxOSConfig).
 
@@ -1596,8 +1596,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 
@@ -1632,8 +1632,8 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -1641,8 +1641,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 
@@ -1650,8 +1650,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS).
 
@@ -1659,8 +1659,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -1668,8 +1668,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -1677,8 +1677,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -1686,8 +1686,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|-------------|-----------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -1695,8 +1695,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|-------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -1704,8 +1704,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|-----------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -1713,8 +1713,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|-------------|-------------------------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -1722,8 +1722,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -1734,8 +1734,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Failed"   |             |
 | "Updating" |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile), [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes), and [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs).
 
@@ -1743,8 +1743,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS), [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS), and [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -1752,8 +1752,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|-------------|------------------------------------|
 | id       |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS).
 
@@ -1761,8 +1761,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS).
 
@@ -1773,8 +1773,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  |             | string<br/><small>Optional</small>                                                                                                                              |
 | target   |             | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20230201.md
+++ b/docs/hugo/content/reference/containerservice/v1api20230201.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20230201
 linktitle: v1api20230201
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-02-01" |             |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Used by: [ManagedClusterList](#ManagedClusterList).
 
@@ -24,7 +24,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -65,7 +65,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  |                                                                                                                                                                                                                                                                                              | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                  | Description                        | Type                                                                                                                                                    |
 |---------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -115,8 +115,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile            |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile |                                    | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 | Property                                                                            | Description | Type                                                            |
 |-------------------------------------------------------------------------------------|-------------|-----------------------------------------------------------------|
@@ -124,8 +124,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-02-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -138,7 +138,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -184,7 +184,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vnetSubnetReference              | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 | workloadRuntime                  | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -234,8 +234,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vnetSubnetID               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-02-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -245,8 +245,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -289,8 +289,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  |                                                                                                                                                                                                                                                                                              | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -342,8 +342,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile            |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile |                                    | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -391,8 +391,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vnetSubnetReference              | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 | workloadRuntime                  | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -444,8 +444,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vnetSubnetID               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -454,8 +454,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -464,8 +464,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -474,8 +474,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -484,8 +484,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -493,8 +493,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|------------------------------------|
 | maxSurge |             | string<br/><small>Optional</small> |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -502,8 +502,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|-------------|------------------------------------|
 | maxSurge |             | string<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -512,8 +512,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername |             | string<br/><small>Required</small>                                                                |
 | ssh           |             | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -522,8 +522,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername |             | string<br/><small>Optional</small>                                                                              |
 | ssh           |             | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -546,8 +546,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                                |
 | serviceCidrs        |             | string[]<br/><small>Optional</small>                                                                                              |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -570,13 +570,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                                              |
 | serviceCidrs        |             | string[]<br/><small>Optional</small>                                                                                                            |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -584,8 +584,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |-------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sourceResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -593,8 +593,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |------------------|-------------|------------------------------------|
 | sourceResourceId |             | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -603,8 +603,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | string<br/><small>Optional</small>                                        |
 | type     |             | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -613,56 +613,37 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | string<br/><small>Optional</small>                                                      |
 | type     |             | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Property              | Description | Type                                 |
-|-----------------------|-------------|--------------------------------------|
-| allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
-| containerLogMaxFiles  |             | int<br/><small>Optional</small>      |
-| containerLogMaxSizeMB |             | int<br/><small>Optional</small>      |
-| cpuCfsQuota           |             | bool<br/><small>Optional</small>     |
-| cpuCfsQuotaPeriod     |             | string<br/><small>Optional</small>   |
-| cpuManagerPolicy      |             | string<br/><small>Optional</small>   |
-| failSwapOn            |             | bool<br/><small>Optional</small>     |
-| imageGcHighThreshold  |             | int<br/><small>Optional</small>      |
-| imageGcLowThreshold   |             | int<br/><small>Optional</small>      |
-| podMaxPids            |             | int<br/><small>Optional</small>      |
-| topologyManagerPolicy |             | string<br/><small>Optional</small>   |
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
 -----------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Property              | Description | Type                                 |
 |-----------------------|-------------|--------------------------------------|
 | allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
@@ -677,8 +658,27 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            |             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy |             | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
 -------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Property              | Description | Type                                 |
+|-----------------------|-------------|--------------------------------------|
+| allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
+| containerLogMaxFiles  |             | int<br/><small>Optional</small>      |
+| containerLogMaxSizeMB |             | int<br/><small>Optional</small>      |
+| cpuCfsQuota           |             | bool<br/><small>Optional</small>     |
+| cpuCfsQuotaPeriod     |             | string<br/><small>Optional</small>   |
+| cpuManagerPolicy      |             | string<br/><small>Optional</small>   |
+| failSwapOn            |             | bool<br/><small>Optional</small>     |
+| imageGcHighThreshold  |             | int<br/><small>Optional</small>      |
+| imageGcLowThreshold   |             | int<br/><small>Optional</small>      |
+| podMaxPids            |             | int<br/><small>Optional</small>      |
+| topologyManagerPolicy |             | string<br/><small>Optional</small>   |
+
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -687,8 +687,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -697,8 +697,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -709,8 +709,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -721,8 +721,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -736,8 +736,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -751,8 +751,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -761,8 +761,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   |             | map[string]string<br/><small>Optional</small> |
 | enabled  |             | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -772,8 +772,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  |             | bool<br/><small>Optional</small>                                                        |
 | identity |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -819,8 +819,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | vnetSubnetReference              |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | workloadRuntime                  |             | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                            |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -869,8 +869,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | vnetSubnetID               |             | string<br/><small>Optional</small>                                                              |
 | workloadRuntime            |             | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -882,8 +882,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | enablePrivateClusterPublicFQDN |             | bool<br/><small>Optional</small>     |
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -895,8 +895,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enablePrivateClusterPublicFQDN |             | bool<br/><small>Optional</small>     |
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -904,8 +904,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------|
 | upgradeChannel |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -913,8 +913,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | upgradeChannel |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfile"></a>ManagedClusterAzureMonitorProfile
--------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile{#ManagedClusterAzureMonitorProfile}
+---------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -922,8 +922,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------|
 | metrics  |             | [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfile_STATUS"></a>ManagedClusterAzureMonitorProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile_STATUS{#ManagedClusterAzureMonitorProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -931,8 +931,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|---------------------------------------------------------------------------------------------------------------------------------|
 | metrics  |             | [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -943,8 +943,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    |             | string[]<br/><small>Optional</small> |
 | trustedCa  |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -955,8 +955,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy    |             | string[]<br/><small>Optional</small> |
 | trustedCa  |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -965,8 +965,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   |             | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities |             | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -977,8 +977,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   |             | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities |             | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile"></a>ManagedClusterOIDCIssuerProfile
----------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile{#ManagedClusterOIDCIssuerProfile}
+-----------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -986,8 +986,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile_STATUS"></a>ManagedClusterOIDCIssuerProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile_STATUS{#ManagedClusterOIDCIssuerProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -996,8 +996,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled   |             | bool<br/><small>Optional</small>   |
 | issuerURL |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1010,8 +1010,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1022,8 +1022,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1034,8 +1034,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1059,8 +1059,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage    |             | string<br/><small>Optional</small>                                                                                                      |
 | skip-nodes-with-system-pods      |             | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1084,8 +1084,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage    |             | string<br/><small>Optional</small>                                                                                                                    |
 | skip-nodes-with-system-pods      |             | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess"></a>ManagedClusterProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess{#ManagedClusterProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1094,8 +1094,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess_STATUS"></a>ManagedClusterProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess_STATUS{#ManagedClusterProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1104,8 +1104,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1116,8 +1116,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile"></a>ManagedClusterSecurityProfile
------------------------------------------------------------------------
+ManagedClusterSecurityProfile{#ManagedClusterSecurityProfile}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1128,8 +1128,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | imageCleaner     |             | [ManagedClusterSecurityProfileImageCleaner](#ManagedClusterSecurityProfileImageCleaner)<br/><small>Optional</small>         |
 | workloadIdentity |             | [ManagedClusterSecurityProfileWorkloadIdentity](#ManagedClusterSecurityProfileWorkloadIdentity)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile_STATUS"></a>ManagedClusterSecurityProfile_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterSecurityProfile_STATUS{#ManagedClusterSecurityProfile_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1140,8 +1140,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | imageCleaner     |             | [ManagedClusterSecurityProfileImageCleaner_STATUS](#ManagedClusterSecurityProfileImageCleaner_STATUS)<br/><small>Optional</small>         |
 | workloadIdentity |             | [ManagedClusterSecurityProfileWorkloadIdentity_STATUS](#ManagedClusterSecurityProfileWorkloadIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1150,8 +1150,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId |             | string<br/><small>Required</small>                                                                                                                     |
 | secret   |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1159,8 +1159,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|------------------------------------|
 | clientId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1169,8 +1169,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1179,8 +1179,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile"></a>ManagedClusterStorageProfile
----------------------------------------------------------------------
+ManagedClusterStorageProfile{#ManagedClusterStorageProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1191,8 +1191,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | fileCSIDriver      |             | [ManagedClusterStorageProfileFileCSIDriver](#ManagedClusterStorageProfileFileCSIDriver)<br/><small>Optional</small>           |
 | snapshotController |             | [ManagedClusterStorageProfileSnapshotController](#ManagedClusterStorageProfileSnapshotController)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile_STATUS"></a>ManagedClusterStorageProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterStorageProfile_STATUS{#ManagedClusterStorageProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1203,8 +1203,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | fileCSIDriver      |             | [ManagedClusterStorageProfileFileCSIDriver_STATUS](#ManagedClusterStorageProfileFileCSIDriver_STATUS)<br/><small>Optional</small>           |
 | snapshotController |             | [ManagedClusterStorageProfileSnapshotController_STATUS](#ManagedClusterStorageProfileSnapshotController_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1216,8 +1216,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | gmsaProfile    |             | [WindowsGmsaProfile](#WindowsGmsaProfile)<br/><small>Optional</small>                                                                                  |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1228,8 +1228,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | gmsaProfile    |             | [WindowsGmsaProfile_STATUS](#WindowsGmsaProfile_STATUS)<br/><small>Optional</small>                                             |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile"></a>ManagedClusterWorkloadAutoScalerProfile
--------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile{#ManagedClusterWorkloadAutoScalerProfile}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1237,8 +1237,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------|
 | keda     |             | [ManagedClusterWorkloadAutoScalerProfileKeda](#ManagedClusterWorkloadAutoScalerProfileKeda)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile_STATUS"></a>ManagedClusterWorkloadAutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile_STATUS{#ManagedClusterWorkloadAutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1246,31 +1246,31 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | keda     |             | [ManagedClusterWorkloadAutoScalerProfileKeda_STATUS](#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSDiskType_STATUS{#OSDiskType_STATUS}
+-------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Value         | Description |
 |---------------|-------------|
 | "CBLMariner"  |             |
@@ -1278,8 +1278,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Windows2019" |             |
 | "Windows2022" |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
--------------------------------------
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1290,8 +1290,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Windows2019" |             |
 | "Windows2022" |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1300,8 +1300,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1310,8 +1310,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PowerState"></a>PowerState
----------------------------------
+PowerState{#PowerState}
+-----------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1319,8 +1319,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|-----------------------------------------------------------------|
 | code     |             | [PowerState_Code](#PowerState_Code)<br/><small>Optional</small> |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1328,8 +1328,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------|-------------------------------------------------------------------------------|
 | code     |             | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1341,8 +1341,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers |             | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            |             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1355,8 +1355,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      |             | string[]<br/><small>Optional</small> |
 | type                 |             | string<br/><small>Optional</small>   |
 
-<a id="ScaleDownMode"></a>ScaleDownMode
----------------------------------------
+ScaleDownMode{#ScaleDownMode}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1365,8 +1365,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleDownMode_STATUS"></a>ScaleDownMode_STATUS
------------------------------------------------------
+ScaleDownMode_STATUS{#ScaleDownMode_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1375,48 +1375,48 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value        | Description |
-|--------------|-------------|
-| "Deallocate" |             |
-| "Delete"     |             |
-
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Deallocate" |             |
-| "Delete"     |             |
-
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="SystemData_STATUS"></a>SystemData_STATUS
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
 -----------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Value        | Description |
+|--------------|-------------|
+| "Deallocate" |             |
+| "Delete"     |             |
+
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Deallocate" |             |
+| "Delete"     |             |
+
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
+-------------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1429,8 +1429,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | lastModifiedBy     |             | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType |             | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIdentity](#ManagedClusterPodIdentity).
 
@@ -1440,8 +1440,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          |             | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonProfile_STATUS](#ManagedClusterAddonProfile_STATUS), and [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -1451,8 +1451,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   |             | string<br/><small>Optional</small> |
 | resourceId |             | string<br/><small>Optional</small> |
 
-<a id="WorkloadRuntime"></a>WorkloadRuntime
--------------------------------------------
+WorkloadRuntime{#WorkloadRuntime}
+---------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1461,8 +1461,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="WorkloadRuntime_STATUS"></a>WorkloadRuntime_STATUS
----------------------------------------------------------
+WorkloadRuntime_STATUS{#WorkloadRuntime_STATUS}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1471,8 +1471,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="AzureKeyVaultKms"></a>AzureKeyVaultKms
----------------------------------------------
+AzureKeyVaultKms{#AzureKeyVaultKms}
+-----------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -1483,8 +1483,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | keyVaultNetworkAccess     |             | [AzureKeyVaultKms_KeyVaultNetworkAccess](#AzureKeyVaultKms_KeyVaultNetworkAccess)<br/><small>Optional</small>                                              |
 | keyVaultResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_STATUS"></a>AzureKeyVaultKms_STATUS
------------------------------------------------------------
+AzureKeyVaultKms_STATUS{#AzureKeyVaultKms_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -1495,88 +1495,88 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | keyVaultNetworkAccess |             | [AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS](#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS)<br/><small>Optional</small> |
 | keyVaultResourceId    |             | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies"></a>ContainerServiceNetworkProfile_IpFamilies
+ContainerServiceNetworkProfile_IpFamilies{#ContainerServiceNetworkProfile_IpFamilies}
+-------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_IpFamilies_STATUS{#ContainerServiceNetworkProfile_IpFamilies_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_LoadBalancerSku{#ContainerServiceNetworkProfile_LoadBalancerSku}
 -----------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
+| Value      | Description |
+|------------|-------------|
+| "basic"    |             |
+| "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies_STATUS"></a>ContainerServiceNetworkProfile_IpFamilies_STATUS
+ContainerServiceNetworkProfile_LoadBalancerSku_STATUS{#ContainerServiceNetworkProfile_LoadBalancerSku_STATUS}
 -------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
-
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku"></a>ContainerServiceNetworkProfile_LoadBalancerSku
----------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
 | Value      | Description |
 |------------|-------------|
 | "basic"    |             |
 | "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku_STATUS"></a>ContainerServiceNetworkProfile_LoadBalancerSku_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "basic"    |             |
-| "standard" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane"></a>ContainerServiceNetworkProfile_NetworkDataplane
------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane_STATUS"></a>ContainerServiceNetworkProfile_NetworkDataplane_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkMode"></a>ContainerServiceNetworkProfile_NetworkMode
+ContainerServiceNetworkProfile_NetworkDataplane{#ContainerServiceNetworkProfile_NetworkDataplane}
 -------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkMode_STATUS
+ContainerServiceNetworkProfile_NetworkDataplane_STATUS{#ContainerServiceNetworkProfile_NetworkDataplane_STATUS}
 ---------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkMode{#ContainerServiceNetworkProfile_NetworkMode}
+---------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value         | Description |
 |---------------|-------------|
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPlugin"></a>ContainerServiceNetworkProfile_NetworkPlugin
+ContainerServiceNetworkProfile_NetworkMode_STATUS{#ContainerServiceNetworkProfile_NetworkMode_STATUS}
 -----------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+ContainerServiceNetworkProfile_NetworkPlugin{#ContainerServiceNetworkProfile_NetworkPlugin}
+-------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1586,8 +1586,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPlugin_STATUS"></a>ContainerServiceNetworkProfile_NetworkPlugin_STATUS
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkPlugin_STATUS{#ContainerServiceNetworkProfile_NetworkPlugin_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1597,51 +1597,51 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode"></a>ContainerServiceNetworkProfile_NetworkPluginMode
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkPluginMode_STATUS
----------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy"></a>ContainerServiceNetworkProfile_NetworkPolicy
------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy_STATUS"></a>ContainerServiceNetworkProfile_NetworkPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
+ContainerServiceNetworkProfile_NetworkPluginMode{#ContainerServiceNetworkProfile_NetworkPluginMode}
 ---------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPluginMode_STATUS{#ContainerServiceNetworkProfile_NetworkPluginMode_STATUS}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy{#ContainerServiceNetworkProfile_NetworkPolicy}
+-------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy_STATUS{#ContainerServiceNetworkProfile_NetworkPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value                    | Description |
 |--------------------------|-------------|
 | "loadBalancer"           |             |
@@ -1649,8 +1649,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1661,8 +1661,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 
@@ -1670,8 +1670,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------|---------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STATUS).
 
@@ -1679,8 +1679,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 Used by: [ExtendedLocation](#ExtendedLocation).
 
@@ -1688,8 +1688,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 
@@ -1697,8 +1697,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -1710,8 +1710,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -1723,8 +1723,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics"></a>ManagedClusterAzureMonitorProfileMetrics
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics{#ManagedClusterAzureMonitorProfileMetrics}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile).
 
@@ -1733,8 +1733,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | enabled          |             | bool<br/><small>Required</small>                                                                                                    |
 | kubeStateMetrics |             | [ManagedClusterAzureMonitorProfileKubeStateMetrics](#ManagedClusterAzureMonitorProfileKubeStateMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileMetrics_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics_STATUS{#ManagedClusterAzureMonitorProfileMetrics_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorProfile_STATUS).
 
@@ -1743,8 +1743,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | enabled          |             | bool<br/><small>Optional</small>                                                                                                                  |
 | kubeStateMetrics |             | [ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS](#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -1754,8 +1754,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -1765,8 +1765,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -1775,8 +1775,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    |             | string<br/><small>Optional</small> |
 | principalId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1790,8 +1790,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes                  |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small> |
 | outboundIPs                         |             | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1805,8 +1805,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes                  |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small> |
 | outboundIPs                         |             | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterNATGatewayProfile"></a>ManagedClusterNATGatewayProfile
----------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile{#ManagedClusterNATGatewayProfile}
+-----------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1816,8 +1816,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | idleTimeoutInMinutes     |             | int<br/><small>Optional</small>                                                                               |
 | managedOutboundIPProfile |             | [ManagedClusterManagedOutboundIPProfile](#ManagedClusterManagedOutboundIPProfile)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNATGatewayProfile_STATUS"></a>ManagedClusterNATGatewayProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile_STATUS{#ManagedClusterNATGatewayProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1827,8 +1827,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | idleTimeoutInMinutes     |             | int<br/><small>Optional</small>                                                                                             |
 | managedOutboundIPProfile |             | [ManagedClusterManagedOutboundIPProfile_STATUS](#ManagedClusterManagedOutboundIPProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorConfigMaps"></a>ManagedClusterOperatorConfigMaps
------------------------------------------------------------------------------
+ManagedClusterOperatorConfigMaps{#ManagedClusterOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -1837,8 +1837,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | oidcIssuerProfile | indicates where the OIDCIssuerProfile config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | principalId       | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created.       | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -1847,8 +1847,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -1859,8 +1859,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            |             | string<br/><small>Required</small>                                        |
 | namespace       |             | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -1873,8 +1873,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |             | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState |             | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -1884,8 +1884,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace |             | string<br/><small>Required</small>            |
 | podLabels |             | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -1895,8 +1895,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace |             | string<br/><small>Optional</small>            |
 | podLabels |             | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander"></a>ManagedClusterProperties_AutoScalerProfile_Expander
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander{#ManagedClusterProperties_AutoScalerProfile_Expander}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_AutoScalerProfile).
 
@@ -1907,8 +1907,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_Expander_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander_STATUS{#ManagedClusterProperties_AutoScalerProfile_Expander_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProperties_AutoScalerProfile_STATUS).
 
@@ -1919,8 +1919,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterSecurityProfileDefender"></a>ManagedClusterSecurityProfileDefender
----------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender{#ManagedClusterSecurityProfileDefender}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -1929,8 +1929,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | logAnalyticsWorkspaceResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityMonitoring                     |             | [ManagedClusterSecurityProfileDefenderSecurityMonitoring](#ManagedClusterSecurityProfileDefenderSecurityMonitoring)<br/><small>Optional</small>            |
 
-<a id="ManagedClusterSecurityProfileDefender_STATUS"></a>ManagedClusterSecurityProfileDefender_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender_STATUS{#ManagedClusterSecurityProfileDefender_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -1939,8 +1939,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | logAnalyticsWorkspaceResourceId |             | string<br/><small>Optional</small>                                                                                                                            |
 | securityMonitoring              |             | [ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS](#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageCleaner"></a>ManagedClusterSecurityProfileImageCleaner
------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner{#ManagedClusterSecurityProfileImageCleaner}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -1949,8 +1949,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | enabled       |             | bool<br/><small>Optional</small> |
 | intervalHours |             | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileImageCleaner_STATUS"></a>ManagedClusterSecurityProfileImageCleaner_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner_STATUS{#ManagedClusterSecurityProfileImageCleaner_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -1959,136 +1959,136 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | enabled       |             | bool<br/><small>Optional</small> |
 | intervalHours |             | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileWorkloadIdentity"></a>ManagedClusterSecurityProfileWorkloadIdentity
--------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileWorkloadIdentity_STATUS"></a>ManagedClusterSecurityProfileWorkloadIdentity_STATUS
----------------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Standard" |             |
-
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Standard" |             |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver"></a>ManagedClusterStorageProfileBlobCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver_STATUS"></a>ManagedClusterStorageProfileBlobCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver"></a>ManagedClusterStorageProfileDiskCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver_STATUS"></a>ManagedClusterStorageProfileDiskCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver"></a>ManagedClusterStorageProfileFileCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver_STATUS"></a>ManagedClusterStorageProfileFileCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController"></a>ManagedClusterStorageProfileSnapshotController
----------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController_STATUS"></a>ManagedClusterStorageProfileSnapshotController_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
+ManagedClusterSecurityProfileWorkloadIdentity{#ManagedClusterSecurityProfileWorkloadIdentity}
 ---------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileWorkloadIdentity_STATUS{#ManagedClusterSecurityProfileWorkloadIdentity_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Standard" |             |
+
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Standard" |             |
+
+ManagedClusterStorageProfileBlobCSIDriver{#ManagedClusterStorageProfileBlobCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileBlobCSIDriver_STATUS{#ManagedClusterStorageProfileBlobCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver{#ManagedClusterStorageProfileDiskCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver_STATUS{#ManagedClusterStorageProfileDiskCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver{#ManagedClusterStorageProfileFileCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver_STATUS{#ManagedClusterStorageProfileFileCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController{#ManagedClusterStorageProfileSnapshotController}
+-----------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController_STATUS{#ManagedClusterStorageProfileSnapshotController_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -2097,8 +2097,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -2107,8 +2107,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda"></a>ManagedClusterWorkloadAutoScalerProfileKeda
----------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda{#ManagedClusterWorkloadAutoScalerProfileKeda}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile).
 
@@ -2116,8 +2116,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda_STATUS{#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS).
 
@@ -2125,8 +2125,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="PowerState_Code"></a>PowerState_Code
--------------------------------------------
+PowerState_Code{#PowerState_Code}
+---------------------------------
 
 Used by: [PowerState](#PowerState).
 
@@ -2135,8 +2135,8 @@ Used by: [PowerState](#PowerState).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -2145,8 +2145,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Used by: [LinuxOSConfig](#LinuxOSConfig).
 
@@ -2181,8 +2181,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 
@@ -2217,7 +2217,19 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2229,20 +2241,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2250,8 +2250,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile"></a>WindowsGmsaProfile
--------------------------------------------------
+WindowsGmsaProfile{#WindowsGmsaProfile}
+---------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -2261,8 +2261,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | enabled        |             | bool<br/><small>Optional</small>   |
 | rootDomainName |             | string<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile_STATUS"></a>WindowsGmsaProfile_STATUS
----------------------------------------------------------------
+WindowsGmsaProfile_STATUS{#WindowsGmsaProfile_STATUS}
+-----------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -2272,8 +2272,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | enabled        |             | bool<br/><small>Optional</small>   |
 | rootDomainName |             | string<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess"></a>AzureKeyVaultKms_KeyVaultNetworkAccess
------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess{#AzureKeyVaultKms_KeyVaultNetworkAccess}
+-------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 
@@ -2282,8 +2282,8 @@ Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS"></a>AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS{#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 
@@ -2292,8 +2292,8 @@ Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 
@@ -2301,8 +2301,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS).
 
@@ -2310,8 +2310,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics
----------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics{#ManagedClusterAzureMonitorProfileKubeStateMetrics}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics).
 
@@ -2320,8 +2320,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 | metricAnnotationsAllowList |             | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS{#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS).
 
@@ -2330,8 +2330,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 | metricAnnotationsAllowList |             | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -2340,8 +2340,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | count     |             | int<br/><small>Optional</small> |
 | countIPv6 |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -2350,8 +2350,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | count     |             | int<br/><small>Optional</small> |
 | countIPv6 |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -2359,8 +2359,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|-------------|-----------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -2368,8 +2368,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|-------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -2377,8 +2377,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|-----------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -2386,8 +2386,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|-------------|-------------------------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile"></a>ManagedClusterManagedOutboundIPProfile
------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile{#ManagedClusterManagedOutboundIPProfile}
+-------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 
@@ -2395,8 +2395,8 @@ Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile_STATUS"></a>ManagedClusterManagedOutboundIPProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile_STATUS{#ManagedClusterManagedOutboundIPProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfile_STATUS).
 
@@ -2404,8 +2404,8 @@ Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfi
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -2413,8 +2413,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -2427,8 +2427,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring{#ManagedClusterSecurityProfileDefenderSecurityMonitoring}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileDefender).
 
@@ -2436,8 +2436,8 @@ Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileD
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS{#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityProfileDefender_STATUS).
 
@@ -2445,8 +2445,8 @@ Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityP
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile), [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes), [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs), and [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 
@@ -2454,8 +2454,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS), [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS), [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS), and [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfile_STATUS).
 
@@ -2463,8 +2463,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|-------------|------------------------------------|
 | id       |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS).
 
@@ -2472,8 +2472,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS).
 
@@ -2484,8 +2484,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  |             | string<br/><small>Optional</small>                                                                                                                              |
 | target   |             | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20230315preview.md
+++ b/docs/hugo/content/reference/containerservice/v1api20230315preview.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20230315preview
 linktitle: v1api20230315preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2023-03-15-preview" |             |
 
-<a id="Fleet"></a>Fleet
------------------------
+Fleet{#Fleet}
+-------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}
 
@@ -26,7 +26,7 @@ Used by: [FleetList](#FleetList).
 | spec                                                                                    |             | [Fleet_Spec](#Fleet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Fleet_STATUS](#Fleet_STATUS)<br/><small>Optional</small> |
 
-### <a id="Fleet_Spec"></a>Fleet_Spec
+### Fleet_Spec {#Fleet_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [FleetList](#FleetList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Fleet_STATUS"></a>Fleet_STATUS
+### Fleet_STATUS{#Fleet_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,8 +52,8 @@ Used by: [FleetList](#FleetList).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetList"></a>FleetList
--------------------------------
+FleetList{#FleetList}
+---------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}
 
@@ -63,8 +63,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Fleet[]](#Fleet)<br/><small>Optional</small> |
 
-<a id="FleetsMember"></a>FleetsMember
--------------------------------------
+FleetsMember{#FleetsMember}
+---------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}/members/{fleetMemberName}
 
@@ -77,7 +77,7 @@ Used by: [FleetsMemberList](#FleetsMemberList).
 | spec                                                                                    |             | [FleetsMember_Spec](#FleetsMember_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FleetsMember_STATUS](#FleetsMember_STATUS)<br/><small>Optional</small> |
 
-### <a id="FleetsMember_Spec"></a>FleetsMember_Spec
+### FleetsMember_Spec {#FleetsMember_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -87,7 +87,7 @@ Used by: [FleetsMemberList](#FleetsMemberList).
 | operatorSpec             | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                                                            | [FleetsMemberOperatorSpec](#FleetsMemberOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner                    | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/Fleet resource                                                | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FleetsMember_STATUS"></a>FleetsMember_STATUS
+### FleetsMember_STATUS{#FleetsMember_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,8 +101,8 @@ Used by: [FleetsMemberList](#FleetsMemberList).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetsMemberList"></a>FleetsMemberList
----------------------------------------------
+FleetsMemberList{#FleetsMemberList}
+-----------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}/members/{fleetMemberName}
 
@@ -112,8 +112,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [FleetsMember[]](#FleetsMember)<br/><small>Optional</small> |
 
-<a id="FleetsUpdateRun"></a>FleetsUpdateRun
--------------------------------------------
+FleetsUpdateRun{#FleetsUpdateRun}
+---------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}
 
@@ -126,7 +126,7 @@ Used by: [FleetsUpdateRunList](#FleetsUpdateRunList).
 | spec                                                                                    |             | [FleetsUpdateRun_Spec](#FleetsUpdateRun_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FleetsUpdateRun_STATUS](#FleetsUpdateRun_STATUS)<br/><small>Optional</small> |
 
-### <a id="FleetsUpdateRun_Spec"></a>FleetsUpdateRun_Spec
+### FleetsUpdateRun_Spec {#FleetsUpdateRun_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -136,7 +136,7 @@ Used by: [FleetsUpdateRunList](#FleetsUpdateRunList).
 | owner                | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/Fleet resource             | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | strategy             | The strategy defines the order in which the clusters will be updated. If not set, all members will be updated sequentially. The UpdateRun status will show a single UpdateStage and a single UpdateGroup targeting all members. The strategy of the UpdateRun can be modified until the run is started. | [UpdateRunStrategy](#UpdateRunStrategy)<br/><small>Optional</small>                                                                                                  |
 
-### <a id="FleetsUpdateRun_STATUS"></a>FleetsUpdateRun_STATUS
+### FleetsUpdateRun_STATUS{#FleetsUpdateRun_STATUS}
 
 | Property             | Description                                                                                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                    |
 |----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -151,8 +151,8 @@ Used by: [FleetsUpdateRunList](#FleetsUpdateRunList).
 | systemData           | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetsUpdateRunList"></a>FleetsUpdateRunList
----------------------------------------------------
+FleetsUpdateRunList{#FleetsUpdateRunList}
+-----------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}
 
@@ -162,8 +162,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [FleetsUpdateRun[]](#FleetsUpdateRun)<br/><small>Optional</small> |
 
-<a id="Fleet_Spec"></a>Fleet_Spec
----------------------------------
+Fleet_Spec{#Fleet_Spec}
+-----------------------
 
 Used by: [Fleet](#Fleet).
 
@@ -176,8 +176,8 @@ Used by: [Fleet](#Fleet).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Fleet_STATUS"></a>Fleet_STATUS
--------------------------------------
+Fleet_STATUS{#Fleet_STATUS}
+---------------------------
 
 The Fleet resource.
 
@@ -196,8 +196,8 @@ Used by: [Fleet](#Fleet).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetsMember_Spec"></a>FleetsMember_Spec
------------------------------------------------
+FleetsMember_Spec{#FleetsMember_Spec}
+-------------------------------------
 
 Used by: [FleetsMember](#FleetsMember).
 
@@ -209,8 +209,8 @@ Used by: [FleetsMember](#FleetsMember).
 | operatorSpec             | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                                                            | [FleetsMemberOperatorSpec](#FleetsMemberOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner                    | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/Fleet resource                                                | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FleetsMember_STATUS"></a>FleetsMember_STATUS
----------------------------------------------------
+FleetsMember_STATUS{#FleetsMember_STATUS}
+-----------------------------------------
 
 Used by: [FleetsMember](#FleetsMember).
 
@@ -226,8 +226,8 @@ Used by: [FleetsMember](#FleetsMember).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetsUpdateRun_Spec"></a>FleetsUpdateRun_Spec
------------------------------------------------------
+FleetsUpdateRun_Spec{#FleetsUpdateRun_Spec}
+-------------------------------------------
 
 Used by: [FleetsUpdateRun](#FleetsUpdateRun).
 
@@ -239,8 +239,8 @@ Used by: [FleetsUpdateRun](#FleetsUpdateRun).
 | owner                | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/Fleet resource             | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | strategy             | The strategy defines the order in which the clusters will be updated. If not set, all members will be updated sequentially. The UpdateRun status will show a single UpdateStage and a single UpdateGroup targeting all members. The strategy of the UpdateRun can be modified until the run is started. | [UpdateRunStrategy](#UpdateRunStrategy)<br/><small>Optional</small>                                                                                                  |
 
-<a id="FleetsUpdateRun_STATUS"></a>FleetsUpdateRun_STATUS
----------------------------------------------------------
+FleetsUpdateRun_STATUS{#FleetsUpdateRun_STATUS}
+-----------------------------------------------
 
 Used by: [FleetsUpdateRun](#FleetsUpdateRun).
 
@@ -257,8 +257,8 @@ Used by: [FleetsUpdateRun](#FleetsUpdateRun).
 | systemData           | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                 | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FleetHubProfile"></a>FleetHubProfile
--------------------------------------------
+FleetHubProfile{#FleetHubProfile}
+---------------------------------
 
 The FleetHubProfile configures the fleet hub.
 
@@ -268,8 +268,8 @@ Used by: [Fleet_Spec](#Fleet_Spec).
 |-----------|-------------------------------------------------------|------------------------------------|
 | dnsPrefix | DNS prefix used to create the FQDN for the Fleet hub. | string<br/><small>Optional</small> |
 
-<a id="FleetHubProfile_STATUS"></a>FleetHubProfile_STATUS
----------------------------------------------------------
+FleetHubProfile_STATUS{#FleetHubProfile_STATUS}
+-----------------------------------------------
 
 The FleetHubProfile configures the fleet hub.
 
@@ -281,8 +281,8 @@ Used by: [Fleet_STATUS](#Fleet_STATUS).
 | fqdn              | The FQDN of the Fleet hub.                            | string<br/><small>Optional</small> |
 | kubernetesVersion | The Kubernetes version of the Fleet hub.              | string<br/><small>Optional</small> |
 
-<a id="FleetMemberProvisioningState_STATUS"></a>FleetMemberProvisioningState_STATUS
------------------------------------------------------------------------------------
+FleetMemberProvisioningState_STATUS{#FleetMemberProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 The provisioning state of the last accepted operation.
 
@@ -297,8 +297,8 @@ Used by: [FleetsMember_STATUS](#FleetsMember_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="FleetOperatorSpec"></a>FleetOperatorSpec
------------------------------------------------
+FleetOperatorSpec{#FleetOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -310,8 +310,8 @@ Used by: [Fleet_Spec](#Fleet_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FleetOperatorSecrets](#FleetOperatorSecrets)<br/><small>Optional</small>                                                                                           |
 
-<a id="FleetProvisioningState_STATUS"></a>FleetProvisioningState_STATUS
------------------------------------------------------------------------
+FleetProvisioningState_STATUS{#FleetProvisioningState_STATUS}
+-------------------------------------------------------------
 
 The provisioning state of the last accepted operation.
 
@@ -326,8 +326,8 @@ Used by: [Fleet_STATUS](#Fleet_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="FleetsMemberOperatorSpec"></a>FleetsMemberOperatorSpec
--------------------------------------------------------------
+FleetsMemberOperatorSpec{#FleetsMemberOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -338,8 +338,8 @@ Used by: [FleetsMember_Spec](#FleetsMember_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FleetsUpdateRunOperatorSpec"></a>FleetsUpdateRunOperatorSpec
--------------------------------------------------------------------
+FleetsUpdateRunOperatorSpec{#FleetsUpdateRunOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -350,8 +350,8 @@ Used by: [FleetsUpdateRun_Spec](#FleetsUpdateRun_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterUpdate"></a>ManagedClusterUpdate
------------------------------------------------------
+ManagedClusterUpdate{#ManagedClusterUpdate}
+-------------------------------------------
 
 The update to be applied to the ManagedClusters.
 
@@ -361,8 +361,8 @@ Used by: [FleetsUpdateRun_Spec](#FleetsUpdateRun_Spec).
 |----------|----------------------------------------------|-------------------------------------------------------------------------------------|
 | upgrade  | The upgrade to apply to the ManagedClusters. | [ManagedClusterUpgradeSpec](#ManagedClusterUpgradeSpec)<br/><small>Required</small> |
 
-<a id="ManagedClusterUpdate_STATUS"></a>ManagedClusterUpdate_STATUS
--------------------------------------------------------------------
+ManagedClusterUpdate_STATUS{#ManagedClusterUpdate_STATUS}
+---------------------------------------------------------
 
 The update to be applied to the ManagedClusters.
 
@@ -372,8 +372,8 @@ Used by: [FleetsUpdateRun_STATUS](#FleetsUpdateRun_STATUS).
 |----------|----------------------------------------------|---------------------------------------------------------------------------------------------------|
 | upgrade  | The upgrade to apply to the ManagedClusters. | [ManagedClusterUpgradeSpec_STATUS](#ManagedClusterUpgradeSpec_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -388,8 +388,8 @@ Used by: [Fleet_STATUS](#Fleet_STATUS), [FleetsMember_STATUS](#FleetsMember_STAT
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UpdateRunProvisioningState_STATUS"></a>UpdateRunProvisioningState_STATUS
--------------------------------------------------------------------------------
+UpdateRunProvisioningState_STATUS{#UpdateRunProvisioningState_STATUS}
+---------------------------------------------------------------------
 
 The provisioning state of the UpdateRun resource.
 
@@ -401,8 +401,8 @@ Used by: [FleetsUpdateRun_STATUS](#FleetsUpdateRun_STATUS).
 | "Failed"    |             |
 | "Succeeded" |             |
 
-<a id="UpdateRunStatus_STATUS"></a>UpdateRunStatus_STATUS
----------------------------------------------------------
+UpdateRunStatus_STATUS{#UpdateRunStatus_STATUS}
+-----------------------------------------------
 
 The status of a UpdateRun.
 
@@ -413,8 +413,8 @@ Used by: [FleetsUpdateRun_STATUS](#FleetsUpdateRun_STATUS).
 | stages   | The stages composing an update run. Stages are run sequentially withing an UpdateRun. | [UpdateStageStatus_STATUS[]](#UpdateStageStatus_STATUS)<br/><small>Optional</small> |
 | status   | The status of the UpdateRun.                                                          | [UpdateStatus_STATUS](#UpdateStatus_STATUS)<br/><small>Optional</small>             |
 
-<a id="UpdateRunStrategy"></a>UpdateRunStrategy
------------------------------------------------
+UpdateRunStrategy{#UpdateRunStrategy}
+-------------------------------------
 
 Defines the update sequence of the clusters via stages and groups. Stages within a run are executed sequentially one after another. Groups within a stage are executed in parallel. Member clusters within a group are updated sequentially one after another. A valid strategy contains no duplicate groups within or across stages.
 
@@ -424,8 +424,8 @@ Used by: [FleetsUpdateRun_Spec](#FleetsUpdateRun_Spec).
 |----------|---------------------------------------------------------------|-----------------------------------------------------------|
 | stages   | The list of stages that compose this update run. Min size: 1. | [UpdateStage[]](#UpdateStage)<br/><small>Required</small> |
 
-<a id="UpdateRunStrategy_STATUS"></a>UpdateRunStrategy_STATUS
--------------------------------------------------------------
+UpdateRunStrategy_STATUS{#UpdateRunStrategy_STATUS}
+---------------------------------------------------
 
 Defines the update sequence of the clusters via stages and groups. Stages within a run are executed sequentially one after another. Groups within a stage are executed in parallel. Member clusters within a group are updated sequentially one after another. A valid strategy contains no duplicate groups within or across stages.
 
@@ -435,8 +435,8 @@ Used by: [FleetsUpdateRun_STATUS](#FleetsUpdateRun_STATUS).
 |----------|---------------------------------------------------------------|-------------------------------------------------------------------------|
 | stages   | The list of stages that compose this update run. Min size: 1. | [UpdateStage_STATUS[]](#UpdateStage_STATUS)<br/><small>Optional</small> |
 
-<a id="FleetOperatorSecrets"></a>FleetOperatorSecrets
------------------------------------------------------
+FleetOperatorSecrets{#FleetOperatorSecrets}
+-------------------------------------------
 
 Used by: [FleetOperatorSpec](#FleetOperatorSpec).
 
@@ -444,8 +444,8 @@ Used by: [FleetOperatorSpec](#FleetOperatorSpec).
 |-----------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userCredentials | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterUpgradeSpec"></a>ManagedClusterUpgradeSpec
----------------------------------------------------------------
+ManagedClusterUpgradeSpec{#ManagedClusterUpgradeSpec}
+-----------------------------------------------------
 
 The upgrade to apply to a ManagedCluster.
 
@@ -456,8 +456,8 @@ Used by: [ManagedClusterUpdate](#ManagedClusterUpdate).
 | kubernetesVersion | The Kubernetes version to upgrade the member clusters to.       | string<br/><small>Optional</small>                                                  |
 | type              | ManagedClusterUpgradeType is the type of upgrade to be applied. | [ManagedClusterUpgradeType](#ManagedClusterUpgradeType)<br/><small>Required</small> |
 
-<a id="ManagedClusterUpgradeSpec_STATUS"></a>ManagedClusterUpgradeSpec_STATUS
------------------------------------------------------------------------------
+ManagedClusterUpgradeSpec_STATUS{#ManagedClusterUpgradeSpec_STATUS}
+-------------------------------------------------------------------
 
 The upgrade to apply to a ManagedCluster.
 
@@ -468,7 +468,19 @@ Used by: [ManagedClusterUpdate_STATUS](#ManagedClusterUpdate_STATUS).
 | kubernetesVersion | The Kubernetes version to upgrade the member clusters to.       | string<br/><small>Optional</small>                                                                |
 | type              | ManagedClusterUpgradeType is the type of upgrade to be applied. | [ManagedClusterUpgradeType_STATUS](#ManagedClusterUpgradeType_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -480,20 +492,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpdateStage"></a>UpdateStage
------------------------------------
+UpdateStage{#UpdateStage}
+-------------------------
 
 Defines a stage which contains the groups to update and the steps to take (e.g., wait for a time period) before starting the next stage.
 
@@ -505,8 +505,8 @@ Used by: [UpdateRunStrategy](#UpdateRunStrategy).
 | groups                  | Defines the groups to be executed in parallel in this stage. Duplicate groups are not allowed. Min size: 1.              | [UpdateGroup[]](#UpdateGroup)<br/><small>Optional</small> |
 | name                    | The name of the stage. Must be unique within the UpdateRun.                                                              | string<br/><small>Required</small>                        |
 
-<a id="UpdateStage_STATUS"></a>UpdateStage_STATUS
--------------------------------------------------
+UpdateStage_STATUS{#UpdateStage_STATUS}
+---------------------------------------
 
 Defines a stage which contains the groups to update and the steps to take (e.g., wait for a time period) before starting the next stage.
 
@@ -518,8 +518,8 @@ Used by: [UpdateRunStrategy_STATUS](#UpdateRunStrategy_STATUS).
 | groups                  | Defines the groups to be executed in parallel in this stage. Duplicate groups are not allowed. Min size: 1.              | [UpdateGroup_STATUS[]](#UpdateGroup_STATUS)<br/><small>Optional</small> |
 | name                    | The name of the stage. Must be unique within the UpdateRun.                                                              | string<br/><small>Optional</small>                                      |
 
-<a id="UpdateStageStatus_STATUS"></a>UpdateStageStatus_STATUS
--------------------------------------------------------------
+UpdateStageStatus_STATUS{#UpdateStageStatus_STATUS}
+---------------------------------------------------
 
 The status of a UpdateStage.
 
@@ -532,8 +532,8 @@ Used by: [UpdateRunStatus_STATUS](#UpdateRunStatus_STATUS).
 | name                 | The name of the UpdateStage.                                  | string<br/><small>Optional</small>                                                  |
 | status               | The status of the UpdateStage.                                | [UpdateStatus_STATUS](#UpdateStatus_STATUS)<br/><small>Optional</small>             |
 
-<a id="UpdateStatus_STATUS"></a>UpdateStatus_STATUS
----------------------------------------------------
+UpdateStatus_STATUS{#UpdateStatus_STATUS}
+-----------------------------------------
 
 The status for an operation or group of operations.
 
@@ -546,8 +546,8 @@ Used by: [MemberUpdateStatus_STATUS](#MemberUpdateStatus_STATUS), [UpdateGroupSt
 | startTime     | The time the operation or group was started.     | string<br/><small>Optional</small>                                    |
 | state         | The State of the operation or group.             | [UpdateState_STATUS](#UpdateState_STATUS)<br/><small>Optional</small> |
 
-<a id="ErrorDetail_STATUS"></a>ErrorDetail_STATUS
--------------------------------------------------
+ErrorDetail_STATUS{#ErrorDetail_STATUS}
+---------------------------------------
 
 The error detail.
 
@@ -561,8 +561,8 @@ Used by: [UpdateStatus_STATUS](#UpdateStatus_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                        |
 | target         | The error target.          | string<br/><small>Optional</small>                                                        |
 
-<a id="ManagedClusterUpgradeType"></a>ManagedClusterUpgradeType
----------------------------------------------------------------
+ManagedClusterUpgradeType{#ManagedClusterUpgradeType}
+-----------------------------------------------------
 
 The type of upgrade to perform when targeting ManagedClusters.
 
@@ -573,8 +573,8 @@ Used by: [ManagedClusterUpgradeSpec](#ManagedClusterUpgradeSpec).
 | "Full"          |             |
 | "NodeImageOnly" |             |
 
-<a id="ManagedClusterUpgradeType_STATUS"></a>ManagedClusterUpgradeType_STATUS
------------------------------------------------------------------------------
+ManagedClusterUpgradeType_STATUS{#ManagedClusterUpgradeType_STATUS}
+-------------------------------------------------------------------
 
 The type of upgrade to perform when targeting ManagedClusters.
 
@@ -585,8 +585,8 @@ Used by: [ManagedClusterUpgradeSpec_STATUS](#ManagedClusterUpgradeSpec_STATUS).
 | "Full"          |             |
 | "NodeImageOnly" |             |
 
-<a id="UpdateGroup"></a>UpdateGroup
------------------------------------
+UpdateGroup{#UpdateGroup}
+-------------------------
 
 A group to be updated.
 
@@ -596,8 +596,8 @@ Used by: [UpdateStage](#UpdateStage).
 |----------|----------------------------------------------------------------------------|------------------------------------|
 | name     | Name of the group. It must match a group name of an existing fleet member. | string<br/><small>Required</small> |
 
-<a id="UpdateGroup_STATUS"></a>UpdateGroup_STATUS
--------------------------------------------------
+UpdateGroup_STATUS{#UpdateGroup_STATUS}
+---------------------------------------
 
 A group to be updated.
 
@@ -607,8 +607,8 @@ Used by: [UpdateStage_STATUS](#UpdateStage_STATUS).
 |----------|----------------------------------------------------------------------------|------------------------------------|
 | name     | Name of the group. It must match a group name of an existing fleet member. | string<br/><small>Optional</small> |
 
-<a id="UpdateGroupStatus_STATUS"></a>UpdateGroupStatus_STATUS
--------------------------------------------------------------
+UpdateGroupStatus_STATUS{#UpdateGroupStatus_STATUS}
+---------------------------------------------------
 
 The status of a UpdateGroup.
 
@@ -620,8 +620,8 @@ Used by: [UpdateStageStatus_STATUS](#UpdateStageStatus_STATUS).
 | name     | The name of the UpdateGroup.                 | string<br/><small>Optional</small>                                                    |
 | status   | The status of the UpdateGroup.               | [UpdateStatus_STATUS](#UpdateStatus_STATUS)<br/><small>Optional</small>               |
 
-<a id="UpdateState_STATUS"></a>UpdateState_STATUS
--------------------------------------------------
+UpdateState_STATUS{#UpdateState_STATUS}
+---------------------------------------
 
 The state of the UpdateRun, UpdateStage, UpdateGroup, or MemberUpdate.
 
@@ -636,8 +636,8 @@ Used by: [UpdateStatus_STATUS](#UpdateStatus_STATUS).
 | "Stopped"    |             |
 | "Stopping"   |             |
 
-<a id="WaitStatus_STATUS"></a>WaitStatus_STATUS
------------------------------------------------
+WaitStatus_STATUS{#WaitStatus_STATUS}
+-------------------------------------
 
 The status of the wait duration.
 
@@ -648,8 +648,8 @@ Used by: [UpdateStageStatus_STATUS](#UpdateStageStatus_STATUS).
 | status                | The status of the wait duration.         | [UpdateStatus_STATUS](#UpdateStatus_STATUS)<br/><small>Optional</small> |
 | waitDurationInSeconds | The wait duration configured in seconds. | int<br/><small>Optional</small>                                         |
 
-<a id="ErrorAdditionalInfo_STATUS"></a>ErrorAdditionalInfo_STATUS
------------------------------------------------------------------
+ErrorAdditionalInfo_STATUS{#ErrorAdditionalInfo_STATUS}
+-------------------------------------------------------
 
 The resource management error additional info.
 
@@ -660,8 +660,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS), and [ErrorDetail_STATUS_Unro
 | info     | The additional info.      | map[string]v1.JSON<br/><small>Optional</small> |
 | type     | The additional info type. | string<br/><small>Optional</small>             |
 
-<a id="ErrorDetail_STATUS_Unrolled"></a>ErrorDetail_STATUS_Unrolled
--------------------------------------------------------------------
+ErrorDetail_STATUS_Unrolled{#ErrorDetail_STATUS_Unrolled}
+---------------------------------------------------------
 
 Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 
@@ -672,8 +672,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                      |
 | target         | The error target.          | string<br/><small>Optional</small>                                                      |
 
-<a id="MemberUpdateStatus_STATUS"></a>MemberUpdateStatus_STATUS
----------------------------------------------------------------
+MemberUpdateStatus_STATUS{#MemberUpdateStatus_STATUS}
+-----------------------------------------------------
 
 The status of a member update operation.
 

--- a/docs/hugo/content/reference/containerservice/v1api20231001.md
+++ b/docs/hugo/content/reference/containerservice/v1api20231001.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20231001
 linktitle: v1api20231001
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-10-01" |             |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -70,7 +70,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -124,8 +124,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile            | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -135,8 +135,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -149,7 +149,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -197,7 +197,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vnetSubnetReference               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -249,8 +249,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | vnetSubnetID               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -260,8 +260,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBinding"></a>TrustedAccessRoleBinding
--------------------------------------------------------------
+TrustedAccessRoleBinding{#TrustedAccessRoleBinding}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -274,7 +274,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | spec                                                                                    |             | [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
+### TrustedAccessRoleBinding_Spec {#TrustedAccessRoleBinding_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -284,7 +284,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-### <a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
+### TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -297,8 +297,8 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TrustedAccessRoleBindingList"></a>TrustedAccessRoleBindingList
----------------------------------------------------------------------
+TrustedAccessRoleBindingList{#TrustedAccessRoleBindingList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-10-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -308,8 +308,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [TrustedAccessRoleBinding[]](#TrustedAccessRoleBinding)<br/><small>Optional</small> |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -355,8 +355,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Managed cluster.
 
@@ -414,8 +414,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile            | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -465,8 +465,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vnetSubnetReference               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -520,8 +520,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | vnetSubnetID               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
------------------------------------------------------------------------
+TrustedAccessRoleBinding_Spec{#TrustedAccessRoleBinding_Spec}
+-------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -533,8 +533,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-<a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
----------------------------------------------------------------------------
+TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
+-----------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -549,8 +549,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -561,8 +561,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -573,8 +573,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolNetworkProfile"></a>AgentPoolNetworkProfile
------------------------------------------------------------
+AgentPoolNetworkProfile{#AgentPoolNetworkProfile}
+-------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -586,8 +586,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | applicationSecurityGroupsReferences | The IDs of the application security groups which agent pool will associate when created. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | nodePublicIPTags                    | IPTags of instance-level public IPs.                                                     | [IPTag[]](#IPTag)<br/><small>Optional</small>                                                                                                                |
 
-<a id="AgentPoolNetworkProfile_STATUS"></a>AgentPoolNetworkProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolNetworkProfile_STATUS{#AgentPoolNetworkProfile_STATUS}
+---------------------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -599,8 +599,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | applicationSecurityGroups | The IDs of the application security groups which agent pool will associate when created. | string[]<br/><small>Optional</small>                                |
 | nodePublicIPTags          | IPTags of instance-level public IPs.                                                     | [IPTag_STATUS[]](#IPTag_STATUS)<br/><small>Optional</small>         |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 The type of Agent Pool.
 
@@ -611,8 +611,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 The type of Agent Pool.
 
@@ -623,8 +623,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -635,8 +635,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | drainTimeoutInMinutes | The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes.                                                                                                                                                             | int<br/><small>Optional</small>    |
 | maxSurge              | This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade | string<br/><small>Optional</small> |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -647,8 +647,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | drainTimeoutInMinutes | The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes.                                                                                                                                                             | int<br/><small>Optional</small>    |
 | maxSurge              | This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade | string<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings"></a>ClusterUpgradeSettings
----------------------------------------------------------
+ClusterUpgradeSettings{#ClusterUpgradeSettings}
+-----------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -658,8 +658,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|-------------------------|---------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings](#UpgradeOverrideSettings)<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings_STATUS"></a>ClusterUpgradeSettings_STATUS
------------------------------------------------------------------------
+ClusterUpgradeSettings_STATUS{#ClusterUpgradeSettings_STATUS}
+-------------------------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -669,8 +669,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|-------------------------|-----------------------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings_STATUS](#UpgradeOverrideSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -681,8 +681,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Required</small>                                                                |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -693,8 +693,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Optional</small>                                                                              |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -718,8 +718,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serviceCidr         | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                                                             | string<br/><small>Optional</small>                                                                                                |
 | serviceCidrs        | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. | string[]<br/><small>Optional</small>                                                                                              |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -743,13 +743,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serviceCidr         | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                                                             | string<br/><small>Optional</small>                                                                                                              |
 | serviceCidrs        | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. | string[]<br/><small>Optional</small>                                                                                                            |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -759,8 +759,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |-------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sourceResourceReference | This is the ARM ID of the source object to be used to create the target object. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -770,8 +770,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |------------------|---------------------------------------------------------------------------------|------------------------------------|
 | sourceResourceId | This is the ARM ID of the source object to be used to create the target object. | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -782,8 +782,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -794,60 +794,60 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
-See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Property              | Description                                                                                                                                                                                                                          | Type                                 |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
-| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
-| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
-| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
-| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
-| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
-| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
-| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
-| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
-| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
-| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
 -----------------------------------------------------
 
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Property              | Description                                                                                                                                                                                                                          | Type                                 |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
+| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
+| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
+| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
+| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
+| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
+| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
+| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
+| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
+| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
+| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
+-------------------------------------------
+
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -866,8 +866,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
--------------------------------------------
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -878,8 +878,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -890,8 +890,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubernetesSupportPlan"></a>KubernetesSupportPlan
--------------------------------------------------------
+KubernetesSupportPlan{#KubernetesSupportPlan}
+---------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -902,8 +902,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="KubernetesSupportPlan_STATUS"></a>KubernetesSupportPlan_STATUS
----------------------------------------------------------------------
+KubernetesSupportPlan_STATUS{#KubernetesSupportPlan_STATUS}
+-----------------------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -914,8 +914,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -928,8 +928,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -942,8 +942,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -959,8 +959,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -976,8 +976,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -988,8 +988,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   | Key-value pairs for configuring an add-on. | map[string]string<br/><small>Optional</small> |
 | enabled  | Whether the add-on is enabled or not.      | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -1001,8 +1001,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  | Whether the add-on is enabled or not.                      | bool<br/><small>Optional</small>                                                        |
 | identity | Information of user assigned identity used by this add-on. | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1052,8 +1052,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | vnetSubnetReference               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                            |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1106,8 +1106,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | vnetSubnetID               | If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                              |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1121,8 +1121,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | enablePrivateClusterPublicFQDN | Whether to create additional public FQDN for private cluster or not.                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>     |
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1136,8 +1136,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enablePrivateClusterPublicFQDN | Whether to create additional public FQDN for private cluster or not.                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>     |
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1148,8 +1148,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeOSUpgradeChannel | Manner in which the OS on your nodes is updated. The default is NodeImage.                                                                              | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1160,8 +1160,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeOSUpgradeChannel | Manner in which the OS on your nodes is updated. The default is NodeImage.                                                                              | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAzureMonitorProfile"></a>ManagedClusterAzureMonitorProfile
--------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile{#ManagedClusterAzureMonitorProfile}
+---------------------------------------------------------------------
 
 Azure Monitor addon profiles for monitoring the managed cluster.
 
@@ -1171,8 +1171,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | metrics  | Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. | [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfile_STATUS"></a>ManagedClusterAzureMonitorProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile_STATUS{#ManagedClusterAzureMonitorProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Azure Monitor addon profiles for monitoring the managed cluster.
 
@@ -1182,8 +1182,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | metrics  | Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. | [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1196,8 +1196,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    | The endpoints that should not go through proxy.             | string[]<br/><small>Optional</small> |
 | trustedCa  | Alternative CA cert to use for connecting to proxy servers. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1210,8 +1210,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy    | The endpoints that should not go through proxy.             | string[]<br/><small>Optional</small> |
 | trustedCa  | Alternative CA cert to use for connecting to proxy servers. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1223,8 +1223,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1238,8 +1238,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile"></a>ManagedClusterOIDCIssuerProfile
----------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile{#ManagedClusterOIDCIssuerProfile}
+-----------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1249,8 +1249,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------------------------------|----------------------------------|
 | enabled  | Whether the OIDC issuer is enabled. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile_STATUS"></a>ManagedClusterOIDCIssuerProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile_STATUS{#ManagedClusterOIDCIssuerProfile_STATUS}
+-------------------------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1261,8 +1261,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled   | Whether the OIDC issuer is enabled.         | bool<br/><small>Optional</small>   |
 | issuerURL | The OIDC issuer url of the Managed Cluster. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1275,8 +1275,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1289,8 +1289,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1303,8 +1303,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1328,8 +1328,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage    | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                      |
 | skip-nodes-with-system-pods      | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1353,8 +1353,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage    | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                    |
 | skip-nodes-with-system-pods      | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess"></a>ManagedClusterProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess{#ManagedClusterProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1363,8 +1363,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess_STATUS"></a>ManagedClusterProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess_STATUS{#ManagedClusterProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1373,8 +1373,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1385,8 +1385,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile"></a>ManagedClusterSecurityProfile
------------------------------------------------------------------------
+ManagedClusterSecurityProfile{#ManagedClusterSecurityProfile}
+-------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1399,8 +1399,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | imageCleaner     | Image Cleaner settings for the security profile.                                                                                                                                                           | [ManagedClusterSecurityProfileImageCleaner](#ManagedClusterSecurityProfileImageCleaner)<br/><small>Optional</small>         |
 | workloadIdentity | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. | [ManagedClusterSecurityProfileWorkloadIdentity](#ManagedClusterSecurityProfileWorkloadIdentity)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile_STATUS"></a>ManagedClusterSecurityProfile_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterSecurityProfile_STATUS{#ManagedClusterSecurityProfile_STATUS}
+---------------------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1413,8 +1413,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | imageCleaner     | Image Cleaner settings for the security profile.                                                                                                                                                           | [ManagedClusterSecurityProfileImageCleaner_STATUS](#ManagedClusterSecurityProfileImageCleaner_STATUS)<br/><small>Optional</small>         |
 | workloadIdentity | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. | [ManagedClusterSecurityProfileWorkloadIdentity_STATUS](#ManagedClusterSecurityProfileWorkloadIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1425,8 +1425,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId | The ID for the service principal.                                        | string<br/><small>Required</small>                                                                                                                     |
 | secret   | The secret password associated with the service principal in plain text. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1436,8 +1436,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-----------------------------------|------------------------------------|
 | clientId | The ID for the service principal. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1448,8 +1448,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1460,8 +1460,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile"></a>ManagedClusterStorageProfile
----------------------------------------------------------------------
+ManagedClusterStorageProfile{#ManagedClusterStorageProfile}
+-----------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1474,8 +1474,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver](#ManagedClusterStorageProfileFileCSIDriver)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController](#ManagedClusterStorageProfileSnapshotController)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile_STATUS"></a>ManagedClusterStorageProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterStorageProfile_STATUS{#ManagedClusterStorageProfile_STATUS}
+-------------------------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1488,8 +1488,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver_STATUS](#ManagedClusterStorageProfileFileCSIDriver_STATUS)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController_STATUS](#ManagedClusterStorageProfileSnapshotController_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1503,8 +1503,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile](#WindowsGmsaProfile)<br/><small>Optional</small>                                                                                  |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1517,8 +1517,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile_STATUS](#WindowsGmsaProfile_STATUS)<br/><small>Optional</small>                                             |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile"></a>ManagedClusterWorkloadAutoScalerProfile
--------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile{#ManagedClusterWorkloadAutoScalerProfile}
+---------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1529,8 +1529,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda](#ManagedClusterWorkloadAutoScalerProfileKeda)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler | VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.              | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile_STATUS"></a>ManagedClusterWorkloadAutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile_STATUS{#ManagedClusterWorkloadAutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1541,48 +1541,48 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda_STATUS](#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler | VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.              | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
-Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Value         | Description |
-|---------------|-------------|
-| "AzureLinux"  |             |
-| "CBLMariner"  |             |
-| "Ubuntu"      |             |
-| "Windows2019" |             |
-| "Windows2022" |             |
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
+OSDiskType_STATUS{#OSDiskType_STATUS}
 -------------------------------------
 
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Value         | Description |
+|---------------|-------------|
+| "AzureLinux"  |             |
+| "CBLMariner"  |             |
+| "Ubuntu"      |             |
+| "Windows2019" |             |
+| "Windows2022" |             |
+
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
+
 Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -1595,8 +1595,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Windows2019" |             |
 | "Windows2022" |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 The operating system type. The default is Linux.
 
@@ -1607,8 +1607,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 The operating system type. The default is Linux.
 
@@ -1619,8 +1619,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PowerState"></a>PowerState
----------------------------------
+PowerState{#PowerState}
+-----------------------
 
 Describes the Power State of the cluster
 
@@ -1630,8 +1630,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------------------------------------------|-----------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code](#PowerState_Code)<br/><small>Optional</small> |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Describes the Power State of the cluster
 
@@ -1641,8 +1641,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------------------------------------------|-------------------------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 A private link resource
 
@@ -1656,8 +1656,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers | The RequiredMembers of the resource    | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            | The resource type.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 A private link resource
 
@@ -1672,8 +1672,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      | The RequiredMembers of the resource                                                        | string[]<br/><small>Optional</small> |
 | type                 | The resource type.                                                                         | string<br/><small>Optional</small>   |
 
-<a id="ScaleDownMode"></a>ScaleDownMode
----------------------------------------
+ScaleDownMode{#ScaleDownMode}
+-----------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -1684,8 +1684,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleDownMode_STATUS"></a>ScaleDownMode_STATUS
------------------------------------------------------
+ScaleDownMode_STATUS{#ScaleDownMode_STATUS}
+-------------------------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -1696,8 +1696,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
+-----------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -1708,8 +1708,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -1720,8 +1720,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
 
 The Virtual Machine Scale Set priority.
 
@@ -1732,20 +1732,20 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
-
-The Virtual Machine Scale Set priority.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="ServiceMeshProfile"></a>ServiceMeshProfile
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
 -------------------------------------------------
+
+The Virtual Machine Scale Set priority.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+ServiceMeshProfile{#ServiceMeshProfile}
+---------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -1756,8 +1756,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh](#IstioServiceMesh)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode](#ServiceMeshProfile_Mode)<br/><small>Required</small> |
 
-<a id="ServiceMeshProfile_STATUS"></a>ServiceMeshProfile_STATUS
----------------------------------------------------------------
+ServiceMeshProfile_STATUS{#ServiceMeshProfile_STATUS}
+-----------------------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -1768,8 +1768,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode_STATUS](#ServiceMeshProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -1784,8 +1784,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), and [TrustedAccessRole
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingOperatorSpec"></a>TrustedAccessRoleBindingOperatorSpec
--------------------------------------------------------------------------------------
+TrustedAccessRoleBindingOperatorSpec{#TrustedAccessRoleBindingOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1796,8 +1796,8 @@ Used by: [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingProperties_ProvisioningState_STATUS"></a>TrustedAccessRoleBindingProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+TrustedAccessRoleBindingProperties_ProvisioningState_STATUS{#TrustedAccessRoleBindingProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 
@@ -1809,8 +1809,8 @@ Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Details about a user assigned identity.
 
@@ -1822,8 +1822,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          | The object ID of the user assigned identity.   | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference | The resource ID of the user assigned identity. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Details about a user assigned identity.
 
@@ -1835,8 +1835,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   | The object ID of the user assigned identity.   | string<br/><small>Optional</small> |
 | resourceId | The resource ID of the user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="WorkloadRuntime"></a>WorkloadRuntime
--------------------------------------------
+WorkloadRuntime{#WorkloadRuntime}
+---------------------------------
 
 Determines the type of workload a node can run.
 
@@ -1847,8 +1847,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="WorkloadRuntime_STATUS"></a>WorkloadRuntime_STATUS
----------------------------------------------------------
+WorkloadRuntime_STATUS{#WorkloadRuntime_STATUS}
+-----------------------------------------------
 
 Determines the type of workload a node can run.
 
@@ -1859,8 +1859,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="AzureKeyVaultKms"></a>AzureKeyVaultKms
----------------------------------------------
+AzureKeyVaultKms{#AzureKeyVaultKms}
+-----------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -1873,8 +1873,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | keyVaultNetworkAccess     | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess](#AzureKeyVaultKms_KeyVaultNetworkAccess)<br/><small>Optional</small>                                              |
 | keyVaultResourceReference | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_STATUS"></a>AzureKeyVaultKms_STATUS
------------------------------------------------------------
+AzureKeyVaultKms_STATUS{#AzureKeyVaultKms_STATUS}
+-------------------------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -1887,78 +1887,78 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | keyVaultNetworkAccess | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS](#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS)<br/><small>Optional</small> |
 | keyVaultResourceId    | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies"></a>ContainerServiceNetworkProfile_IpFamilies
+ContainerServiceNetworkProfile_IpFamilies{#ContainerServiceNetworkProfile_IpFamilies}
+-------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_IpFamilies_STATUS{#ContainerServiceNetworkProfile_IpFamilies_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_LoadBalancerSku{#ContainerServiceNetworkProfile_LoadBalancerSku}
 -----------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
+| Value      | Description |
+|------------|-------------|
+| "basic"    |             |
+| "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies_STATUS"></a>ContainerServiceNetworkProfile_IpFamilies_STATUS
+ContainerServiceNetworkProfile_LoadBalancerSku_STATUS{#ContainerServiceNetworkProfile_LoadBalancerSku_STATUS}
 -------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
-
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku"></a>ContainerServiceNetworkProfile_LoadBalancerSku
----------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
 | Value      | Description |
 |------------|-------------|
 | "basic"    |             |
 | "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku_STATUS"></a>ContainerServiceNetworkProfile_LoadBalancerSku_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "basic"    |             |
-| "standard" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane"></a>ContainerServiceNetworkProfile_NetworkDataplane
------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane_STATUS"></a>ContainerServiceNetworkProfile_NetworkDataplane_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkMode"></a>ContainerServiceNetworkProfile_NetworkMode
+ContainerServiceNetworkProfile_NetworkDataplane{#ContainerServiceNetworkProfile_NetworkDataplane}
 -------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkDataplane_STATUS{#ContainerServiceNetworkProfile_NetworkDataplane_STATUS}
+---------------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkMode{#ContainerServiceNetworkProfile_NetworkMode}
+---------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value         | Description |
 |---------------|-------------|
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkMode_STATUS
----------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkMode_STATUS{#ContainerServiceNetworkProfile_NetworkMode_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1967,8 +1967,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPlugin_STATUS"></a>ContainerServiceNetworkProfile_NetworkPlugin_STATUS
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkPlugin_STATUS{#ContainerServiceNetworkProfile_NetworkPlugin_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1978,51 +1978,51 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode"></a>ContainerServiceNetworkProfile_NetworkPluginMode
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkPluginMode_STATUS
----------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy"></a>ContainerServiceNetworkProfile_NetworkPolicy
------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy_STATUS"></a>ContainerServiceNetworkProfile_NetworkPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
+ContainerServiceNetworkProfile_NetworkPluginMode{#ContainerServiceNetworkProfile_NetworkPluginMode}
 ---------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPluginMode_STATUS{#ContainerServiceNetworkProfile_NetworkPluginMode_STATUS}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy{#ContainerServiceNetworkProfile_NetworkPolicy}
+-------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy_STATUS{#ContainerServiceNetworkProfile_NetworkPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value                    | Description |
 |--------------------------|-------------|
 | "loadBalancer"           |             |
@@ -2030,8 +2030,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2042,8 +2042,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2053,8 +2053,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2064,8 +2064,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="DelegatedResource"></a>DelegatedResource
------------------------------------------------
+DelegatedResource{#DelegatedResource}
+-------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2078,8 +2078,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | resourceReference | The ARM resource id of the delegated resource - internal use only.           | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="DelegatedResource_STATUS"></a>DelegatedResource_STATUS
--------------------------------------------------------------
+DelegatedResource_STATUS{#DelegatedResource_STATUS}
+---------------------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2092,8 +2092,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | resourceId       | The ARM resource id of the delegated resource - internal use only.           | string<br/><small>Optional</small> |
 | tenantId         | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -2103,8 +2103,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -2114,8 +2114,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="IPTag"></a>IPTag
------------------------
+IPTag{#IPTag}
+-------------
 
 Contains the IPTag associated with the object.
 
@@ -2126,8 +2126,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IPTag_STATUS"></a>IPTag_STATUS
--------------------------------------
+IPTag_STATUS{#IPTag_STATUS}
+---------------------------
 
 Contains the IPTag associated with the object.
 
@@ -2138,8 +2138,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IstioServiceMesh"></a>IstioServiceMesh
----------------------------------------------
+IstioServiceMesh{#IstioServiceMesh}
+-----------------------------------
 
 Istio service mesh configuration.
 
@@ -2151,8 +2151,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents](#IstioComponents)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                |
 
-<a id="IstioServiceMesh_STATUS"></a>IstioServiceMesh_STATUS
------------------------------------------------------------
+IstioServiceMesh_STATUS{#IstioServiceMesh_STATUS}
+-------------------------------------------------
 
 Istio service mesh configuration.
 
@@ -2164,8 +2164,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents_STATUS](#IstioComponents_STATUS)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                              |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2175,8 +2175,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "None"      |             |
 | "Unmanaged" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2186,8 +2186,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "None"      |             |
 | "Unmanaged" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2199,8 +2199,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2212,8 +2212,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics"></a>ManagedClusterAzureMonitorProfileMetrics
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics{#ManagedClusterAzureMonitorProfileMetrics}
+-----------------------------------------------------------------------------------
 
 Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
 
@@ -2224,8 +2224,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | enabled          | Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.                                                    | bool<br/><small>Required</small>                                                                                                    |
 | kubeStateMetrics | Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. | [ManagedClusterAzureMonitorProfileKubeStateMetrics](#ManagedClusterAzureMonitorProfileKubeStateMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileMetrics_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics_STATUS{#ManagedClusterAzureMonitorProfileMetrics_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
 
@@ -2236,8 +2236,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | enabled          | Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.                                                    | bool<br/><small>Optional</small>                                                                                                                  |
 | kubeStateMetrics | Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. | [ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS](#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2247,8 +2247,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2258,8 +2258,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2268,8 +2268,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2286,8 +2286,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes                  | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small> |
 | outboundIPs                         | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2304,8 +2304,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes                  | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small> |
 | outboundIPs                         | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterNATGatewayProfile"></a>ManagedClusterNATGatewayProfile
----------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile{#ManagedClusterNATGatewayProfile}
+-----------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2317,8 +2317,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                               |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile](#ManagedClusterManagedOutboundIPProfile)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNATGatewayProfile_STATUS"></a>ManagedClusterNATGatewayProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile_STATUS{#ManagedClusterNATGatewayProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2330,8 +2330,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                                             |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile_STATUS](#ManagedClusterManagedOutboundIPProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorConfigMaps"></a>ManagedClusterOperatorConfigMaps
------------------------------------------------------------------------------
+ManagedClusterOperatorConfigMaps{#ManagedClusterOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2340,8 +2340,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | oidcIssuerProfile | indicates where the OIDCIssuerProfile config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | principalId       | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created.       | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2350,8 +2350,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -2364,8 +2364,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            | The name of the pod identity.                                      | string<br/><small>Required</small>                                        |
 | namespace       | The namespace of the pod identity.                                 | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -2380,8 +2380,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |                                                                    | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState | The current provisioning state of the pod identity.                | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -2393,8 +2393,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace | The namespace of the pod identity exception. | string<br/><small>Required</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -2406,8 +2406,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace | The namespace of the pod identity exception. | string<br/><small>Optional</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander"></a>ManagedClusterProperties_AutoScalerProfile_Expander
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander{#ManagedClusterProperties_AutoScalerProfile_Expander}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_AutoScalerProfile).
 
@@ -2418,8 +2418,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_Expander_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander_STATUS{#ManagedClusterProperties_AutoScalerProfile_Expander_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProperties_AutoScalerProfile_STATUS).
 
@@ -2430,8 +2430,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterSecurityProfileDefender"></a>ManagedClusterSecurityProfileDefender
----------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender{#ManagedClusterSecurityProfileDefender}
+-----------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -2442,8 +2442,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | logAnalyticsWorkspaceResourceReference | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityMonitoring                     | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring](#ManagedClusterSecurityProfileDefenderSecurityMonitoring)<br/><small>Optional</small>            |
 
-<a id="ManagedClusterSecurityProfileDefender_STATUS"></a>ManagedClusterSecurityProfileDefender_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender_STATUS{#ManagedClusterSecurityProfileDefender_STATUS}
+-------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -2454,8 +2454,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | logAnalyticsWorkspaceResourceId | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | string<br/><small>Optional</small>                                                                                                                            |
 | securityMonitoring              | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS](#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageCleaner"></a>ManagedClusterSecurityProfileImageCleaner
------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner{#ManagedClusterSecurityProfileImageCleaner}
+-------------------------------------------------------------------------------------
 
 Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
 
@@ -2466,8 +2466,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
 | intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileImageCleaner_STATUS"></a>ManagedClusterSecurityProfileImageCleaner_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner_STATUS{#ManagedClusterSecurityProfileImageCleaner_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
 
@@ -2478,158 +2478,158 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
 | intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileWorkloadIdentity"></a>ManagedClusterSecurityProfileWorkloadIdentity
--------------------------------------------------------------------------------------------------------
-
-Workload identity settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
-
-| Property | Description                          | Type                             |
-|----------|--------------------------------------|----------------------------------|
-| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileWorkloadIdentity_STATUS"></a>ManagedClusterSecurityProfileWorkloadIdentity_STATUS
----------------------------------------------------------------------------------------------------------------------
-
-Workload identity settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description                          | Type                             |
-|----------|--------------------------------------|----------------------------------|
-| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver"></a>ManagedClusterStorageProfileBlobCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureBlob CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                         | Type                             |
-|----------|---------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver_STATUS"></a>ManagedClusterStorageProfileBlobCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureBlob CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                         | Type                             |
-|----------|---------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver"></a>ManagedClusterStorageProfileDiskCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureDisk CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver_STATUS"></a>ManagedClusterStorageProfileDiskCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureDisk CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver"></a>ManagedClusterStorageProfileFileCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureFile CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver_STATUS"></a>ManagedClusterStorageProfileFileCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureFile CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController"></a>ManagedClusterStorageProfileSnapshotController
----------------------------------------------------------------------------------------------------------
-
-Snapshot Controller settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                       | Type                             |
-|----------|-------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController_STATUS"></a>ManagedClusterStorageProfileSnapshotController_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Snapshot Controller settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                       | Type                             |
-|----------|-------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
+ManagedClusterSecurityProfileWorkloadIdentity{#ManagedClusterSecurityProfileWorkloadIdentity}
 ---------------------------------------------------------------------------------------------
+
+Workload identity settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
+
+| Property | Description                          | Type                             |
+|----------|--------------------------------------|----------------------------------|
+| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileWorkloadIdentity_STATUS{#ManagedClusterSecurityProfileWorkloadIdentity_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Workload identity settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description                          | Type                             |
+|----------|--------------------------------------|----------------------------------|
+| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
+
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterStorageProfileBlobCSIDriver{#ManagedClusterStorageProfileBlobCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureBlob CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                         | Type                             |
+|----------|---------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileBlobCSIDriver_STATUS{#ManagedClusterStorageProfileBlobCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureBlob CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                         | Type                             |
+|----------|---------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver{#ManagedClusterStorageProfileDiskCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureDisk CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver_STATUS{#ManagedClusterStorageProfileDiskCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureDisk CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver{#ManagedClusterStorageProfileFileCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver_STATUS{#ManagedClusterStorageProfileFileCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController{#ManagedClusterStorageProfileSnapshotController}
+-----------------------------------------------------------------------------------------------
+
+Snapshot Controller settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                       | Type                             |
+|----------|-------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController_STATUS{#ManagedClusterStorageProfileSnapshotController_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Snapshot Controller settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                       | Type                             |
+|----------|-------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -2638,8 +2638,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -2648,8 +2648,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda"></a>ManagedClusterWorkloadAutoScalerProfileKeda
----------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda{#ManagedClusterWorkloadAutoScalerProfileKeda}
+-----------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -2659,8 +2659,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda_STATUS{#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -2670,8 +2670,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler}
+---------------------------------------------------------------------------------------------------------------------------
 
 VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
 
@@ -2681,8 +2681,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable VPA. Default value is false. | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
 
@@ -2692,8 +2692,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable VPA. Default value is false. | bool<br/><small>Optional</small> |
 
-<a id="NetworkPlugin"></a>NetworkPlugin
----------------------------------------
+NetworkPlugin{#NetworkPlugin}
+-----------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2703,8 +2703,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="PortRange"></a>PortRange
--------------------------------
+PortRange{#PortRange}
+---------------------
 
 The port range.
 
@@ -2716,8 +2716,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                       |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol](#PortRange_Protocol)<br/><small>Optional</small> |
 
-<a id="PortRange_STATUS"></a>PortRange_STATUS
----------------------------------------------
+PortRange_STATUS{#PortRange_STATUS}
+-----------------------------------
 
 The port range.
 
@@ -2729,8 +2729,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                                     |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol_STATUS](#PortRange_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="PowerState_Code"></a>PowerState_Code
--------------------------------------------
+PowerState_Code{#PowerState_Code}
+---------------------------------
 
 Used by: [PowerState](#PowerState).
 
@@ -2739,8 +2739,8 @@ Used by: [PowerState](#PowerState).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -2749,8 +2749,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="ServiceMeshProfile_Mode"></a>ServiceMeshProfile_Mode
------------------------------------------------------------
+ServiceMeshProfile_Mode{#ServiceMeshProfile_Mode}
+-------------------------------------------------
 
 Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 
@@ -2759,8 +2759,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="ServiceMeshProfile_Mode_STATUS"></a>ServiceMeshProfile_Mode_STATUS
--------------------------------------------------------------------------
+ServiceMeshProfile_Mode_STATUS{#ServiceMeshProfile_Mode_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 
@@ -2769,8 +2769,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -2807,8 +2807,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -2845,7 +2845,19 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2857,20 +2869,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpgradeOverrideSettings"></a>UpgradeOverrideSettings
------------------------------------------------------------
+UpgradeOverrideSettings{#UpgradeOverrideSettings}
+-------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -2881,8 +2881,8 @@ Used by: [ClusterUpgradeSettings](#ClusterUpgradeSettings).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UpgradeOverrideSettings_STATUS"></a>UpgradeOverrideSettings_STATUS
--------------------------------------------------------------------------
+UpgradeOverrideSettings_STATUS{#UpgradeOverrideSettings_STATUS}
+---------------------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -2893,8 +2893,8 @@ Used by: [ClusterUpgradeSettings_STATUS](#ClusterUpgradeSettings_STATUS).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2904,8 +2904,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile"></a>WindowsGmsaProfile
--------------------------------------------------
+WindowsGmsaProfile{#WindowsGmsaProfile}
+---------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -2917,8 +2917,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile_STATUS"></a>WindowsGmsaProfile_STATUS
----------------------------------------------------------------
+WindowsGmsaProfile_STATUS{#WindowsGmsaProfile_STATUS}
+-----------------------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -2930,8 +2930,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess"></a>AzureKeyVaultKms_KeyVaultNetworkAccess
------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess{#AzureKeyVaultKms_KeyVaultNetworkAccess}
+-------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 
@@ -2940,8 +2940,8 @@ Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS"></a>AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS{#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 
@@ -2950,8 +2950,8 @@ Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -2961,8 +2961,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -2972,8 +2972,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority"></a>IstioCertificateAuthority
----------------------------------------------------------------
+IstioCertificateAuthority{#IstioCertificateAuthority}
+-----------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -2983,8 +2983,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 |----------|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority](#IstioPluginCertificateAuthority)<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority_STATUS"></a>IstioCertificateAuthority_STATUS
------------------------------------------------------------------------------
+IstioCertificateAuthority_STATUS{#IstioCertificateAuthority_STATUS}
+-------------------------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -2994,8 +2994,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 |----------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority_STATUS](#IstioPluginCertificateAuthority_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioComponents"></a>IstioComponents
--------------------------------------------
+IstioComponents{#IstioComponents}
+---------------------------------
 
 Istio components configuration.
 
@@ -3006,8 +3006,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway[]](#IstioEgressGateway)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway[]](#IstioIngressGateway)<br/><small>Optional</small> |
 
-<a id="IstioComponents_STATUS"></a>IstioComponents_STATUS
----------------------------------------------------------
+IstioComponents_STATUS{#IstioComponents_STATUS}
+-----------------------------------------------
 
 Istio components configuration.
 
@@ -3018,8 +3018,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway_STATUS[]](#IstioEgressGateway_STATUS)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway_STATUS[]](#IstioIngressGateway_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics
----------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics{#ManagedClusterAzureMonitorProfileKubeStateMetrics}
+-----------------------------------------------------------------------------------------------------
 
 Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
 
@@ -3030,8 +3030,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 | metricAnnotationsAllowList | Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS{#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
 
@@ -3042,8 +3042,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 | metricAnnotationsAllowList | Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType"></a>ManagedClusterLoadBalancerProfile_BackendPoolType
----------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType{#ManagedClusterLoadBalancerProfile_BackendPoolType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3052,8 +3052,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS"></a>ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS{#ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3062,8 +3062,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3072,8 +3072,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3082,8 +3082,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3091,8 +3091,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|---------------------------------------|-----------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3100,8 +3100,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|---------------------------------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3109,8 +3109,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|--------------------------------|-----------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3118,8 +3118,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|--------------------------------|-------------------------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile"></a>ManagedClusterManagedOutboundIPProfile
------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile{#ManagedClusterManagedOutboundIPProfile}
+-------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -3129,8 +3129,8 @@ Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile_STATUS"></a>ManagedClusterManagedOutboundIPProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile_STATUS{#ManagedClusterManagedOutboundIPProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -3140,8 +3140,8 @@ Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfi
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3149,8 +3149,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Pod identity assignment error (if any). | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3163,8 +3163,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring{#ManagedClusterSecurityProfileDefenderSecurityMonitoring}
+-----------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -3174,8 +3174,8 @@ Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileD
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS{#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -3185,8 +3185,8 @@ Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityP
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="PortRange_Protocol"></a>PortRange_Protocol
--------------------------------------------------
+PortRange_Protocol{#PortRange_Protocol}
+---------------------------------------
 
 Used by: [PortRange](#PortRange).
 
@@ -3195,8 +3195,8 @@ Used by: [PortRange](#PortRange).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="PortRange_Protocol_STATUS"></a>PortRange_Protocol_STATUS
----------------------------------------------------------------
+PortRange_Protocol_STATUS{#PortRange_Protocol_STATUS}
+-----------------------------------------------------
 
 Used by: [PortRange_STATUS](#PortRange_STATUS).
 
@@ -3205,8 +3205,8 @@ Used by: [PortRange_STATUS](#PortRange_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 A reference to an Azure resource.
 
@@ -3216,8 +3216,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The fully qualified Azure resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 A reference to an Azure resource.
 
@@ -3227,8 +3227,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|----------------------------------------|------------------------------------|
 | id       | The fully qualified Azure resource id. | string<br/><small>Optional</small> |
 
-<a id="IstioEgressGateway"></a>IstioEgressGateway
--------------------------------------------------
+IstioEgressGateway{#IstioEgressGateway}
+---------------------------------------
 
 Istio egress gateway configuration.
 
@@ -3239,8 +3239,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled      | Whether to enable the egress gateway.           | bool<br/><small>Required</small>              |
 | nodeSelector | NodeSelector for scheduling the egress gateway. | map[string]string<br/><small>Optional</small> |
 
-<a id="IstioEgressGateway_STATUS"></a>IstioEgressGateway_STATUS
----------------------------------------------------------------
+IstioEgressGateway_STATUS{#IstioEgressGateway_STATUS}
+-----------------------------------------------------
 
 Istio egress gateway configuration.
 
@@ -3251,8 +3251,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled      | Whether to enable the egress gateway.           | bool<br/><small>Optional</small>              |
 | nodeSelector | NodeSelector for scheduling the egress gateway. | map[string]string<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway"></a>IstioIngressGateway
----------------------------------------------------
+IstioIngressGateway{#IstioIngressGateway}
+-----------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -3263,8 +3263,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Required</small>                                                  |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode](#IstioIngressGateway_Mode)<br/><small>Required</small> |
 
-<a id="IstioIngressGateway_STATUS"></a>IstioIngressGateway_STATUS
------------------------------------------------------------------
+IstioIngressGateway_STATUS{#IstioIngressGateway_STATUS}
+-------------------------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -3275,8 +3275,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Optional</small>                                                                |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode_STATUS](#IstioIngressGateway_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioPluginCertificateAuthority"></a>IstioPluginCertificateAuthority
----------------------------------------------------------------------------
+IstioPluginCertificateAuthority{#IstioPluginCertificateAuthority}
+-----------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -3290,8 +3290,8 @@ Used by: [IstioCertificateAuthority](#IstioCertificateAuthority).
 | keyVaultReference   | The resource ID of the Key Vault.                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="IstioPluginCertificateAuthority_STATUS"></a>IstioPluginCertificateAuthority_STATUS
------------------------------------------------------------------------------------------
+IstioPluginCertificateAuthority_STATUS{#IstioPluginCertificateAuthority_STATUS}
+-------------------------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -3305,8 +3305,8 @@ Used by: [IstioCertificateAuthority_STATUS](#IstioCertificateAuthority_STATUS).
 | keyVaultId          | The resource ID of the Key Vault.                                    | string<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -3316,8 +3316,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Details about the error. | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway_Mode"></a>IstioIngressGateway_Mode
--------------------------------------------------------------
+IstioIngressGateway_Mode{#IstioIngressGateway_Mode}
+---------------------------------------------------
 
 Used by: [IstioIngressGateway](#IstioIngressGateway).
 
@@ -3326,8 +3326,8 @@ Used by: [IstioIngressGateway](#IstioIngressGateway).
 | "External" |             |
 | "Internal" |             |
 
-<a id="IstioIngressGateway_Mode_STATUS"></a>IstioIngressGateway_Mode_STATUS
----------------------------------------------------------------------------
+IstioIngressGateway_Mode_STATUS{#IstioIngressGateway_Mode_STATUS}
+-----------------------------------------------------------------
 
 Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 
@@ -3336,8 +3336,8 @@ Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 | "External" |             |
 | "Internal" |             |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -3350,8 +3350,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  | A message describing the error, intended to be suitable for display in a user interface.           | string<br/><small>Optional</small>                                                                                                                              |
 | target   | The target of the particular error. For example, the name of the property in error.                | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20231102preview.md
+++ b/docs/hugo/content/reference/containerservice/v1api20231102preview.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20231102preview
 linktitle: v1api20231102preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2023-11-02-preview" |             |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Used by: [ManagedClusterList](#ManagedClusterList).
 
@@ -24,7 +24,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -76,7 +76,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  |                                                                                                                                                                                                                                                                                              | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                   | Description                        | Type                                                                                                                                                    |
 |----------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -138,8 +138,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile  |                                    | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 | Property                                                                            | Description | Type                                                            |
 |-------------------------------------------------------------------------------------|-------------|-----------------------------------------------------------------|
@@ -147,8 +147,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-11-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -161,7 +161,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -218,7 +218,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -279,8 +279,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-11-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -290,8 +290,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -345,8 +345,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             |                                                                                                                                                                                                                                                                                              | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  |                                                                                                                                                                                                                                                                                              | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -410,8 +410,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             |                                    | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile  |                                    | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -470,8 +470,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -534,8 +534,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="AgentPoolArtifactStreamingProfile"></a>AgentPoolArtifactStreamingProfile
--------------------------------------------------------------------------------
+AgentPoolArtifactStreamingProfile{#AgentPoolArtifactStreamingProfile}
+---------------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -543,8 +543,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolArtifactStreamingProfile_STATUS"></a>AgentPoolArtifactStreamingProfile_STATUS
----------------------------------------------------------------------------------------------
+AgentPoolArtifactStreamingProfile_STATUS{#AgentPoolArtifactStreamingProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -552,8 +552,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolGPUProfile"></a>AgentPoolGPUProfile
----------------------------------------------------
+AgentPoolGPUProfile{#AgentPoolGPUProfile}
+-----------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -561,8 +561,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |------------------|-------------|----------------------------------|
 | installGPUDriver |             | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolGPUProfile_STATUS"></a>AgentPoolGPUProfile_STATUS
------------------------------------------------------------------
+AgentPoolGPUProfile_STATUS{#AgentPoolGPUProfile_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -570,8 +570,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |------------------|-------------|----------------------------------|
 | installGPUDriver |             | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -580,8 +580,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -590,8 +590,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolNetworkProfile"></a>AgentPoolNetworkProfile
------------------------------------------------------------
+AgentPoolNetworkProfile{#AgentPoolNetworkProfile}
+-------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -601,8 +601,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | applicationSecurityGroupsReferences |             | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | nodePublicIPTags                    |             | [IPTag[]](#IPTag)<br/><small>Optional</small>                                                                                                                |
 
-<a id="AgentPoolNetworkProfile_STATUS"></a>AgentPoolNetworkProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolNetworkProfile_STATUS{#AgentPoolNetworkProfile_STATUS}
+---------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -612,8 +612,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | applicationSecurityGroups |             | string[]<br/><small>Optional</small>                                |
 | nodePublicIPTags          |             | [IPTag_STATUS[]](#IPTag_STATUS)<br/><small>Optional</small>         |
 
-<a id="AgentPoolSecurityProfile"></a>AgentPoolSecurityProfile
--------------------------------------------------------------
+AgentPoolSecurityProfile{#AgentPoolSecurityProfile}
+---------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -623,8 +623,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | enableVTPM       |             | bool<br/><small>Optional</small>                                      |
 | sshAccess        |             | [AgentPoolSSHAccess](#AgentPoolSSHAccess)<br/><small>Optional</small> |
 
-<a id="AgentPoolSecurityProfile_STATUS"></a>AgentPoolSecurityProfile_STATUS
----------------------------------------------------------------------------
+AgentPoolSecurityProfile_STATUS{#AgentPoolSecurityProfile_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -634,8 +634,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | enableVTPM       |             | bool<br/><small>Optional</small>                                                    |
 | sshAccess        |             | [AgentPoolSSHAccess_STATUS](#AgentPoolSSHAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -645,8 +645,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "VirtualMachineScaleSets" |             |
 | "VirtualMachines"         |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -656,8 +656,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "VirtualMachineScaleSets" |             |
 | "VirtualMachines"         |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -667,8 +667,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | maxSurge                  |             | string<br/><small>Optional</small> |
 | nodeSoakDurationInMinutes |             | int<br/><small>Optional</small>    |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -678,8 +678,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | maxSurge                  |             | string<br/><small>Optional</small> |
 | nodeSoakDurationInMinutes |             | int<br/><small>Optional</small>    |
 
-<a id="AgentPoolWindowsProfile"></a>AgentPoolWindowsProfile
------------------------------------------------------------
+AgentPoolWindowsProfile{#AgentPoolWindowsProfile}
+-------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -687,8 +687,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |--------------------|-------------|----------------------------------|
 | disableOutboundNat |             | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolWindowsProfile_STATUS"></a>AgentPoolWindowsProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolWindowsProfile_STATUS{#AgentPoolWindowsProfile_STATUS}
+---------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -696,8 +696,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |--------------------|-------------|----------------------------------|
 | disableOutboundNat |             | bool<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings"></a>ClusterUpgradeSettings
----------------------------------------------------------
+ClusterUpgradeSettings{#ClusterUpgradeSettings}
+-----------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -705,8 +705,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|-------------|---------------------------------------------------------------------------------|
 | overrideSettings |             | [UpgradeOverrideSettings](#UpgradeOverrideSettings)<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings_STATUS"></a>ClusterUpgradeSettings_STATUS
------------------------------------------------------------------------
+ClusterUpgradeSettings_STATUS{#ClusterUpgradeSettings_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -714,8 +714,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|-------------|-----------------------------------------------------------------------------------------------|
 | overrideSettings |             | [UpgradeOverrideSettings_STATUS](#UpgradeOverrideSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -724,8 +724,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername |             | string<br/><small>Required</small>                                                                |
 | ssh           |             | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -734,8 +734,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername |             | string<br/><small>Optional</small>                                                                              |
 | ssh           |             | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -759,8 +759,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                            |
 | serviceCidrs        |             | string[]<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -784,13 +784,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serviceCidr         |             | string<br/><small>Optional</small>                                                                                                          |
 | serviceCidrs        |             | string[]<br/><small>Optional</small>                                                                                                        |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -798,8 +798,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), [ManagedClusterAgentPoolPr
 |-------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sourceResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -807,8 +807,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |------------------|-------------|------------------------------------|
 | sourceResourceId |             | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -817,8 +817,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | string<br/><small>Optional</small>                                        |
 | type     |             | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -827,37 +827,37 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | string<br/><small>Optional</small>                                                      |
 | type     |             | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
+-----------------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Property              | Description | Type                                 |
 |-----------------------|-------------|--------------------------------------|
 | allowedUnsafeSysctls  |             | string[]<br/><small>Optional</small> |
@@ -872,8 +872,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | podMaxPids            |             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy |             | string<br/><small>Optional</small>   |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
------------------------------------------------------
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -891,8 +891,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            |             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy |             | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
--------------------------------------------
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -901,8 +901,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -911,8 +911,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubernetesSupportPlan"></a>KubernetesSupportPlan
--------------------------------------------------------
+KubernetesSupportPlan{#KubernetesSupportPlan}
+---------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -921,8 +921,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="KubernetesSupportPlan_STATUS"></a>KubernetesSupportPlan_STATUS
----------------------------------------------------------------------
+KubernetesSupportPlan_STATUS{#KubernetesSupportPlan_STATUS}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -931,8 +931,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -943,8 +943,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -955,8 +955,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  |             | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled |             | string<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -970,8 +970,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -985,8 +985,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     |             | string<br/><small>Optional</small>   |
 | tenantID            |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -995,8 +995,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   |             | map[string]string<br/><small>Optional</small> |
 | enabled  |             | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1006,8 +1006,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  |             | bool<br/><small>Optional</small>                                                        |
 | identity |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1064,8 +1064,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | windowsProfile                    |             | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadRuntime                   |             | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                            |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1125,8 +1125,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | windowsProfile             |             | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                     |
 | workloadRuntime            |             | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                     |
 
-<a id="ManagedClusterAIToolchainOperatorProfile"></a>ManagedClusterAIToolchainOperatorProfile
----------------------------------------------------------------------------------------------
+ManagedClusterAIToolchainOperatorProfile{#ManagedClusterAIToolchainOperatorProfile}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1134,8 +1134,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAIToolchainOperatorProfile_STATUS"></a>ManagedClusterAIToolchainOperatorProfile_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAIToolchainOperatorProfile_STATUS{#ManagedClusterAIToolchainOperatorProfile_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1143,8 +1143,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1158,8 +1158,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 | subnetId                       |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1173,8 +1173,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | privateDNSZone                 |             | string<br/><small>Optional</small>   |
 | subnetId                       |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1183,8 +1183,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeOSUpgradeChannel |             | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel)<br/><small>Optional</small> |
 | upgradeChannel       |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1193,8 +1193,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeOSUpgradeChannel |             | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS)<br/><small>Optional</small> |
 | upgradeChannel       |             | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAzureMonitorProfile"></a>ManagedClusterAzureMonitorProfile
--------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile{#ManagedClusterAzureMonitorProfile}
+---------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1203,8 +1203,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | logs     |             | [ManagedClusterAzureMonitorProfileLogs](#ManagedClusterAzureMonitorProfileLogs)<br/><small>Optional</small>       |
 | metrics  |             | [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfile_STATUS"></a>ManagedClusterAzureMonitorProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile_STATUS{#ManagedClusterAzureMonitorProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1213,8 +1213,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | logs     |             | [ManagedClusterAzureMonitorProfileLogs_STATUS](#ManagedClusterAzureMonitorProfileLogs_STATUS)<br/><small>Optional</small>       |
 | metrics  |             | [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1225,8 +1225,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    |             | string[]<br/><small>Optional</small> |
 | trustedCa  |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1238,8 +1238,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy          |             | string[]<br/><small>Optional</small> |
 | trustedCa        |             | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1249,8 +1249,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   |             | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities |             | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1262,8 +1262,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   |             | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities |             | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile"></a>ManagedClusterIngressProfile
----------------------------------------------------------------------
+ManagedClusterIngressProfile{#ManagedClusterIngressProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1271,8 +1271,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |---------------|-------------|---------------------------------------------------------------------------------------------------------------------|
 | webAppRouting |             | [ManagedClusterIngressProfileWebAppRouting](#ManagedClusterIngressProfileWebAppRouting)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile_STATUS"></a>ManagedClusterIngressProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterIngressProfile_STATUS{#ManagedClusterIngressProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1280,8 +1280,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |---------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | webAppRouting |             | [ManagedClusterIngressProfileWebAppRouting_STATUS](#ManagedClusterIngressProfileWebAppRouting_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile"></a>ManagedClusterMetricsProfile
----------------------------------------------------------------------
+ManagedClusterMetricsProfile{#ManagedClusterMetricsProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1289,8 +1289,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |--------------|-------------|---------------------------------------------------------------------------------------|
 | costAnalysis |             | [ManagedClusterCostAnalysis](#ManagedClusterCostAnalysis)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile_STATUS"></a>ManagedClusterMetricsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterMetricsProfile_STATUS{#ManagedClusterMetricsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1298,8 +1298,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |--------------|-------------|-----------------------------------------------------------------------------------------------------|
 | costAnalysis |             | [ManagedClusterCostAnalysis_STATUS](#ManagedClusterCostAnalysis_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile"></a>ManagedClusterNodeProvisioningProfile
----------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile{#ManagedClusterNodeProvisioningProfile}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1307,8 +1307,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|-----------------------------------------------------------------------------------------------------------------------|
 | mode     |             | [ManagedClusterNodeProvisioningProfile_Mode](#ManagedClusterNodeProvisioningProfile_Mode)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile_STATUS"></a>ManagedClusterNodeProvisioningProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_STATUS{#ManagedClusterNodeProvisioningProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1316,8 +1316,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | mode     |             | [ManagedClusterNodeProvisioningProfile_Mode_STATUS](#ManagedClusterNodeProvisioningProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile"></a>ManagedClusterNodeResourceGroupProfile
------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile{#ManagedClusterNodeResourceGroupProfile}
+-------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1325,8 +1325,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel |             | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile_STATUS"></a>ManagedClusterNodeResourceGroupProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_STATUS{#ManagedClusterNodeResourceGroupProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1334,8 +1334,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel |             | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile"></a>ManagedClusterOIDCIssuerProfile
----------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile{#ManagedClusterOIDCIssuerProfile}
+-----------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1343,8 +1343,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile_STATUS"></a>ManagedClusterOIDCIssuerProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile_STATUS{#ManagedClusterOIDCIssuerProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1353,8 +1353,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled   |             | bool<br/><small>Optional</small>   |
 | issuerURL |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1367,8 +1367,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1379,8 +1379,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1391,8 +1391,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         |             | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions |             | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1419,8 +1419,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage         |             | string<br/><small>Optional</small>                |
 | skip-nodes-with-system-pods           |             | string<br/><small>Optional</small>                |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1447,8 +1447,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage         |             | string<br/><small>Optional</small>                              |
 | skip-nodes-with-system-pods           |             | string<br/><small>Optional</small>                              |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess"></a>ManagedClusterProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess{#ManagedClusterProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1458,8 +1458,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess_STATUS"></a>ManagedClusterProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess_STATUS{#ManagedClusterProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1469,8 +1469,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1481,8 +1481,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile"></a>ManagedClusterSecurityProfile
------------------------------------------------------------------------
+ManagedClusterSecurityProfile{#ManagedClusterSecurityProfile}
+-------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1496,8 +1496,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeRestriction           |             | [ManagedClusterSecurityProfileNodeRestriction](#ManagedClusterSecurityProfileNodeRestriction)<br/><small>Optional</small>   |
 | workloadIdentity          |             | [ManagedClusterSecurityProfileWorkloadIdentity](#ManagedClusterSecurityProfileWorkloadIdentity)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile_STATUS"></a>ManagedClusterSecurityProfile_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterSecurityProfile_STATUS{#ManagedClusterSecurityProfile_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1511,8 +1511,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeRestriction           |             | [ManagedClusterSecurityProfileNodeRestriction_STATUS](#ManagedClusterSecurityProfileNodeRestriction_STATUS)<br/><small>Optional</small>   |
 | workloadIdentity          |             | [ManagedClusterSecurityProfileWorkloadIdentity_STATUS](#ManagedClusterSecurityProfileWorkloadIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1521,8 +1521,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId |             | string<br/><small>Required</small>                                                                                                                     |
 | secret   |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1530,8 +1530,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------|------------------------------------|
 | clientId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1540,8 +1540,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     |             | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1550,8 +1550,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     |             | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     |             | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile"></a>ManagedClusterStorageProfile
----------------------------------------------------------------------
+ManagedClusterStorageProfile{#ManagedClusterStorageProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1562,8 +1562,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | fileCSIDriver      |             | [ManagedClusterStorageProfileFileCSIDriver](#ManagedClusterStorageProfileFileCSIDriver)<br/><small>Optional</small>           |
 | snapshotController |             | [ManagedClusterStorageProfileSnapshotController](#ManagedClusterStorageProfileSnapshotController)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile_STATUS"></a>ManagedClusterStorageProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterStorageProfile_STATUS{#ManagedClusterStorageProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1574,8 +1574,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | fileCSIDriver      |             | [ManagedClusterStorageProfileFileCSIDriver_STATUS](#ManagedClusterStorageProfileFileCSIDriver_STATUS)<br/><small>Optional</small>           |
 | snapshotController |             | [ManagedClusterStorageProfileSnapshotController_STATUS](#ManagedClusterStorageProfileSnapshotController_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1587,8 +1587,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | gmsaProfile    |             | [WindowsGmsaProfile](#WindowsGmsaProfile)<br/><small>Optional</small>                                                                                  |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1599,8 +1599,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | gmsaProfile    |             | [WindowsGmsaProfile_STATUS](#WindowsGmsaProfile_STATUS)<br/><small>Optional</small>                                             |
 | licenseType    |             | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile"></a>ManagedClusterWorkloadAutoScalerProfile
--------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile{#ManagedClusterWorkloadAutoScalerProfile}
+---------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1609,8 +1609,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | keda                  |             | [ManagedClusterWorkloadAutoScalerProfileKeda](#ManagedClusterWorkloadAutoScalerProfileKeda)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler |             | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile_STATUS"></a>ManagedClusterWorkloadAutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile_STATUS{#ManagedClusterWorkloadAutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1619,31 +1619,31 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | keda                  |             | [ManagedClusterWorkloadAutoScalerProfileKeda_STATUS](#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler |             | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSDiskType_STATUS{#OSDiskType_STATUS}
+-------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
 | Value           | Description |
 |-----------------|-------------|
 | "AzureLinux"    |             |
@@ -1654,8 +1654,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Windows2022"   |             |
 | "WindowsAnnual" |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
--------------------------------------
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1669,8 +1669,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Windows2022"   |             |
 | "WindowsAnnual" |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1679,8 +1679,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1689,8 +1689,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PowerState"></a>PowerState
----------------------------------
+PowerState{#PowerState}
+-----------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1698,8 +1698,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|-----------------------------------------------------------------|
 | code     |             | [PowerState_Code](#PowerState_Code)<br/><small>Optional</small> |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1707,8 +1707,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------|-------------------------------------------------------------------------------|
 | code     |             | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1720,8 +1720,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers |             | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            |             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1734,8 +1734,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      |             | string[]<br/><small>Optional</small> |
 | type                 |             | string<br/><small>Optional</small>   |
 
-<a id="SafeguardsProfile"></a>SafeguardsProfile
------------------------------------------------
+SafeguardsProfile{#SafeguardsProfile}
+-------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1745,8 +1745,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | level              |             | [SafeguardsProfile_Level](#SafeguardsProfile_Level)<br/><small>Required</small> |
 | version            |             | string<br/><small>Optional</small>                                              |
 
-<a id="SafeguardsProfile_STATUS"></a>SafeguardsProfile_STATUS
--------------------------------------------------------------
+SafeguardsProfile_STATUS{#SafeguardsProfile_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1757,8 +1757,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | systemExcludedNamespaces |             | string[]<br/><small>Optional</small>                                                          |
 | version                  |             | string<br/><small>Optional</small>                                                            |
 
-<a id="ScaleDownMode"></a>ScaleDownMode
----------------------------------------
+ScaleDownMode{#ScaleDownMode}
+-----------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1767,8 +1767,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleDownMode_STATUS"></a>ScaleDownMode_STATUS
------------------------------------------------------
+ScaleDownMode_STATUS{#ScaleDownMode_STATUS}
+-------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1777,8 +1777,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1787,8 +1787,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1797,8 +1797,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1807,18 +1807,18 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="ServiceMeshProfile"></a>ServiceMeshProfile
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
 -------------------------------------------------
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+ServiceMeshProfile{#ServiceMeshProfile}
+---------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1827,8 +1827,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | istio    |             | [IstioServiceMesh](#IstioServiceMesh)<br/><small>Optional</small>               |
 | mode     |             | [ServiceMeshProfile_Mode](#ServiceMeshProfile_Mode)<br/><small>Required</small> |
 
-<a id="ServiceMeshProfile_STATUS"></a>ServiceMeshProfile_STATUS
----------------------------------------------------------------
+ServiceMeshProfile_STATUS{#ServiceMeshProfile_STATUS}
+-----------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1837,8 +1837,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | istio    |             | [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS)<br/><small>Optional</small>               |
 | mode     |             | [ServiceMeshProfile_Mode_STATUS](#ServiceMeshProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1851,8 +1851,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | lastModifiedBy     |             | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType |             | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIdentity](#ManagedClusterPodIdentity).
 
@@ -1862,8 +1862,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          |             | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonProfile_STATUS](#ManagedClusterAddonProfile_STATUS), [ManagedClusterIngressProfileWebAppRouting_STATUS](#ManagedClusterIngressProfileWebAppRouting_STATUS), and [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -1873,8 +1873,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   |             | string<br/><small>Optional</small> |
 | resourceId |             | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineNodes"></a>VirtualMachineNodes
----------------------------------------------------
+VirtualMachineNodes{#VirtualMachineNodes}
+-----------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1883,8 +1883,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | count    |             | int<br/><small>Optional</small>    |
 | size     |             | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineNodes_STATUS"></a>VirtualMachineNodes_STATUS
------------------------------------------------------------------
+VirtualMachineNodes_STATUS{#VirtualMachineNodes_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1893,8 +1893,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | count    |             | int<br/><small>Optional</small>    |
 | size     |             | string<br/><small>Optional</small> |
 
-<a id="VirtualMachinesProfile"></a>VirtualMachinesProfile
----------------------------------------------------------
+VirtualMachinesProfile{#VirtualMachinesProfile}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1902,8 +1902,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------|-----------------------------------------------------------|
 | scale    |             | [ScaleProfile](#ScaleProfile)<br/><small>Optional</small> |
 
-<a id="VirtualMachinesProfile_STATUS"></a>VirtualMachinesProfile_STATUS
------------------------------------------------------------------------
+VirtualMachinesProfile_STATUS{#VirtualMachinesProfile_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1911,8 +1911,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|-------------|-------------------------------------------------------------------------|
 | scale    |             | [ScaleProfile_STATUS](#ScaleProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkloadRuntime"></a>WorkloadRuntime
--------------------------------------------
+WorkloadRuntime{#WorkloadRuntime}
+---------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -1922,8 +1922,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OCIContainer"        |             |
 | "WasmWasi"            |             |
 
-<a id="WorkloadRuntime_STATUS"></a>WorkloadRuntime_STATUS
----------------------------------------------------------
+WorkloadRuntime_STATUS{#WorkloadRuntime_STATUS}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -1933,8 +1933,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OCIContainer"        |             |
 | "WasmWasi"            |             |
 
-<a id="AgentPoolSSHAccess"></a>AgentPoolSSHAccess
--------------------------------------------------
+AgentPoolSSHAccess{#AgentPoolSSHAccess}
+---------------------------------------
 
 Used by: [AgentPoolSecurityProfile](#AgentPoolSecurityProfile).
 
@@ -1943,8 +1943,8 @@ Used by: [AgentPoolSecurityProfile](#AgentPoolSecurityProfile).
 | "Disabled"  |             |
 | "LocalUser" |             |
 
-<a id="AgentPoolSSHAccess_STATUS"></a>AgentPoolSSHAccess_STATUS
----------------------------------------------------------------
+AgentPoolSSHAccess_STATUS{#AgentPoolSSHAccess_STATUS}
+-----------------------------------------------------
 
 Used by: [AgentPoolSecurityProfile_STATUS](#AgentPoolSecurityProfile_STATUS).
 
@@ -1953,8 +1953,8 @@ Used by: [AgentPoolSecurityProfile_STATUS](#AgentPoolSecurityProfile_STATUS).
 | "Disabled"  |             |
 | "LocalUser" |             |
 
-<a id="AzureKeyVaultKms"></a>AzureKeyVaultKms
----------------------------------------------
+AzureKeyVaultKms{#AzureKeyVaultKms}
+-----------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -1965,8 +1965,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | keyVaultNetworkAccess     |             | [AzureKeyVaultKms_KeyVaultNetworkAccess](#AzureKeyVaultKms_KeyVaultNetworkAccess)<br/><small>Optional</small>                                              |
 | keyVaultResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_STATUS"></a>AzureKeyVaultKms_STATUS
------------------------------------------------------------
+AzureKeyVaultKms_STATUS{#AzureKeyVaultKms_STATUS}
+-------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -1977,8 +1977,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | keyVaultNetworkAccess |             | [AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS](#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS)<br/><small>Optional</small> |
 | keyVaultResourceId    |             | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig"></a>ContainerServiceNetworkProfile_KubeProxyConfig
----------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig{#ContainerServiceNetworkProfile_KubeProxyConfig}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -1988,8 +1988,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | ipvsConfig |             | [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig)<br/><small>Optional</small> |
 | mode       |             | [ContainerServiceNetworkProfile_KubeProxyConfig_Mode](#ContainerServiceNetworkProfile_KubeProxyConfig_Mode)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_STATUS
------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -1999,8 +1999,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | ipvsConfig |             | [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS)<br/><small>Optional</small> |
 | mode       |             | [ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
----------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2011,8 +2011,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2023,8 +2023,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 
@@ -2032,8 +2032,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------|---------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STATUS).
 
@@ -2041,8 +2041,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys |             | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="DelegatedResource"></a>DelegatedResource
------------------------------------------------
+DelegatedResource{#DelegatedResource}
+-------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2053,8 +2053,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | resourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          |             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="DelegatedResource_STATUS"></a>DelegatedResource_STATUS
--------------------------------------------------------------
+DelegatedResource_STATUS{#DelegatedResource_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2065,8 +2065,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | resourceId       |             | string<br/><small>Optional</small> |
 | tenantId         |             | string<br/><small>Optional</small> |
 
-<a id="Expander"></a>Expander
------------------------------
+Expander{#Expander}
+-------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_AutoScalerProfile).
 
@@ -2077,8 +2077,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="Expander_STATUS"></a>Expander_STATUS
--------------------------------------------
+Expander_STATUS{#Expander_STATUS}
+---------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProperties_AutoScalerProfile_STATUS).
 
@@ -2089,8 +2089,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 Used by: [ExtendedLocation](#ExtendedLocation).
 
@@ -2098,8 +2098,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 
@@ -2107,8 +2107,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="IpFamily"></a>IpFamily
------------------------------
+IpFamily{#IpFamily}
+-------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2117,8 +2117,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IpFamily_STATUS"></a>IpFamily_STATUS
--------------------------------------------
+IpFamily_STATUS{#IpFamily_STATUS}
+---------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2127,8 +2127,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IPTag"></a>IPTag
------------------------
+IPTag{#IPTag}
+-------------
 
 Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 
@@ -2137,8 +2137,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | ipTagType |             | string<br/><small>Optional</small> |
 | tag       |             | string<br/><small>Optional</small> |
 
-<a id="IPTag_STATUS"></a>IPTag_STATUS
--------------------------------------
+IPTag_STATUS{#IPTag_STATUS}
+---------------------------
 
 Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 
@@ -2147,8 +2147,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | ipTagType |             | string<br/><small>Optional</small> |
 | tag       |             | string<br/><small>Optional</small> |
 
-<a id="IstioServiceMesh"></a>IstioServiceMesh
----------------------------------------------
+IstioServiceMesh{#IstioServiceMesh}
+-----------------------------------
 
 Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 
@@ -2158,8 +2158,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | components           |             | [IstioComponents](#IstioComponents)<br/><small>Optional</small>                     |
 | revisions            |             | string[]<br/><small>Optional</small>                                                |
 
-<a id="IstioServiceMesh_STATUS"></a>IstioServiceMesh_STATUS
------------------------------------------------------------
+IstioServiceMesh_STATUS{#IstioServiceMesh_STATUS}
+-------------------------------------------------
 
 Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 
@@ -2169,8 +2169,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | components           |             | [IstioComponents_STATUS](#IstioComponents_STATUS)<br/><small>Optional</small>                     |
 | revisions            |             | string[]<br/><small>Optional</small>                                                              |
 
-<a id="LoadBalancerSku"></a>LoadBalancerSku
--------------------------------------------
+LoadBalancerSku{#LoadBalancerSku}
+---------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2179,8 +2179,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "basic"    |             |
 | "standard" |             |
 
-<a id="LoadBalancerSku_STATUS"></a>LoadBalancerSku_STATUS
----------------------------------------------------------
+LoadBalancerSku_STATUS{#LoadBalancerSku_STATUS}
+-----------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2189,8 +2189,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "basic"    |             |
 | "standard" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2201,8 +2201,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2213,8 +2213,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2226,8 +2226,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2239,8 +2239,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAzureMonitorProfileLogs"></a>ManagedClusterAzureMonitorProfileLogs
----------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileLogs{#ManagedClusterAzureMonitorProfileLogs}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile).
 
@@ -2249,8 +2249,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | appMonitoring     |             | [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMonitorProfileAppMonitoring)<br/><small>Optional</small>         |
 | containerInsights |             | [ManagedClusterAzureMonitorProfileContainerInsights](#ManagedClusterAzureMonitorProfileContainerInsights)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileLogs_STATUS"></a>ManagedClusterAzureMonitorProfileLogs_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileLogs_STATUS{#ManagedClusterAzureMonitorProfileLogs_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorProfile_STATUS).
 
@@ -2259,8 +2259,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | appMonitoring     |             | [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS)<br/><small>Optional</small>         |
 | containerInsights |             | [ManagedClusterAzureMonitorProfileContainerInsights_STATUS](#ManagedClusterAzureMonitorProfileContainerInsights_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics"></a>ManagedClusterAzureMonitorProfileMetrics
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics{#ManagedClusterAzureMonitorProfileMetrics}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile).
 
@@ -2270,8 +2270,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | enabled                           |             | bool<br/><small>Required</small>                                                                                                                                      |
 | kubeStateMetrics                  |             | [ManagedClusterAzureMonitorProfileKubeStateMetrics](#ManagedClusterAzureMonitorProfileKubeStateMetrics)<br/><small>Optional</small>                                   |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileMetrics_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics_STATUS{#ManagedClusterAzureMonitorProfileMetrics_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorProfile_STATUS).
 
@@ -2281,8 +2281,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | enabled                           |             | bool<br/><small>Optional</small>                                                                                                                                                    |
 | kubeStateMetrics                  |             | [ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS](#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="ManagedClusterCostAnalysis"></a>ManagedClusterCostAnalysis
------------------------------------------------------------------
+ManagedClusterCostAnalysis{#ManagedClusterCostAnalysis}
+-------------------------------------------------------
 
 Used by: [ManagedClusterMetricsProfile](#ManagedClusterMetricsProfile).
 
@@ -2290,8 +2290,8 @@ Used by: [ManagedClusterMetricsProfile](#ManagedClusterMetricsProfile).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterCostAnalysis_STATUS"></a>ManagedClusterCostAnalysis_STATUS
--------------------------------------------------------------------------------
+ManagedClusterCostAnalysis_STATUS{#ManagedClusterCostAnalysis_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ManagedClusterMetricsProfile_STATUS](#ManagedClusterMetricsProfile_STATUS).
 
@@ -2299,8 +2299,8 @@ Used by: [ManagedClusterMetricsProfile_STATUS](#ManagedClusterMetricsProfile_STA
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2310,8 +2310,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2321,8 +2321,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2331,8 +2331,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    |             | string<br/><small>Optional</small> |
 | principalId |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfileWebAppRouting"></a>ManagedClusterIngressProfileWebAppRouting
------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting{#ManagedClusterIngressProfileWebAppRouting}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIngressProfile](#ManagedClusterIngressProfile).
 
@@ -2341,8 +2341,8 @@ Used by: [ManagedClusterIngressProfile](#ManagedClusterIngressProfile).
 | dnsZoneResourceReferences |             | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | enabled                   |             | bool<br/><small>Optional</small>                                                                                                                             |
 
-<a id="ManagedClusterIngressProfileWebAppRouting_STATUS"></a>ManagedClusterIngressProfileWebAppRouting_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting_STATUS{#ManagedClusterIngressProfileWebAppRouting_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIngressProfile_STATUS](#ManagedClusterIngressProfile_STATUS).
 
@@ -2352,8 +2352,8 @@ Used by: [ManagedClusterIngressProfile_STATUS](#ManagedClusterIngressProfile_STA
 | enabled            |             | bool<br/><small>Optional</small>                                                        |
 | identity           |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2368,8 +2368,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes                  |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small> |
 | outboundIPs                         |             | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2384,8 +2384,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes                  |             | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small> |
 | outboundIPs                         |             | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterNATGatewayProfile"></a>ManagedClusterNATGatewayProfile
----------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile{#ManagedClusterNATGatewayProfile}
+-----------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2395,8 +2395,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | idleTimeoutInMinutes     |             | int<br/><small>Optional</small>                                                                               |
 | managedOutboundIPProfile |             | [ManagedClusterManagedOutboundIPProfile](#ManagedClusterManagedOutboundIPProfile)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNATGatewayProfile_STATUS"></a>ManagedClusterNATGatewayProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile_STATUS{#ManagedClusterNATGatewayProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2406,8 +2406,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | idleTimeoutInMinutes     |             | int<br/><small>Optional</small>                                                                                             |
 | managedOutboundIPProfile |             | [ManagedClusterManagedOutboundIPProfile_STATUS](#ManagedClusterManagedOutboundIPProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile_Mode"></a>ManagedClusterNodeProvisioningProfile_Mode
--------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_Mode{#ManagedClusterNodeProvisioningProfile_Mode}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeProvisioningProfile](#ManagedClusterNodeProvisioningProfile).
 
@@ -2416,8 +2416,8 @@ Used by: [ManagedClusterNodeProvisioningProfile](#ManagedClusterNodeProvisioning
 | "Auto"   |             |
 | "Manual" |             |
 
-<a id="ManagedClusterNodeProvisioningProfile_Mode_STATUS"></a>ManagedClusterNodeProvisioningProfile_Mode_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_Mode_STATUS{#ManagedClusterNodeProvisioningProfile_Mode_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeProvisioningProfile_STATUS](#ManagedClusterNodeProvisioningProfile_STATUS).
 
@@ -2426,8 +2426,8 @@ Used by: [ManagedClusterNodeProvisioningProfile_STATUS](#ManagedClusterNodeProvi
 | "Auto"   |             |
 | "Manual" |             |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGroupProfile).
 
@@ -2436,8 +2436,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGro
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeResourceGroupProfile_STATUS).
 
@@ -2446,8 +2446,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeReso
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterOperatorConfigMaps"></a>ManagedClusterOperatorConfigMaps
------------------------------------------------------------------------------
+ManagedClusterOperatorConfigMaps{#ManagedClusterOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2455,8 +2455,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 |-------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | oidcIssuerProfile | indicates where the OIDCIssuerProfile config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2465,8 +2465,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -2477,8 +2477,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            |             | string<br/><small>Required</small>                                        |
 | namespace       |             | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -2491,8 +2491,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |             | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState |             | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 
@@ -2502,8 +2502,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace |             | string<br/><small>Required</small>            |
 | podLabels |             | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityProfile_STATUS).
 
@@ -2513,8 +2513,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace |             | string<br/><small>Optional</small>            |
 | podLabels |             | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefender"></a>ManagedClusterSecurityProfileDefender
----------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender{#ManagedClusterSecurityProfileDefender}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -2523,8 +2523,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | logAnalyticsWorkspaceResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityMonitoring                     |             | [ManagedClusterSecurityProfileDefenderSecurityMonitoring](#ManagedClusterSecurityProfileDefenderSecurityMonitoring)<br/><small>Optional</small>            |
 
-<a id="ManagedClusterSecurityProfileDefender_STATUS"></a>ManagedClusterSecurityProfileDefender_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender_STATUS{#ManagedClusterSecurityProfileDefender_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -2533,8 +2533,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | logAnalyticsWorkspaceResourceId |             | string<br/><small>Optional</small>                                                                                                                            |
 | securityMonitoring              |             | [ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS](#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageCleaner"></a>ManagedClusterSecurityProfileImageCleaner
------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner{#ManagedClusterSecurityProfileImageCleaner}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -2543,36 +2543,18 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | enabled       |             | bool<br/><small>Optional</small> |
 | intervalHours |             | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileImageCleaner_STATUS"></a>ManagedClusterSecurityProfileImageCleaner_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property      | Description | Type                             |
-|---------------|-------------|----------------------------------|
-| enabled       |             | bool<br/><small>Optional</small> |
-| intervalHours |             | int<br/><small>Optional</small>  |
-
-<a id="ManagedClusterSecurityProfileImageIntegrity"></a>ManagedClusterSecurityProfileImageIntegrity
+ManagedClusterSecurityProfileImageCleaner_STATUS{#ManagedClusterSecurityProfileImageCleaner_STATUS}
 ---------------------------------------------------------------------------------------------------
 
-Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileImageIntegrity_STATUS"></a>ManagedClusterSecurityProfileImageIntegrity_STATUS
------------------------------------------------------------------------------------------------------------------
-
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
+| Property      | Description | Type                             |
+|---------------|-------------|----------------------------------|
+| enabled       |             | bool<br/><small>Optional</small> |
+| intervalHours |             | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileNodeRestriction"></a>ManagedClusterSecurityProfileNodeRestriction
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageIntegrity{#ManagedClusterSecurityProfileImageIntegrity}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
@@ -2580,26 +2562,26 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileNodeRestriction_STATUS"></a>ManagedClusterSecurityProfileNodeRestriction_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileWorkloadIdentity"></a>ManagedClusterSecurityProfileWorkloadIdentity
+ManagedClusterSecurityProfileImageIntegrity_STATUS{#ManagedClusterSecurityProfileImageIntegrity_STATUS}
 -------------------------------------------------------------------------------------------------------
 
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileNodeRestriction{#ManagedClusterSecurityProfileNodeRestriction}
+-------------------------------------------------------------------------------------------
+
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 
 | Property | Description | Type                             |
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileWorkloadIdentity_STATUS"></a>ManagedClusterSecurityProfileWorkloadIdentity_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileNodeRestriction_STATUS{#ManagedClusterSecurityProfileNodeRestriction_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
 
@@ -2607,122 +2589,140 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver"></a>ManagedClusterStorageProfileBlobCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver_STATUS"></a>ManagedClusterStorageProfileBlobCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver"></a>ManagedClusterStorageProfileDiskCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                               |
-|----------|-------------|------------------------------------|
-| enabled  |             | bool<br/><small>Optional</small>   |
-| version  |             | string<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver_STATUS"></a>ManagedClusterStorageProfileDiskCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                               |
-|----------|-------------|------------------------------------|
-| enabled  |             | bool<br/><small>Optional</small>   |
-| version  |             | string<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver"></a>ManagedClusterStorageProfileFileCSIDriver
------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver_STATUS"></a>ManagedClusterStorageProfileFileCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController"></a>ManagedClusterStorageProfileSnapshotController
----------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController_STATUS"></a>ManagedClusterStorageProfileSnapshotController_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description | Type                             |
-|----------|-------------|----------------------------------|
-| enabled  |             | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
+ManagedClusterSecurityProfileWorkloadIdentity{#ManagedClusterSecurityProfileWorkloadIdentity}
 ---------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileWorkloadIdentity_STATUS{#ManagedClusterSecurityProfileWorkloadIdentity_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterStorageProfileBlobCSIDriver{#ManagedClusterStorageProfileBlobCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileBlobCSIDriver_STATUS{#ManagedClusterStorageProfileBlobCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver{#ManagedClusterStorageProfileDiskCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                               |
+|----------|-------------|------------------------------------|
+| enabled  |             | bool<br/><small>Optional</small>   |
+| version  |             | string<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver_STATUS{#ManagedClusterStorageProfileDiskCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                               |
+|----------|-------------|------------------------------------|
+| enabled  |             | bool<br/><small>Optional</small>   |
+| version  |             | string<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver{#ManagedClusterStorageProfileFileCSIDriver}
+-------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver_STATUS{#ManagedClusterStorageProfileFileCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController{#ManagedClusterStorageProfileSnapshotController}
+-----------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController_STATUS{#ManagedClusterStorageProfileSnapshotController_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description | Type                             |
+|----------|-------------|----------------------------------|
+| enabled  |             | bool<br/><small>Optional</small> |
+
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -2731,8 +2731,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -2741,8 +2741,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda"></a>ManagedClusterWorkloadAutoScalerProfileKeda
----------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda{#ManagedClusterWorkloadAutoScalerProfileKeda}
+-----------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile).
 
@@ -2750,8 +2750,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda_STATUS{#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS).
 
@@ -2759,8 +2759,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile).
 
@@ -2769,8 +2769,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 | addonAutoscaling |             | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling)<br/><small>Optional</small> |
 | enabled          |             | bool<br/><small>Required</small>                                                                                                                                                            |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS).
 
@@ -2779,48 +2779,48 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 | addonAutoscaling |             | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS)<br/><small>Optional</small> |
 | enabled          |             | bool<br/><small>Optional</small>                                                                                                                                                                          |
 
-<a id="NetworkDataplane"></a>NetworkDataplane
----------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="NetworkDataplane_STATUS"></a>NetworkDataplane_STATUS
------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="NetworkMode"></a>NetworkMode
+NetworkDataplane{#NetworkDataplane}
 -----------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
 
-<a id="NetworkMode_STATUS"></a>NetworkMode_STATUS
+NetworkDataplane_STATUS{#NetworkDataplane_STATUS}
 -------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+NetworkMode{#NetworkMode}
+-------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value         | Description |
 |---------------|-------------|
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="NetworkMonitoring"></a>NetworkMonitoring
------------------------------------------------
+NetworkMode_STATUS{#NetworkMode_STATUS}
+---------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+NetworkMonitoring{#NetworkMonitoring}
+-------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2828,8 +2828,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="NetworkMonitoring_STATUS"></a>NetworkMonitoring_STATUS
--------------------------------------------------------------
+NetworkMonitoring_STATUS{#NetworkMonitoring_STATUS}
+---------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2837,8 +2837,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="NetworkPlugin"></a>NetworkPlugin
----------------------------------------
+NetworkPlugin{#NetworkPlugin}
+-----------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2848,8 +2848,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="NetworkPlugin_STATUS"></a>NetworkPlugin_STATUS
------------------------------------------------------
+NetworkPlugin_STATUS{#NetworkPlugin_STATUS}
+-------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2859,8 +2859,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="NetworkPluginMode"></a>NetworkPluginMode
------------------------------------------------
+NetworkPluginMode{#NetworkPluginMode}
+-------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2868,8 +2868,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 |-----------|-------------|
 | "overlay" |             |
 
-<a id="NetworkPluginMode_STATUS"></a>NetworkPluginMode_STATUS
--------------------------------------------------------------
+NetworkPluginMode_STATUS{#NetworkPluginMode_STATUS}
+---------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2877,8 +2877,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 |-----------|-------------|
 | "overlay" |             |
 
-<a id="NetworkPolicy"></a>NetworkPolicy
----------------------------------------
+NetworkPolicy{#NetworkPolicy}
+-----------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2889,8 +2889,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "cilium" |             |
 | "none"   |             |
 
-<a id="NetworkPolicy_STATUS"></a>NetworkPolicy_STATUS
------------------------------------------------------
+NetworkPolicy_STATUS{#NetworkPolicy_STATUS}
+-------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2901,8 +2901,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "cilium" |             |
 | "none"   |             |
 
-<a id="PortRange"></a>PortRange
--------------------------------
+PortRange{#PortRange}
+---------------------
 
 Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 
@@ -2912,8 +2912,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | portStart |             | int<br/><small>Optional</small>                                       |
 | protocol  |             | [PortRange_Protocol](#PortRange_Protocol)<br/><small>Optional</small> |
 
-<a id="PortRange_STATUS"></a>PortRange_STATUS
----------------------------------------------
+PortRange_STATUS{#PortRange_STATUS}
+-----------------------------------
 
 Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 
@@ -2923,8 +2923,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | portStart |             | int<br/><small>Optional</small>                                                     |
 | protocol  |             | [PortRange_Protocol_STATUS](#PortRange_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="PowerState_Code"></a>PowerState_Code
--------------------------------------------
+PowerState_Code{#PowerState_Code}
+---------------------------------
 
 Used by: [PowerState](#PowerState).
 
@@ -2933,8 +2933,8 @@ Used by: [PowerState](#PowerState).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -2943,8 +2943,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="SafeguardsProfile_Level"></a>SafeguardsProfile_Level
------------------------------------------------------------
+SafeguardsProfile_Level{#SafeguardsProfile_Level}
+-------------------------------------------------
 
 Used by: [SafeguardsProfile](#SafeguardsProfile).
 
@@ -2954,8 +2954,8 @@ Used by: [SafeguardsProfile](#SafeguardsProfile).
 | "Off"         |             |
 | "Warning"     |             |
 
-<a id="SafeguardsProfile_Level_STATUS"></a>SafeguardsProfile_Level_STATUS
--------------------------------------------------------------------------
+SafeguardsProfile_Level_STATUS{#SafeguardsProfile_Level_STATUS}
+---------------------------------------------------------------
 
 Used by: [SafeguardsProfile_STATUS](#SafeguardsProfile_STATUS).
 
@@ -2965,8 +2965,8 @@ Used by: [SafeguardsProfile_STATUS](#SafeguardsProfile_STATUS).
 | "Off"         |             |
 | "Warning"     |             |
 
-<a id="ScaleProfile"></a>ScaleProfile
--------------------------------------
+ScaleProfile{#ScaleProfile}
+---------------------------
 
 Used by: [VirtualMachinesProfile](#VirtualMachinesProfile).
 
@@ -2974,8 +2974,8 @@ Used by: [VirtualMachinesProfile](#VirtualMachinesProfile).
 |----------|-------------|-------------------------------------------------------------------------|
 | manual   |             | [ManualScaleProfile[]](#ManualScaleProfile)<br/><small>Optional</small> |
 
-<a id="ScaleProfile_STATUS"></a>ScaleProfile_STATUS
----------------------------------------------------
+ScaleProfile_STATUS{#ScaleProfile_STATUS}
+-----------------------------------------
 
 Used by: [VirtualMachinesProfile_STATUS](#VirtualMachinesProfile_STATUS).
 
@@ -2983,8 +2983,8 @@ Used by: [VirtualMachinesProfile_STATUS](#VirtualMachinesProfile_STATUS).
 |----------|-------------|---------------------------------------------------------------------------------------|
 | manual   |             | [ManualScaleProfile_STATUS[]](#ManualScaleProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ServiceMeshProfile_Mode"></a>ServiceMeshProfile_Mode
------------------------------------------------------------
+ServiceMeshProfile_Mode{#ServiceMeshProfile_Mode}
+-------------------------------------------------
 
 Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 
@@ -2993,8 +2993,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="ServiceMeshProfile_Mode_STATUS"></a>ServiceMeshProfile_Mode_STATUS
--------------------------------------------------------------------------
+ServiceMeshProfile_Mode_STATUS{#ServiceMeshProfile_Mode_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 
@@ -3003,8 +3003,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Used by: [LinuxOSConfig](#LinuxOSConfig).
 
@@ -3039,8 +3039,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 
@@ -3075,7 +3075,19 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   |             | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             |             | int<br/><small>Optional</small>    |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3087,20 +3099,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpgradeOverrideSettings"></a>UpgradeOverrideSettings
------------------------------------------------------------
+UpgradeOverrideSettings{#UpgradeOverrideSettings}
+-------------------------------------------------
 
 Used by: [ClusterUpgradeSettings](#ClusterUpgradeSettings).
 
@@ -3109,8 +3109,8 @@ Used by: [ClusterUpgradeSettings](#ClusterUpgradeSettings).
 | forceUpgrade |             | bool<br/><small>Optional</small>   |
 | until        |             | string<br/><small>Optional</small> |
 
-<a id="UpgradeOverrideSettings_STATUS"></a>UpgradeOverrideSettings_STATUS
--------------------------------------------------------------------------
+UpgradeOverrideSettings_STATUS{#UpgradeOverrideSettings_STATUS}
+---------------------------------------------------------------
 
 Used by: [ClusterUpgradeSettings_STATUS](#ClusterUpgradeSettings_STATUS).
 
@@ -3119,8 +3119,8 @@ Used by: [ClusterUpgradeSettings_STATUS](#ClusterUpgradeSettings_STATUS).
 | forceUpgrade |             | bool<br/><small>Optional</small>   |
 | until        |             | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -3128,8 +3128,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile"></a>WindowsGmsaProfile
--------------------------------------------------
+WindowsGmsaProfile{#WindowsGmsaProfile}
+---------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -3139,8 +3139,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | enabled        |             | bool<br/><small>Optional</small>   |
 | rootDomainName |             | string<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile_STATUS"></a>WindowsGmsaProfile_STATUS
----------------------------------------------------------------
+WindowsGmsaProfile_STATUS{#WindowsGmsaProfile_STATUS}
+-----------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -3150,8 +3150,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | enabled        |             | bool<br/><small>Optional</small>   |
 | rootDomainName |             | string<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess"></a>AzureKeyVaultKms_KeyVaultNetworkAccess
------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess{#AzureKeyVaultKms_KeyVaultNetworkAccess}
+-------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 
@@ -3160,8 +3160,8 @@ Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS"></a>AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS{#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 
@@ -3170,8 +3170,8 @@ Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig
--------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetworkProfile_KubeProxyConfig).
 
@@ -3182,8 +3182,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetwo
 | tcpTimeoutSeconds    |             | int<br/><small>Optional</small>                                                                                                                                         |
 | udpTimeoutSeconds    |             | int<br/><small>Optional</small>                                                                                                                                         |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS).
 
@@ -3194,8 +3194,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServi
 | tcpTimeoutSeconds    |             | int<br/><small>Optional</small>                                                                                                                                                       |
 | udpTimeoutSeconds    |             | int<br/><small>Optional</small>                                                                                                                                                       |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_Mode"></a>ContainerServiceNetworkProfile_KubeProxyConfig_Mode
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_Mode{#ContainerServiceNetworkProfile_KubeProxyConfig_Mode}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetworkProfile_KubeProxyConfig).
 
@@ -3204,8 +3204,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetwo
 | "IPTABLES" |             |
 | "IPVS"     |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS).
 
@@ -3214,8 +3214,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServi
 | "IPTABLES" |             |
 | "IPVS"     |             |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 
@@ -3223,8 +3223,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS).
 
@@ -3232,8 +3232,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|-------------|------------------------------------|
 | keyData  |             | string<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority"></a>IstioCertificateAuthority
----------------------------------------------------------------
+IstioCertificateAuthority{#IstioCertificateAuthority}
+-----------------------------------------------------
 
 Used by: [IstioServiceMesh](#IstioServiceMesh).
 
@@ -3241,8 +3241,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 |----------|-------------|-------------------------------------------------------------------------------------------------|
 | plugin   |             | [IstioPluginCertificateAuthority](#IstioPluginCertificateAuthority)<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority_STATUS"></a>IstioCertificateAuthority_STATUS
------------------------------------------------------------------------------
+IstioCertificateAuthority_STATUS{#IstioCertificateAuthority_STATUS}
+-------------------------------------------------------------------
 
 Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 
@@ -3250,8 +3250,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 |----------|-------------|---------------------------------------------------------------------------------------------------------------|
 | plugin   |             | [IstioPluginCertificateAuthority_STATUS](#IstioPluginCertificateAuthority_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioComponents"></a>IstioComponents
--------------------------------------------
+IstioComponents{#IstioComponents}
+---------------------------------
 
 Used by: [IstioServiceMesh](#IstioServiceMesh).
 
@@ -3260,8 +3260,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 | egressGateways  |             | [IstioEgressGateway[]](#IstioEgressGateway)<br/><small>Optional</small>   |
 | ingressGateways |             | [IstioIngressGateway[]](#IstioIngressGateway)<br/><small>Optional</small> |
 
-<a id="IstioComponents_STATUS"></a>IstioComponents_STATUS
----------------------------------------------------------
+IstioComponents_STATUS{#IstioComponents_STATUS}
+-----------------------------------------------
 
 Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 
@@ -3270,8 +3270,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 | egressGateways  |             | [IstioEgressGateway_STATUS[]](#IstioEgressGateway_STATUS)<br/><small>Optional</small>   |
 | ingressGateways |             | [IstioIngressGateway_STATUS[]](#IstioIngressGateway_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoring"></a>ManagedClusterAzureMonitorProfileAppMonitoring
----------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoring{#ManagedClusterAzureMonitorProfileAppMonitoring}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileLogs](#ManagedClusterAzureMonitorProfileLogs).
 
@@ -3279,8 +3279,8 @@ Used by: [ManagedClusterAzureMonitorProfileLogs](#ManagedClusterAzureMonitorProf
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoring_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoring_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileLogs_STATUS](#ManagedClusterAzureMonitorProfileLogs_STATUS).
 
@@ -3288,8 +3288,8 @@ Used by: [ManagedClusterAzureMonitorProfileLogs_STATUS](#ManagedClusterAzureMoni
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics
--------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics).
 
@@ -3297,8 +3297,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS).
 
@@ -3306,8 +3306,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileContainerInsights"></a>ManagedClusterAzureMonitorProfileContainerInsights
------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileContainerInsights{#ManagedClusterAzureMonitorProfileContainerInsights}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileLogs](#ManagedClusterAzureMonitorProfileLogs).
 
@@ -3317,8 +3317,8 @@ Used by: [ManagedClusterAzureMonitorProfileLogs](#ManagedClusterAzureMonitorProf
 | logAnalyticsWorkspaceResourceReference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | windowsHostLogs                        |             | [ManagedClusterAzureMonitorProfileWindowsHostLogs](#ManagedClusterAzureMonitorProfileWindowsHostLogs)<br/><small>Optional</small>                          |
 
-<a id="ManagedClusterAzureMonitorProfileContainerInsights_STATUS"></a>ManagedClusterAzureMonitorProfileContainerInsights_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileContainerInsights_STATUS{#ManagedClusterAzureMonitorProfileContainerInsights_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileLogs_STATUS](#ManagedClusterAzureMonitorProfileLogs_STATUS).
 
@@ -3328,8 +3328,8 @@ Used by: [ManagedClusterAzureMonitorProfileLogs_STATUS](#ManagedClusterAzureMoni
 | logAnalyticsWorkspaceResourceId |             | string<br/><small>Optional</small>                                                                                                              |
 | windowsHostLogs                 |             | [ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS](#ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics
----------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics{#ManagedClusterAzureMonitorProfileKubeStateMetrics}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics).
 
@@ -3338,8 +3338,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 | metricAnnotationsAllowList |             | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS{#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS).
 
@@ -3348,8 +3348,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 | metricAnnotationsAllowList |             | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType"></a>ManagedClusterLoadBalancerProfile_BackendPoolType
----------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType{#ManagedClusterLoadBalancerProfile_BackendPoolType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3358,8 +3358,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS"></a>ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS{#ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3368,8 +3368,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3378,8 +3378,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | count     |             | int<br/><small>Optional</small> |
 | countIPv6 |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3388,8 +3388,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | count     |             | int<br/><small>Optional</small> |
 | countIPv6 |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3397,8 +3397,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|-------------|-----------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3406,8 +3406,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|-------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3415,8 +3415,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|-----------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3424,8 +3424,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|-------------|-------------------------------------------------------------------------------------|
 | publicIPs |             | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile"></a>ManagedClusterManagedOutboundIPProfile
------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile{#ManagedClusterManagedOutboundIPProfile}
+-------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 
@@ -3433,8 +3433,8 @@ Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile_STATUS"></a>ManagedClusterManagedOutboundIPProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile_STATUS{#ManagedClusterManagedOutboundIPProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfile_STATUS).
 
@@ -3442,8 +3442,8 @@ Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfi
 |----------|-------------|---------------------------------|
 | count    |             | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3451,8 +3451,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3465,8 +3465,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring{#ManagedClusterSecurityProfileDefenderSecurityMonitoring}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileDefender).
 
@@ -3474,8 +3474,8 @@ Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileD
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS{#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityProfileDefender_STATUS).
 
@@ -3483,8 +3483,8 @@ Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityP
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler).
 
@@ -3493,8 +3493,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#Managed
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS).
 
@@ -3503,8 +3503,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManualScaleProfile"></a>ManualScaleProfile
--------------------------------------------------
+ManualScaleProfile{#ManualScaleProfile}
+---------------------------------------
 
 Used by: [ScaleProfile](#ScaleProfile).
 
@@ -3513,8 +3513,8 @@ Used by: [ScaleProfile](#ScaleProfile).
 | count    |             | int<br/><small>Optional</small>      |
 | sizes    |             | string[]<br/><small>Optional</small> |
 
-<a id="ManualScaleProfile_STATUS"></a>ManualScaleProfile_STATUS
----------------------------------------------------------------
+ManualScaleProfile_STATUS{#ManualScaleProfile_STATUS}
+-----------------------------------------------------
 
 Used by: [ScaleProfile_STATUS](#ScaleProfile_STATUS).
 
@@ -3523,8 +3523,8 @@ Used by: [ScaleProfile_STATUS](#ScaleProfile_STATUS).
 | count    |             | int<br/><small>Optional</small>      |
 | sizes    |             | string[]<br/><small>Optional</small> |
 
-<a id="PortRange_Protocol"></a>PortRange_Protocol
--------------------------------------------------
+PortRange_Protocol{#PortRange_Protocol}
+---------------------------------------
 
 Used by: [PortRange](#PortRange).
 
@@ -3533,8 +3533,8 @@ Used by: [PortRange](#PortRange).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="PortRange_Protocol_STATUS"></a>PortRange_Protocol_STATUS
----------------------------------------------------------------
+PortRange_Protocol_STATUS{#PortRange_Protocol_STATUS}
+-----------------------------------------------------
 
 Used by: [PortRange_STATUS](#PortRange_STATUS).
 
@@ -3543,8 +3543,8 @@ Used by: [PortRange_STATUS](#PortRange_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile), [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes), [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs), and [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 
@@ -3552,8 +3552,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS), [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS), [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS), and [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfile_STATUS).
 
@@ -3561,8 +3561,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|-------------|------------------------------------|
 | id       |             | string<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler
----------------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig).
 
@@ -3571,8 +3571,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerS
 | "LeastConnection" |             |
 | "RoundRobin"      |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS).
 
@@ -3581,8 +3581,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#Con
 | "LeastConnection" |             |
 | "RoundRobin"      |             |
 
-<a id="IstioEgressGateway"></a>IstioEgressGateway
--------------------------------------------------
+IstioEgressGateway{#IstioEgressGateway}
+---------------------------------------
 
 Used by: [IstioComponents](#IstioComponents).
 
@@ -3591,8 +3591,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled      |             | bool<br/><small>Required</small>              |
 | nodeSelector |             | map[string]string<br/><small>Optional</small> |
 
-<a id="IstioEgressGateway_STATUS"></a>IstioEgressGateway_STATUS
----------------------------------------------------------------
+IstioEgressGateway_STATUS{#IstioEgressGateway_STATUS}
+-----------------------------------------------------
 
 Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 
@@ -3601,8 +3601,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled      |             | bool<br/><small>Optional</small>              |
 | nodeSelector |             | map[string]string<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway"></a>IstioIngressGateway
----------------------------------------------------
+IstioIngressGateway{#IstioIngressGateway}
+-----------------------------------------
 
 Used by: [IstioComponents](#IstioComponents).
 
@@ -3611,8 +3611,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled  |             | bool<br/><small>Required</small>                                                  |
 | mode     |             | [IstioIngressGateway_Mode](#IstioIngressGateway_Mode)<br/><small>Required</small> |
 
-<a id="IstioIngressGateway_STATUS"></a>IstioIngressGateway_STATUS
------------------------------------------------------------------
+IstioIngressGateway_STATUS{#IstioIngressGateway_STATUS}
+-------------------------------------------------------
 
 Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 
@@ -3621,8 +3621,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled  |             | bool<br/><small>Optional</small>                                                                |
 | mode     |             | [IstioIngressGateway_Mode_STATUS](#IstioIngressGateway_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioPluginCertificateAuthority"></a>IstioPluginCertificateAuthority
----------------------------------------------------------------------------
+IstioPluginCertificateAuthority{#IstioPluginCertificateAuthority}
+-----------------------------------------------------------------
 
 Used by: [IstioCertificateAuthority](#IstioCertificateAuthority).
 
@@ -3634,8 +3634,8 @@ Used by: [IstioCertificateAuthority](#IstioCertificateAuthority).
 | keyVaultReference   |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | rootCertObjectName  |             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="IstioPluginCertificateAuthority_STATUS"></a>IstioPluginCertificateAuthority_STATUS
------------------------------------------------------------------------------------------
+IstioPluginCertificateAuthority_STATUS{#IstioPluginCertificateAuthority_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [IstioCertificateAuthority_STATUS](#IstioCertificateAuthority_STATUS).
 
@@ -3647,8 +3647,8 @@ Used by: [IstioCertificateAuthority_STATUS](#IstioCertificateAuthority_STATUS).
 | keyVaultId          |             | string<br/><small>Optional</small> |
 | rootCertObjectName  |             | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileWindowsHostLogs"></a>ManagedClusterAzureMonitorProfileWindowsHostLogs
--------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileWindowsHostLogs{#ManagedClusterAzureMonitorProfileWindowsHostLogs}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileContainerInsights](#ManagedClusterAzureMonitorProfileContainerInsights).
 
@@ -3656,8 +3656,8 @@ Used by: [ManagedClusterAzureMonitorProfileContainerInsights](#ManagedClusterAzu
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS"></a>ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS{#ManagedClusterAzureMonitorProfileWindowsHostLogs_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAzureMonitorProfileContainerInsights_STATUS](#ManagedClusterAzureMonitorProfileContainerInsights_STATUS).
 
@@ -3665,8 +3665,8 @@ Used by: [ManagedClusterAzureMonitorProfileContainerInsights_STATUS](#ManagedClu
 |----------|-------------|----------------------------------|
 | enabled  |             | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS).
 
@@ -3674,8 +3674,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    |             | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway_Mode"></a>IstioIngressGateway_Mode
--------------------------------------------------------------
+IstioIngressGateway_Mode{#IstioIngressGateway_Mode}
+---------------------------------------------------
 
 Used by: [IstioIngressGateway](#IstioIngressGateway).
 
@@ -3684,8 +3684,8 @@ Used by: [IstioIngressGateway](#IstioIngressGateway).
 | "External" |             |
 | "Internal" |             |
 
-<a id="IstioIngressGateway_Mode_STATUS"></a>IstioIngressGateway_Mode_STATUS
----------------------------------------------------------------------------
+IstioIngressGateway_Mode_STATUS{#IstioIngressGateway_Mode_STATUS}
+-----------------------------------------------------------------
 
 Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 
@@ -3694,8 +3694,8 @@ Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 | "External" |             |
 | "Internal" |             |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS).
 
@@ -3706,8 +3706,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  |             | string<br/><small>Optional</small>                                                                                                                              |
 | target   |             | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20240402preview.md
+++ b/docs/hugo/content/reference/containerservice/v1api20240402preview.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20240402preview
 linktitle: v1api20240402preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2024-04-02-preview" |             |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -80,7 +80,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                         | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                       | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -145,8 +145,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                         | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                       | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -156,8 +156,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -170,7 +170,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -229,7 +229,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -293,8 +293,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -304,8 +304,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBinding"></a>TrustedAccessRoleBinding
--------------------------------------------------------------
+TrustedAccessRoleBinding{#TrustedAccessRoleBinding}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -318,7 +318,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | spec                                                                                    |             | [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
+### TrustedAccessRoleBinding_Spec {#TrustedAccessRoleBinding_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -328,7 +328,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-### <a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
+### TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -341,8 +341,8 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TrustedAccessRoleBindingList"></a>TrustedAccessRoleBindingList
----------------------------------------------------------------------
+TrustedAccessRoleBindingList{#TrustedAccessRoleBindingList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-04-02-preview/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -352,8 +352,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [TrustedAccessRoleBinding[]](#TrustedAccessRoleBinding)<br/><small>Optional</small> |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -409,8 +409,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                         | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                       | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Managed cluster.
 
@@ -479,8 +479,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                         | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                       | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -541,8 +541,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -608,8 +608,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
------------------------------------------------------------------------
+TrustedAccessRoleBinding_Spec{#TrustedAccessRoleBinding_Spec}
+-------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -621,8 +621,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-<a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
----------------------------------------------------------------------------
+TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
+-----------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -637,8 +637,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AgentPoolArtifactStreamingProfile"></a>AgentPoolArtifactStreamingProfile
--------------------------------------------------------------------------------
+AgentPoolArtifactStreamingProfile{#AgentPoolArtifactStreamingProfile}
+---------------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -646,8 +646,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolArtifactStreamingProfile_STATUS"></a>AgentPoolArtifactStreamingProfile_STATUS
----------------------------------------------------------------------------------------------
+AgentPoolArtifactStreamingProfile_STATUS{#AgentPoolArtifactStreamingProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -655,8 +655,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolGatewayProfile"></a>AgentPoolGatewayProfile
------------------------------------------------------------
+AgentPoolGatewayProfile{#AgentPoolGatewayProfile}
+-------------------------------------------------
 
 Profile of the managed cluster gateway agent pool.
 
@@ -666,8 +666,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | publicIPPrefixSize | The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31](/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. | int<br/><small>Optional</small> |
 
-<a id="AgentPoolGatewayProfile_STATUS"></a>AgentPoolGatewayProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolGatewayProfile_STATUS{#AgentPoolGatewayProfile_STATUS}
+---------------------------------------------------------------
 
 Profile of the managed cluster gateway agent pool.
 
@@ -677,8 +677,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | publicIPPrefixSize | The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31](/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. | int<br/><small>Optional</small> |
 
-<a id="AgentPoolGPUProfile"></a>AgentPoolGPUProfile
----------------------------------------------------
+AgentPoolGPUProfile{#AgentPoolGPUProfile}
+-----------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
@@ -686,8 +686,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | installGPUDriver | The default value is true when the vmSize of the agent pool contains a GPU, false otherwise. GPU Driver Installation can only be set true when VM has an associated GPU resource. Setting this field to false prevents automatic GPU driver installation. In that case, in order for the GPU to be usable, the user must perform GPU driver installation themselves. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolGPUProfile_STATUS"></a>AgentPoolGPUProfile_STATUS
------------------------------------------------------------------
+AgentPoolGPUProfile_STATUS{#AgentPoolGPUProfile_STATUS}
+-------------------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
 
@@ -695,8 +695,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | installGPUDriver | The default value is true when the vmSize of the agent pool contains a GPU, false otherwise. GPU Driver Installation can only be set true when VM has an associated GPU resource. Setting this field to false prevents automatic GPU driver installation. In that case, in order for the GPU to be usable, the user must perform GPU driver installation themselves. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -708,8 +708,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System"  |             |
 | "User"    |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -721,8 +721,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System"  |             |
 | "User"    |             |
 
-<a id="AgentPoolNetworkProfile"></a>AgentPoolNetworkProfile
------------------------------------------------------------
+AgentPoolNetworkProfile{#AgentPoolNetworkProfile}
+-------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -734,8 +734,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | applicationSecurityGroupsReferences | The IDs of the application security groups which agent pool will associate when created. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | nodePublicIPTags                    | IPTags of instance-level public IPs.                                                     | [IPTag[]](#IPTag)<br/><small>Optional</small>                                                                                                                |
 
-<a id="AgentPoolNetworkProfile_STATUS"></a>AgentPoolNetworkProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolNetworkProfile_STATUS{#AgentPoolNetworkProfile_STATUS}
+---------------------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -747,8 +747,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | applicationSecurityGroups | The IDs of the application security groups which agent pool will associate when created. | string[]<br/><small>Optional</small>                                |
 | nodePublicIPTags          | IPTags of instance-level public IPs.                                                     | [IPTag_STATUS[]](#IPTag_STATUS)<br/><small>Optional</small>         |
 
-<a id="AgentPoolSecurityProfile"></a>AgentPoolSecurityProfile
--------------------------------------------------------------
+AgentPoolSecurityProfile{#AgentPoolSecurityProfile}
+---------------------------------------------------
 
 The security settings of an agent pool.
 
@@ -760,8 +760,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | enableVTPM       | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. | bool<br/><small>Optional</small>                                      |
 | sshAccess        | SSH access method of an agent pool.                                                                                                                                                                                   | [AgentPoolSSHAccess](#AgentPoolSSHAccess)<br/><small>Optional</small> |
 
-<a id="AgentPoolSecurityProfile_STATUS"></a>AgentPoolSecurityProfile_STATUS
----------------------------------------------------------------------------
+AgentPoolSecurityProfile_STATUS{#AgentPoolSecurityProfile_STATUS}
+-----------------------------------------------------------------
 
 The security settings of an agent pool.
 
@@ -773,8 +773,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | enableVTPM       | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. | bool<br/><small>Optional</small>                                                    |
 | sshAccess        | SSH access method of an agent pool.                                                                                                                                                                                   | [AgentPoolSSHAccess_STATUS](#AgentPoolSSHAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 The type of Agent Pool.
 
@@ -786,8 +786,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "VirtualMachineScaleSets" |             |
 | "VirtualMachines"         |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 The type of Agent Pool.
 
@@ -799,8 +799,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "VirtualMachineScaleSets" |             |
 | "VirtualMachines"         |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -813,8 +813,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | nodeSoakDurationInMinutes | The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.                                                                                                                                                                                                                                                          | int<br/><small>Optional</small>                                                                                                   |
 | undrainableNodeBehavior   | Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.                                                                                           | [AgentPoolUpgradeSettings_UndrainableNodeBehavior](#AgentPoolUpgradeSettings_UndrainableNodeBehavior)<br/><small>Optional</small> |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -827,8 +827,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | nodeSoakDurationInMinutes | The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.                                                                                                                                                                                                                                                          | int<br/><small>Optional</small>                                                                                                                 |
 | undrainableNodeBehavior   | Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.                                                                                           | [AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS](#AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS)<br/><small>Optional</small> |
 
-<a id="AgentPoolWindowsProfile"></a>AgentPoolWindowsProfile
------------------------------------------------------------
+AgentPoolWindowsProfile{#AgentPoolWindowsProfile}
+-------------------------------------------------
 
 The Windows agent pool's specific profile.
 
@@ -838,8 +838,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | disableOutboundNat | The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolWindowsProfile_STATUS"></a>AgentPoolWindowsProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolWindowsProfile_STATUS{#AgentPoolWindowsProfile_STATUS}
+---------------------------------------------------------------
 
 The Windows agent pool's specific profile.
 
@@ -849,8 +849,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | disableOutboundNat | The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. | bool<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings"></a>ClusterUpgradeSettings
----------------------------------------------------------
+ClusterUpgradeSettings{#ClusterUpgradeSettings}
+-----------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -860,8 +860,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|-------------------------|---------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings](#UpgradeOverrideSettings)<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings_STATUS"></a>ClusterUpgradeSettings_STATUS
------------------------------------------------------------------------
+ClusterUpgradeSettings_STATUS{#ClusterUpgradeSettings_STATUS}
+-------------------------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -871,8 +871,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|-------------------------|-----------------------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings_STATUS](#UpgradeOverrideSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -883,8 +883,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Required</small>                                                                |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -895,8 +895,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Optional</small>                                                                              |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -924,8 +924,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serviceCidrs               | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges.                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                          |
 | staticEgressGatewayProfile | The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway.                                                                                                                                                                                                       | [ManagedClusterStaticEgressGatewayProfile](#ManagedClusterStaticEgressGatewayProfile)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -953,13 +953,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serviceCidrs               | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges.                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                        |
 | staticEgressGatewayProfile | The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway.                                                                                                                                                                                                       | [ManagedClusterStaticEgressGatewayProfile_STATUS](#ManagedClusterStaticEgressGatewayProfile_STATUS)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -969,8 +969,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), [ManagedClusterAgentPoolPr
 |-------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sourceResourceReference | This is the ARM ID of the source object to be used to create the target object. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -980,8 +980,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |------------------|---------------------------------------------------------------------------------|------------------------------------|
 | sourceResourceId | This is the ARM ID of the source object to be used to create the target object. | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -992,8 +992,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -1004,60 +1004,60 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
-See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Property              | Description                                                                                                                                                                                                                          | Type                                 |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
-| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
-| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
-| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
-| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
-| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
-| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
-| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
-| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
-| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
-| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
 -----------------------------------------------------
 
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Property              | Description                                                                                                                                                                                                                          | Type                                 |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
+| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
+| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
+| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
+| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
+| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
+| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
+| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
+| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
+| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
+| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
+-------------------------------------------
+
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -1076,8 +1076,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
--------------------------------------------
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -1088,8 +1088,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -1100,8 +1100,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubernetesSupportPlan"></a>KubernetesSupportPlan
--------------------------------------------------------
+KubernetesSupportPlan{#KubernetesSupportPlan}
+---------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -1112,8 +1112,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="KubernetesSupportPlan_STATUS"></a>KubernetesSupportPlan_STATUS
----------------------------------------------------------------------
+KubernetesSupportPlan_STATUS{#KubernetesSupportPlan_STATUS}
+-----------------------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -1124,8 +1124,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -1138,8 +1138,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -1152,8 +1152,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -1169,8 +1169,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -1186,8 +1186,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -1198,8 +1198,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   | Key-value pairs for configuring an add-on. | map[string]string<br/><small>Optional</small> |
 | enabled  | Whether the add-on is enabled or not.      | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -1211,8 +1211,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  | Whether the add-on is enabled or not.                      | bool<br/><small>Optional</small>                                                        |
 | identity | Information of user assigned identity used by this add-on. | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1273,8 +1273,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                            |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1339,8 +1339,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                     |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                     |
 
-<a id="ManagedClusterAIToolchainOperatorProfile"></a>ManagedClusterAIToolchainOperatorProfile
----------------------------------------------------------------------------------------------
+ManagedClusterAIToolchainOperatorProfile{#ManagedClusterAIToolchainOperatorProfile}
+-----------------------------------------------------------------------------------
 
 When enabling the operator, a set of AKS managed CRDs and controllers will be installed in the cluster. The operator automates the deployment of OSS models for inference and/or training purposes. It provides a set of preset models and enables distributed inference against them.
 
@@ -1350,8 +1350,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|----------------------------------------------------|----------------------------------|
 | enabled  | Indicates if AI toolchain operator enabled or not. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAIToolchainOperatorProfile_STATUS"></a>ManagedClusterAIToolchainOperatorProfile_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAIToolchainOperatorProfile_STATUS{#ManagedClusterAIToolchainOperatorProfile_STATUS}
+-------------------------------------------------------------------------------------------------
 
 When enabling the operator, a set of AKS managed CRDs and controllers will be installed in the cluster. The operator automates the deployment of OSS models for inference and/or training purposes. It provides a set of preset models and enables distributed inference against them.
 
@@ -1361,8 +1361,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|----------------------------------------------------|----------------------------------|
 | enabled  | Indicates if AI toolchain operator enabled or not. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1378,8 +1378,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 | subnetId                       | It is required when: 1. creating a new cluster with BYO Vnet; 2. updating an existing cluster to enable apiserver vnet integration.                                                                                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1395,8 +1395,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 | subnetId                       | It is required when: 1. creating a new cluster with BYO Vnet; 2. updating an existing cluster to enable apiserver vnet integration.                                                                                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1407,8 +1407,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeOSUpgradeChannel | The default is Unmanaged, but may change to either NodeImage or SecurityPatch at GA.                                                                    | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1419,8 +1419,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeOSUpgradeChannel | The default is Unmanaged, but may change to either NodeImage or SecurityPatch at GA.                                                                    | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAzureMonitorProfile"></a>ManagedClusterAzureMonitorProfile
--------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile{#ManagedClusterAzureMonitorProfile}
+---------------------------------------------------------------------
 
 Prometheus addon profile for the container service cluster
 
@@ -1432,8 +1432,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | containerInsights | Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview.                                                                                                    | [ManagedClusterAzureMonitorProfileContainerInsights](#ManagedClusterAzureMonitorProfileContainerInsights)<br/><small>Optional</small> |
 | metrics           | Metrics profile for the prometheus service addon                                                                                                                                                                                                                               | [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics)<br/><small>Optional</small>                     |
 
-<a id="ManagedClusterAzureMonitorProfile_STATUS"></a>ManagedClusterAzureMonitorProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile_STATUS{#ManagedClusterAzureMonitorProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Prometheus addon profile for the container service cluster
 
@@ -1445,8 +1445,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | containerInsights | Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview.                                                                                                    | [ManagedClusterAzureMonitorProfileContainerInsights_STATUS](#ManagedClusterAzureMonitorProfileContainerInsights_STATUS)<br/><small>Optional</small> |
 | metrics           | Metrics profile for the prometheus service addon                                                                                                                                                                                                                               | [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS)<br/><small>Optional</small>                     |
 
-<a id="ManagedClusterBootstrapProfile"></a>ManagedClusterBootstrapProfile
--------------------------------------------------------------------------
+ManagedClusterBootstrapProfile{#ManagedClusterBootstrapProfile}
+---------------------------------------------------------------
 
 The bootstrap profile.
 
@@ -1457,8 +1457,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | artifactSource             | The source where the artifacts are downloaded from.                                                                          | [ManagedClusterBootstrapProfile_ArtifactSource](#ManagedClusterBootstrapProfile_ArtifactSource)<br/><small>Optional</small>                                |
 | containerRegistryReference | The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterBootstrapProfile_STATUS"></a>ManagedClusterBootstrapProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterBootstrapProfile_STATUS{#ManagedClusterBootstrapProfile_STATUS}
+-----------------------------------------------------------------------------
 
 The bootstrap profile.
 
@@ -1469,8 +1469,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | artifactSource      | The source where the artifacts are downloaded from.                                                                          | [ManagedClusterBootstrapProfile_ArtifactSource_STATUS](#ManagedClusterBootstrapProfile_ArtifactSource_STATUS)<br/><small>Optional</small> |
 | containerRegistryId | The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy. | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1483,8 +1483,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    | The endpoints that should not go through proxy.             | string[]<br/><small>Optional</small> |
 | trustedCa  | Alternative CA cert to use for connecting to proxy servers. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1498,8 +1498,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy          | The endpoints that should not go through proxy.                                                                                                     | string[]<br/><small>Optional</small> |
 | trustedCa        | Alternative CA cert to use for connecting to proxy servers.                                                                                         | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1511,8 +1511,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1526,8 +1526,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile"></a>ManagedClusterIngressProfile
----------------------------------------------------------------------
+ManagedClusterIngressProfile{#ManagedClusterIngressProfile}
+-----------------------------------------------------------
 
 Ingress profile for the container service cluster.
 
@@ -1537,8 +1537,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |---------------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | webAppRouting | Web App Routing settings for the ingress profile. | [ManagedClusterIngressProfileWebAppRouting](#ManagedClusterIngressProfileWebAppRouting)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile_STATUS"></a>ManagedClusterIngressProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterIngressProfile_STATUS{#ManagedClusterIngressProfile_STATUS}
+-------------------------------------------------------------------------
 
 Ingress profile for the container service cluster.
 
@@ -1548,8 +1548,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |---------------|---------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | webAppRouting | Web App Routing settings for the ingress profile. | [ManagedClusterIngressProfileWebAppRouting_STATUS](#ManagedClusterIngressProfileWebAppRouting_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile"></a>ManagedClusterMetricsProfile
----------------------------------------------------------------------
+ManagedClusterMetricsProfile{#ManagedClusterMetricsProfile}
+-----------------------------------------------------------
 
 The metrics profile for the ManagedCluster.
 
@@ -1559,8 +1559,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |--------------|-------------------------------------------------|---------------------------------------------------------------------------------------|
 | costAnalysis | The cost analysis configuration for the cluster | [ManagedClusterCostAnalysis](#ManagedClusterCostAnalysis)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile_STATUS"></a>ManagedClusterMetricsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterMetricsProfile_STATUS{#ManagedClusterMetricsProfile_STATUS}
+-------------------------------------------------------------------------
 
 The metrics profile for the ManagedCluster.
 
@@ -1570,8 +1570,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | costAnalysis | The cost analysis configuration for the cluster | [ManagedClusterCostAnalysis_STATUS](#ManagedClusterCostAnalysis_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile"></a>ManagedClusterNodeProvisioningProfile
----------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile{#ManagedClusterNodeProvisioningProfile}
+-----------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1579,8 +1579,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | mode     | Once the mode it set to Auto, it cannot be changed back to Manual. | [ManagedClusterNodeProvisioningProfile_Mode](#ManagedClusterNodeProvisioningProfile_Mode)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile_STATUS"></a>ManagedClusterNodeProvisioningProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_STATUS{#ManagedClusterNodeProvisioningProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1588,8 +1588,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|--------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | mode     | Once the mode it set to Auto, it cannot be changed back to Manual. | [ManagedClusterNodeProvisioningProfile_Mode_STATUS](#ManagedClusterNodeProvisioningProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile"></a>ManagedClusterNodeResourceGroupProfile
------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile{#ManagedClusterNodeResourceGroupProfile}
+-------------------------------------------------------------------------------
 
 Node resource group lockdown profile for a managed cluster.
 
@@ -1599,8 +1599,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|--------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel | The restriction level applied to the cluster's node resource group | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile_STATUS"></a>ManagedClusterNodeResourceGroupProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_STATUS{#ManagedClusterNodeResourceGroupProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Node resource group lockdown profile for a managed cluster.
 
@@ -1610,8 +1610,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel | The restriction level applied to the cluster's node resource group | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile"></a>ManagedClusterOIDCIssuerProfile
----------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile{#ManagedClusterOIDCIssuerProfile}
+-----------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1621,8 +1621,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------------------------------|----------------------------------|
 | enabled  | Whether the OIDC issuer is enabled. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile_STATUS"></a>ManagedClusterOIDCIssuerProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile_STATUS{#ManagedClusterOIDCIssuerProfile_STATUS}
+-------------------------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1633,8 +1633,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled   | Whether the OIDC issuer is enabled.         | bool<br/><small>Optional</small>   |
 | issuerURL | The OIDC issuer url of the Managed Cluster. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1647,8 +1647,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1661,8 +1661,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1675,8 +1675,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1703,8 +1703,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage         | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                |
 | skip-nodes-with-system-pods           | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1731,8 +1731,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage         | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                              |
 | skip-nodes-with-system-pods           | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                              |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess"></a>ManagedClusterProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess{#ManagedClusterProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1742,8 +1742,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess_STATUS"></a>ManagedClusterProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess_STATUS{#ManagedClusterProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1753,8 +1753,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1765,8 +1765,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile"></a>ManagedClusterSecurityProfile
------------------------------------------------------------------------
+ManagedClusterSecurityProfile{#ManagedClusterSecurityProfile}
+-------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1782,8 +1782,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeRestriction           | [Node Restriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction) settings for the security profile.                                                                                                                      | [ManagedClusterSecurityProfileNodeRestriction](#ManagedClusterSecurityProfileNodeRestriction)<br/><small>Optional</small>   |
 | workloadIdentity          | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details.                                                                 | [ManagedClusterSecurityProfileWorkloadIdentity](#ManagedClusterSecurityProfileWorkloadIdentity)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile_STATUS"></a>ManagedClusterSecurityProfile_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterSecurityProfile_STATUS{#ManagedClusterSecurityProfile_STATUS}
+---------------------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1799,8 +1799,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeRestriction           | [Node Restriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction) settings for the security profile.                                                                                                                      | [ManagedClusterSecurityProfileNodeRestriction_STATUS](#ManagedClusterSecurityProfileNodeRestriction_STATUS)<br/><small>Optional</small>   |
 | workloadIdentity          | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details.                                                                 | [ManagedClusterSecurityProfileWorkloadIdentity_STATUS](#ManagedClusterSecurityProfileWorkloadIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1811,8 +1811,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId | The ID for the service principal.                                        | string<br/><small>Required</small>                                                                                                                     |
 | secret   | The secret password associated with the service principal in plain text. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1822,8 +1822,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-----------------------------------|------------------------------------|
 | clientId | The ID for the service principal. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1834,8 +1834,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1846,8 +1846,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile"></a>ManagedClusterStorageProfile
----------------------------------------------------------------------
+ManagedClusterStorageProfile{#ManagedClusterStorageProfile}
+-----------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1860,8 +1860,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver](#ManagedClusterStorageProfileFileCSIDriver)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController](#ManagedClusterStorageProfileSnapshotController)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile_STATUS"></a>ManagedClusterStorageProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterStorageProfile_STATUS{#ManagedClusterStorageProfile_STATUS}
+-------------------------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1874,8 +1874,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver_STATUS](#ManagedClusterStorageProfileFileCSIDriver_STATUS)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController_STATUS](#ManagedClusterStorageProfileSnapshotController_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1889,8 +1889,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile](#WindowsGmsaProfile)<br/><small>Optional</small>                                                                                  |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1903,8 +1903,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile_STATUS](#WindowsGmsaProfile_STATUS)<br/><small>Optional</small>                                             |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile"></a>ManagedClusterWorkloadAutoScalerProfile
--------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile{#ManagedClusterWorkloadAutoScalerProfile}
+---------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1915,8 +1915,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda](#ManagedClusterWorkloadAutoScalerProfileKeda)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler |                                                                                           | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile_STATUS"></a>ManagedClusterWorkloadAutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile_STATUS{#ManagedClusterWorkloadAutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1927,50 +1927,50 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda_STATUS](#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler |                                                                                           | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
-Specifies the OS SKU used by the agent pool. If not specified, the default is Ubuntu if OSType=Linux or Windows2019 if OSType=Windows. And the default Windows OSSKU will be changed to Windows2022 after Windows2019 is deprecated.
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Value           | Description |
-|-----------------|-------------|
-| "AzureLinux"    |             |
-| "CBLMariner"    |             |
-| "Mariner"       |             |
-| "Ubuntu"        |             |
-| "Windows2019"   |             |
-| "Windows2022"   |             |
-| "WindowsAnnual" |             |
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
+OSDiskType_STATUS{#OSDiskType_STATUS}
 -------------------------------------
 
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Specifies the OS SKU used by the agent pool. If not specified, the default is Ubuntu if OSType=Linux or Windows2019 if OSType=Windows. And the default Windows OSSKU will be changed to Windows2022 after Windows2019 is deprecated.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Value           | Description |
+|-----------------|-------------|
+| "AzureLinux"    |             |
+| "CBLMariner"    |             |
+| "Mariner"       |             |
+| "Ubuntu"        |             |
+| "Windows2019"   |             |
+| "Windows2022"   |             |
+| "WindowsAnnual" |             |
+
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
+
 Specifies the OS SKU used by the agent pool. If not specified, the default is Ubuntu if OSType=Linux or Windows2019 if OSType=Windows. And the default Windows OSSKU will be changed to Windows2022 after Windows2019 is deprecated.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -1985,8 +1985,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Windows2022"   |             |
 | "WindowsAnnual" |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 The operating system type. The default is Linux.
 
@@ -1997,8 +1997,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 The operating system type. The default is Linux.
 
@@ -2009,8 +2009,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PodIPAllocationMode"></a>PodIPAllocationMode
----------------------------------------------------
+PodIPAllocationMode{#PodIPAllocationMode}
+-----------------------------------------
 
 The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
 
@@ -2021,8 +2021,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "DynamicIndividual" |             |
 | "StaticBlock"       |             |
 
-<a id="PodIPAllocationMode_STATUS"></a>PodIPAllocationMode_STATUS
------------------------------------------------------------------
+PodIPAllocationMode_STATUS{#PodIPAllocationMode_STATUS}
+-------------------------------------------------------
 
 The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
 
@@ -2033,8 +2033,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "DynamicIndividual" |             |
 | "StaticBlock"       |             |
 
-<a id="PowerState"></a>PowerState
----------------------------------
+PowerState{#PowerState}
+-----------------------
 
 Describes the Power State of the cluster
 
@@ -2044,8 +2044,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------------------------------------------|-----------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code](#PowerState_Code)<br/><small>Optional</small> |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Describes the Power State of the cluster
 
@@ -2055,8 +2055,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------------------------------------------|-------------------------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 A private link resource
 
@@ -2070,8 +2070,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers | The RequiredMembers of the resource    | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            | The resource type.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 A private link resource
 
@@ -2086,8 +2086,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      | The RequiredMembers of the resource                                                        | string[]<br/><small>Optional</small> |
 | type                 | The resource type.                                                                         | string<br/><small>Optional</small>   |
 
-<a id="SafeguardsProfile"></a>SafeguardsProfile
------------------------------------------------
+SafeguardsProfile{#SafeguardsProfile}
+-------------------------------------
 
 The Safeguards profile.
 
@@ -2099,8 +2099,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | level              | The Safeguards level to be used. By default, Safeguards is enabled for all namespaces except those that AKS excludes via systemExcludedNamespaces | [SafeguardsProfile_Level](#SafeguardsProfile_Level)<br/><small>Required</small> |
 | version            | The version of constraints to use                                                                                                                 | string<br/><small>Optional</small>                                              |
 
-<a id="SafeguardsProfile_STATUS"></a>SafeguardsProfile_STATUS
--------------------------------------------------------------
+SafeguardsProfile_STATUS{#SafeguardsProfile_STATUS}
+---------------------------------------------------
 
 The Safeguards profile.
 
@@ -2113,8 +2113,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | systemExcludedNamespaces | List of namespaces specified by AKS to be excluded from Safeguards                                                                                | string[]<br/><small>Optional</small>                                                          |
 | version                  | The version of constraints to use                                                                                                                 | string<br/><small>Optional</small>                                                            |
 
-<a id="ScaleDownMode"></a>ScaleDownMode
----------------------------------------
+ScaleDownMode{#ScaleDownMode}
+-----------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -2125,8 +2125,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleDownMode_STATUS"></a>ScaleDownMode_STATUS
------------------------------------------------------
+ScaleDownMode_STATUS{#ScaleDownMode_STATUS}
+-------------------------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -2137,8 +2137,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
+-----------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -2149,8 +2149,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -2161,8 +2161,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
 
 The Virtual Machine Scale Set priority.
 
@@ -2173,20 +2173,20 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
-
-The Virtual Machine Scale Set priority.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="ServiceMeshProfile"></a>ServiceMeshProfile
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
 -------------------------------------------------
+
+The Virtual Machine Scale Set priority.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+ServiceMeshProfile{#ServiceMeshProfile}
+---------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -2197,8 +2197,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh](#IstioServiceMesh)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode](#ServiceMeshProfile_Mode)<br/><small>Required</small> |
 
-<a id="ServiceMeshProfile_STATUS"></a>ServiceMeshProfile_STATUS
----------------------------------------------------------------
+ServiceMeshProfile_STATUS{#ServiceMeshProfile_STATUS}
+-----------------------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -2209,8 +2209,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode_STATUS](#ServiceMeshProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2225,8 +2225,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), and [TrustedAccessRole
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingOperatorSpec"></a>TrustedAccessRoleBindingOperatorSpec
--------------------------------------------------------------------------------------
+TrustedAccessRoleBindingOperatorSpec{#TrustedAccessRoleBindingOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2237,8 +2237,8 @@ Used by: [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingProperties_ProvisioningState_STATUS"></a>TrustedAccessRoleBindingProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+TrustedAccessRoleBindingProperties_ProvisioningState_STATUS{#TrustedAccessRoleBindingProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 
@@ -2250,8 +2250,8 @@ Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Details about a user assigned identity.
 
@@ -2263,8 +2263,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          | The object ID of the user assigned identity.   | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference | The resource ID of the user assigned identity. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Details about a user assigned identity.
 
@@ -2276,8 +2276,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   | The object ID of the user assigned identity.   | string<br/><small>Optional</small> |
 | resourceId | The resource ID of the user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineNodes"></a>VirtualMachineNodes
----------------------------------------------------
+VirtualMachineNodes{#VirtualMachineNodes}
+-----------------------------------------
 
 Current status on a group of nodes of the same vm size.
 
@@ -2288,8 +2288,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | count    | Number of nodes.                                            | int<br/><small>Optional</small>    |
 | size     | The VM size of the agents used to host this group of nodes. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineNodes_STATUS"></a>VirtualMachineNodes_STATUS
------------------------------------------------------------------
+VirtualMachineNodes_STATUS{#VirtualMachineNodes_STATUS}
+-------------------------------------------------------
 
 Current status on a group of nodes of the same vm size.
 
@@ -2300,8 +2300,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | count    | Number of nodes.                                            | int<br/><small>Optional</small>    |
 | size     | The VM size of the agents used to host this group of nodes. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachinesProfile"></a>VirtualMachinesProfile
----------------------------------------------------------
+VirtualMachinesProfile{#VirtualMachinesProfile}
+-----------------------------------------------
 
 Specifications on VirtualMachines agent pool.
 
@@ -2311,8 +2311,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|--------------------------------------------------------------|-----------------------------------------------------------|
 | scale    | Specifications on how to scale a VirtualMachines agent pool. | [ScaleProfile](#ScaleProfile)<br/><small>Optional</small> |
 
-<a id="VirtualMachinesProfile_STATUS"></a>VirtualMachinesProfile_STATUS
------------------------------------------------------------------------
+VirtualMachinesProfile_STATUS{#VirtualMachinesProfile_STATUS}
+-------------------------------------------------------------
 
 Specifications on VirtualMachines agent pool.
 
@@ -2322,8 +2322,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |----------|--------------------------------------------------------------|-------------------------------------------------------------------------|
 | scale    | Specifications on how to scale a VirtualMachines agent pool. | [ScaleProfile_STATUS](#ScaleProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkloadRuntime"></a>WorkloadRuntime
--------------------------------------------
+WorkloadRuntime{#WorkloadRuntime}
+---------------------------------
 
 Determines the type of workload a node can run.
 
@@ -2335,8 +2335,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OCIContainer"        |             |
 | "WasmWasi"            |             |
 
-<a id="WorkloadRuntime_STATUS"></a>WorkloadRuntime_STATUS
----------------------------------------------------------
+WorkloadRuntime_STATUS{#WorkloadRuntime_STATUS}
+-----------------------------------------------
 
 Determines the type of workload a node can run.
 
@@ -2348,8 +2348,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OCIContainer"        |             |
 | "WasmWasi"            |             |
 
-<a id="AdvancedNetworking"></a>AdvancedNetworking
--------------------------------------------------
+AdvancedNetworking{#AdvancedNetworking}
+---------------------------------------
 
 Advanced Networking profile for enabling observability on a cluster. Note that enabling advanced networking features may incur additional costs. For more information see aka.ms/aksadvancednetworking.
 
@@ -2359,8 +2359,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 |---------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | observability | Observability profile to enable advanced network metrics and flow logs with historical contexts. | [AdvancedNetworkingObservability](#AdvancedNetworkingObservability)<br/><small>Optional</small> |
 
-<a id="AdvancedNetworking_STATUS"></a>AdvancedNetworking_STATUS
----------------------------------------------------------------
+AdvancedNetworking_STATUS{#AdvancedNetworking_STATUS}
+-----------------------------------------------------
 
 Advanced Networking profile for enabling observability on a cluster. Note that enabling advanced networking features may incur additional costs. For more information see aka.ms/aksadvancednetworking.
 
@@ -2370,8 +2370,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 |---------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | observability | Observability profile to enable advanced network metrics and flow logs with historical contexts. | [AdvancedNetworkingObservability_STATUS](#AdvancedNetworkingObservability_STATUS)<br/><small>Optional</small> |
 
-<a id="AgentPoolSSHAccess"></a>AgentPoolSSHAccess
--------------------------------------------------
+AgentPoolSSHAccess{#AgentPoolSSHAccess}
+---------------------------------------
 
 SSH access method of an agent pool.
 
@@ -2382,8 +2382,8 @@ Used by: [AgentPoolSecurityProfile](#AgentPoolSecurityProfile).
 | "Disabled"  |             |
 | "LocalUser" |             |
 
-<a id="AgentPoolSSHAccess_STATUS"></a>AgentPoolSSHAccess_STATUS
----------------------------------------------------------------
+AgentPoolSSHAccess_STATUS{#AgentPoolSSHAccess_STATUS}
+-----------------------------------------------------
 
 SSH access method of an agent pool.
 
@@ -2394,8 +2394,8 @@ Used by: [AgentPoolSecurityProfile_STATUS](#AgentPoolSecurityProfile_STATUS).
 | "Disabled"  |             |
 | "LocalUser" |             |
 
-<a id="AgentPoolUpgradeSettings_UndrainableNodeBehavior"></a>AgentPoolUpgradeSettings_UndrainableNodeBehavior
--------------------------------------------------------------------------------------------------------------
+AgentPoolUpgradeSettings_UndrainableNodeBehavior{#AgentPoolUpgradeSettings_UndrainableNodeBehavior}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AgentPoolUpgradeSettings](#AgentPoolUpgradeSettings).
 
@@ -2404,8 +2404,8 @@ Used by: [AgentPoolUpgradeSettings](#AgentPoolUpgradeSettings).
 | "Cordon"   |             |
 | "Schedule" |             |
 
-<a id="AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS"></a>AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS{#AgentPoolUpgradeSettings_UndrainableNodeBehavior_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AgentPoolUpgradeSettings_STATUS](#AgentPoolUpgradeSettings_STATUS).
 
@@ -2414,8 +2414,8 @@ Used by: [AgentPoolUpgradeSettings_STATUS](#AgentPoolUpgradeSettings_STATUS).
 | "Cordon"   |             |
 | "Schedule" |             |
 
-<a id="AzureKeyVaultKms"></a>AzureKeyVaultKms
----------------------------------------------
+AzureKeyVaultKms{#AzureKeyVaultKms}
+-----------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -2428,8 +2428,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | keyVaultNetworkAccess     | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess](#AzureKeyVaultKms_KeyVaultNetworkAccess)<br/><small>Optional</small>                                              |
 | keyVaultResourceReference | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_STATUS"></a>AzureKeyVaultKms_STATUS
------------------------------------------------------------
+AzureKeyVaultKms_STATUS{#AzureKeyVaultKms_STATUS}
+-------------------------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -2442,8 +2442,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | keyVaultNetworkAccess | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS](#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS)<br/><small>Optional</small> |
 | keyVaultResourceId    | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig"></a>ContainerServiceNetworkProfile_KubeProxyConfig
----------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig{#ContainerServiceNetworkProfile_KubeProxyConfig}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2453,8 +2453,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | ipvsConfig | Holds configuration customizations for IPVS. May only be specified if 'mode' is set to 'IPVS'.                                                         | [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig)<br/><small>Optional</small> |
 | mode       | Specify which proxy mode to use ('IPTABLES' or 'IPVS')                                                                                                 | [ContainerServiceNetworkProfile_KubeProxyConfig_Mode](#ContainerServiceNetworkProfile_KubeProxyConfig_Mode)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_STATUS
------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2464,8 +2464,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | ipvsConfig | Holds configuration customizations for IPVS. May only be specified if 'mode' is set to 'IPVS'.                                                         | [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS)<br/><small>Optional</small> |
 | mode       | Specify which proxy mode to use ('IPTABLES' or 'IPVS')                                                                                                 | [ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS)<br/><small>Optional</small>             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
----------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2477,8 +2477,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2490,8 +2490,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2501,8 +2501,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2512,8 +2512,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="DelegatedResource"></a>DelegatedResource
------------------------------------------------
+DelegatedResource{#DelegatedResource}
+-------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2526,8 +2526,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | resourceReference | The ARM resource id of the delegated resource - internal use only.           | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="DelegatedResource_STATUS"></a>DelegatedResource_STATUS
--------------------------------------------------------------
+DelegatedResource_STATUS{#DelegatedResource_STATUS}
+---------------------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2540,8 +2540,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | resourceId       | The ARM resource id of the delegated resource - internal use only.           | string<br/><small>Optional</small> |
 | tenantId         | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small> |
 
-<a id="Expander"></a>Expander
------------------------------
+Expander{#Expander}
+-------------------
 
 If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
 
@@ -2554,8 +2554,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="Expander_STATUS"></a>Expander_STATUS
--------------------------------------------
+Expander_STATUS{#Expander_STATUS}
+---------------------------------
 
 If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
 
@@ -2568,8 +2568,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -2579,8 +2579,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -2590,8 +2590,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="IpFamily"></a>IpFamily
------------------------------
+IpFamily{#IpFamily}
+-------------------
 
 To determine if address belongs IPv4 or IPv6 family.
 
@@ -2602,8 +2602,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IpFamily_STATUS"></a>IpFamily_STATUS
--------------------------------------------
+IpFamily_STATUS{#IpFamily_STATUS}
+---------------------------------
 
 To determine if address belongs IPv4 or IPv6 family.
 
@@ -2614,8 +2614,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IPTag"></a>IPTag
------------------------
+IPTag{#IPTag}
+-------------
 
 Contains the IPTag associated with the object.
 
@@ -2626,8 +2626,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IPTag_STATUS"></a>IPTag_STATUS
--------------------------------------
+IPTag_STATUS{#IPTag_STATUS}
+---------------------------
 
 Contains the IPTag associated with the object.
 
@@ -2638,8 +2638,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IstioServiceMesh"></a>IstioServiceMesh
----------------------------------------------
+IstioServiceMesh{#IstioServiceMesh}
+-----------------------------------
 
 Istio service mesh configuration.
 
@@ -2651,8 +2651,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents](#IstioComponents)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                |
 
-<a id="IstioServiceMesh_STATUS"></a>IstioServiceMesh_STATUS
------------------------------------------------------------
+IstioServiceMesh_STATUS{#IstioServiceMesh_STATUS}
+-------------------------------------------------
 
 Istio service mesh configuration.
 
@@ -2664,8 +2664,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents_STATUS](#IstioComponents_STATUS)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                              |
 
-<a id="LoadBalancerSku"></a>LoadBalancerSku
--------------------------------------------
+LoadBalancerSku{#LoadBalancerSku}
+---------------------------------
 
 The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.
 
@@ -2676,8 +2676,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "basic"    |             |
 | "standard" |             |
 
-<a id="LoadBalancerSku_STATUS"></a>LoadBalancerSku_STATUS
----------------------------------------------------------
+LoadBalancerSku_STATUS{#LoadBalancerSku_STATUS}
+-----------------------------------------------
 
 The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.
 
@@ -2688,8 +2688,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "basic"    |             |
 | "standard" |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2700,8 +2700,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2712,8 +2712,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2725,8 +2725,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2738,8 +2738,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoring"></a>ManagedClusterAzureMonitorProfileAppMonitoring
----------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoring{#ManagedClusterAzureMonitorProfileAppMonitoring}
+-----------------------------------------------------------------------------------------------
 
 Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
 
@@ -2751,8 +2751,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | openTelemetryLogs    | Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Logs and Traces. Collects OpenTelemetry logs and traces of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.                | [ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs](#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs)<br/><small>Optional</small>       |
 | openTelemetryMetrics | Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.                                | [ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics](#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoring_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoring_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
 
@@ -2764,8 +2764,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | openTelemetryLogs    | Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Logs and Traces. Collects OpenTelemetry logs and traces of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.                | [ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS)<br/><small>Optional</small>       |
 | openTelemetryMetrics | Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.                                | [ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileContainerInsights"></a>ManagedClusterAzureMonitorProfileContainerInsights
------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileContainerInsights{#ManagedClusterAzureMonitorProfileContainerInsights}
+-------------------------------------------------------------------------------------------------------
 
 Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview.
 
@@ -2779,8 +2779,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | logAnalyticsWorkspaceResourceReference | Fully Qualified ARM Resource Id of Azure Log Analytics Workspace for storing Azure Monitor Container Insights Logs.                                                                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | syslogPort                             | The syslog host port. If not specified, the default port is 28330.                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                            |
 
-<a id="ManagedClusterAzureMonitorProfileContainerInsights_STATUS"></a>ManagedClusterAzureMonitorProfileContainerInsights_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileContainerInsights_STATUS{#ManagedClusterAzureMonitorProfileContainerInsights_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview.
 
@@ -2794,8 +2794,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | logAnalyticsWorkspaceResourceId  | Fully Qualified ARM Resource Id of Azure Log Analytics Workspace for storing Azure Monitor Container Insights Logs.                                                                                                      | string<br/><small>Optional</small> |
 | syslogPort                       | The syslog host port. If not specified, the default port is 28330.                                                                                                                                                       | int<br/><small>Optional</small>    |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics"></a>ManagedClusterAzureMonitorProfileMetrics
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics{#ManagedClusterAzureMonitorProfileMetrics}
+-----------------------------------------------------------------------------------
 
 Metrics profile for the prometheus service addon
 
@@ -2806,8 +2806,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | enabled          | Whether to enable the Prometheus collector                                        | bool<br/><small>Required</small>                                                                                                    |
 | kubeStateMetrics | Kube State Metrics for prometheus addon profile for the container service cluster | [ManagedClusterAzureMonitorProfileKubeStateMetrics](#ManagedClusterAzureMonitorProfileKubeStateMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileMetrics_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics_STATUS{#ManagedClusterAzureMonitorProfileMetrics_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Metrics profile for the prometheus service addon
 
@@ -2818,8 +2818,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | enabled          | Whether to enable the Prometheus collector                                        | bool<br/><small>Optional</small>                                                                                                                  |
 | kubeStateMetrics | Kube State Metrics for prometheus addon profile for the container service cluster | [ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS](#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterBootstrapProfile_ArtifactSource"></a>ManagedClusterBootstrapProfile_ArtifactSource
--------------------------------------------------------------------------------------------------------
+ManagedClusterBootstrapProfile_ArtifactSource{#ManagedClusterBootstrapProfile_ArtifactSource}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterBootstrapProfile](#ManagedClusterBootstrapProfile).
 
@@ -2828,8 +2828,8 @@ Used by: [ManagedClusterBootstrapProfile](#ManagedClusterBootstrapProfile).
 | "Cache"  |             |
 | "Direct" |             |
 
-<a id="ManagedClusterBootstrapProfile_ArtifactSource_STATUS"></a>ManagedClusterBootstrapProfile_ArtifactSource_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterBootstrapProfile_ArtifactSource_STATUS{#ManagedClusterBootstrapProfile_ArtifactSource_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterBootstrapProfile_STATUS](#ManagedClusterBootstrapProfile_STATUS).
 
@@ -2838,8 +2838,8 @@ Used by: [ManagedClusterBootstrapProfile_STATUS](#ManagedClusterBootstrapProfile
 | "Cache"  |             |
 | "Direct" |             |
 
-<a id="ManagedClusterCostAnalysis"></a>ManagedClusterCostAnalysis
------------------------------------------------------------------
+ManagedClusterCostAnalysis{#ManagedClusterCostAnalysis}
+-------------------------------------------------------
 
 The cost analysis configuration for the cluster
 
@@ -2849,8 +2849,8 @@ Used by: [ManagedClusterMetricsProfile](#ManagedClusterMetricsProfile).
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterCostAnalysis_STATUS"></a>ManagedClusterCostAnalysis_STATUS
--------------------------------------------------------------------------------
+ManagedClusterCostAnalysis_STATUS{#ManagedClusterCostAnalysis_STATUS}
+---------------------------------------------------------------------
 
 The cost analysis configuration for the cluster
 
@@ -2860,8 +2860,8 @@ Used by: [ManagedClusterMetricsProfile_STATUS](#ManagedClusterMetricsProfile_STA
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2871,8 +2871,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2882,8 +2882,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2892,8 +2892,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfileWebAppRouting"></a>ManagedClusterIngressProfileWebAppRouting
------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting{#ManagedClusterIngressProfileWebAppRouting}
+-------------------------------------------------------------------------------------
 
 Web App Routing settings for the ingress profile.
 
@@ -2904,8 +2904,8 @@ Used by: [ManagedClusterIngressProfile](#ManagedClusterIngressProfile).
 | dnsZoneResourceReferences | Resource IDs of the DNS zones to be associated with the Web App Routing add-on. Used only when Web App Routing is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | enabled                   | Whether to enable Web App Routing.                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                             |
 
-<a id="ManagedClusterIngressProfileWebAppRouting_STATUS"></a>ManagedClusterIngressProfileWebAppRouting_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting_STATUS{#ManagedClusterIngressProfileWebAppRouting_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Web App Routing settings for the ingress profile.
 
@@ -2917,8 +2917,8 @@ Used by: [ManagedClusterIngressProfile_STATUS](#ManagedClusterIngressProfile_STA
 | enabled            | Whether to enable Web App Routing.                                                                                                                                                                                                                                                                                                                       | bool<br/><small>Optional</small>                                                        |
 | identity           | Managed identity of the Web Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions. | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2936,8 +2936,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes                        | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small>                                               |
 | outboundIPs                               | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>                                                             |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2955,8 +2955,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes                        | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small>                                               |
 | outboundIPs                               | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>                                                             |
 
-<a id="ManagedClusterNATGatewayProfile"></a>ManagedClusterNATGatewayProfile
----------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile{#ManagedClusterNATGatewayProfile}
+-----------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2968,8 +2968,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                               |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile](#ManagedClusterManagedOutboundIPProfile)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNATGatewayProfile_STATUS"></a>ManagedClusterNATGatewayProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile_STATUS{#ManagedClusterNATGatewayProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2981,8 +2981,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                                             |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile_STATUS](#ManagedClusterManagedOutboundIPProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeProvisioningProfile_Mode"></a>ManagedClusterNodeProvisioningProfile_Mode
--------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_Mode{#ManagedClusterNodeProvisioningProfile_Mode}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeProvisioningProfile](#ManagedClusterNodeProvisioningProfile).
 
@@ -2991,8 +2991,8 @@ Used by: [ManagedClusterNodeProvisioningProfile](#ManagedClusterNodeProvisioning
 | "Auto"   |             |
 | "Manual" |             |
 
-<a id="ManagedClusterNodeProvisioningProfile_Mode_STATUS"></a>ManagedClusterNodeProvisioningProfile_Mode_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeProvisioningProfile_Mode_STATUS{#ManagedClusterNodeProvisioningProfile_Mode_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeProvisioningProfile_STATUS](#ManagedClusterNodeProvisioningProfile_STATUS).
 
@@ -3001,8 +3001,8 @@ Used by: [ManagedClusterNodeProvisioningProfile_STATUS](#ManagedClusterNodeProvi
 | "Auto"   |             |
 | "Manual" |             |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGroupProfile).
 
@@ -3011,8 +3011,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGro
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeResourceGroupProfile_STATUS).
 
@@ -3021,8 +3021,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeReso
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterOperatorConfigMaps"></a>ManagedClusterOperatorConfigMaps
------------------------------------------------------------------------------
+ManagedClusterOperatorConfigMaps{#ManagedClusterOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -3030,8 +3030,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 |-------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | oidcIssuerProfile | indicates where the OIDCIssuerProfile config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -3040,8 +3040,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -3054,8 +3054,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            | The name of the pod identity.                                      | string<br/><small>Required</small>                                        |
 | namespace       | The namespace of the pod identity.                                 | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -3070,8 +3070,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |                                                                    | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState | The current provisioning state of the pod identity.                | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -3083,8 +3083,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace | The namespace of the pod identity exception. | string<br/><small>Required</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -3096,8 +3096,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace | The namespace of the pod identity exception. | string<br/><small>Optional</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefender"></a>ManagedClusterSecurityProfileDefender
----------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender{#ManagedClusterSecurityProfileDefender}
+-----------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -3108,8 +3108,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | logAnalyticsWorkspaceResourceReference | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityMonitoring                     | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring](#ManagedClusterSecurityProfileDefenderSecurityMonitoring)<br/><small>Optional</small>            |
 
-<a id="ManagedClusterSecurityProfileDefender_STATUS"></a>ManagedClusterSecurityProfileDefender_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender_STATUS{#ManagedClusterSecurityProfileDefender_STATUS}
+-------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -3120,8 +3120,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | logAnalyticsWorkspaceResourceId | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | string<br/><small>Optional</small>                                                                                                                            |
 | securityMonitoring              | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS](#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageCleaner"></a>ManagedClusterSecurityProfileImageCleaner
------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner{#ManagedClusterSecurityProfileImageCleaner}
+-------------------------------------------------------------------------------------
 
 Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
 
@@ -3132,21 +3132,21 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
 | intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileImageCleaner_STATUS"></a>ManagedClusterSecurityProfileImageCleaner_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property      | Description                                     | Type                             |
-|---------------|-------------------------------------------------|----------------------------------|
-| enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
-| intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
-
-<a id="ManagedClusterSecurityProfileImageIntegrity"></a>ManagedClusterSecurityProfileImageIntegrity
+ManagedClusterSecurityProfileImageCleaner_STATUS{#ManagedClusterSecurityProfileImageCleaner_STATUS}
 ---------------------------------------------------------------------------------------------------
 
+Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property      | Description                                     | Type                             |
+|---------------|-------------------------------------------------|----------------------------------|
+| enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
+| intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
+
+ManagedClusterSecurityProfileImageIntegrity{#ManagedClusterSecurityProfileImageIntegrity}
+-----------------------------------------------------------------------------------------
+
 Image integrity related settings for the security profile.
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
@@ -3155,42 +3155,42 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 |----------|----------------------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable image integrity. The default value is false. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageIntegrity_STATUS"></a>ManagedClusterSecurityProfileImageIntegrity_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Image integrity related settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description                                                    | Type                             |
-|----------|----------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable image integrity. The default value is false. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileNodeRestriction"></a>ManagedClusterSecurityProfileNodeRestriction
------------------------------------------------------------------------------------------------------
-
-Node Restriction settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
-
-| Property | Description                        | Type                             |
-|----------|------------------------------------|----------------------------------|
-| enabled  | Whether to enable Node Restriction | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileNodeRestriction_STATUS"></a>ManagedClusterSecurityProfileNodeRestriction_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Node Restriction settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description                        | Type                             |
-|----------|------------------------------------|----------------------------------|
-| enabled  | Whether to enable Node Restriction | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileWorkloadIdentity"></a>ManagedClusterSecurityProfileWorkloadIdentity
+ManagedClusterSecurityProfileImageIntegrity_STATUS{#ManagedClusterSecurityProfileImageIntegrity_STATUS}
 -------------------------------------------------------------------------------------------------------
 
+Image integrity related settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description                                                    | Type                             |
+|----------|----------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable image integrity. The default value is false. | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileNodeRestriction{#ManagedClusterSecurityProfileNodeRestriction}
+-------------------------------------------------------------------------------------------
+
+Node Restriction settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
+
+| Property | Description                        | Type                             |
+|----------|------------------------------------|----------------------------------|
+| enabled  | Whether to enable Node Restriction | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileNodeRestriction_STATUS{#ManagedClusterSecurityProfileNodeRestriction_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Node Restriction settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description                        | Type                             |
+|----------|------------------------------------|----------------------------------|
+| enabled  | Whether to enable Node Restriction | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileWorkloadIdentity{#ManagedClusterSecurityProfileWorkloadIdentity}
+---------------------------------------------------------------------------------------------
+
 Workload identity settings for the security profile.
 
 Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
@@ -3199,8 +3199,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 |----------|--------------------------------------|----------------------------------|
 | enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileWorkloadIdentity_STATUS"></a>ManagedClusterSecurityProfileWorkloadIdentity_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileWorkloadIdentity_STATUS{#ManagedClusterSecurityProfileWorkloadIdentity_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Workload identity settings for the security profile.
 
@@ -3210,8 +3210,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 |----------|--------------------------------------|----------------------------------|
 | enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
 
 Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 
@@ -3220,8 +3220,8 @@ Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 | "Automatic" |             |
 | "Base"      |             |
 
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 
@@ -3230,8 +3230,8 @@ Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 | "Automatic" |             |
 | "Base"      |             |
 
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
 
 Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 
@@ -3241,8 +3241,8 @@ Used by: [ManagedClusterSKU](#ManagedClusterSKU).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 
@@ -3252,8 +3252,8 @@ Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="ManagedClusterStaticEgressGatewayProfile"></a>ManagedClusterStaticEgressGatewayProfile
----------------------------------------------------------------------------------------------
+ManagedClusterStaticEgressGatewayProfile{#ManagedClusterStaticEgressGatewayProfile}
+-----------------------------------------------------------------------------------
 
 The Static Egress Gateway addon configuration for the cluster.
 
@@ -3263,8 +3263,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 |----------|-------------------------------------------------------------|----------------------------------|
 | enabled  | Indicates if Static Egress Gateway addon is enabled or not. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterStaticEgressGatewayProfile_STATUS"></a>ManagedClusterStaticEgressGatewayProfile_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterStaticEgressGatewayProfile_STATUS{#ManagedClusterStaticEgressGatewayProfile_STATUS}
+-------------------------------------------------------------------------------------------------
 
 The Static Egress Gateway addon configuration for the cluster.
 
@@ -3274,8 +3274,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 |----------|-------------------------------------------------------------|----------------------------------|
 | enabled  | Indicates if Static Egress Gateway addon is enabled or not. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileBlobCSIDriver"></a>ManagedClusterStorageProfileBlobCSIDriver
------------------------------------------------------------------------------------------------
+ManagedClusterStorageProfileBlobCSIDriver{#ManagedClusterStorageProfileBlobCSIDriver}
+-------------------------------------------------------------------------------------
 
 AzureBlob CSI Driver settings for the storage profile.
 
@@ -3285,8 +3285,8 @@ Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
 |----------|---------------------------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileBlobCSIDriver_STATUS"></a>ManagedClusterStorageProfileBlobCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterStorageProfileBlobCSIDriver_STATUS{#ManagedClusterStorageProfileBlobCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
 
 AzureBlob CSI Driver settings for the storage profile.
 
@@ -3296,8 +3296,8 @@ Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STA
 |----------|---------------------------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileDiskCSIDriver"></a>ManagedClusterStorageProfileDiskCSIDriver
------------------------------------------------------------------------------------------------
+ManagedClusterStorageProfileDiskCSIDriver{#ManagedClusterStorageProfileDiskCSIDriver}
+-------------------------------------------------------------------------------------
 
 AzureDisk CSI Driver settings for the storage profile.
 
@@ -3308,8 +3308,8 @@ Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
 | enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small>   |
 | version  | The version of AzureDisk CSI Driver. The default value is v1.      | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileDiskCSIDriver_STATUS"></a>ManagedClusterStorageProfileDiskCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterStorageProfileDiskCSIDriver_STATUS{#ManagedClusterStorageProfileDiskCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
 
 AzureDisk CSI Driver settings for the storage profile.
 
@@ -3320,42 +3320,42 @@ Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STA
 | enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small>   |
 | version  | The version of AzureDisk CSI Driver. The default value is v1.      | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileFileCSIDriver"></a>ManagedClusterStorageProfileFileCSIDriver
+ManagedClusterStorageProfileFileCSIDriver{#ManagedClusterStorageProfileFileCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver_STATUS{#ManagedClusterStorageProfileFileCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController{#ManagedClusterStorageProfileSnapshotController}
 -----------------------------------------------------------------------------------------------
 
-AzureFile CSI Driver settings for the storage profile.
+Snapshot Controller settings for the storage profile.
 
 Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
 
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+| Property | Description                                                       | Type                             |
+|----------|-------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfileFileCSIDriver_STATUS"></a>ManagedClusterStorageProfileFileCSIDriver_STATUS
+ManagedClusterStorageProfileSnapshotController_STATUS{#ManagedClusterStorageProfileSnapshotController_STATUS}
 -------------------------------------------------------------------------------------------------------------
 
-AzureFile CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController"></a>ManagedClusterStorageProfileSnapshotController
----------------------------------------------------------------------------------------------------------
-
-Snapshot Controller settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                       | Type                             |
-|----------|-------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController_STATUS"></a>ManagedClusterStorageProfileSnapshotController_STATUS
------------------------------------------------------------------------------------------------------------------------
-
 Snapshot Controller settings for the storage profile.
 
 Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
@@ -3364,8 +3364,8 @@ Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STA
 |----------|-------------------------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
----------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -3374,8 +3374,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -3384,8 +3384,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda"></a>ManagedClusterWorkloadAutoScalerProfileKeda
----------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda{#ManagedClusterWorkloadAutoScalerProfileKeda}
+-----------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -3395,8 +3395,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda_STATUS{#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -3406,8 +3406,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile).
 
@@ -3416,8 +3416,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 | addonAutoscaling | Whether VPA add-on is enabled and configured to scale AKS-managed add-ons. | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling)<br/><small>Optional</small> |
 | enabled          | Whether to enable VPA add-on in cluster. Default value is false.           | bool<br/><small>Required</small>                                                                                                                                                            |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS).
 
@@ -3426,45 +3426,45 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 | addonAutoscaling | Whether VPA add-on is enabled and configured to scale AKS-managed add-ons. | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS)<br/><small>Optional</small> |
 | enabled          | Whether to enable VPA add-on in cluster. Default value is false.           | bool<br/><small>Optional</small>                                                                                                                                                                          |
 
-<a id="NetworkDataplane"></a>NetworkDataplane
----------------------------------------------
-
-Network dataplane used in the Kubernetes cluster.
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="NetworkDataplane_STATUS"></a>NetworkDataplane_STATUS
------------------------------------------------------------
-
-Network dataplane used in the Kubernetes cluster.
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="NetworkMode"></a>NetworkMode
+NetworkDataplane{#NetworkDataplane}
 -----------------------------------
 
-This cannot be specified if networkPlugin is anything other than 'azure'.
+Network dataplane used in the Kubernetes cluster.
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
 
-<a id="NetworkMode_STATUS"></a>NetworkMode_STATUS
+NetworkDataplane_STATUS{#NetworkDataplane_STATUS}
 -------------------------------------------------
 
+Network dataplane used in the Kubernetes cluster.
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+NetworkMode{#NetworkMode}
+-------------------------
+
+This cannot be specified if networkPlugin is anything other than 'azure'.
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+NetworkMode_STATUS{#NetworkMode_STATUS}
+---------------------------------------
+
 This cannot be specified if networkPlugin is anything other than 'azure'.
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
@@ -3474,8 +3474,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="NetworkPlugin"></a>NetworkPlugin
----------------------------------------
+NetworkPlugin{#NetworkPlugin}
+-----------------------------
 
 Network plugin used for building the Kubernetes network.
 
@@ -3487,8 +3487,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="NetworkPlugin_STATUS"></a>NetworkPlugin_STATUS
------------------------------------------------------
+NetworkPlugin_STATUS{#NetworkPlugin_STATUS}
+-------------------------------------------
 
 Network plugin used for building the Kubernetes network.
 
@@ -3500,8 +3500,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="NetworkPluginMode"></a>NetworkPluginMode
------------------------------------------------
+NetworkPluginMode{#NetworkPluginMode}
+-------------------------------------
 
 The mode the network plugin should use.
 
@@ -3511,8 +3511,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 |-----------|-------------|
 | "overlay" |             |
 
-<a id="NetworkPluginMode_STATUS"></a>NetworkPluginMode_STATUS
--------------------------------------------------------------
+NetworkPluginMode_STATUS{#NetworkPluginMode_STATUS}
+---------------------------------------------------
 
 The mode the network plugin should use.
 
@@ -3522,8 +3522,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 |-----------|-------------|
 | "overlay" |             |
 
-<a id="NetworkPolicy"></a>NetworkPolicy
----------------------------------------
+NetworkPolicy{#NetworkPolicy}
+-----------------------------
 
 Network policy used for building the Kubernetes network.
 
@@ -3536,8 +3536,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "cilium" |             |
 | "none"   |             |
 
-<a id="NetworkPolicy_STATUS"></a>NetworkPolicy_STATUS
------------------------------------------------------
+NetworkPolicy_STATUS{#NetworkPolicy_STATUS}
+-------------------------------------------
 
 Network policy used for building the Kubernetes network.
 
@@ -3550,8 +3550,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "cilium" |             |
 | "none"   |             |
 
-<a id="PodLinkLocalAccess"></a>PodLinkLocalAccess
--------------------------------------------------
+PodLinkLocalAccess{#PodLinkLocalAccess}
+---------------------------------------
 
 Defines access to special link local addresses (Azure Instance Metadata Service, aka IMDS) for pods with hostNetwork=false. If not specified, the default is 'IMDS'.
 
@@ -3562,8 +3562,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "IMDS" |             |
 | "None" |             |
 
-<a id="PodLinkLocalAccess_STATUS"></a>PodLinkLocalAccess_STATUS
----------------------------------------------------------------
+PodLinkLocalAccess_STATUS{#PodLinkLocalAccess_STATUS}
+-----------------------------------------------------
 
 Defines access to special link local addresses (Azure Instance Metadata Service, aka IMDS) for pods with hostNetwork=false. If not specified, the default is 'IMDS'.
 
@@ -3574,8 +3574,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "IMDS" |             |
 | "None" |             |
 
-<a id="PortRange"></a>PortRange
--------------------------------
+PortRange{#PortRange}
+---------------------
 
 The port range.
 
@@ -3587,8 +3587,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                       |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol](#PortRange_Protocol)<br/><small>Optional</small> |
 
-<a id="PortRange_STATUS"></a>PortRange_STATUS
----------------------------------------------
+PortRange_STATUS{#PortRange_STATUS}
+-----------------------------------
 
 The port range.
 
@@ -3600,8 +3600,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                                     |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol_STATUS](#PortRange_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="PowerState_Code"></a>PowerState_Code
--------------------------------------------
+PowerState_Code{#PowerState_Code}
+---------------------------------
 
 Used by: [PowerState](#PowerState).
 
@@ -3610,8 +3610,8 @@ Used by: [PowerState](#PowerState).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -3620,8 +3620,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="SafeguardsProfile_Level"></a>SafeguardsProfile_Level
------------------------------------------------------------
+SafeguardsProfile_Level{#SafeguardsProfile_Level}
+-------------------------------------------------
 
 Used by: [SafeguardsProfile](#SafeguardsProfile).
 
@@ -3631,8 +3631,8 @@ Used by: [SafeguardsProfile](#SafeguardsProfile).
 | "Off"         |             |
 | "Warning"     |             |
 
-<a id="SafeguardsProfile_Level_STATUS"></a>SafeguardsProfile_Level_STATUS
--------------------------------------------------------------------------
+SafeguardsProfile_Level_STATUS{#SafeguardsProfile_Level_STATUS}
+---------------------------------------------------------------
 
 Used by: [SafeguardsProfile_STATUS](#SafeguardsProfile_STATUS).
 
@@ -3642,8 +3642,8 @@ Used by: [SafeguardsProfile_STATUS](#SafeguardsProfile_STATUS).
 | "Off"         |             |
 | "Warning"     |             |
 
-<a id="ScaleProfile"></a>ScaleProfile
--------------------------------------
+ScaleProfile{#ScaleProfile}
+---------------------------
 
 Specifications on how to scale a VirtualMachines agent pool.
 
@@ -3654,8 +3654,8 @@ Used by: [VirtualMachinesProfile](#VirtualMachinesProfile).
 | autoscale | Specifications on how to auto-scale the VirtualMachines agent pool within a predefined size range. Currently, at most one AutoScaleProfile is allowed. | [AutoScaleProfile[]](#AutoScaleProfile)<br/><small>Optional</small>     |
 | manual    | Specifications on how to scale the VirtualMachines agent pool to a fixed size.                                                                         | [ManualScaleProfile[]](#ManualScaleProfile)<br/><small>Optional</small> |
 
-<a id="ScaleProfile_STATUS"></a>ScaleProfile_STATUS
----------------------------------------------------
+ScaleProfile_STATUS{#ScaleProfile_STATUS}
+-----------------------------------------
 
 Specifications on how to scale a VirtualMachines agent pool.
 
@@ -3666,8 +3666,8 @@ Used by: [VirtualMachinesProfile_STATUS](#VirtualMachinesProfile_STATUS).
 | autoscale | Specifications on how to auto-scale the VirtualMachines agent pool within a predefined size range. Currently, at most one AutoScaleProfile is allowed. | [AutoScaleProfile_STATUS[]](#AutoScaleProfile_STATUS)<br/><small>Optional</small>     |
 | manual    | Specifications on how to scale the VirtualMachines agent pool to a fixed size.                                                                         | [ManualScaleProfile_STATUS[]](#ManualScaleProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ServiceMeshProfile_Mode"></a>ServiceMeshProfile_Mode
------------------------------------------------------------
+ServiceMeshProfile_Mode{#ServiceMeshProfile_Mode}
+-------------------------------------------------
 
 Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 
@@ -3676,8 +3676,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="ServiceMeshProfile_Mode_STATUS"></a>ServiceMeshProfile_Mode_STATUS
--------------------------------------------------------------------------
+ServiceMeshProfile_Mode_STATUS{#ServiceMeshProfile_Mode_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 
@@ -3686,8 +3686,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -3724,8 +3724,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -3762,7 +3762,19 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3774,20 +3786,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpgradeOverrideSettings"></a>UpgradeOverrideSettings
------------------------------------------------------------
+UpgradeOverrideSettings{#UpgradeOverrideSettings}
+-------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -3798,8 +3798,8 @@ Used by: [ClusterUpgradeSettings](#ClusterUpgradeSettings).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UpgradeOverrideSettings_STATUS"></a>UpgradeOverrideSettings_STATUS
--------------------------------------------------------------------------
+UpgradeOverrideSettings_STATUS{#UpgradeOverrideSettings_STATUS}
+---------------------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -3810,8 +3810,8 @@ Used by: [ClusterUpgradeSettings_STATUS](#ClusterUpgradeSettings_STATUS).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -3821,8 +3821,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile"></a>WindowsGmsaProfile
--------------------------------------------------
+WindowsGmsaProfile{#WindowsGmsaProfile}
+---------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -3834,8 +3834,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile_STATUS"></a>WindowsGmsaProfile_STATUS
----------------------------------------------------------------
+WindowsGmsaProfile_STATUS{#WindowsGmsaProfile_STATUS}
+-----------------------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -3847,8 +3847,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="AdvancedNetworkingObservability"></a>AdvancedNetworkingObservability
----------------------------------------------------------------------------
+AdvancedNetworkingObservability{#AdvancedNetworkingObservability}
+-----------------------------------------------------------------
 
 Observability profile to enable advanced network metrics and flow logs with historical contexts.
 
@@ -3858,8 +3858,8 @@ Used by: [AdvancedNetworking](#AdvancedNetworking).
 |----------|--------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
 
-<a id="AdvancedNetworkingObservability_STATUS"></a>AdvancedNetworkingObservability_STATUS
------------------------------------------------------------------------------------------
+AdvancedNetworkingObservability_STATUS{#AdvancedNetworkingObservability_STATUS}
+-------------------------------------------------------------------------------
 
 Observability profile to enable advanced network metrics and flow logs with historical contexts.
 
@@ -3869,8 +3869,8 @@ Used by: [AdvancedNetworking_STATUS](#AdvancedNetworking_STATUS).
 |----------|--------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
 
-<a id="AutoScaleProfile"></a>AutoScaleProfile
----------------------------------------------
+AutoScaleProfile{#AutoScaleProfile}
+-----------------------------------
 
 Specifications on auto-scaling.
 
@@ -3882,8 +3882,8 @@ Used by: [ScaleProfile](#ScaleProfile).
 | minCount | The minimum number of nodes of the specified sizes.                                                                                                                                                                                                              | int<br/><small>Optional</small>      |
 | sizes    | The list of allowed vm sizes e.g. ['Standard_E4s_v3', 'Standard_E16s_v3', 'Standard_D16s_v5']. AKS will use the first available one when auto scaling. If a VM size is unavailable (e.g. due to quota or regional capacity reasons), AKS will use the next size. | string[]<br/><small>Optional</small> |
 
-<a id="AutoScaleProfile_STATUS"></a>AutoScaleProfile_STATUS
------------------------------------------------------------
+AutoScaleProfile_STATUS{#AutoScaleProfile_STATUS}
+-------------------------------------------------
 
 Specifications on auto-scaling.
 
@@ -3895,8 +3895,8 @@ Used by: [ScaleProfile_STATUS](#ScaleProfile_STATUS).
 | minCount | The minimum number of nodes of the specified sizes.                                                                                                                                                                                                              | int<br/><small>Optional</small>      |
 | sizes    | The list of allowed vm sizes e.g. ['Standard_E4s_v3', 'Standard_E16s_v3', 'Standard_D16s_v5']. AKS will use the first available one when auto scaling. If a VM size is unavailable (e.g. due to quota or regional capacity reasons), AKS will use the next size. | string[]<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess"></a>AzureKeyVaultKms_KeyVaultNetworkAccess
------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess{#AzureKeyVaultKms_KeyVaultNetworkAccess}
+-------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 
@@ -3905,8 +3905,8 @@ Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS"></a>AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS{#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 
@@ -3915,8 +3915,8 @@ Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig
--------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetworkProfile_KubeProxyConfig).
 
@@ -3927,8 +3927,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetwo
 | tcpTimeoutSeconds    | The timeout value used for idle IPVS TCP sessions in seconds. Must be a positive integer value.                  | int<br/><small>Optional</small>                                                                                                                                         |
 | udpTimeoutSeconds    | The timeout value used for IPVS UDP packets in seconds. Must be a positive integer value.                        | int<br/><small>Optional</small>                                                                                                                                         |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS).
 
@@ -3939,8 +3939,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServi
 | tcpTimeoutSeconds    | The timeout value used for idle IPVS TCP sessions in seconds. Must be a positive integer value.                  | int<br/><small>Optional</small>                                                                                                                                                       |
 | udpTimeoutSeconds    | The timeout value used for IPVS UDP packets in seconds. Must be a positive integer value.                        | int<br/><small>Optional</small>                                                                                                                                                       |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_Mode"></a>ContainerServiceNetworkProfile_KubeProxyConfig_Mode
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_Mode{#ContainerServiceNetworkProfile_KubeProxyConfig_Mode}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetworkProfile_KubeProxyConfig).
 
@@ -3949,8 +3949,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig](#ContainerServiceNetwo
 | "IPTABLES" |             |
 | "IPVS"     |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_Mode_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_STATUS).
 
@@ -3959,8 +3959,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_STATUS](#ContainerServi
 | "IPTABLES" |             |
 | "IPVS"     |             |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -3970,8 +3970,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -3981,8 +3981,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority"></a>IstioCertificateAuthority
----------------------------------------------------------------
+IstioCertificateAuthority{#IstioCertificateAuthority}
+-----------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -3992,8 +3992,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 |----------|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority](#IstioPluginCertificateAuthority)<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority_STATUS"></a>IstioCertificateAuthority_STATUS
------------------------------------------------------------------------------
+IstioCertificateAuthority_STATUS{#IstioCertificateAuthority_STATUS}
+-------------------------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -4003,8 +4003,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 |----------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority_STATUS](#IstioPluginCertificateAuthority_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioComponents"></a>IstioComponents
--------------------------------------------
+IstioComponents{#IstioComponents}
+---------------------------------
 
 Istio components configuration.
 
@@ -4015,8 +4015,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway[]](#IstioEgressGateway)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway[]](#IstioIngressGateway)<br/><small>Optional</small> |
 
-<a id="IstioComponents_STATUS"></a>IstioComponents_STATUS
----------------------------------------------------------
+IstioComponents_STATUS{#IstioComponents_STATUS}
+-----------------------------------------------
 
 Istio components configuration.
 
@@ -4027,43 +4027,43 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway_STATUS[]](#IstioEgressGateway_STATUS)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway_STATUS[]](#IstioIngressGateway_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation"></a>ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation
+ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation{#ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation}
+-------------------------------------------------------------------------------------------------------------------------------------
+
+Application Monitoring Auto Instrumentation for Kubernetes Application Container. Deploys web hook to auto-instrument Azure Monitor OpenTelemetry based SDKs to collect OpenTelemetry metrics, logs and traces of the application. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
+
+Used by: [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMonitorProfileAppMonitoring).
+
+| Property | Description                                                                 | Type                             |
+|----------|-----------------------------------------------------------------------------|----------------------------------|
+| enabled  | Indicates if Application Monitoring Auto Instrumentation is enabled or not. | bool<br/><small>Optional</small> |
+
+ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
+
+Application Monitoring Auto Instrumentation for Kubernetes Application Container. Deploys web hook to auto-instrument Azure Monitor OpenTelemetry based SDKs to collect OpenTelemetry metrics, logs and traces of the application. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
+
+Used by: [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS).
+
+| Property | Description                                                                 | Type                             |
+|----------|-----------------------------------------------------------------------------|----------------------------------|
+| enabled  | Indicates if Application Monitoring Auto Instrumentation is enabled or not. | bool<br/><small>Optional</small> |
+
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs}
+---------------------------------------------------------------------------------------------------------------------------------
+
+Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Logs and Traces. Collects OpenTelemetry logs and traces of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
+
+Used by: [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMonitorProfileAppMonitoring).
+
+| Property | Description                                                                                                   | Type                             |
+|----------|---------------------------------------------------------------------------------------------------------------|----------------------------------|
+| enabled  | Indicates if Application Monitoring Open Telemetry Logs and traces is enabled or not.                         | bool<br/><small>Optional</small> |
+| port     | The Open Telemetry host port for Open Telemetry logs and traces. If not specified, the default port is 28331. | int<br/><small>Optional</small>  |
+
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS}
 -----------------------------------------------------------------------------------------------------------------------------------------------
 
-Application Monitoring Auto Instrumentation for Kubernetes Application Container. Deploys web hook to auto-instrument Azure Monitor OpenTelemetry based SDKs to collect OpenTelemetry metrics, logs and traces of the application. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
-
-Used by: [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMonitorProfileAppMonitoring).
-
-| Property | Description                                                                 | Type                             |
-|----------|-----------------------------------------------------------------------------|----------------------------------|
-| enabled  | Indicates if Application Monitoring Auto Instrumentation is enabled or not. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Application Monitoring Auto Instrumentation for Kubernetes Application Container. Deploys web hook to auto-instrument Azure Monitor OpenTelemetry based SDKs to collect OpenTelemetry metrics, logs and traces of the application. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
-
-Used by: [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS).
-
-| Property | Description                                                                 | Type                             |
-|----------|-----------------------------------------------------------------------------|----------------------------------|
-| enabled  | Indicates if Application Monitoring Auto Instrumentation is enabled or not. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs
--------------------------------------------------------------------------------------------------------------------------------------------
-
-Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Logs and Traces. Collects OpenTelemetry logs and traces of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
-
-Used by: [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMonitorProfileAppMonitoring).
-
-| Property | Description                                                                                                   | Type                             |
-|----------|---------------------------------------------------------------------------------------------------------------|----------------------------------|
-| enabled  | Indicates if Application Monitoring Open Telemetry Logs and traces is enabled or not.                         | bool<br/><small>Optional</small> |
-| port     | The Open Telemetry host port for Open Telemetry logs and traces. If not specified, the default port is 28331. | int<br/><small>Optional</small>  |
-
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------
-
 Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Logs and Traces. Collects OpenTelemetry logs and traces of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
 
 Used by: [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedClusterAzureMonitorProfileAppMonitoring_STATUS).
@@ -4073,8 +4073,8 @@ Used by: [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedCluster
 | enabled  | Indicates if Application Monitoring Open Telemetry Logs and traces is enabled or not.                         | bool<br/><small>Optional</small> |
 | port     | The Open Telemetry host port for Open Telemetry logs and traces. If not specified, the default port is 28331. | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics
--------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
 
@@ -4085,8 +4085,8 @@ Used by: [ManagedClusterAzureMonitorProfileAppMonitoring](#ManagedClusterAzureMo
 | enabled  | Indicates if Application Monitoring Open Telemetry Metrics is enabled or not.                         | bool<br/><small>Optional</small> |
 | port     | The Open Telemetry host port for Open Telemetry metrics. If not specified, the default port is 28333. | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS{#ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview.
 
@@ -4097,8 +4097,8 @@ Used by: [ManagedClusterAzureMonitorProfileAppMonitoring_STATUS](#ManagedCluster
 | enabled  | Indicates if Application Monitoring Open Telemetry Metrics is enabled or not.                         | bool<br/><small>Optional</small> |
 | port     | The Open Telemetry host port for Open Telemetry metrics. If not specified, the default port is 28333. | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics
----------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics{#ManagedClusterAzureMonitorProfileKubeStateMetrics}
+-----------------------------------------------------------------------------------------------------
 
 Kube State Metrics for prometheus addon profile for the container service cluster
 
@@ -4109,8 +4109,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 | metricAnnotationsAllowList | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of Kubernetes annotations keys that will be used in the resource's labels metric.      | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS{#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Kube State Metrics for prometheus addon profile for the container service cluster
 
@@ -4121,8 +4121,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 | metricAnnotationsAllowList | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of Kubernetes annotations keys that will be used in the resource's labels metric.      | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType"></a>ManagedClusterLoadBalancerProfile_BackendPoolType
----------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType{#ManagedClusterLoadBalancerProfile_BackendPoolType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -4131,8 +4131,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS"></a>ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS{#ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -4141,8 +4141,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode"></a>ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode{#ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode}
+---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -4151,8 +4151,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | "ServiceNodePort" |             |
 | "Shared"          |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode_STATUS"></a>ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode_STATUS{#ManagedClusterLoadBalancerProfile_ClusterServiceLoadBalancerHealthProbeMode_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -4161,8 +4161,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | "ServiceNodePort" |             |
 | "Shared"          |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -4171,8 +4171,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -4181,8 +4181,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -4190,8 +4190,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|---------------------------------------|-----------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -4199,8 +4199,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|---------------------------------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -4208,8 +4208,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|--------------------------------|-----------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -4217,8 +4217,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|--------------------------------|-------------------------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile"></a>ManagedClusterManagedOutboundIPProfile
------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile{#ManagedClusterManagedOutboundIPProfile}
+-------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -4228,8 +4228,8 @@ Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile_STATUS"></a>ManagedClusterManagedOutboundIPProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile_STATUS{#ManagedClusterManagedOutboundIPProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -4239,8 +4239,8 @@ Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfi
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -4248,8 +4248,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Pod identity assignment error (if any). | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -4262,8 +4262,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring{#ManagedClusterSecurityProfileDefenderSecurityMonitoring}
+-----------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -4273,8 +4273,8 @@ Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileD
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS{#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -4284,8 +4284,8 @@ Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityP
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler).
 
@@ -4294,8 +4294,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#Managed
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscaling_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS).
 
@@ -4304,8 +4304,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManualScaleProfile"></a>ManualScaleProfile
--------------------------------------------------
+ManualScaleProfile{#ManualScaleProfile}
+---------------------------------------
 
 Specifications on number of machines.
 
@@ -4316,8 +4316,8 @@ Used by: [ScaleProfile](#ScaleProfile).
 | count    | Number of nodes.                                                                                                                                                                                                                                            | int<br/><small>Optional</small>      |
 | sizes    | The list of allowed vm sizes e.g. ['Standard_E4s_v3', 'Standard_E16s_v3', 'Standard_D16s_v5']. AKS will use the first available one when scaling. If a VM size is unavailable (e.g. due to quota or regional capacity reasons), AKS will use the next size. | string[]<br/><small>Optional</small> |
 
-<a id="ManualScaleProfile_STATUS"></a>ManualScaleProfile_STATUS
----------------------------------------------------------------
+ManualScaleProfile_STATUS{#ManualScaleProfile_STATUS}
+-----------------------------------------------------
 
 Specifications on number of machines.
 
@@ -4328,8 +4328,8 @@ Used by: [ScaleProfile_STATUS](#ScaleProfile_STATUS).
 | count    | Number of nodes.                                                                                                                                                                                                                                            | int<br/><small>Optional</small>      |
 | sizes    | The list of allowed vm sizes e.g. ['Standard_E4s_v3', 'Standard_E16s_v3', 'Standard_D16s_v5']. AKS will use the first available one when scaling. If a VM size is unavailable (e.g. due to quota or regional capacity reasons), AKS will use the next size. | string[]<br/><small>Optional</small> |
 
-<a id="PortRange_Protocol"></a>PortRange_Protocol
--------------------------------------------------
+PortRange_Protocol{#PortRange_Protocol}
+---------------------------------------
 
 Used by: [PortRange](#PortRange).
 
@@ -4338,8 +4338,8 @@ Used by: [PortRange](#PortRange).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="PortRange_Protocol_STATUS"></a>PortRange_Protocol_STATUS
----------------------------------------------------------------
+PortRange_Protocol_STATUS{#PortRange_Protocol_STATUS}
+-----------------------------------------------------
 
 Used by: [PortRange_STATUS](#PortRange_STATUS).
 
@@ -4348,8 +4348,8 @@ Used by: [PortRange_STATUS](#PortRange_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 A reference to an Azure resource.
 
@@ -4359,8 +4359,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The fully qualified Azure resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 A reference to an Azure resource.
 
@@ -4370,8 +4370,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|----------------------------------------|------------------------------------|
 | id       | The fully qualified Azure resource id. | string<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler
----------------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig).
 
@@ -4380,8 +4380,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig](#ContainerS
 | "LeastConnection" |             |
 | "RoundRobin"      |             |
 
-<a id="ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS"></a>ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS{#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_Scheduler_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS).
 
@@ -4390,8 +4390,8 @@ Used by: [ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS](#Con
 | "LeastConnection" |             |
 | "RoundRobin"      |             |
 
-<a id="IstioEgressGateway"></a>IstioEgressGateway
--------------------------------------------------
+IstioEgressGateway{#IstioEgressGateway}
+---------------------------------------
 
 Istio egress gateway configuration.
 
@@ -4401,8 +4401,8 @@ Used by: [IstioComponents](#IstioComponents).
 |----------|---------------------------------------|----------------------------------|
 | enabled  | Whether to enable the egress gateway. | bool<br/><small>Required</small> |
 
-<a id="IstioEgressGateway_STATUS"></a>IstioEgressGateway_STATUS
----------------------------------------------------------------
+IstioEgressGateway_STATUS{#IstioEgressGateway_STATUS}
+-----------------------------------------------------
 
 Istio egress gateway configuration.
 
@@ -4412,8 +4412,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 |----------|---------------------------------------|----------------------------------|
 | enabled  | Whether to enable the egress gateway. | bool<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway"></a>IstioIngressGateway
----------------------------------------------------
+IstioIngressGateway{#IstioIngressGateway}
+-----------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -4424,8 +4424,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Required</small>                                                  |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode](#IstioIngressGateway_Mode)<br/><small>Required</small> |
 
-<a id="IstioIngressGateway_STATUS"></a>IstioIngressGateway_STATUS
------------------------------------------------------------------
+IstioIngressGateway_STATUS{#IstioIngressGateway_STATUS}
+-------------------------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -4436,8 +4436,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Optional</small>                                                                |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode_STATUS](#IstioIngressGateway_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioPluginCertificateAuthority"></a>IstioPluginCertificateAuthority
----------------------------------------------------------------------------
+IstioPluginCertificateAuthority{#IstioPluginCertificateAuthority}
+-----------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -4451,8 +4451,8 @@ Used by: [IstioCertificateAuthority](#IstioCertificateAuthority).
 | keyVaultReference   | The resource ID of the Key Vault.                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="IstioPluginCertificateAuthority_STATUS"></a>IstioPluginCertificateAuthority_STATUS
------------------------------------------------------------------------------------------
+IstioPluginCertificateAuthority_STATUS{#IstioPluginCertificateAuthority_STATUS}
+-------------------------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -4466,8 +4466,8 @@ Used by: [IstioCertificateAuthority_STATUS](#IstioCertificateAuthority_STATUS).
 | keyVaultId          | The resource ID of the Key Vault.                                    | string<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -4477,8 +4477,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Details about the error. | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway_Mode"></a>IstioIngressGateway_Mode
--------------------------------------------------------------
+IstioIngressGateway_Mode{#IstioIngressGateway_Mode}
+---------------------------------------------------
 
 Used by: [IstioIngressGateway](#IstioIngressGateway).
 
@@ -4487,8 +4487,8 @@ Used by: [IstioIngressGateway](#IstioIngressGateway).
 | "External" |             |
 | "Internal" |             |
 
-<a id="IstioIngressGateway_Mode_STATUS"></a>IstioIngressGateway_Mode_STATUS
----------------------------------------------------------------------------
+IstioIngressGateway_Mode_STATUS{#IstioIngressGateway_Mode_STATUS}
+-----------------------------------------------------------------
 
 Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 
@@ -4497,8 +4497,8 @@ Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 | "External" |             |
 | "Internal" |             |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -4511,8 +4511,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  | A message describing the error, intended to be suitable for display in a user interface.           | string<br/><small>Optional</small>                                                                                                                              |
 | target   | The target of the particular error. For example, the name of the property in error.                | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/containerservice/v1api20240901.md
+++ b/docs/hugo/content/reference/containerservice/v1api20240901.md
@@ -5,15 +5,15 @@ title: containerservice.azure.com/v1api20240901
 linktitle: v1api20240901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-09-01" |             |
 
-<a id="MaintenanceConfiguration"></a>MaintenanceConfiguration
--------------------------------------------------------------
+MaintenanceConfiguration{#MaintenanceConfiguration}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/maintenanceConfigurations/{configName}
 
@@ -26,7 +26,7 @@ Used by: [MaintenanceConfigurationList](#MaintenanceConfigurationList).
 | spec                                                                                    |             | [MaintenanceConfiguration_Spec](#MaintenanceConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MaintenanceConfiguration_STATUS](#MaintenanceConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="MaintenanceConfiguration_Spec"></a>MaintenanceConfiguration_Spec
+### MaintenanceConfiguration_Spec {#MaintenanceConfiguration_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [MaintenanceConfigurationList](#MaintenanceConfigurationList).
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/ManagedCluster resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | timeInWeek        | If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.                                                                                                                                                                              | [TimeInWeek[]](#TimeInWeek)<br/><small>Optional</small>                                                                                                              |
 
-### <a id="MaintenanceConfiguration_STATUS"></a>MaintenanceConfiguration_STATUS
+### MaintenanceConfiguration_STATUS{#MaintenanceConfiguration_STATUS}
 
 | Property          | Description                                                                                                             | Type                                                                                                                                                    |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,8 +50,8 @@ Used by: [MaintenanceConfigurationList](#MaintenanceConfigurationList).
 | timeInWeek        | If two array entries specify the same day of the week, the applied configuration is the union of times in both entries. | [TimeInWeek_STATUS[]](#TimeInWeek_STATUS)<br/><small>Optional</small>                                                                                   |
 | type              | Resource type                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MaintenanceConfigurationList"></a>MaintenanceConfigurationList
----------------------------------------------------------------------
+MaintenanceConfigurationList{#MaintenanceConfigurationList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/maintenanceConfigurations/{configName}
 
@@ -61,8 +61,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [MaintenanceConfiguration[]](#MaintenanceConfiguration)<br/><small>Optional</small> |
 
-<a id="ManagedCluster"></a>ManagedCluster
------------------------------------------
+ManagedCluster{#ManagedCluster}
+-------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -75,7 +75,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | spec                                                                                    |             | [ManagedCluster_Spec](#ManagedCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedCluster_STATUS](#ManagedCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
+### ManagedCluster_Spec {#ManagedCluster_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -122,7 +122,7 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-### <a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
+### ManagedCluster_STATUS{#ManagedCluster_STATUS}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -180,8 +180,8 @@ Used by: [ManagedClusterList](#ManagedClusterList).
 | windowsProfile            | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClusterList"></a>ManagedClusterList
--------------------------------------------------
+ManagedClusterList{#ManagedClusterList}
+---------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}
 
@@ -191,8 +191,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [ManagedCluster[]](#ManagedCluster)<br/><small>Optional</small> |
 
-<a id="ManagedClustersAgentPool"></a>ManagedClustersAgentPool
--------------------------------------------------------------
+ManagedClustersAgentPool{#ManagedClustersAgentPool}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -205,7 +205,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | spec                                                                                    |             | [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
+### ManagedClustersAgentPool_Spec {#ManagedClustersAgentPool_Spec}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -255,7 +255,7 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-### <a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
+### ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                    |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -310,8 +310,8 @@ Used by: [ManagedClustersAgentPoolList](#ManagedClustersAgentPoolList).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="ManagedClustersAgentPoolList"></a>ManagedClustersAgentPoolList
----------------------------------------------------------------------
+ManagedClustersAgentPoolList{#ManagedClustersAgentPoolList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}
 
@@ -321,8 +321,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ManagedClustersAgentPool[]](#ManagedClustersAgentPool)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBinding"></a>TrustedAccessRoleBinding
--------------------------------------------------------------
+TrustedAccessRoleBinding{#TrustedAccessRoleBinding}
+---------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -335,7 +335,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | spec                                                                                    |             | [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
+### TrustedAccessRoleBinding_Spec {#TrustedAccessRoleBinding_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -345,7 +345,7 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-### <a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
+### TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -358,8 +358,8 @@ Used by: [TrustedAccessRoleBindingList](#TrustedAccessRoleBindingList).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TrustedAccessRoleBindingList"></a>TrustedAccessRoleBindingList
----------------------------------------------------------------------
+TrustedAccessRoleBindingList{#TrustedAccessRoleBindingList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2024-09-01/managedClusters.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}
 
@@ -369,8 +369,8 @@ Generator information: - Generated from: /containerservice/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [TrustedAccessRoleBinding[]](#TrustedAccessRoleBinding)<br/><small>Optional</small> |
 
-<a id="MaintenanceConfiguration_Spec"></a>MaintenanceConfiguration_Spec
------------------------------------------------------------------------
+MaintenanceConfiguration_Spec{#MaintenanceConfiguration_Spec}
+-------------------------------------------------------------
 
 Used by: [MaintenanceConfiguration](#MaintenanceConfiguration).
 
@@ -383,8 +383,8 @@ Used by: [MaintenanceConfiguration](#MaintenanceConfiguration).
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a containerservice.azure.com/ManagedCluster resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | timeInWeek        | If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.                                                                                                                                                                              | [TimeInWeek[]](#TimeInWeek)<br/><small>Optional</small>                                                                                                              |
 
-<a id="MaintenanceConfiguration_STATUS"></a>MaintenanceConfiguration_STATUS
----------------------------------------------------------------------------
+MaintenanceConfiguration_STATUS{#MaintenanceConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Used by: [MaintenanceConfiguration](#MaintenanceConfiguration).
 
@@ -399,8 +399,8 @@ Used by: [MaintenanceConfiguration](#MaintenanceConfiguration).
 | timeInWeek        | If two array entries specify the same day of the week, the applied configuration is the union of times in both entries. | [TimeInWeek_STATUS[]](#TimeInWeek_STATUS)<br/><small>Optional</small>                                                                                   |
 | type              | Resource type                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ManagedCluster_Spec"></a>ManagedCluster_Spec
----------------------------------------------------
+ManagedCluster_Spec{#ManagedCluster_Spec}
+-----------------------------------------
 
 Used by: [ManagedCluster](#ManagedCluster).
 
@@ -449,8 +449,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile             | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadAutoScalerProfile  | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoScalerProfile)<br/><small>Optional</small>                                                      |
 
-<a id="ManagedCluster_STATUS"></a>ManagedCluster_STATUS
--------------------------------------------------------
+ManagedCluster_STATUS{#ManagedCluster_STATUS}
+---------------------------------------------
 
 Managed cluster.
 
@@ -512,8 +512,8 @@ Used by: [ManagedCluster](#ManagedCluster).
 | windowsProfile            | The profile for Windows VMs in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS)<br/><small>Optional</small>                                                 |
 | workloadAutoScalerProfile | Workload Auto-scaler profile for the managed cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloadAutoScalerProfile_STATUS)<br/><small>Optional</small>                           |
 
-<a id="ManagedClustersAgentPool_Spec"></a>ManagedClustersAgentPool_Spec
------------------------------------------------------------------------
+ManagedClustersAgentPool_Spec{#ManagedClustersAgentPool_Spec}
+-------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -565,8 +565,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                                      |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClustersAgentPool_STATUS"></a>ManagedClustersAgentPool_STATUS
----------------------------------------------------------------------------
+ManagedClustersAgentPool_STATUS{#ManagedClustersAgentPool_STATUS}
+-----------------------------------------------------------------
 
 Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 
@@ -623,8 +623,8 @@ Used by: [ManagedClustersAgentPool](#ManagedClustersAgentPool).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>                                                           |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                                                                           |
 
-<a id="TrustedAccessRoleBinding_Spec"></a>TrustedAccessRoleBinding_Spec
------------------------------------------------------------------------
+TrustedAccessRoleBinding_Spec{#TrustedAccessRoleBinding_Spec}
+-------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -636,8 +636,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | roles                   | A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.                                                                                                                                                       | string[]<br/><small>Required</small>                                                                                                                                 |
 | sourceResourceReference | The ARM resource ID of source resource that trusted access is configured for.                                                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-<a id="TrustedAccessRoleBinding_STATUS"></a>TrustedAccessRoleBinding_STATUS
----------------------------------------------------------------------------
+TrustedAccessRoleBinding_STATUS{#TrustedAccessRoleBinding_STATUS}
+-----------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 
@@ -652,8 +652,8 @@ Used by: [TrustedAccessRoleBinding](#TrustedAccessRoleBinding).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AgentPoolMode"></a>AgentPoolMode
----------------------------------------
+AgentPoolMode{#AgentPoolMode}
+-----------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -664,8 +664,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolMode_STATUS"></a>AgentPoolMode_STATUS
------------------------------------------------------
+AgentPoolMode_STATUS{#AgentPoolMode_STATUS}
+-------------------------------------------
 
 A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
 
@@ -676,8 +676,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "System" |             |
 | "User"   |             |
 
-<a id="AgentPoolNetworkProfile"></a>AgentPoolNetworkProfile
------------------------------------------------------------
+AgentPoolNetworkProfile{#AgentPoolNetworkProfile}
+-------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -689,8 +689,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | applicationSecurityGroupsReferences | The IDs of the application security groups which agent pool will associate when created. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | nodePublicIPTags                    | IPTags of instance-level public IPs.                                                     | [IPTag[]](#IPTag)<br/><small>Optional</small>                                                                                                                |
 
-<a id="AgentPoolNetworkProfile_STATUS"></a>AgentPoolNetworkProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolNetworkProfile_STATUS{#AgentPoolNetworkProfile_STATUS}
+---------------------------------------------------------------
 
 Network settings of an agent pool.
 
@@ -702,8 +702,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | applicationSecurityGroups | The IDs of the application security groups which agent pool will associate when created. | string[]<br/><small>Optional</small>                                |
 | nodePublicIPTags          | IPTags of instance-level public IPs.                                                     | [IPTag_STATUS[]](#IPTag_STATUS)<br/><small>Optional</small>         |
 
-<a id="AgentPoolSecurityProfile"></a>AgentPoolSecurityProfile
--------------------------------------------------------------
+AgentPoolSecurityProfile{#AgentPoolSecurityProfile}
+---------------------------------------------------
 
 The security settings of an agent pool.
 
@@ -714,8 +714,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | enableSecureBoot | Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.             | bool<br/><small>Optional</small> |
 | enableVTPM       | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolSecurityProfile_STATUS"></a>AgentPoolSecurityProfile_STATUS
----------------------------------------------------------------------------
+AgentPoolSecurityProfile_STATUS{#AgentPoolSecurityProfile_STATUS}
+-----------------------------------------------------------------
 
 The security settings of an agent pool.
 
@@ -726,8 +726,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | enableSecureBoot | Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.             | bool<br/><small>Optional</small> |
 | enableVTPM       | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolType"></a>AgentPoolType
----------------------------------------
+AgentPoolType{#AgentPoolType}
+-----------------------------
 
 The type of Agent Pool.
 
@@ -738,8 +738,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolType_STATUS"></a>AgentPoolType_STATUS
------------------------------------------------------
+AgentPoolType_STATUS{#AgentPoolType_STATUS}
+-------------------------------------------
 
 The type of Agent Pool.
 
@@ -750,8 +750,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "AvailabilitySet"         |             |
 | "VirtualMachineScaleSets" |             |
 
-<a id="AgentPoolUpgradeSettings"></a>AgentPoolUpgradeSettings
--------------------------------------------------------------
+AgentPoolUpgradeSettings{#AgentPoolUpgradeSettings}
+---------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -763,8 +763,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | maxSurge                  | This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade | string<br/><small>Optional</small> |
 | nodeSoakDurationInMinutes | The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.                                                                                                                                                                                                                                                          | int<br/><small>Optional</small>    |
 
-<a id="AgentPoolUpgradeSettings_STATUS"></a>AgentPoolUpgradeSettings_STATUS
----------------------------------------------------------------------------
+AgentPoolUpgradeSettings_STATUS{#AgentPoolUpgradeSettings_STATUS}
+-----------------------------------------------------------------
 
 Settings for upgrading an agentpool
 
@@ -776,8 +776,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | maxSurge                  | This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade | string<br/><small>Optional</small> |
 | nodeSoakDurationInMinutes | The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.                                                                                                                                                                                                                                                          | int<br/><small>Optional</small>    |
 
-<a id="AgentPoolWindowsProfile"></a>AgentPoolWindowsProfile
------------------------------------------------------------
+AgentPoolWindowsProfile{#AgentPoolWindowsProfile}
+-------------------------------------------------
 
 The Windows agent pool's specific profile.
 
@@ -787,8 +787,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | disableOutboundNat | The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. | bool<br/><small>Optional</small> |
 
-<a id="AgentPoolWindowsProfile_STATUS"></a>AgentPoolWindowsProfile_STATUS
--------------------------------------------------------------------------
+AgentPoolWindowsProfile_STATUS{#AgentPoolWindowsProfile_STATUS}
+---------------------------------------------------------------
 
 The Windows agent pool's specific profile.
 
@@ -798,8 +798,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | disableOutboundNat | The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. | bool<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings"></a>ClusterUpgradeSettings
----------------------------------------------------------
+ClusterUpgradeSettings{#ClusterUpgradeSettings}
+-----------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -809,8 +809,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|-------------------------|---------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings](#UpgradeOverrideSettings)<br/><small>Optional</small> |
 
-<a id="ClusterUpgradeSettings_STATUS"></a>ClusterUpgradeSettings_STATUS
------------------------------------------------------------------------
+ClusterUpgradeSettings_STATUS{#ClusterUpgradeSettings_STATUS}
+-------------------------------------------------------------
 
 Settings for upgrading a cluster.
 
@@ -820,8 +820,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|-------------------------|-----------------------------------------------------------------------------------------------|
 | overrideSettings | Settings for overrides. | [UpgradeOverrideSettings_STATUS](#UpgradeOverrideSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceLinuxProfile"></a>ContainerServiceLinuxProfile
----------------------------------------------------------------------
+ContainerServiceLinuxProfile{#ContainerServiceLinuxProfile}
+-----------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -832,8 +832,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Required</small>                                                                |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration)<br/><small>Required</small> |
 
-<a id="ContainerServiceLinuxProfile_STATUS"></a>ContainerServiceLinuxProfile_STATUS
------------------------------------------------------------------------------------
+ContainerServiceLinuxProfile_STATUS{#ContainerServiceLinuxProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Linux VMs in the container service cluster.
 
@@ -844,8 +844,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | adminUsername | The administrator username to use for Linux VMs.            | string<br/><small>Optional</small>                                                                              |
 | ssh           | The SSH configuration for Linux-based VMs running on Azure. | [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfiguration_STATUS)<br/><small>Optional</small> |
 
-<a id="ContainerServiceNetworkProfile"></a>ContainerServiceNetworkProfile
--------------------------------------------------------------------------
+ContainerServiceNetworkProfile{#ContainerServiceNetworkProfile}
+---------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -870,8 +870,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serviceCidr         | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                                                             | string<br/><small>Optional</small>                                                                                                |
 | serviceCidrs        | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. | string[]<br/><small>Optional</small>                                                                                              |
 
-<a id="ContainerServiceNetworkProfile_STATUS"></a>ContainerServiceNetworkProfile_STATUS
----------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_STATUS{#ContainerServiceNetworkProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile of network configuration.
 
@@ -896,13 +896,13 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serviceCidr         | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                                                             | string<br/><small>Optional</small>                                                                                                              |
 | serviceCidrs        | One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. | string[]<br/><small>Optional</small>                                                                                                            |
 
-<a id="ContainerServiceOSDisk"></a>ContainerServiceOSDisk
----------------------------------------------------------
+ContainerServiceOSDisk{#ContainerServiceOSDisk}
+-----------------------------------------------
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-<a id="CreationData"></a>CreationData
--------------------------------------
+CreationData{#CreationData}
+---------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -912,8 +912,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |-------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sourceResourceReference | This is the ARM ID of the source object to be used to create the target object. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CreationData_STATUS"></a>CreationData_STATUS
----------------------------------------------------
+CreationData_STATUS{#CreationData_STATUS}
+-----------------------------------------
 
 Data used when creating a target resource from a source resource.
 
@@ -923,8 +923,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 |------------------|---------------------------------------------------------------------------------|------------------------------------|
 | sourceResourceId | This is the ARM ID of the source object to be used to create the target object. | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -935,8 +935,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -947,60 +947,60 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GPUInstanceProfile"></a>GPUInstanceProfile
--------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="GPUInstanceProfile_STATUS"></a>GPUInstanceProfile_STATUS
----------------------------------------------------------------
-
-GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "MIG1g" |             |
-| "MIG2g" |             |
-| "MIG3g" |             |
-| "MIG4g" |             |
-| "MIG7g" |             |
-
-<a id="KubeletConfig"></a>KubeletConfig
+GPUInstanceProfile{#GPUInstanceProfile}
 ---------------------------------------
 
-See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Property              | Description                                                                                                                                                                                                                          | Type                                 |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
-| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
-| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
-| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
-| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
-| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
-| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
-| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
-| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
-| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
-| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
 
-<a id="KubeletConfig_STATUS"></a>KubeletConfig_STATUS
+GPUInstanceProfile_STATUS{#GPUInstanceProfile_STATUS}
 -----------------------------------------------------
 
+GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "MIG1g" |             |
+| "MIG2g" |             |
+| "MIG3g" |             |
+| "MIG4g" |             |
+| "MIG7g" |             |
+
+KubeletConfig{#KubeletConfig}
+-----------------------------
+
+See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Property              | Description                                                                                                                                                                                                                          | Type                                 |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| allowedUnsafeSysctls  | Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).                                                                                                                                                            | string[]<br/><small>Optional</small> |
+| containerLogMaxFiles  | The maximum number of container log files that can be present for a container. The number must be ≥ 2.                                                                                                                               | int<br/><small>Optional</small>      |
+| containerLogMaxSizeMB | The maximum size (e.g. 10Mi) of container log file before it is rotated.                                                                                                                                                             | int<br/><small>Optional</small>      |
+| cpuCfsQuota           | The default is true.                                                                                                                                                                                                                 | bool<br/><small>Optional</small>     |
+| cpuCfsQuotaPeriod     | The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.                          | string<br/><small>Optional</small>   |
+| cpuManagerPolicy      | The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.  | string<br/><small>Optional</small>   |
+| failSwapOn            | If set to true it will make the Kubelet fail to start if swap is enabled on the node.                                                                                                                                                | bool<br/><small>Optional</small>     |
+| imageGcHighThreshold  | To disable image garbage collection, set to 100. The default is 85%                                                                                                                                                                  | int<br/><small>Optional</small>      |
+| imageGcLowThreshold   | This cannot be set higher than imageGcHighThreshold. The default is 80%                                                                                                                                                              | int<br/><small>Optional</small>      |
+| podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
+| topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
+
+KubeletConfig_STATUS{#KubeletConfig_STATUS}
+-------------------------------------------
+
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -1019,8 +1019,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | podMaxPids            | The maximum number of processes per pod.                                                                                                                                                                                             | int<br/><small>Optional</small>      |
 | topologyManagerPolicy | For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. | string<br/><small>Optional</small>   |
 
-<a id="KubeletDiskType"></a>KubeletDiskType
--------------------------------------------
+KubeletDiskType{#KubeletDiskType}
+---------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -1031,8 +1031,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubeletDiskType_STATUS"></a>KubeletDiskType_STATUS
----------------------------------------------------------
+KubeletDiskType_STATUS{#KubeletDiskType_STATUS}
+-----------------------------------------------
 
 Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
 
@@ -1043,8 +1043,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OS"        |             |
 | "Temporary" |             |
 
-<a id="KubernetesSupportPlan"></a>KubernetesSupportPlan
--------------------------------------------------------
+KubernetesSupportPlan{#KubernetesSupportPlan}
+---------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -1055,8 +1055,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="KubernetesSupportPlan_STATUS"></a>KubernetesSupportPlan_STATUS
----------------------------------------------------------------------
+KubernetesSupportPlan_STATUS{#KubernetesSupportPlan_STATUS}
+-----------------------------------------------------------
 
 Different support tiers for AKS managed clusters
 
@@ -1067,8 +1067,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "AKSLongTermSupport" |             |
 | "KubernetesOfficial" |             |
 
-<a id="LinuxOSConfig"></a>LinuxOSConfig
----------------------------------------
+LinuxOSConfig{#LinuxOSConfig}
+-----------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -1081,8 +1081,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                        |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                        |
 
-<a id="LinuxOSConfig_STATUS"></a>LinuxOSConfig_STATUS
------------------------------------------------------
+LinuxOSConfig_STATUS{#LinuxOSConfig_STATUS}
+-------------------------------------------
 
 See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
 
@@ -1095,8 +1095,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | transparentHugePageDefrag  | Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). | string<br/><small>Optional</small>                                      |
 | transparentHugePageEnabled | Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).                           | string<br/><small>Optional</small>                                      |
 
-<a id="MaintenanceConfigurationOperatorSpec"></a>MaintenanceConfigurationOperatorSpec
--------------------------------------------------------------------------------------
+MaintenanceConfigurationOperatorSpec{#MaintenanceConfigurationOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1107,8 +1107,8 @@ Used by: [MaintenanceConfiguration_Spec](#MaintenanceConfiguration_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster.
 
@@ -1123,8 +1123,8 @@ Used by: [MaintenanceConfiguration_Spec](#MaintenanceConfiguration_Spec).
 | startTime       | The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.                                                                 | string<br/><small>Required</small>                  |
 | utcOffset       | The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'.                                                                                                                               | string<br/><small>Optional</small>                  |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster.
 
@@ -1139,8 +1139,8 @@ Used by: [MaintenanceConfiguration_STATUS](#MaintenanceConfiguration_STATUS).
 | startTime       | The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.                                                                 | string<br/><small>Optional</small>                                |
 | utcOffset       | The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'.                                                                                                                               | string<br/><small>Optional</small>                                |
 
-<a id="ManagedClusterAADProfile"></a>ManagedClusterAADProfile
--------------------------------------------------------------
+ManagedClusterAADProfile{#ManagedClusterAADProfile}
+---------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -1156,8 +1156,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAADProfile_STATUS"></a>ManagedClusterAADProfile_STATUS
----------------------------------------------------------------------------
+ManagedClusterAADProfile_STATUS{#ManagedClusterAADProfile_STATUS}
+-----------------------------------------------------------------
 
 For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
 
@@ -1173,8 +1173,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | serverAppSecret     | (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.                       | string<br/><small>Optional</small>   |
 | tenantID            | The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAddonProfile"></a>ManagedClusterAddonProfile
------------------------------------------------------------------
+ManagedClusterAddonProfile{#ManagedClusterAddonProfile}
+-------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -1185,8 +1185,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | config   | Key-value pairs for configuring an add-on. | map[string]string<br/><small>Optional</small> |
 | enabled  | Whether the add-on is enabled or not.      | bool<br/><small>Required</small>              |
 
-<a id="ManagedClusterAddonProfile_STATUS"></a>ManagedClusterAddonProfile_STATUS
--------------------------------------------------------------------------------
+ManagedClusterAddonProfile_STATUS{#ManagedClusterAddonProfile_STATUS}
+---------------------------------------------------------------------
 
 A Kubernetes add-on profile for a managed cluster.
 
@@ -1198,8 +1198,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled  | Whether the add-on is enabled or not.                      | bool<br/><small>Optional</small>                                                        |
 | identity | Information of user assigned identity used by this add-on. | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAgentPoolProfile"></a>ManagedClusterAgentPoolProfile
--------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile{#ManagedClusterAgentPoolProfile}
+---------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1251,8 +1251,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | windowsProfile                    | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile](#AgentPoolWindowsProfile)<br/><small>Optional</small>                                                                            |
 | workloadRuntime                   | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime](#WorkloadRuntime)<br/><small>Optional</small>                                                                                            |
 
-<a id="ManagedClusterAgentPoolProfile_STATUS"></a>ManagedClusterAgentPoolProfile_STATUS
----------------------------------------------------------------------------------------
+ManagedClusterAgentPoolProfile_STATUS{#ManagedClusterAgentPoolProfile_STATUS}
+-----------------------------------------------------------------------------
 
 Profile for the container service agent pool.
 
@@ -1308,8 +1308,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | windowsProfile             | The Windows agent pool's specific profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [AgentPoolWindowsProfile_STATUS](#AgentPoolWindowsProfile_STATUS)<br/><small>Optional</small>   |
 | workloadRuntime            | Determines the type of workload a node can run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [WorkloadRuntime_STATUS](#WorkloadRuntime_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ManagedClusterAPIServerAccessProfile"></a>ManagedClusterAPIServerAccessProfile
--------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile{#ManagedClusterAPIServerAccessProfile}
+---------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1323,8 +1323,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | enablePrivateClusterPublicFQDN | Whether to create additional public FQDN for private cluster or not.                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>     |
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAPIServerAccessProfile_STATUS"></a>ManagedClusterAPIServerAccessProfile_STATUS
----------------------------------------------------------------------------------------------------
+ManagedClusterAPIServerAccessProfile_STATUS{#ManagedClusterAPIServerAccessProfile_STATUS}
+-----------------------------------------------------------------------------------------
 
 Access profile for managed cluster API server.
 
@@ -1338,8 +1338,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enablePrivateClusterPublicFQDN | Whether to create additional public FQDN for private cluster or not.                                                                                                                                                                                                                                                          | bool<br/><small>Optional</small>     |
 | privateDNSZone                 | The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.                                                                                                                           | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterAutoUpgradeProfile"></a>ManagedClusterAutoUpgradeProfile
------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile{#ManagedClusterAutoUpgradeProfile}
+-------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1350,8 +1350,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | nodeOSUpgradeChannel | Manner in which the OS on your nodes is updated. The default is NodeImage.                                                                              | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel](#ManagedClusterAutoUpgradeProfile_UpgradeChannel)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAutoUpgradeProfile_STATUS"></a>ManagedClusterAutoUpgradeProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_STATUS{#ManagedClusterAutoUpgradeProfile_STATUS}
+---------------------------------------------------------------------------------
 
 Auto upgrade profile for a managed cluster.
 
@@ -1362,8 +1362,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | nodeOSUpgradeChannel | Manner in which the OS on your nodes is updated. The default is NodeImage.                                                                              | [ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS)<br/><small>Optional</small> |
 | upgradeChannel       | For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). | [ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS](#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS)<br/><small>Optional</small>             |
 
-<a id="ManagedClusterAzureMonitorProfile"></a>ManagedClusterAzureMonitorProfile
--------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile{#ManagedClusterAzureMonitorProfile}
+---------------------------------------------------------------------
 
 Azure Monitor addon profiles for monitoring the managed cluster.
 
@@ -1373,8 +1373,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | metrics  | Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. | [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorProfileMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfile_STATUS"></a>ManagedClusterAzureMonitorProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfile_STATUS{#ManagedClusterAzureMonitorProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Azure Monitor addon profiles for monitoring the managed cluster.
 
@@ -1384,8 +1384,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | metrics  | Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. | [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureMonitorProfileMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterHTTPProxyConfig"></a>ManagedClusterHTTPProxyConfig
------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig{#ManagedClusterHTTPProxyConfig}
+-------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1398,8 +1398,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | noProxy    | The endpoints that should not go through proxy.             | string[]<br/><small>Optional</small> |
 | trustedCa  | Alternative CA cert to use for connecting to proxy servers. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterHTTPProxyConfig_STATUS"></a>ManagedClusterHTTPProxyConfig_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterHTTPProxyConfig_STATUS{#ManagedClusterHTTPProxyConfig_STATUS}
+---------------------------------------------------------------------------
 
 Cluster HTTP proxy configuration.
 
@@ -1412,8 +1412,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | noProxy    | The endpoints that should not go through proxy.             | string[]<br/><small>Optional</small> |
 | trustedCa  | Alternative CA cert to use for connecting to proxy servers. | string<br/><small>Optional</small>   |
 
-<a id="ManagedClusterIdentity"></a>ManagedClusterIdentity
----------------------------------------------------------
+ManagedClusterIdentity{#ManagedClusterIdentity}
+-----------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1425,8 +1425,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type](#ManagedClusterIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_STATUS"></a>ManagedClusterIdentity_STATUS
------------------------------------------------------------------------
+ManagedClusterIdentity_STATUS{#ManagedClusterIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the managed cluster.
 
@@ -1440,8 +1440,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | type                   | For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).                                                                                                                                                                           | [ManagedClusterIdentity_Type_STATUS](#ManagedClusterIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The keys must be ARM resource IDs in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS](#ManagedClusterIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile"></a>ManagedClusterIngressProfile
----------------------------------------------------------------------
+ManagedClusterIngressProfile{#ManagedClusterIngressProfile}
+-----------------------------------------------------------
 
 Ingress profile for the container service cluster.
 
@@ -1451,8 +1451,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | webAppRouting | App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default. | [ManagedClusterIngressProfileWebAppRouting](#ManagedClusterIngressProfileWebAppRouting)<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfile_STATUS"></a>ManagedClusterIngressProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterIngressProfile_STATUS{#ManagedClusterIngressProfile_STATUS}
+-------------------------------------------------------------------------
 
 Ingress profile for the container service cluster.
 
@@ -1462,8 +1462,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | webAppRouting | App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default. | [ManagedClusterIngressProfileWebAppRouting_STATUS](#ManagedClusterIngressProfileWebAppRouting_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile"></a>ManagedClusterMetricsProfile
----------------------------------------------------------------------
+ManagedClusterMetricsProfile{#ManagedClusterMetricsProfile}
+-----------------------------------------------------------
 
 The metrics profile for the ManagedCluster.
 
@@ -1473,8 +1473,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |--------------|-------------------------------------------------|---------------------------------------------------------------------------------------|
 | costAnalysis | The cost analysis configuration for the cluster | [ManagedClusterCostAnalysis](#ManagedClusterCostAnalysis)<br/><small>Optional</small> |
 
-<a id="ManagedClusterMetricsProfile_STATUS"></a>ManagedClusterMetricsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterMetricsProfile_STATUS{#ManagedClusterMetricsProfile_STATUS}
+-------------------------------------------------------------------------
 
 The metrics profile for the ManagedCluster.
 
@@ -1484,8 +1484,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | costAnalysis | The cost analysis configuration for the cluster | [ManagedClusterCostAnalysis_STATUS](#ManagedClusterCostAnalysis_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile"></a>ManagedClusterNodeResourceGroupProfile
------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile{#ManagedClusterNodeResourceGroupProfile}
+-------------------------------------------------------------------------------
 
 Node resource group lockdown profile for a managed cluster.
 
@@ -1495,8 +1495,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel | The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted' | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile_STATUS"></a>ManagedClusterNodeResourceGroupProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_STATUS{#ManagedClusterNodeResourceGroupProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Node resource group lockdown profile for a managed cluster.
 
@@ -1506,8 +1506,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | restrictionLevel | The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted' | [ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS](#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile"></a>ManagedClusterOIDCIssuerProfile
----------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile{#ManagedClusterOIDCIssuerProfile}
+-----------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1517,8 +1517,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 |----------|-------------------------------------|----------------------------------|
 | enabled  | Whether the OIDC issuer is enabled. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterOIDCIssuerProfile_STATUS"></a>ManagedClusterOIDCIssuerProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterOIDCIssuerProfile_STATUS{#ManagedClusterOIDCIssuerProfile_STATUS}
+-------------------------------------------------------------------------------
 
 The OIDC issuer profile of the Managed Cluster.
 
@@ -1529,8 +1529,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | enabled   | Whether the OIDC issuer is enabled.         | bool<br/><small>Optional</small>   |
 | issuerURL | The OIDC issuer url of the Managed Cluster. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSpec"></a>ManagedClusterOperatorSpec
------------------------------------------------------------------
+ManagedClusterOperatorSpec{#ManagedClusterOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1543,8 +1543,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ManagedClusterOperatorSecrets](#ManagedClusterOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="ManagedClusterPodIdentityProfile"></a>ManagedClusterPodIdentityProfile
------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile{#ManagedClusterPodIdentityProfile}
+-------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1557,8 +1557,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity[]](#ManagedClusterPodIdentity)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException[]](#ManagedClusterPodIdentityException)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProfile_STATUS"></a>ManagedClusterPodIdentityProfile_STATUS
--------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProfile_STATUS{#ManagedClusterPodIdentityProfile_STATUS}
+---------------------------------------------------------------------------------
 
 See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
 
@@ -1571,8 +1571,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | userAssignedIdentities         | The pod identities to use in the cluster.                                                                                                                                                                                                                                                                                                                     | [ManagedClusterPodIdentity_STATUS[]](#ManagedClusterPodIdentity_STATUS)<br/><small>Optional</small>                   |
 | userAssignedIdentityExceptions | The pod identity exceptions to allow.                                                                                                                                                                                                                                                                                                                         | [ManagedClusterPodIdentityException_STATUS[]](#ManagedClusterPodIdentityException_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile"></a>ManagedClusterProperties_AutoScalerProfile
--------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile{#ManagedClusterProperties_AutoScalerProfile}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1599,8 +1599,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | skip-nodes-with-local-storage         | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                      |
 | skip-nodes-with-system-pods           | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_STATUS{#ManagedClusterProperties_AutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1627,8 +1627,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | skip-nodes-with-local-storage         | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                    |
 | skip-nodes-with-system-pods           | The default is true.                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess"></a>ManagedClusterProperties_PublicNetworkAccess
------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess{#ManagedClusterProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 
@@ -1637,8 +1637,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClusterProperties_PublicNetworkAccess_STATUS"></a>ManagedClusterProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_PublicNetworkAccess_STATUS{#ManagedClusterProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 
@@ -1647,8 +1647,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedClustersAgentPoolOperatorSpec"></a>ManagedClustersAgentPoolOperatorSpec
--------------------------------------------------------------------------------------
+ManagedClustersAgentPoolOperatorSpec{#ManagedClustersAgentPoolOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1659,8 +1659,8 @@ Used by: [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile"></a>ManagedClusterSecurityProfile
------------------------------------------------------------------------
+ManagedClusterSecurityProfile{#ManagedClusterSecurityProfile}
+-------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1673,8 +1673,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | imageCleaner     | Image Cleaner settings for the security profile.                                                                                                                                                           | [ManagedClusterSecurityProfileImageCleaner](#ManagedClusterSecurityProfileImageCleaner)<br/><small>Optional</small>         |
 | workloadIdentity | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. | [ManagedClusterSecurityProfileWorkloadIdentity](#ManagedClusterSecurityProfileWorkloadIdentity)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfile_STATUS"></a>ManagedClusterSecurityProfile_STATUS
--------------------------------------------------------------------------------------
+ManagedClusterSecurityProfile_STATUS{#ManagedClusterSecurityProfile_STATUS}
+---------------------------------------------------------------------------
 
 Security profile for the container service cluster.
 
@@ -1687,8 +1687,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | imageCleaner     | Image Cleaner settings for the security profile.                                                                                                                                                           | [ManagedClusterSecurityProfileImageCleaner_STATUS](#ManagedClusterSecurityProfileImageCleaner_STATUS)<br/><small>Optional</small>         |
 | workloadIdentity | Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. | [ManagedClusterSecurityProfileWorkloadIdentity_STATUS](#ManagedClusterSecurityProfileWorkloadIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile"></a>ManagedClusterServicePrincipalProfile
----------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile{#ManagedClusterServicePrincipalProfile}
+-----------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1699,8 +1699,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | clientId | The ID for the service principal.                                        | string<br/><small>Required</small>                                                                                                                     |
 | secret   | The secret password associated with the service principal in plain text. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterServicePrincipalProfile_STATUS"></a>ManagedClusterServicePrincipalProfile_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterServicePrincipalProfile_STATUS{#ManagedClusterServicePrincipalProfile_STATUS}
+-------------------------------------------------------------------------------------------
 
 Information about a service principal identity for the cluster to use for manipulating Azure APIs.
 
@@ -1710,8 +1710,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 |----------|-----------------------------------|------------------------------------|
 | clientId | The ID for the service principal. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU"></a>ManagedClusterSKU
------------------------------------------------
+ManagedClusterSKU{#ManagedClusterSKU}
+-------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1722,8 +1722,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name](#ManagedClusterSKU_Name)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier](#ManagedClusterSKU_Tier)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSKU_STATUS"></a>ManagedClusterSKU_STATUS
--------------------------------------------------------------
+ManagedClusterSKU_STATUS{#ManagedClusterSKU_STATUS}
+---------------------------------------------------
 
 The SKU of a Managed Cluster.
 
@@ -1734,8 +1734,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | name     | The name of a managed cluster SKU.                                                                                                                   | [ManagedClusterSKU_Name_STATUS](#ManagedClusterSKU_Name_STATUS)<br/><small>Optional</small> |
 | tier     | If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. | [ManagedClusterSKU_Tier_STATUS](#ManagedClusterSKU_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile"></a>ManagedClusterStorageProfile
----------------------------------------------------------------------
+ManagedClusterStorageProfile{#ManagedClusterStorageProfile}
+-----------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1748,8 +1748,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver](#ManagedClusterStorageProfileFileCSIDriver)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController](#ManagedClusterStorageProfileSnapshotController)<br/><small>Optional</small> |
 
-<a id="ManagedClusterStorageProfile_STATUS"></a>ManagedClusterStorageProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterStorageProfile_STATUS{#ManagedClusterStorageProfile_STATUS}
+-------------------------------------------------------------------------
 
 Storage profile for the container service cluster.
 
@@ -1762,8 +1762,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | fileCSIDriver      | AzureFile CSI Driver settings for the storage profile. | [ManagedClusterStorageProfileFileCSIDriver_STATUS](#ManagedClusterStorageProfileFileCSIDriver_STATUS)<br/><small>Optional</small>           |
 | snapshotController | Snapshot Controller settings for the storage profile.  | [ManagedClusterStorageProfileSnapshotController_STATUS](#ManagedClusterStorageProfileSnapshotController_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWindowsProfile"></a>ManagedClusterWindowsProfile
----------------------------------------------------------------------
+ManagedClusterWindowsProfile{#ManagedClusterWindowsProfile}
+-----------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1777,8 +1777,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile](#WindowsGmsaProfile)<br/><small>Optional</small>                                                                                  |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType](#ManagedClusterWindowsProfile_LicenseType)<br/><small>Optional</small>                                      |
 
-<a id="ManagedClusterWindowsProfile_STATUS"></a>ManagedClusterWindowsProfile_STATUS
------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_STATUS{#ManagedClusterWindowsProfile_STATUS}
+-------------------------------------------------------------------------
 
 Profile for Windows VMs in the managed cluster.
 
@@ -1791,8 +1791,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | gmsaProfile    | The Windows gMSA Profile in the Managed Cluster.                                                                                                                                                                                                                                                                                                                                                                                                                   | [WindowsGmsaProfile_STATUS](#WindowsGmsaProfile_STATUS)<br/><small>Optional</small>                                             |
 | licenseType    | The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.                                                                                                                                                                                                                                                                                                               | [ManagedClusterWindowsProfile_LicenseType_STATUS](#ManagedClusterWindowsProfile_LicenseType_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile"></a>ManagedClusterWorkloadAutoScalerProfile
--------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile{#ManagedClusterWorkloadAutoScalerProfile}
+---------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1803,8 +1803,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda](#ManagedClusterWorkloadAutoScalerProfileKeda)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler | VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.              | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler)<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfile_STATUS"></a>ManagedClusterWorkloadAutoScalerProfile_STATUS
----------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfile_STATUS{#ManagedClusterWorkloadAutoScalerProfile_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Workload Auto-scaler profile for the managed cluster.
 
@@ -1815,48 +1815,48 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | keda                  | KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. | [ManagedClusterWorkloadAutoScalerProfileKeda_STATUS](#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS)<br/><small>Optional</small>                                   |
 | verticalPodAutoscaler | VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.              | [ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS](#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS)<br/><small>Optional</small> |
 
-<a id="OSDiskType"></a>OSDiskType
----------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSDiskType_STATUS"></a>OSDiskType_STATUS
------------------------------------------------
-
-The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "Ephemeral" |             |
-| "Managed"   |             |
-
-<a id="OSSKU"></a>OSSKU
+OSDiskType{#OSDiskType}
 -----------------------
 
-Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
 
 Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
 
-| Value         | Description |
-|---------------|-------------|
-| "AzureLinux"  |             |
-| "CBLMariner"  |             |
-| "Ubuntu"      |             |
-| "Windows2019" |             |
-| "Windows2022" |             |
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
 
-<a id="OSSKU_STATUS"></a>OSSKU_STATUS
+OSDiskType_STATUS{#OSDiskType_STATUS}
 -------------------------------------
 
+The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Ephemeral" |             |
+| "Managed"   |             |
+
+OSSKU{#OSSKU}
+-------------
+
+Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
+
+Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and [ManagedClustersAgentPool_Spec](#ManagedClustersAgentPool_Spec).
+
+| Value         | Description |
+|---------------|-------------|
+| "AzureLinux"  |             |
+| "CBLMariner"  |             |
+| "Ubuntu"      |             |
+| "Windows2019" |             |
+| "Windows2022" |             |
+
+OSSKU_STATUS{#OSSKU_STATUS}
+---------------------------
+
 Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.
 
 Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
@@ -1869,8 +1869,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Windows2019" |             |
 | "Windows2022" |             |
 
-<a id="OSType"></a>OSType
--------------------------
+OSType{#OSType}
+---------------
 
 The operating system type. The default is Linux.
 
@@ -1881,8 +1881,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="OSType_STATUS"></a>OSType_STATUS
----------------------------------------
+OSType_STATUS{#OSType_STATUS}
+-----------------------------
 
 The operating system type. The default is Linux.
 
@@ -1893,8 +1893,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="PowerState"></a>PowerState
----------------------------------
+PowerState{#PowerState}
+-----------------------
 
 Describes the Power State of the cluster
 
@@ -1904,8 +1904,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 |----------|-------------------------------------------------|-----------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code](#PowerState_Code)<br/><small>Optional</small> |
 
-<a id="PowerState_STATUS"></a>PowerState_STATUS
------------------------------------------------
+PowerState_STATUS{#PowerState_STATUS}
+-------------------------------------
 
 Describes the Power State of the cluster
 
@@ -1915,8 +1915,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAgentPo
 |----------|-------------------------------------------------|-------------------------------------------------------------------------------|
 | code     | Tells whether the cluster is Running or Stopped | [PowerState_Code_STATUS](#PowerState_Code_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateLinkResource"></a>PrivateLinkResource
----------------------------------------------------
+PrivateLinkResource{#PrivateLinkResource}
+-----------------------------------------
 
 A private link resource
 
@@ -1930,8 +1930,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | requiredMembers | The RequiredMembers of the resource    | string[]<br/><small>Optional</small>                                                                                                                       |
 | type            | The resource type.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkResource_STATUS"></a>PrivateLinkResource_STATUS
------------------------------------------------------------------
+PrivateLinkResource_STATUS{#PrivateLinkResource_STATUS}
+-------------------------------------------------------
 
 A private link resource
 
@@ -1946,8 +1946,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | requiredMembers      | The RequiredMembers of the resource                                                        | string[]<br/><small>Optional</small> |
 | type                 | The resource type.                                                                         | string<br/><small>Optional</small>   |
 
-<a id="ScaleDownMode"></a>ScaleDownMode
----------------------------------------
+ScaleDownMode{#ScaleDownMode}
+-----------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -1958,8 +1958,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleDownMode_STATUS"></a>ScaleDownMode_STATUS
------------------------------------------------------
+ScaleDownMode_STATUS{#ScaleDownMode_STATUS}
+-------------------------------------------
 
 Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
 
@@ -1970,8 +1970,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy"></a>ScaleSetEvictionPolicy
----------------------------------------------------------
+ScaleSetEvictionPolicy{#ScaleSetEvictionPolicy}
+-----------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -1982,8 +1982,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetEvictionPolicy_STATUS"></a>ScaleSetEvictionPolicy_STATUS
------------------------------------------------------------------------
+ScaleSetEvictionPolicy_STATUS{#ScaleSetEvictionPolicy_STATUS}
+-------------------------------------------------------------
 
 The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
 
@@ -1994,8 +1994,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "Deallocate" |             |
 | "Delete"     |             |
 
-<a id="ScaleSetPriority"></a>ScaleSetPriority
----------------------------------------------
+ScaleSetPriority{#ScaleSetPriority}
+-----------------------------------
 
 The Virtual Machine Scale Set priority.
 
@@ -2006,20 +2006,20 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "Regular" |             |
 | "Spot"    |             |
 
-<a id="ScaleSetPriority_STATUS"></a>ScaleSetPriority_STATUS
------------------------------------------------------------
-
-The Virtual Machine Scale Set priority.
-
-Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Regular" |             |
-| "Spot"    |             |
-
-<a id="ServiceMeshProfile"></a>ServiceMeshProfile
+ScaleSetPriority_STATUS{#ScaleSetPriority_STATUS}
 -------------------------------------------------
+
+The Virtual Machine Scale Set priority.
+
+Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile_STATUS), and [ManagedClustersAgentPool_STATUS](#ManagedClustersAgentPool_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Regular" |             |
+| "Spot"    |             |
+
+ServiceMeshProfile{#ServiceMeshProfile}
+---------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -2030,8 +2030,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh](#IstioServiceMesh)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode](#ServiceMeshProfile_Mode)<br/><small>Required</small> |
 
-<a id="ServiceMeshProfile_STATUS"></a>ServiceMeshProfile_STATUS
----------------------------------------------------------------
+ServiceMeshProfile_STATUS{#ServiceMeshProfile_STATUS}
+-----------------------------------------------------
 
 Service mesh profile for a managed cluster.
 
@@ -2042,8 +2042,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS).
 | istio    | Istio service mesh configuration. | [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS)<br/><small>Optional</small>               |
 | mode     | Mode of the service mesh.         | [ServiceMeshProfile_Mode_STATUS](#ServiceMeshProfile_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2058,8 +2058,8 @@ Used by: [MaintenanceConfiguration_STATUS](#MaintenanceConfiguration_STATUS), [M
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TimeInWeek"></a>TimeInWeek
----------------------------------
+TimeInWeek{#TimeInWeek}
+-----------------------
 
 Time in a week.
 
@@ -2070,8 +2070,8 @@ Used by: [MaintenanceConfiguration_Spec](#MaintenanceConfiguration_Spec).
 | day       | The day of the week.                                                                                                                                                                                                                 | [WeekDay](#WeekDay)<br/><small>Optional</small>       |
 | hourSlots | Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range. | [HourInDay[]](#HourInDay)<br/><small>Optional</small> |
 
-<a id="TimeInWeek_STATUS"></a>TimeInWeek_STATUS
------------------------------------------------
+TimeInWeek_STATUS{#TimeInWeek_STATUS}
+-------------------------------------
 
 Time in a week.
 
@@ -2082,8 +2082,8 @@ Used by: [MaintenanceConfiguration_STATUS](#MaintenanceConfiguration_STATUS).
 | day       | The day of the week.                                                                                                                                                                                                                 | [WeekDay_STATUS](#WeekDay_STATUS)<br/><small>Optional</small> |
 | hourSlots | Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range. | int[]<br/><small>Optional</small>                             |
 
-<a id="TimeSpan"></a>TimeSpan
------------------------------
+TimeSpan{#TimeSpan}
+-------------------
 
 For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z.
 
@@ -2094,8 +2094,8 @@ Used by: [MaintenanceConfiguration_Spec](#MaintenanceConfiguration_Spec).
 | end      | The end of a time span   | string<br/><small>Optional</small> |
 | start    | The start of a time span | string<br/><small>Optional</small> |
 
-<a id="TimeSpan_STATUS"></a>TimeSpan_STATUS
--------------------------------------------
+TimeSpan_STATUS{#TimeSpan_STATUS}
+---------------------------------
 
 For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z.
 
@@ -2106,8 +2106,8 @@ Used by: [MaintenanceConfiguration_STATUS](#MaintenanceConfiguration_STATUS).
 | end      | The end of a time span   | string<br/><small>Optional</small> |
 | start    | The start of a time span | string<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingOperatorSpec"></a>TrustedAccessRoleBindingOperatorSpec
--------------------------------------------------------------------------------------
+TrustedAccessRoleBindingOperatorSpec{#TrustedAccessRoleBindingOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2118,8 +2118,8 @@ Used by: [TrustedAccessRoleBinding_Spec](#TrustedAccessRoleBinding_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrustedAccessRoleBindingProperties_ProvisioningState_STATUS"></a>TrustedAccessRoleBindingProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+TrustedAccessRoleBindingProperties_ProvisioningState_STATUS{#TrustedAccessRoleBindingProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 
@@ -2131,8 +2131,8 @@ Used by: [TrustedAccessRoleBinding_STATUS](#TrustedAccessRoleBinding_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Details about a user assigned identity.
 
@@ -2144,8 +2144,8 @@ Used by: [ManagedCluster_Spec](#ManagedCluster_Spec), and [ManagedClusterPodIden
 | objectId          | The object ID of the user assigned identity.   | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference | The resource ID of the user assigned identity. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Details about a user assigned identity.
 
@@ -2157,8 +2157,8 @@ Used by: [ManagedCluster_STATUS](#ManagedCluster_STATUS), [ManagedClusterAddonPr
 | objectId   | The object ID of the user assigned identity.   | string<br/><small>Optional</small> |
 | resourceId | The resource ID of the user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="WorkloadRuntime"></a>WorkloadRuntime
--------------------------------------------
+WorkloadRuntime{#WorkloadRuntime}
+---------------------------------
 
 Determines the type of workload a node can run.
 
@@ -2169,8 +2169,8 @@ Used by: [ManagedClusterAgentPoolProfile](#ManagedClusterAgentPoolProfile), and 
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="WorkloadRuntime_STATUS"></a>WorkloadRuntime_STATUS
----------------------------------------------------------
+WorkloadRuntime_STATUS{#WorkloadRuntime_STATUS}
+-----------------------------------------------
 
 Determines the type of workload a node can run.
 
@@ -2181,8 +2181,8 @@ Used by: [ManagedClusterAgentPoolProfile_STATUS](#ManagedClusterAgentPoolProfile
 | "OCIContainer" |             |
 | "WasmWasi"     |             |
 
-<a id="AdvancedNetworking"></a>AdvancedNetworking
--------------------------------------------------
+AdvancedNetworking{#AdvancedNetworking}
+---------------------------------------
 
 Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.
 
@@ -2194,8 +2194,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | observability | Observability profile to enable advanced network metrics and flow logs with historical contexts.                                                                                                                                                                            | [AdvancedNetworkingObservability](#AdvancedNetworkingObservability)<br/><small>Optional</small> |
 | security      | Security profile to enable security features on cilium based cluster.                                                                                                                                                                                                       | [AdvancedNetworkingSecurity](#AdvancedNetworkingSecurity)<br/><small>Optional</small>           |
 
-<a id="AdvancedNetworking_STATUS"></a>AdvancedNetworking_STATUS
----------------------------------------------------------------
+AdvancedNetworking_STATUS{#AdvancedNetworking_STATUS}
+-----------------------------------------------------
 
 Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.
 
@@ -2207,8 +2207,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | observability | Observability profile to enable advanced network metrics and flow logs with historical contexts.                                                                                                                                                                            | [AdvancedNetworkingObservability_STATUS](#AdvancedNetworkingObservability_STATUS)<br/><small>Optional</small> |
 | security      | Security profile to enable security features on cilium based cluster.                                                                                                                                                                                                       | [AdvancedNetworkingSecurity_STATUS](#AdvancedNetworkingSecurity_STATUS)<br/><small>Optional</small>           |
 
-<a id="AzureKeyVaultKms"></a>AzureKeyVaultKms
----------------------------------------------
+AzureKeyVaultKms{#AzureKeyVaultKms}
+-----------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -2221,8 +2221,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | keyVaultNetworkAccess     | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess](#AzureKeyVaultKms_KeyVaultNetworkAccess)<br/><small>Optional</small>                                              |
 | keyVaultResourceReference | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_STATUS"></a>AzureKeyVaultKms_STATUS
------------------------------------------------------------
+AzureKeyVaultKms_STATUS{#AzureKeyVaultKms_STATUS}
+-------------------------------------------------
 
 Azure Key Vault key management service settings for the security profile.
 
@@ -2235,88 +2235,88 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | keyVaultNetworkAccess | Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.                                                                                                                                          | [AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS](#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS)<br/><small>Optional</small> |
 | keyVaultResourceId    | Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies"></a>ContainerServiceNetworkProfile_IpFamilies
+ContainerServiceNetworkProfile_IpFamilies{#ContainerServiceNetworkProfile_IpFamilies}
+-------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_IpFamilies_STATUS{#ContainerServiceNetworkProfile_IpFamilies_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "IPv4" |             |
+| "IPv6" |             |
+
+ContainerServiceNetworkProfile_LoadBalancerSku{#ContainerServiceNetworkProfile_LoadBalancerSku}
 -----------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
+| Value      | Description |
+|------------|-------------|
+| "basic"    |             |
+| "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_IpFamilies_STATUS"></a>ContainerServiceNetworkProfile_IpFamilies_STATUS
+ContainerServiceNetworkProfile_LoadBalancerSku_STATUS{#ContainerServiceNetworkProfile_LoadBalancerSku_STATUS}
 -------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
-| Value  | Description |
-|--------|-------------|
-| "IPv4" |             |
-| "IPv6" |             |
-
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku"></a>ContainerServiceNetworkProfile_LoadBalancerSku
----------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
 | Value      | Description |
 |------------|-------------|
 | "basic"    |             |
 | "standard" |             |
 
-<a id="ContainerServiceNetworkProfile_LoadBalancerSku_STATUS"></a>ContainerServiceNetworkProfile_LoadBalancerSku_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "basic"    |             |
-| "standard" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane"></a>ContainerServiceNetworkProfile_NetworkDataplane
------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkDataplane_STATUS"></a>ContainerServiceNetworkProfile_NetworkDataplane_STATUS
--------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "cilium" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkMode"></a>ContainerServiceNetworkProfile_NetworkMode
+ContainerServiceNetworkProfile_NetworkDataplane{#ContainerServiceNetworkProfile_NetworkDataplane}
 -------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
-| Value         | Description |
-|---------------|-------------|
-| "bridge"      |             |
-| "transparent" |             |
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkMode_STATUS
+ContainerServiceNetworkProfile_NetworkDataplane_STATUS{#ContainerServiceNetworkProfile_NetworkDataplane_STATUS}
 ---------------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "cilium" |             |
+
+ContainerServiceNetworkProfile_NetworkMode{#ContainerServiceNetworkProfile_NetworkMode}
+---------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value         | Description |
 |---------------|-------------|
 | "bridge"      |             |
 | "transparent" |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPlugin"></a>ContainerServiceNetworkProfile_NetworkPlugin
+ContainerServiceNetworkProfile_NetworkMode_STATUS{#ContainerServiceNetworkProfile_NetworkMode_STATUS}
 -----------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "bridge"      |             |
+| "transparent" |             |
+
+ContainerServiceNetworkProfile_NetworkPlugin{#ContainerServiceNetworkProfile_NetworkPlugin}
+-------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
@@ -2326,8 +2326,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPlugin_STATUS"></a>ContainerServiceNetworkProfile_NetworkPlugin_STATUS
--------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_NetworkPlugin_STATUS{#ContainerServiceNetworkProfile_NetworkPlugin_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2337,53 +2337,53 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "kubenet" |             |
 | "none"    |             |
 
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode"></a>ContainerServiceNetworkProfile_NetworkPluginMode
--------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPluginMode_STATUS"></a>ContainerServiceNetworkProfile_NetworkPluginMode_STATUS
----------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "overlay" |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy"></a>ContainerServiceNetworkProfile_NetworkPolicy
------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-| "none"   |             |
-
-<a id="ContainerServiceNetworkProfile_NetworkPolicy_STATUS"></a>ContainerServiceNetworkProfile_NetworkPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------
-
-Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "azure"  |             |
-| "calico" |             |
-| "cilium" |             |
-| "none"   |             |
-
-<a id="ContainerServiceNetworkProfile_OutboundType"></a>ContainerServiceNetworkProfile_OutboundType
+ContainerServiceNetworkProfile_NetworkPluginMode{#ContainerServiceNetworkProfile_NetworkPluginMode}
 ---------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPluginMode_STATUS{#ContainerServiceNetworkProfile_NetworkPluginMode_STATUS}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "overlay" |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy{#ContainerServiceNetworkProfile_NetworkPolicy}
+-------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+| "none"   |             |
+
+ContainerServiceNetworkProfile_NetworkPolicy_STATUS{#ContainerServiceNetworkProfile_NetworkPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "azure"  |             |
+| "calico" |             |
+| "cilium" |             |
+| "none"   |             |
+
+ContainerServiceNetworkProfile_OutboundType{#ContainerServiceNetworkProfile_OutboundType}
+-----------------------------------------------------------------------------------------
+
+Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
+
 | Value                    | Description |
 |--------------------------|-------------|
 | "loadBalancer"           |             |
@@ -2391,8 +2391,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceNetworkProfile_OutboundType_STATUS"></a>ContainerServiceNetworkProfile_OutboundType_STATUS
------------------------------------------------------------------------------------------------------------------
+ContainerServiceNetworkProfile_OutboundType_STATUS{#ContainerServiceNetworkProfile_OutboundType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile_STATUS).
 
@@ -2403,8 +2403,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | "userAssignedNATGateway" |             |
 | "userDefinedRouting"     |             |
 
-<a id="ContainerServiceSshConfiguration"></a>ContainerServiceSshConfiguration
------------------------------------------------------------------------------
+ContainerServiceSshConfiguration{#ContainerServiceSshConfiguration}
+-------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2414,8 +2414,8 @@ Used by: [ContainerServiceLinuxProfile](#ContainerServiceLinuxProfile).
 |------------|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey[]](#ContainerServiceSshPublicKey)<br/><small>Required</small> |
 
-<a id="ContainerServiceSshConfiguration_STATUS"></a>ContainerServiceSshConfiguration_STATUS
--------------------------------------------------------------------------------------------
+ContainerServiceSshConfiguration_STATUS{#ContainerServiceSshConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 SSH configuration for Linux-based VMs running on Azure.
 
@@ -2425,8 +2425,8 @@ Used by: [ContainerServiceLinuxProfile_STATUS](#ContainerServiceLinuxProfile_STA
 |------------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | publicKeys | The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. | [ContainerServiceSshPublicKey_STATUS[]](#ContainerServiceSshPublicKey_STATUS)<br/><small>Optional</small> |
 
-<a id="DateSpan"></a>DateSpan
------------------------------
+DateSpan{#DateSpan}
+-------------------
 
 For example, between '2022-12-23' and '2023-01-05'.
 
@@ -2437,8 +2437,8 @@ Used by: [MaintenanceWindow](#MaintenanceWindow).
 | end      | The end date of the date span.   | string<br/><small>Required</small> |
 | start    | The start date of the date span. | string<br/><small>Required</small> |
 
-<a id="DateSpan_STATUS"></a>DateSpan_STATUS
--------------------------------------------
+DateSpan_STATUS{#DateSpan_STATUS}
+---------------------------------
 
 For example, between '2022-12-23' and '2023-01-05'.
 
@@ -2449,8 +2449,8 @@ Used by: [MaintenanceWindow_STATUS](#MaintenanceWindow_STATUS).
 | end      | The end date of the date span.   | string<br/><small>Optional</small> |
 | start    | The start date of the date span. | string<br/><small>Optional</small> |
 
-<a id="DelegatedResource"></a>DelegatedResource
------------------------------------------------
+DelegatedResource{#DelegatedResource}
+-------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2463,8 +2463,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | resourceReference | The ARM resource id of the delegated resource - internal use only.           | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="DelegatedResource_STATUS"></a>DelegatedResource_STATUS
--------------------------------------------------------------
+DelegatedResource_STATUS{#DelegatedResource_STATUS}
+---------------------------------------------------
 
 Delegated resource properties - internal use only.
 
@@ -2477,8 +2477,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | resourceId       | The ARM resource id of the delegated resource - internal use only.           | string<br/><small>Optional</small> |
 | tenantId         | The tenant id of the delegated resource - internal use only.                 | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -2488,8 +2488,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -2499,13 +2499,13 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="HourInDay"></a>HourInDay
--------------------------------
+HourInDay{#HourInDay}
+---------------------
 
 Used by: [TimeInWeek](#TimeInWeek).
 
-<a id="IPTag"></a>IPTag
------------------------
+IPTag{#IPTag}
+-------------
 
 Contains the IPTag associated with the object.
 
@@ -2516,8 +2516,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IPTag_STATUS"></a>IPTag_STATUS
--------------------------------------
+IPTag_STATUS{#IPTag_STATUS}
+---------------------------
 
 Contains the IPTag associated with the object.
 
@@ -2528,8 +2528,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | ipTagType | The IP tag type. Example: RoutingPreference.                              | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: Internet. | string<br/><small>Optional</small> |
 
-<a id="IstioServiceMesh"></a>IstioServiceMesh
----------------------------------------------
+IstioServiceMesh{#IstioServiceMesh}
+-----------------------------------
 
 Istio service mesh configuration.
 
@@ -2541,8 +2541,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents](#IstioComponents)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                |
 
-<a id="IstioServiceMesh_STATUS"></a>IstioServiceMesh_STATUS
------------------------------------------------------------
+IstioServiceMesh_STATUS{#IstioServiceMesh_STATUS}
+-------------------------------------------------
 
 Istio service mesh configuration.
 
@@ -2554,8 +2554,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | components           | Istio components configuration.                                                                                                                                                                                                                                                 | [IstioComponents_STATUS](#IstioComponents_STATUS)<br/><small>Optional</small>                     |
 | revisions            | The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade | string[]<br/><small>Optional</small>                                                              |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2566,8 +2566,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_NodeOSUpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2578,8 +2578,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "SecurityPatch" |             |
 | "Unmanaged"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel
------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel{#ManagedClusterAutoUpgradeProfile_UpgradeChannel}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 
@@ -2591,8 +2591,8 @@ Used by: [ManagedClusterAutoUpgradeProfile](#ManagedClusterAutoUpgradeProfile).
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS"></a>ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS{#ManagedClusterAutoUpgradeProfile_UpgradeChannel_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradeProfile_STATUS).
 
@@ -2604,8 +2604,8 @@ Used by: [ManagedClusterAutoUpgradeProfile_STATUS](#ManagedClusterAutoUpgradePro
 | "rapid"      |             |
 | "stable"     |             |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics"></a>ManagedClusterAzureMonitorProfileMetrics
----------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics{#ManagedClusterAzureMonitorProfileMetrics}
+-----------------------------------------------------------------------------------
 
 Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
 
@@ -2616,8 +2616,8 @@ Used by: [ManagedClusterAzureMonitorProfile](#ManagedClusterAzureMonitorProfile)
 | enabled          | Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.                                                    | bool<br/><small>Required</small>                                                                                                    |
 | kubeStateMetrics | Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. | [ManagedClusterAzureMonitorProfileKubeStateMetrics](#ManagedClusterAzureMonitorProfileKubeStateMetrics)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileMetrics_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileMetrics_STATUS{#ManagedClusterAzureMonitorProfileMetrics_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
 
@@ -2628,8 +2628,8 @@ Used by: [ManagedClusterAzureMonitorProfile_STATUS](#ManagedClusterAzureMonitorP
 | enabled          | Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.                                                    | bool<br/><small>Optional</small>                                                                                                                  |
 | kubeStateMetrics | Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. | [ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS](#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterCostAnalysis"></a>ManagedClusterCostAnalysis
------------------------------------------------------------------
+ManagedClusterCostAnalysis{#ManagedClusterCostAnalysis}
+-------------------------------------------------------
 
 The cost analysis configuration for the cluster
 
@@ -2639,8 +2639,8 @@ Used by: [ManagedClusterMetricsProfile](#ManagedClusterMetricsProfile).
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterCostAnalysis_STATUS"></a>ManagedClusterCostAnalysis_STATUS
--------------------------------------------------------------------------------
+ManagedClusterCostAnalysis_STATUS{#ManagedClusterCostAnalysis_STATUS}
+---------------------------------------------------------------------
 
 The cost analysis configuration for the cluster
 
@@ -2650,8 +2650,8 @@ Used by: [ManagedClusterMetricsProfile_STATUS](#ManagedClusterMetricsProfile_STA
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterIdentity_Type"></a>ManagedClusterIdentity_Type
--------------------------------------------------------------------
+ManagedClusterIdentity_Type{#ManagedClusterIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 
@@ -2661,8 +2661,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_Type_STATUS"></a>ManagedClusterIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedClusterIdentity_Type_STATUS{#ManagedClusterIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2672,8 +2672,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedClusterIdentity_UserAssignedIdentities_STATUS"></a>ManagedClusterIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterIdentity_UserAssignedIdentities_STATUS{#ManagedClusterIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 
@@ -2682,8 +2682,8 @@ Used by: [ManagedClusterIdentity_STATUS](#ManagedClusterIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterIngressProfileWebAppRouting"></a>ManagedClusterIngressProfileWebAppRouting
------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting{#ManagedClusterIngressProfileWebAppRouting}
+-------------------------------------------------------------------------------------
 
 Application Routing add-on settings for the ingress profile.
 
@@ -2694,8 +2694,8 @@ Used by: [ManagedClusterIngressProfile](#ManagedClusterIngressProfile).
 | dnsZoneResourceReferences | Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | enabled                   | Whether to enable the Application Routing add-on.                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                             |
 
-<a id="ManagedClusterIngressProfileWebAppRouting_STATUS"></a>ManagedClusterIngressProfileWebAppRouting_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterIngressProfileWebAppRouting_STATUS{#ManagedClusterIngressProfileWebAppRouting_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Application Routing add-on settings for the ingress profile.
 
@@ -2707,8 +2707,8 @@ Used by: [ManagedClusterIngressProfile_STATUS](#ManagedClusterIngressProfile_STA
 | enabled            | Whether to enable the Application Routing add-on.                                                                                                                                                                                                                                                                                                    | bool<br/><small>Optional</small>                                                        |
 | identity           | Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions. | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile"></a>ManagedClusterLoadBalancerProfile
--------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile{#ManagedClusterLoadBalancerProfile}
+---------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2725,8 +2725,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | outboundIPPrefixes                  | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes)<br/><small>Optional</small> |
 | outboundIPs                         | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs](#ManagedClusterLoadBalancerProfile_OutboundIPs)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterLoadBalancerProfile_STATUS"></a>ManagedClusterLoadBalancerProfile_STATUS
----------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_STATUS{#ManagedClusterLoadBalancerProfile_STATUS}
+-----------------------------------------------------------------------------------
 
 Profile of the managed cluster load balancer.
 
@@ -2743,8 +2743,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | outboundIPPrefixes                  | Desired outbound IP Prefix resources for the cluster load balancer.                                                                                                                       | [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS)<br/><small>Optional</small> |
 | outboundIPs                         | Desired outbound IP resources for the cluster load balancer.                                                                                                                              | [ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS](#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedClusterNATGatewayProfile"></a>ManagedClusterNATGatewayProfile
----------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile{#ManagedClusterNATGatewayProfile}
+-----------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2756,8 +2756,8 @@ Used by: [ContainerServiceNetworkProfile](#ContainerServiceNetworkProfile).
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                               |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile](#ManagedClusterManagedOutboundIPProfile)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNATGatewayProfile_STATUS"></a>ManagedClusterNATGatewayProfile_STATUS
------------------------------------------------------------------------------------------
+ManagedClusterNATGatewayProfile_STATUS{#ManagedClusterNATGatewayProfile_STATUS}
+-------------------------------------------------------------------------------
 
 Profile of the managed cluster NAT gateway.
 
@@ -2769,8 +2769,8 @@ Used by: [ContainerServiceNetworkProfile_STATUS](#ContainerServiceNetworkProfile
 | idleTimeoutInMinutes     | Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. | int<br/><small>Optional</small>                                                                                             |
 | managedOutboundIPProfile | Profile of the managed outbound IP resources of the cluster NAT gateway.                                                                | [ManagedClusterManagedOutboundIPProfile_STATUS](#ManagedClusterManagedOutboundIPProfile_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGroupProfile).
 
@@ -2779,8 +2779,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile](#ManagedClusterNodeResourceGro
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS"></a>ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS{#ManagedClusterNodeResourceGroupProfile_RestrictionLevel_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeResourceGroupProfile_STATUS).
 
@@ -2789,8 +2789,8 @@ Used by: [ManagedClusterNodeResourceGroupProfile_STATUS](#ManagedClusterNodeReso
 | "ReadOnly"     |             |
 | "Unrestricted" |             |
 
-<a id="ManagedClusterOperatorConfigMaps"></a>ManagedClusterOperatorConfigMaps
------------------------------------------------------------------------------
+ManagedClusterOperatorConfigMaps{#ManagedClusterOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2798,8 +2798,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 |-------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | oidcIssuerProfile | indicates where the OIDCIssuerProfile config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterOperatorSecrets"></a>ManagedClusterOperatorSecrets
------------------------------------------------------------------------
+ManagedClusterOperatorSecrets{#ManagedClusterOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 
@@ -2808,8 +2808,8 @@ Used by: [ManagedClusterOperatorSpec](#ManagedClusterOperatorSpec).
 | adminCredentials | indicates where the AdminCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userCredentials  | indicates where the UserCredentials secret should be placed. If omitted, the secret will not be retrieved from Azure.  | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity"></a>ManagedClusterPodIdentity
----------------------------------------------------------------
+ManagedClusterPodIdentity{#ManagedClusterPodIdentity}
+-----------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -2822,8 +2822,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | name            | The name of the pod identity.                                      | string<br/><small>Required</small>                                        |
 | namespace       | The namespace of the pod identity.                                 | string<br/><small>Required</small>                                        |
 
-<a id="ManagedClusterPodIdentity_STATUS"></a>ManagedClusterPodIdentity_STATUS
------------------------------------------------------------------------------
+ManagedClusterPodIdentity_STATUS{#ManagedClusterPodIdentity_STATUS}
+-------------------------------------------------------------------
 
 Details about the pod identity assigned to the Managed Cluster.
 
@@ -2838,8 +2838,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | provisioningInfo  |                                                                    | [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodIdentity_ProvisioningInfo_STATUS)<br/><small>Optional</small>   |
 | provisioningState | The current provisioning state of the pod identity.                | [ManagedClusterPodIdentity_ProvisioningState_STATUS](#ManagedClusterPodIdentity_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityException"></a>ManagedClusterPodIdentityException
----------------------------------------------------------------------------------
+ManagedClusterPodIdentityException{#ManagedClusterPodIdentityException}
+-----------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -2851,8 +2851,8 @@ Used by: [ManagedClusterPodIdentityProfile](#ManagedClusterPodIdentityProfile).
 | namespace | The namespace of the pod identity exception. | string<br/><small>Required</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Required</small> |
 
-<a id="ManagedClusterPodIdentityException_STATUS"></a>ManagedClusterPodIdentityException_STATUS
------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityException_STATUS{#ManagedClusterPodIdentityException_STATUS}
+-------------------------------------------------------------------------------------
 
 See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
 
@@ -2864,8 +2864,8 @@ Used by: [ManagedClusterPodIdentityProfile_STATUS](#ManagedClusterPodIdentityPro
 | namespace | The namespace of the pod identity exception. | string<br/><small>Optional</small>            |
 | podLabels | The pod labels to match.                     | map[string]string<br/><small>Optional</small> |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander"></a>ManagedClusterProperties_AutoScalerProfile_Expander
--------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander{#ManagedClusterProperties_AutoScalerProfile_Expander}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_AutoScalerProfile).
 
@@ -2876,8 +2876,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile](#ManagedClusterProperties_
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterProperties_AutoScalerProfile_Expander_STATUS"></a>ManagedClusterProperties_AutoScalerProfile_Expander_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterProperties_AutoScalerProfile_Expander_STATUS{#ManagedClusterProperties_AutoScalerProfile_Expander_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProperties_AutoScalerProfile_STATUS).
 
@@ -2888,8 +2888,8 @@ Used by: [ManagedClusterProperties_AutoScalerProfile_STATUS](#ManagedClusterProp
 | "priority"    |             |
 | "random"      |             |
 
-<a id="ManagedClusterSecurityProfileDefender"></a>ManagedClusterSecurityProfileDefender
----------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender{#ManagedClusterSecurityProfileDefender}
+-----------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -2900,8 +2900,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | logAnalyticsWorkspaceResourceReference | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | securityMonitoring                     | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring](#ManagedClusterSecurityProfileDefenderSecurityMonitoring)<br/><small>Optional</small>            |
 
-<a id="ManagedClusterSecurityProfileDefender_STATUS"></a>ManagedClusterSecurityProfileDefender_STATUS
------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefender_STATUS{#ManagedClusterSecurityProfileDefender_STATUS}
+-------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile.
 
@@ -2912,8 +2912,8 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | logAnalyticsWorkspaceResourceId | Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. | string<br/><small>Optional</small>                                                                                                                            |
 | securityMonitoring              | Microsoft Defender threat detection for Cloud settings for the security profile.                                                                                                                                                                       | [ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS](#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileImageCleaner"></a>ManagedClusterSecurityProfileImageCleaner
------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner{#ManagedClusterSecurityProfileImageCleaner}
+-------------------------------------------------------------------------------------
 
 Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
 
@@ -2924,8 +2924,8 @@ Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
 | enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
 | intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileImageCleaner_STATUS"></a>ManagedClusterSecurityProfileImageCleaner_STATUS
--------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileImageCleaner_STATUS{#ManagedClusterSecurityProfileImageCleaner_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
 
@@ -2936,158 +2936,158 @@ Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_S
 | enabled       | Whether to enable Image Cleaner on AKS cluster. | bool<br/><small>Optional</small> |
 | intervalHours | Image Cleaner scanning interval in hours.       | int<br/><small>Optional</small>  |
 
-<a id="ManagedClusterSecurityProfileWorkloadIdentity"></a>ManagedClusterSecurityProfileWorkloadIdentity
--------------------------------------------------------------------------------------------------------
-
-Workload identity settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
-
-| Property | Description                          | Type                             |
-|----------|--------------------------------------|----------------------------------|
-| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSecurityProfileWorkloadIdentity_STATUS"></a>ManagedClusterSecurityProfileWorkloadIdentity_STATUS
----------------------------------------------------------------------------------------------------------------------
-
-Workload identity settings for the security profile.
-
-Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
-
-| Property | Description                          | Type                             |
-|----------|--------------------------------------|----------------------------------|
-| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterSKU_Name"></a>ManagedClusterSKU_Name
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Name_STATUS"></a>ManagedClusterSKU_Name_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "Base" |             |
-
-<a id="ManagedClusterSKU_Tier"></a>ManagedClusterSKU_Tier
----------------------------------------------------------
-
-Used by: [ManagedClusterSKU](#ManagedClusterSKU).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterSKU_Tier_STATUS"></a>ManagedClusterSKU_Tier_STATUS
------------------------------------------------------------------------
-
-Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Free"     |             |
-| "Premium"  |             |
-| "Standard" |             |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver"></a>ManagedClusterStorageProfileBlobCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureBlob CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                         | Type                             |
-|----------|---------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileBlobCSIDriver_STATUS"></a>ManagedClusterStorageProfileBlobCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureBlob CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                         | Type                             |
-|----------|---------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver"></a>ManagedClusterStorageProfileDiskCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureDisk CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileDiskCSIDriver_STATUS"></a>ManagedClusterStorageProfileDiskCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureDisk CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver"></a>ManagedClusterStorageProfileFileCSIDriver
------------------------------------------------------------------------------------------------
-
-AzureFile CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileFileCSIDriver_STATUS"></a>ManagedClusterStorageProfileFileCSIDriver_STATUS
--------------------------------------------------------------------------------------------------------------
-
-AzureFile CSI Driver settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                        | Type                             |
-|----------|--------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController"></a>ManagedClusterStorageProfileSnapshotController
----------------------------------------------------------------------------------------------------------
-
-Snapshot Controller settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
-
-| Property | Description                                                       | Type                             |
-|----------|-------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterStorageProfileSnapshotController_STATUS"></a>ManagedClusterStorageProfileSnapshotController_STATUS
------------------------------------------------------------------------------------------------------------------------
-
-Snapshot Controller settings for the storage profile.
-
-Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
-
-| Property | Description                                                       | Type                             |
-|----------|-------------------------------------------------------------------|----------------------------------|
-| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
-
-<a id="ManagedClusterWindowsProfile_LicenseType"></a>ManagedClusterWindowsProfile_LicenseType
+ManagedClusterSecurityProfileWorkloadIdentity{#ManagedClusterSecurityProfileWorkloadIdentity}
 ---------------------------------------------------------------------------------------------
+
+Workload identity settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile](#ManagedClusterSecurityProfile).
+
+| Property | Description                          | Type                             |
+|----------|--------------------------------------|----------------------------------|
+| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
+
+ManagedClusterSecurityProfileWorkloadIdentity_STATUS{#ManagedClusterSecurityProfileWorkloadIdentity_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Workload identity settings for the security profile.
+
+Used by: [ManagedClusterSecurityProfile_STATUS](#ManagedClusterSecurityProfile_STATUS).
+
+| Property | Description                          | Type                             |
+|----------|--------------------------------------|----------------------------------|
+| enabled  | Whether to enable workload identity. | bool<br/><small>Optional</small> |
+
+ManagedClusterSKU_Name{#ManagedClusterSKU_Name}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Name_STATUS{#ManagedClusterSKU_Name_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "Base" |             |
+
+ManagedClusterSKU_Tier{#ManagedClusterSKU_Tier}
+-----------------------------------------------
+
+Used by: [ManagedClusterSKU](#ManagedClusterSKU).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterSKU_Tier_STATUS{#ManagedClusterSKU_Tier_STATUS}
+-------------------------------------------------------------
+
+Used by: [ManagedClusterSKU_STATUS](#ManagedClusterSKU_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Free"     |             |
+| "Premium"  |             |
+| "Standard" |             |
+
+ManagedClusterStorageProfileBlobCSIDriver{#ManagedClusterStorageProfileBlobCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureBlob CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                         | Type                             |
+|----------|---------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileBlobCSIDriver_STATUS{#ManagedClusterStorageProfileBlobCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureBlob CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                         | Type                             |
+|----------|---------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureBlob CSI Driver. The default value is false. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver{#ManagedClusterStorageProfileDiskCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureDisk CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileDiskCSIDriver_STATUS{#ManagedClusterStorageProfileDiskCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureDisk CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureDisk CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver{#ManagedClusterStorageProfileFileCSIDriver}
+-------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileFileCSIDriver_STATUS{#ManagedClusterStorageProfileFileCSIDriver_STATUS}
+---------------------------------------------------------------------------------------------------
+
+AzureFile CSI Driver settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                        | Type                             |
+|----------|--------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable AzureFile CSI Driver. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController{#ManagedClusterStorageProfileSnapshotController}
+-----------------------------------------------------------------------------------------------
+
+Snapshot Controller settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile](#ManagedClusterStorageProfile).
+
+| Property | Description                                                       | Type                             |
+|----------|-------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterStorageProfileSnapshotController_STATUS{#ManagedClusterStorageProfileSnapshotController_STATUS}
+-------------------------------------------------------------------------------------------------------------
+
+Snapshot Controller settings for the storage profile.
+
+Used by: [ManagedClusterStorageProfile_STATUS](#ManagedClusterStorageProfile_STATUS).
+
+| Property | Description                                                       | Type                             |
+|----------|-------------------------------------------------------------------|----------------------------------|
+| enabled  | Whether to enable Snapshot Controller. The default value is true. | bool<br/><small>Optional</small> |
+
+ManagedClusterWindowsProfile_LicenseType{#ManagedClusterWindowsProfile_LicenseType}
+-----------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 
@@ -3096,8 +3096,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWindowsProfile_LicenseType_STATUS"></a>ManagedClusterWindowsProfile_LicenseType_STATUS
------------------------------------------------------------------------------------------------------------
+ManagedClusterWindowsProfile_LicenseType_STATUS{#ManagedClusterWindowsProfile_LicenseType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STATUS).
 
@@ -3106,8 +3106,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | "None"           |             |
 | "Windows_Server" |             |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda"></a>ManagedClusterWorkloadAutoScalerProfileKeda
----------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda{#ManagedClusterWorkloadAutoScalerProfileKeda}
+-----------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -3117,8 +3117,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileKeda_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileKeda_STATUS{#ManagedClusterWorkloadAutoScalerProfileKeda_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
 
@@ -3128,8 +3128,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|-------------------------|----------------------------------|
 | enabled  | Whether to enable KEDA. | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
--------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler}
+---------------------------------------------------------------------------------------------------------------------------
 
 VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
 
@@ -3139,8 +3139,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile](#ManagedClusterWorkloadAutoSc
 |----------|------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable VPA. Default value is false. | bool<br/><small>Required</small> |
 
-<a id="ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS"></a>ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS{#ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
 
@@ -3150,8 +3150,8 @@ Used by: [ManagedClusterWorkloadAutoScalerProfile_STATUS](#ManagedClusterWorkloa
 |----------|------------------------------------------------|----------------------------------|
 | enabled  | Whether to enable VPA. Default value is false. | bool<br/><small>Optional</small> |
 
-<a id="PortRange"></a>PortRange
--------------------------------
+PortRange{#PortRange}
+---------------------
 
 The port range.
 
@@ -3163,8 +3163,8 @@ Used by: [AgentPoolNetworkProfile](#AgentPoolNetworkProfile).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                       |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol](#PortRange_Protocol)<br/><small>Optional</small> |
 
-<a id="PortRange_STATUS"></a>PortRange_STATUS
----------------------------------------------
+PortRange_STATUS{#PortRange_STATUS}
+-----------------------------------
 
 The port range.
 
@@ -3176,8 +3176,8 @@ Used by: [AgentPoolNetworkProfile_STATUS](#AgentPoolNetworkProfile_STATUS).
 | portStart | The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.      | int<br/><small>Optional</small>                                                     |
 | protocol  | The network protocol of the port.                                                                                               | [PortRange_Protocol_STATUS](#PortRange_Protocol_STATUS)<br/><small>Optional</small> |
 
-<a id="PowerState_Code"></a>PowerState_Code
--------------------------------------------
+PowerState_Code{#PowerState_Code}
+---------------------------------
 
 Used by: [PowerState](#PowerState).
 
@@ -3186,8 +3186,8 @@ Used by: [PowerState](#PowerState).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="PowerState_Code_STATUS"></a>PowerState_Code_STATUS
----------------------------------------------------------
+PowerState_Code_STATUS{#PowerState_Code_STATUS}
+-----------------------------------------------
 
 Used by: [PowerState_STATUS](#PowerState_STATUS).
 
@@ -3196,8 +3196,8 @@ Used by: [PowerState_STATUS](#PowerState_STATUS).
 | "Running" |             |
 | "Stopped" |             |
 
-<a id="Schedule"></a>Schedule
------------------------------
+Schedule{#Schedule}
+-------------------
 
 One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule.
 
@@ -3210,8 +3210,8 @@ Used by: [MaintenanceWindow](#MaintenanceWindow).
 | relativeMonthly | For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'. | [RelativeMonthlySchedule](#RelativeMonthlySchedule)<br/><small>Optional</small> |
 | weekly          | For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.                       | [WeeklySchedule](#WeeklySchedule)<br/><small>Optional</small>                   |
 
-<a id="Schedule_STATUS"></a>Schedule_STATUS
--------------------------------------------
+Schedule_STATUS{#Schedule_STATUS}
+---------------------------------
 
 One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule.
 
@@ -3224,8 +3224,8 @@ Used by: [MaintenanceWindow_STATUS](#MaintenanceWindow_STATUS).
 | relativeMonthly | For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'. | [RelativeMonthlySchedule_STATUS](#RelativeMonthlySchedule_STATUS)<br/><small>Optional</small> |
 | weekly          | For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.                       | [WeeklySchedule_STATUS](#WeeklySchedule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ServiceMeshProfile_Mode"></a>ServiceMeshProfile_Mode
------------------------------------------------------------
+ServiceMeshProfile_Mode{#ServiceMeshProfile_Mode}
+-------------------------------------------------
 
 Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 
@@ -3234,8 +3234,8 @@ Used by: [ServiceMeshProfile](#ServiceMeshProfile).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="ServiceMeshProfile_Mode_STATUS"></a>ServiceMeshProfile_Mode_STATUS
--------------------------------------------------------------------------
+ServiceMeshProfile_Mode_STATUS{#ServiceMeshProfile_Mode_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 
@@ -3244,8 +3244,8 @@ Used by: [ServiceMeshProfile_STATUS](#ServiceMeshProfile_STATUS).
 | "Disabled" |             |
 | "Istio"    |             |
 
-<a id="SysctlConfig"></a>SysctlConfig
--------------------------------------
+SysctlConfig{#SysctlConfig}
+---------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -3282,8 +3282,8 @@ Used by: [LinuxOSConfig](#LinuxOSConfig).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SysctlConfig_STATUS"></a>SysctlConfig_STATUS
----------------------------------------------------
+SysctlConfig_STATUS{#SysctlConfig_STATUS}
+-----------------------------------------
 
 Sysctl settings for Linux agent nodes.
 
@@ -3320,7 +3320,19 @@ Used by: [LinuxOSConfig_STATUS](#LinuxOSConfig_STATUS).
 | vmSwappiness                   | Sysctl setting vm.swappiness.                      | int<br/><small>Optional</small>    |
 | vmVfsCachePressure             | Sysctl setting vm.vfs_cache_pressure.              | int<br/><small>Optional</small>    |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3332,20 +3344,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpgradeOverrideSettings"></a>UpgradeOverrideSettings
------------------------------------------------------------
+UpgradeOverrideSettings{#UpgradeOverrideSettings}
+-------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -3356,8 +3356,8 @@ Used by: [ClusterUpgradeSettings](#ClusterUpgradeSettings).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UpgradeOverrideSettings_STATUS"></a>UpgradeOverrideSettings_STATUS
--------------------------------------------------------------------------
+UpgradeOverrideSettings_STATUS{#UpgradeOverrideSettings_STATUS}
+---------------------------------------------------------------
 
 Settings for overrides when upgrading a cluster.
 
@@ -3368,8 +3368,8 @@ Used by: [ClusterUpgradeSettings_STATUS](#ClusterUpgradeSettings_STATUS).
 | forceUpgrade | Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.                                                                                          | bool<br/><small>Optional</small>   |
 | until        | Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -3379,8 +3379,8 @@ Used by: [ManagedClusterIdentity](#ManagedClusterIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="WeekDay"></a>WeekDay
----------------------------
+WeekDay{#WeekDay}
+-----------------
 
 The weekday enum.
 
@@ -3396,8 +3396,8 @@ Used by: [RelativeMonthlySchedule](#RelativeMonthlySchedule), [TimeInWeek](#Time
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="WeekDay_STATUS"></a>WeekDay_STATUS
------------------------------------------
+WeekDay_STATUS{#WeekDay_STATUS}
+-------------------------------
 
 The weekday enum.
 
@@ -3413,8 +3413,8 @@ Used by: [RelativeMonthlySchedule_STATUS](#RelativeMonthlySchedule_STATUS), [Tim
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="WindowsGmsaProfile"></a>WindowsGmsaProfile
--------------------------------------------------
+WindowsGmsaProfile{#WindowsGmsaProfile}
+---------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -3426,8 +3426,8 @@ Used by: [ManagedClusterWindowsProfile](#ManagedClusterWindowsProfile).
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="WindowsGmsaProfile_STATUS"></a>WindowsGmsaProfile_STATUS
----------------------------------------------------------------
+WindowsGmsaProfile_STATUS{#WindowsGmsaProfile_STATUS}
+-----------------------------------------------------
 
 Windows gMSA Profile in the managed cluster.
 
@@ -3439,8 +3439,8 @@ Used by: [ManagedClusterWindowsProfile_STATUS](#ManagedClusterWindowsProfile_STA
 | enabled        | Specifies whether to enable Windows gMSA in the managed cluster.                                                                                                | bool<br/><small>Optional</small>   |
 | rootDomainName | Specifies the root domain name for Windows gMSA. Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. | string<br/><small>Optional</small> |
 
-<a id="AbsoluteMonthlySchedule"></a>AbsoluteMonthlySchedule
------------------------------------------------------------
+AbsoluteMonthlySchedule{#AbsoluteMonthlySchedule}
+-------------------------------------------------
 
 For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.
 
@@ -3451,8 +3451,8 @@ Used by: [Schedule](#Schedule).
 | dayOfMonth     | The date of the month.                                          | int<br/><small>Required</small> |
 | intervalMonths | Specifies the number of months between each set of occurrences. | int<br/><small>Required</small> |
 
-<a id="AbsoluteMonthlySchedule_STATUS"></a>AbsoluteMonthlySchedule_STATUS
--------------------------------------------------------------------------
+AbsoluteMonthlySchedule_STATUS{#AbsoluteMonthlySchedule_STATUS}
+---------------------------------------------------------------
 
 For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.
 
@@ -3463,31 +3463,31 @@ Used by: [Schedule_STATUS](#Schedule_STATUS).
 | dayOfMonth     | The date of the month.                                          | int<br/><small>Optional</small> |
 | intervalMonths | Specifies the number of months between each set of occurrences. | int<br/><small>Optional</small> |
 
-<a id="AdvancedNetworkingObservability"></a>AdvancedNetworkingObservability
----------------------------------------------------------------------------
-
-Observability profile to enable advanced network metrics and flow logs with historical contexts.
-
-Used by: [AdvancedNetworking](#AdvancedNetworking).
-
-| Property | Description                                                                                | Type                             |
-|----------|--------------------------------------------------------------------------------------------|----------------------------------|
-| enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
-
-<a id="AdvancedNetworkingObservability_STATUS"></a>AdvancedNetworkingObservability_STATUS
------------------------------------------------------------------------------------------
-
-Observability profile to enable advanced network metrics and flow logs with historical contexts.
-
-Used by: [AdvancedNetworking_STATUS](#AdvancedNetworking_STATUS).
-
-| Property | Description                                                                                | Type                             |
-|----------|--------------------------------------------------------------------------------------------|----------------------------------|
-| enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
-
-<a id="AdvancedNetworkingSecurity"></a>AdvancedNetworkingSecurity
+AdvancedNetworkingObservability{#AdvancedNetworkingObservability}
 -----------------------------------------------------------------
 
+Observability profile to enable advanced network metrics and flow logs with historical contexts.
+
+Used by: [AdvancedNetworking](#AdvancedNetworking).
+
+| Property | Description                                                                                | Type                             |
+|----------|--------------------------------------------------------------------------------------------|----------------------------------|
+| enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
+
+AdvancedNetworkingObservability_STATUS{#AdvancedNetworkingObservability_STATUS}
+-------------------------------------------------------------------------------
+
+Observability profile to enable advanced network metrics and flow logs with historical contexts.
+
+Used by: [AdvancedNetworking_STATUS](#AdvancedNetworking_STATUS).
+
+| Property | Description                                                                                | Type                             |
+|----------|--------------------------------------------------------------------------------------------|----------------------------------|
+| enabled  | Indicates the enablement of Advanced Networking observability functionalities on clusters. | bool<br/><small>Optional</small> |
+
+AdvancedNetworkingSecurity{#AdvancedNetworkingSecurity}
+-------------------------------------------------------
+
 Security profile to enable security features on cilium based cluster.
 
 Used by: [AdvancedNetworking](#AdvancedNetworking).
@@ -3496,8 +3496,8 @@ Used by: [AdvancedNetworking](#AdvancedNetworking).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AdvancedNetworkingSecurity_STATUS"></a>AdvancedNetworkingSecurity_STATUS
--------------------------------------------------------------------------------
+AdvancedNetworkingSecurity_STATUS{#AdvancedNetworkingSecurity_STATUS}
+---------------------------------------------------------------------
 
 Security profile to enable security features on cilium based cluster.
 
@@ -3507,8 +3507,8 @@ Used by: [AdvancedNetworking_STATUS](#AdvancedNetworking_STATUS).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false. | bool<br/><small>Optional</small> |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess"></a>AzureKeyVaultKms_KeyVaultNetworkAccess
------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess{#AzureKeyVaultKms_KeyVaultNetworkAccess}
+-------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 
@@ -3517,8 +3517,8 @@ Used by: [AzureKeyVaultKms](#AzureKeyVaultKms).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS"></a>AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------
+AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS{#AzureKeyVaultKms_KeyVaultNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 
@@ -3527,8 +3527,8 @@ Used by: [AzureKeyVaultKms_STATUS](#AzureKeyVaultKms_STATUS).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ContainerServiceSshPublicKey"></a>ContainerServiceSshPublicKey
----------------------------------------------------------------------
+ContainerServiceSshPublicKey{#ContainerServiceSshPublicKey}
+-----------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -3538,8 +3538,8 @@ Used by: [ContainerServiceSshConfiguration](#ContainerServiceSshConfiguration).
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Required</small> |
 
-<a id="ContainerServiceSshPublicKey_STATUS"></a>ContainerServiceSshPublicKey_STATUS
------------------------------------------------------------------------------------
+ContainerServiceSshPublicKey_STATUS{#ContainerServiceSshPublicKey_STATUS}
+-------------------------------------------------------------------------
 
 Contains information about SSH certificate public key data.
 
@@ -3549,8 +3549,8 @@ Used by: [ContainerServiceSshConfiguration_STATUS](#ContainerServiceSshConfigura
 |----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | keyData  | Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. | string<br/><small>Optional</small> |
 
-<a id="DailySchedule"></a>DailySchedule
----------------------------------------
+DailySchedule{#DailySchedule}
+-----------------------------
 
 For schedules like: 'recur every day' or 'recur every 3 days'.
 
@@ -3560,8 +3560,8 @@ Used by: [Schedule](#Schedule).
 |--------------|---------------------------------------------------------------|---------------------------------|
 | intervalDays | Specifies the number of days between each set of occurrences. | int<br/><small>Required</small> |
 
-<a id="DailySchedule_STATUS"></a>DailySchedule_STATUS
------------------------------------------------------
+DailySchedule_STATUS{#DailySchedule_STATUS}
+-------------------------------------------
 
 For schedules like: 'recur every day' or 'recur every 3 days'.
 
@@ -3571,8 +3571,8 @@ Used by: [Schedule_STATUS](#Schedule_STATUS).
 |--------------|---------------------------------------------------------------|---------------------------------|
 | intervalDays | Specifies the number of days between each set of occurrences. | int<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority"></a>IstioCertificateAuthority
----------------------------------------------------------------
+IstioCertificateAuthority{#IstioCertificateAuthority}
+-----------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -3582,8 +3582,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 |----------|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority](#IstioPluginCertificateAuthority)<br/><small>Optional</small> |
 
-<a id="IstioCertificateAuthority_STATUS"></a>IstioCertificateAuthority_STATUS
------------------------------------------------------------------------------
+IstioCertificateAuthority_STATUS{#IstioCertificateAuthority_STATUS}
+-------------------------------------------------------------------
 
 Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
 
@@ -3593,8 +3593,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 |----------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | plugin   | Plugin certificates information for Service Mesh. | [IstioPluginCertificateAuthority_STATUS](#IstioPluginCertificateAuthority_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioComponents"></a>IstioComponents
--------------------------------------------
+IstioComponents{#IstioComponents}
+---------------------------------
 
 Istio components configuration.
 
@@ -3605,8 +3605,8 @@ Used by: [IstioServiceMesh](#IstioServiceMesh).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway[]](#IstioEgressGateway)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway[]](#IstioIngressGateway)<br/><small>Optional</small> |
 
-<a id="IstioComponents_STATUS"></a>IstioComponents_STATUS
----------------------------------------------------------
+IstioComponents_STATUS{#IstioComponents_STATUS}
+-----------------------------------------------
 
 Istio components configuration.
 
@@ -3617,8 +3617,8 @@ Used by: [IstioServiceMesh_STATUS](#IstioServiceMesh_STATUS).
 | egressGateways  | Istio egress gateways.  | [IstioEgressGateway_STATUS[]](#IstioEgressGateway_STATUS)<br/><small>Optional</small>   |
 | ingressGateways | Istio ingress gateways. | [IstioIngressGateway_STATUS[]](#IstioIngressGateway_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics
----------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics{#ManagedClusterAzureMonitorProfileKubeStateMetrics}
+-----------------------------------------------------------------------------------------------------
 
 Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
 
@@ -3629,8 +3629,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics](#ManagedClusterAzureMonitorP
 | metricAnnotationsAllowList | Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS"></a>ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS{#ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
 
@@ -3641,8 +3641,8 @@ Used by: [ManagedClusterAzureMonitorProfileMetrics_STATUS](#ManagedClusterAzureM
 | metricAnnotationsAllowList | Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. | string<br/><small>Optional</small> |
 | metricLabelsAllowlist      | Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType"></a>ManagedClusterLoadBalancerProfile_BackendPoolType
----------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType{#ManagedClusterLoadBalancerProfile_BackendPoolType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3651,8 +3651,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS"></a>ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS{#ManagedClusterLoadBalancerProfile_BackendPoolType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3661,8 +3661,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | "NodeIP"              |             |
 | "NodeIPConfiguration" |             |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3671,8 +3671,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3681,8 +3681,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 | count     | The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.                                       | int<br/><small>Optional</small> |
 | countIPv6 | The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3690,8 +3690,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |------------------|---------------------------------------|-----------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3699,8 +3699,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |------------------|---------------------------------------|-------------------------------------------------------------------------------------|
 | publicIPPrefixes | A list of public IP prefix resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs"></a>ManagedClusterLoadBalancerProfile_OutboundIPs
--------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs{#ManagedClusterLoadBalancerProfile_OutboundIPs}
+---------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile).
 
@@ -3708,8 +3708,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|--------------------------------|-----------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference[]](#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS"></a>ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS{#ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerProfile_STATUS).
 
@@ -3717,8 +3717,8 @@ Used by: [ManagedClusterLoadBalancerProfile_STATUS](#ManagedClusterLoadBalancerP
 |-----------|--------------------------------|-------------------------------------------------------------------------------------|
 | publicIPs | A list of public IP resources. | [ResourceReference_STATUS[]](#ResourceReference_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile"></a>ManagedClusterManagedOutboundIPProfile
------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile{#ManagedClusterManagedOutboundIPProfile}
+-------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -3728,8 +3728,8 @@ Used by: [ManagedClusterNATGatewayProfile](#ManagedClusterNATGatewayProfile).
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterManagedOutboundIPProfile_STATUS"></a>ManagedClusterManagedOutboundIPProfile_STATUS
--------------------------------------------------------------------------------------------------------
+ManagedClusterManagedOutboundIPProfile_STATUS{#ManagedClusterManagedOutboundIPProfile_STATUS}
+---------------------------------------------------------------------------------------------
 
 Profile of the managed outbound IP resources of the managed cluster.
 
@@ -3739,8 +3739,8 @@ Used by: [ManagedClusterNATGatewayProfile_STATUS](#ManagedClusterNATGatewayProfi
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningInfo_STATUS"></a>ManagedClusterPodIdentity_ProvisioningInfo_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningInfo_STATUS{#ManagedClusterPodIdentity_ProvisioningInfo_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3748,8 +3748,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 |----------|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Pod identity assignment error (if any). | [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodIdentityProvisioningError_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentity_ProvisioningState_STATUS"></a>ManagedClusterPodIdentity_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentity_ProvisioningState_STATUS{#ManagedClusterPodIdentity_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 
@@ -3762,8 +3762,8 @@ Used by: [ManagedClusterPodIdentity_STATUS](#ManagedClusterPodIdentity_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring
----------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring{#ManagedClusterSecurityProfileDefenderSecurityMonitoring}
+-----------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -3773,8 +3773,8 @@ Used by: [ManagedClusterSecurityProfileDefender](#ManagedClusterSecurityProfileD
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS"></a>ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS{#ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Microsoft Defender settings for the security profile threat detection.
 
@@ -3784,8 +3784,8 @@ Used by: [ManagedClusterSecurityProfileDefender_STATUS](#ManagedClusterSecurityP
 |----------|---------------------------------------------|----------------------------------|
 | enabled  | Whether to enable Defender threat detection | bool<br/><small>Optional</small> |
 
-<a id="PortRange_Protocol"></a>PortRange_Protocol
--------------------------------------------------
+PortRange_Protocol{#PortRange_Protocol}
+---------------------------------------
 
 Used by: [PortRange](#PortRange).
 
@@ -3794,8 +3794,8 @@ Used by: [PortRange](#PortRange).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="PortRange_Protocol_STATUS"></a>PortRange_Protocol_STATUS
----------------------------------------------------------------
+PortRange_Protocol_STATUS{#PortRange_Protocol_STATUS}
+-----------------------------------------------------
 
 Used by: [PortRange_STATUS](#PortRange_STATUS).
 
@@ -3804,8 +3804,8 @@ Used by: [PortRange_STATUS](#PortRange_STATUS).
 | "TCP" |             |
 | "UDP" |             |
 
-<a id="RelativeMonthlySchedule"></a>RelativeMonthlySchedule
------------------------------------------------------------
+RelativeMonthlySchedule{#RelativeMonthlySchedule}
+-------------------------------------------------
 
 For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.
 
@@ -3817,8 +3817,8 @@ Used by: [Schedule](#Schedule).
 | intervalMonths | Specifies the number of months between each set of occurrences. | int<br/><small>Required</small>                                                                     |
 | weekIndex      | Specifies on which week of the month the dayOfWeek applies.     | [RelativeMonthlySchedule_WeekIndex](#RelativeMonthlySchedule_WeekIndex)<br/><small>Required</small> |
 
-<a id="RelativeMonthlySchedule_STATUS"></a>RelativeMonthlySchedule_STATUS
--------------------------------------------------------------------------
+RelativeMonthlySchedule_STATUS{#RelativeMonthlySchedule_STATUS}
+---------------------------------------------------------------
 
 For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.
 
@@ -3830,8 +3830,8 @@ Used by: [Schedule_STATUS](#Schedule_STATUS).
 | intervalMonths | Specifies the number of months between each set of occurrences. | int<br/><small>Optional</small>                                                                                   |
 | weekIndex      | Specifies on which week of the month the dayOfWeek applies.     | [RelativeMonthlySchedule_WeekIndex_STATUS](#RelativeMonthlySchedule_WeekIndex_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 A reference to an Azure resource.
 
@@ -3841,8 +3841,8 @@ Used by: [ManagedClusterLoadBalancerProfile](#ManagedClusterLoadBalancerProfile)
 |-----------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The fully qualified Azure resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 A reference to an Azure resource.
 
@@ -3852,8 +3852,8 @@ Used by: [ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS](#ManagedC
 |----------|----------------------------------------|------------------------------------|
 | id       | The fully qualified Azure resource id. | string<br/><small>Optional</small> |
 
-<a id="WeeklySchedule"></a>WeeklySchedule
------------------------------------------
+WeeklySchedule{#WeeklySchedule}
+-------------------------------
 
 For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.
 
@@ -3864,8 +3864,8 @@ Used by: [Schedule](#Schedule).
 | dayOfWeek     | Specifies on which day of the week the maintenance occurs.     | [WeekDay](#WeekDay)<br/><small>Required</small> |
 | intervalWeeks | Specifies the number of weeks between each set of occurrences. | int<br/><small>Required</small>                 |
 
-<a id="WeeklySchedule_STATUS"></a>WeeklySchedule_STATUS
--------------------------------------------------------
+WeeklySchedule_STATUS{#WeeklySchedule_STATUS}
+---------------------------------------------
 
 For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.
 
@@ -3876,8 +3876,8 @@ Used by: [Schedule_STATUS](#Schedule_STATUS).
 | dayOfWeek     | Specifies on which day of the week the maintenance occurs.     | [WeekDay_STATUS](#WeekDay_STATUS)<br/><small>Optional</small> |
 | intervalWeeks | Specifies the number of weeks between each set of occurrences. | int<br/><small>Optional</small>                               |
 
-<a id="IstioEgressGateway"></a>IstioEgressGateway
--------------------------------------------------
+IstioEgressGateway{#IstioEgressGateway}
+---------------------------------------
 
 Istio egress gateway configuration.
 
@@ -3887,8 +3887,8 @@ Used by: [IstioComponents](#IstioComponents).
 |----------|---------------------------------------|----------------------------------|
 | enabled  | Whether to enable the egress gateway. | bool<br/><small>Required</small> |
 
-<a id="IstioEgressGateway_STATUS"></a>IstioEgressGateway_STATUS
----------------------------------------------------------------
+IstioEgressGateway_STATUS{#IstioEgressGateway_STATUS}
+-----------------------------------------------------
 
 Istio egress gateway configuration.
 
@@ -3898,8 +3898,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 |----------|---------------------------------------|----------------------------------|
 | enabled  | Whether to enable the egress gateway. | bool<br/><small>Optional</small> |
 
-<a id="IstioIngressGateway"></a>IstioIngressGateway
----------------------------------------------------
+IstioIngressGateway{#IstioIngressGateway}
+-----------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -3910,8 +3910,8 @@ Used by: [IstioComponents](#IstioComponents).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Required</small>                                                  |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode](#IstioIngressGateway_Mode)<br/><small>Required</small> |
 
-<a id="IstioIngressGateway_STATUS"></a>IstioIngressGateway_STATUS
------------------------------------------------------------------
+IstioIngressGateway_STATUS{#IstioIngressGateway_STATUS}
+-------------------------------------------------------
 
 Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
 
@@ -3922,8 +3922,8 @@ Used by: [IstioComponents_STATUS](#IstioComponents_STATUS).
 | enabled  | Whether to enable the ingress gateway. | bool<br/><small>Optional</small>                                                                |
 | mode     | Mode of an ingress gateway.            | [IstioIngressGateway_Mode_STATUS](#IstioIngressGateway_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="IstioPluginCertificateAuthority"></a>IstioPluginCertificateAuthority
----------------------------------------------------------------------------
+IstioPluginCertificateAuthority{#IstioPluginCertificateAuthority}
+-----------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -3937,8 +3937,8 @@ Used by: [IstioCertificateAuthority](#IstioCertificateAuthority).
 | keyVaultReference   | The resource ID of the Key Vault.                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="IstioPluginCertificateAuthority_STATUS"></a>IstioPluginCertificateAuthority_STATUS
------------------------------------------------------------------------------------------
+IstioPluginCertificateAuthority_STATUS{#IstioPluginCertificateAuthority_STATUS}
+-------------------------------------------------------------------------------
 
 Plugin certificates information for Service Mesh.
 
@@ -3952,8 +3952,8 @@ Used by: [IstioCertificateAuthority_STATUS](#IstioCertificateAuthority_STATUS).
 | keyVaultId          | The resource ID of the Key Vault.                                    | string<br/><small>Optional</small> |
 | rootCertObjectName  | Root certificate object name in Azure Key Vault.                     | string<br/><small>Optional</small> |
 
-<a id="ManagedClusterPodIdentityProvisioningError_STATUS"></a>ManagedClusterPodIdentityProvisioningError_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningError_STATUS{#ManagedClusterPodIdentityProvisioningError_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -3963,8 +3963,8 @@ Used by: [ManagedClusterPodIdentity_ProvisioningInfo_STATUS](#ManagedClusterPodI
 |----------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | error    | Details about the error. | [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS)<br/><small>Optional</small> |
 
-<a id="RelativeMonthlySchedule_WeekIndex"></a>RelativeMonthlySchedule_WeekIndex
--------------------------------------------------------------------------------
+RelativeMonthlySchedule_WeekIndex{#RelativeMonthlySchedule_WeekIndex}
+---------------------------------------------------------------------
 
 Used by: [RelativeMonthlySchedule](#RelativeMonthlySchedule).
 
@@ -3976,8 +3976,8 @@ Used by: [RelativeMonthlySchedule](#RelativeMonthlySchedule).
 | "Second" |             |
 | "Third"  |             |
 
-<a id="RelativeMonthlySchedule_WeekIndex_STATUS"></a>RelativeMonthlySchedule_WeekIndex_STATUS
----------------------------------------------------------------------------------------------
+RelativeMonthlySchedule_WeekIndex_STATUS{#RelativeMonthlySchedule_WeekIndex_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [RelativeMonthlySchedule_STATUS](#RelativeMonthlySchedule_STATUS).
 
@@ -3989,8 +3989,8 @@ Used by: [RelativeMonthlySchedule_STATUS](#RelativeMonthlySchedule_STATUS).
 | "Second" |             |
 | "Third"  |             |
 
-<a id="IstioIngressGateway_Mode"></a>IstioIngressGateway_Mode
--------------------------------------------------------------
+IstioIngressGateway_Mode{#IstioIngressGateway_Mode}
+---------------------------------------------------
 
 Used by: [IstioIngressGateway](#IstioIngressGateway).
 
@@ -3999,8 +3999,8 @@ Used by: [IstioIngressGateway](#IstioIngressGateway).
 | "External" |             |
 | "Internal" |             |
 
-<a id="IstioIngressGateway_Mode_STATUS"></a>IstioIngressGateway_Mode_STATUS
----------------------------------------------------------------------------
+IstioIngressGateway_Mode_STATUS{#IstioIngressGateway_Mode_STATUS}
+-----------------------------------------------------------------
 
 Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 
@@ -4009,8 +4009,8 @@ Used by: [IstioIngressGateway_STATUS](#IstioIngressGateway_STATUS).
 | "External" |             |
 | "Internal" |             |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS
------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 An error response from the pod identity provisioning.
 
@@ -4023,8 +4023,8 @@ Used by: [ManagedClusterPodIdentityProvisioningError_STATUS](#ManagedClusterPodI
 | message  | A message describing the error, intended to be suitable for display in a user interface.           | string<br/><small>Optional</small>                                                                                                                              |
 | target   | The target of the particular error. For example, the name of the property in error.                | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled"></a>ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
------------------------------------------------------------------------------------------------------------------------------------------
+ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled{#ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedClusterPodIdentityProvisioningErrorBody_STATUS](#ManagedClusterPodIdentityProvisioningErrorBody_STATUS).
 

--- a/docs/hugo/content/reference/datafactory/v1api20180601.md
+++ b/docs/hugo/content/reference/datafactory/v1api20180601.md
@@ -5,15 +5,15 @@ title: datafactory.azure.com/v1api20180601
 linktitle: v1api20180601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-06-01" |             |
 
-<a id="Factory"></a>Factory
----------------------------
+Factory{#Factory}
+-----------------
 
 Generator information: - Generated from: /datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/datafactory.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataFactory/factories/{factoryName}
 
@@ -26,7 +26,7 @@ Used by: [FactoryList](#FactoryList).
 | spec                                                                                    |             | [Factory_Spec](#Factory_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Factory_STATUS](#Factory_STATUS)<br/><small>Optional</small> |
 
-### <a id="Factory_Spec"></a>Factory_Spec
+### Factory_Spec {#Factory_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -43,7 +43,7 @@ Used by: [FactoryList](#FactoryList).
 | repoConfiguration    | Git repo information of the factory.                                                                                                                                                                                                                                                         | [FactoryRepoConfiguration](#FactoryRepoConfiguration)<br/><small>Optional</small>                                                                                    |
 | tags                 | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Factory_STATUS"></a>Factory_STATUS
+### Factory_STATUS{#Factory_STATUS}
 
 | Property             | Description                                                           | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -65,8 +65,8 @@ Used by: [FactoryList](#FactoryList).
 | type                 | The resource type.                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | version              | Version of the factory.                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FactoryList"></a>FactoryList
------------------------------------
+FactoryList{#FactoryList}
+-------------------------
 
 Generator information: - Generated from: /datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/datafactory.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataFactory/factories/{factoryName}
 
@@ -76,8 +76,8 @@ Generator information: - Generated from: /datafactory/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Factory[]](#Factory)<br/><small>Optional</small> |
 
-<a id="Factory_Spec"></a>Factory_Spec
--------------------------------------
+Factory_Spec{#Factory_Spec}
+---------------------------
 
 Used by: [Factory](#Factory).
 
@@ -96,8 +96,8 @@ Used by: [Factory](#Factory).
 | repoConfiguration    | Git repo information of the factory.                                                                                                                                                                                                                                                         | [FactoryRepoConfiguration](#FactoryRepoConfiguration)<br/><small>Optional</small>                                                                                    |
 | tags                 | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Factory_STATUS"></a>Factory_STATUS
------------------------------------------
+Factory_STATUS{#Factory_STATUS}
+-------------------------------
 
 Factory resource type.
 
@@ -123,8 +123,8 @@ Used by: [Factory](#Factory).
 | type                 | The resource type.                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | version              | Version of the factory.                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="EncryptionConfiguration"></a>EncryptionConfiguration
------------------------------------------------------------
+EncryptionConfiguration{#EncryptionConfiguration}
+-------------------------------------------------
 
 Definition of CMK for the factory.
 
@@ -137,8 +137,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | keyVersion   | The version of the key used for CMK. If not provided, latest version will be used.                                            | string<br/><small>Optional</small>                                          |
 | vaultBaseUrl | The url of the Azure Key Vault used for CMK.                                                                                  | string<br/><small>Required</small>                                          |
 
-<a id="EncryptionConfiguration_STATUS"></a>EncryptionConfiguration_STATUS
--------------------------------------------------------------------------
+EncryptionConfiguration_STATUS{#EncryptionConfiguration_STATUS}
+---------------------------------------------------------------
 
 Definition of CMK for the factory.
 
@@ -151,8 +151,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 | keyVersion   | The version of the key used for CMK. If not provided, latest version will be used.                                            | string<br/><small>Optional</small>                                                        |
 | vaultBaseUrl | The url of the Azure Key Vault used for CMK.                                                                                  | string<br/><small>Optional</small>                                                        |
 
-<a id="FactoryIdentity"></a>FactoryIdentity
--------------------------------------------
+FactoryIdentity{#FactoryIdentity}
+---------------------------------
 
 Identity properties of the factory resource.
 
@@ -163,8 +163,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | type                   | The identity type.                                | [FactoryIdentity_Type](#FactoryIdentity_Type)<br/><small>Required</small>                 |
 | userAssignedIdentities | List of user assigned identities for the factory. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="FactoryIdentity_STATUS"></a>FactoryIdentity_STATUS
----------------------------------------------------------
+FactoryIdentity_STATUS{#FactoryIdentity_STATUS}
+-----------------------------------------------
 
 Identity properties of the factory resource.
 
@@ -177,8 +177,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 | type                   | The identity type.                                | [FactoryIdentity_Type_STATUS](#FactoryIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | List of user assigned identities for the factory. | map[string]v1.JSON<br/><small>Optional</small>                                          |
 
-<a id="FactoryOperatorSpec"></a>FactoryOperatorSpec
----------------------------------------------------
+FactoryOperatorSpec{#FactoryOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -189,8 +189,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FactoryProperties_PublicNetworkAccess"></a>FactoryProperties_PublicNetworkAccess
----------------------------------------------------------------------------------------
+FactoryProperties_PublicNetworkAccess{#FactoryProperties_PublicNetworkAccess}
+-----------------------------------------------------------------------------
 
 Used by: [Factory_Spec](#Factory_Spec).
 
@@ -199,8 +199,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FactoryProperties_PublicNetworkAccess_STATUS"></a>FactoryProperties_PublicNetworkAccess_STATUS
------------------------------------------------------------------------------------------------------
+FactoryProperties_PublicNetworkAccess_STATUS{#FactoryProperties_PublicNetworkAccess_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [Factory_STATUS](#Factory_STATUS).
 
@@ -209,8 +209,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FactoryRepoConfiguration"></a>FactoryRepoConfiguration
--------------------------------------------------------------
+FactoryRepoConfiguration{#FactoryRepoConfiguration}
+---------------------------------------------------
 
 Used by: [Factory_Spec](#Factory_Spec).
 
@@ -219,8 +219,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | factoryGitHubConfiguration | Mutually exclusive with all other properties | [FactoryGitHubConfiguration](#FactoryGitHubConfiguration)<br/><small>Optional</small> |
 | factoryVSTSConfiguration   | Mutually exclusive with all other properties | [FactoryVSTSConfiguration](#FactoryVSTSConfiguration)<br/><small>Optional</small>     |
 
-<a id="FactoryRepoConfiguration_STATUS"></a>FactoryRepoConfiguration_STATUS
----------------------------------------------------------------------------
+FactoryRepoConfiguration_STATUS{#FactoryRepoConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Factory_STATUS](#Factory_STATUS).
 
@@ -229,8 +229,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 | factoryGitHubConfiguration | Mutually exclusive with all other properties | [FactoryGitHubConfiguration_STATUS](#FactoryGitHubConfiguration_STATUS)<br/><small>Optional</small> |
 | factoryVSTSConfiguration   | Mutually exclusive with all other properties | [FactoryVSTSConfiguration_STATUS](#FactoryVSTSConfiguration_STATUS)<br/><small>Optional</small>     |
 
-<a id="GlobalParameterSpecification"></a>GlobalParameterSpecification
----------------------------------------------------------------------
+GlobalParameterSpecification{#GlobalParameterSpecification}
+-----------------------------------------------------------
 
 Definition of a single parameter for an entity.
 
@@ -241,8 +241,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 | type     | Global Parameter type. | [GlobalParameterSpecification_Type](#GlobalParameterSpecification_Type)<br/><small>Required</small> |
 | value    | Value of parameter.    | map[string]v1.JSON<br/><small>Required</small>                                                      |
 
-<a id="GlobalParameterSpecification_STATUS"></a>GlobalParameterSpecification_STATUS
------------------------------------------------------------------------------------
+GlobalParameterSpecification_STATUS{#GlobalParameterSpecification_STATUS}
+-------------------------------------------------------------------------
 
 Definition of a single parameter for an entity.
 
@@ -253,8 +253,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 | type     | Global Parameter type. | [GlobalParameterSpecification_Type_STATUS](#GlobalParameterSpecification_Type_STATUS)<br/><small>Optional</small> |
 | value    | Value of parameter.    | map[string]v1.JSON<br/><small>Optional</small>                                                                    |
 
-<a id="PurviewConfiguration"></a>PurviewConfiguration
------------------------------------------------------
+PurviewConfiguration{#PurviewConfiguration}
+-------------------------------------------
 
 Purview configuration.
 
@@ -264,8 +264,8 @@ Used by: [Factory_Spec](#Factory_Spec).
 |--------------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | purviewResourceReference | Purview resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PurviewConfiguration_STATUS"></a>PurviewConfiguration_STATUS
--------------------------------------------------------------------
+PurviewConfiguration_STATUS{#PurviewConfiguration_STATUS}
+---------------------------------------------------------
 
 Purview configuration.
 
@@ -275,8 +275,8 @@ Used by: [Factory_STATUS](#Factory_STATUS).
 |-------------------|----------------------|------------------------------------|
 | purviewResourceId | Purview resource id. | string<br/><small>Optional</small> |
 
-<a id="CMKIdentityDefinition"></a>CMKIdentityDefinition
--------------------------------------------------------
+CMKIdentityDefinition{#CMKIdentityDefinition}
+---------------------------------------------
 
 Managed Identity used for CMK.
 
@@ -286,8 +286,8 @@ Used by: [EncryptionConfiguration](#EncryptionConfiguration).
 |-------------------------------|----------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | The resource id of the user assigned identity to authenticate to customer's key vault. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CMKIdentityDefinition_STATUS"></a>CMKIdentityDefinition_STATUS
----------------------------------------------------------------------
+CMKIdentityDefinition_STATUS{#CMKIdentityDefinition_STATUS}
+-----------------------------------------------------------
 
 Managed Identity used for CMK.
 
@@ -297,8 +297,8 @@ Used by: [EncryptionConfiguration_STATUS](#EncryptionConfiguration_STATUS).
 |----------------------|----------------------------------------------------------------------------------------|------------------------------------|
 | userAssignedIdentity | The resource id of the user assigned identity to authenticate to customer's key vault. | string<br/><small>Optional</small> |
 
-<a id="FactoryGitHubConfiguration"></a>FactoryGitHubConfiguration
------------------------------------------------------------------
+FactoryGitHubConfiguration{#FactoryGitHubConfiguration}
+-------------------------------------------------------
 
 Used by: [FactoryRepoConfiguration](#FactoryRepoConfiguration).
 
@@ -315,8 +315,8 @@ Used by: [FactoryRepoConfiguration](#FactoryRepoConfiguration).
 | rootFolder          | Root folder.                                                               | string<br/><small>Required</small>                                                              |
 | type                | Type of repo configuration.                                                | [FactoryGitHubConfiguration_Type](#FactoryGitHubConfiguration_Type)<br/><small>Required</small> |
 
-<a id="FactoryGitHubConfiguration_STATUS"></a>FactoryGitHubConfiguration_STATUS
--------------------------------------------------------------------------------
+FactoryGitHubConfiguration_STATUS{#FactoryGitHubConfiguration_STATUS}
+---------------------------------------------------------------------
 
 Used by: [FactoryRepoConfiguration_STATUS](#FactoryRepoConfiguration_STATUS).
 
@@ -333,8 +333,8 @@ Used by: [FactoryRepoConfiguration_STATUS](#FactoryRepoConfiguration_STATUS).
 | rootFolder          | Root folder.                                                               | string<br/><small>Optional</small>                                                                            |
 | type                | Type of repo configuration.                                                | [FactoryGitHubConfiguration_Type_STATUS](#FactoryGitHubConfiguration_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="FactoryIdentity_Type"></a>FactoryIdentity_Type
------------------------------------------------------
+FactoryIdentity_Type{#FactoryIdentity_Type}
+-------------------------------------------
 
 Used by: [FactoryIdentity](#FactoryIdentity).
 
@@ -344,8 +344,8 @@ Used by: [FactoryIdentity](#FactoryIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="FactoryIdentity_Type_STATUS"></a>FactoryIdentity_Type_STATUS
--------------------------------------------------------------------
+FactoryIdentity_Type_STATUS{#FactoryIdentity_Type_STATUS}
+---------------------------------------------------------
 
 Used by: [FactoryIdentity_STATUS](#FactoryIdentity_STATUS).
 
@@ -355,8 +355,8 @@ Used by: [FactoryIdentity_STATUS](#FactoryIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="FactoryVSTSConfiguration"></a>FactoryVSTSConfiguration
--------------------------------------------------------------
+FactoryVSTSConfiguration{#FactoryVSTSConfiguration}
+---------------------------------------------------
 
 Used by: [FactoryRepoConfiguration](#FactoryRepoConfiguration).
 
@@ -372,8 +372,8 @@ Used by: [FactoryRepoConfiguration](#FactoryRepoConfiguration).
 | tenantId            | VSTS tenant id.                                                            | string<br/><small>Optional</small>                                                          |
 | type                | Type of repo configuration.                                                | [FactoryVSTSConfiguration_Type](#FactoryVSTSConfiguration_Type)<br/><small>Required</small> |
 
-<a id="FactoryVSTSConfiguration_STATUS"></a>FactoryVSTSConfiguration_STATUS
----------------------------------------------------------------------------
+FactoryVSTSConfiguration_STATUS{#FactoryVSTSConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Used by: [FactoryRepoConfiguration_STATUS](#FactoryRepoConfiguration_STATUS).
 
@@ -389,8 +389,8 @@ Used by: [FactoryRepoConfiguration_STATUS](#FactoryRepoConfiguration_STATUS).
 | tenantId            | VSTS tenant id.                                                            | string<br/><small>Optional</small>                                                                        |
 | type                | Type of repo configuration.                                                | [FactoryVSTSConfiguration_Type_STATUS](#FactoryVSTSConfiguration_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="GlobalParameterSpecification_Type"></a>GlobalParameterSpecification_Type
--------------------------------------------------------------------------------
+GlobalParameterSpecification_Type{#GlobalParameterSpecification_Type}
+---------------------------------------------------------------------
 
 Used by: [GlobalParameterSpecification](#GlobalParameterSpecification).
 
@@ -403,8 +403,8 @@ Used by: [GlobalParameterSpecification](#GlobalParameterSpecification).
 | "Object" |             |
 | "String" |             |
 
-<a id="GlobalParameterSpecification_Type_STATUS"></a>GlobalParameterSpecification_Type_STATUS
----------------------------------------------------------------------------------------------
+GlobalParameterSpecification_Type_STATUS{#GlobalParameterSpecification_Type_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [GlobalParameterSpecification_STATUS](#GlobalParameterSpecification_STATUS).
 
@@ -417,8 +417,8 @@ Used by: [GlobalParameterSpecification_STATUS](#GlobalParameterSpecification_STA
 | "Object" |             |
 | "String" |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -428,8 +428,8 @@ Used by: [FactoryIdentity](#FactoryIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="FactoryGitHubConfiguration_Type"></a>FactoryGitHubConfiguration_Type
----------------------------------------------------------------------------
+FactoryGitHubConfiguration_Type{#FactoryGitHubConfiguration_Type}
+-----------------------------------------------------------------
 
 Used by: [FactoryGitHubConfiguration](#FactoryGitHubConfiguration).
 
@@ -437,8 +437,8 @@ Used by: [FactoryGitHubConfiguration](#FactoryGitHubConfiguration).
 |------------------------------|-------------|
 | "FactoryGitHubConfiguration" |             |
 
-<a id="FactoryGitHubConfiguration_Type_STATUS"></a>FactoryGitHubConfiguration_Type_STATUS
------------------------------------------------------------------------------------------
+FactoryGitHubConfiguration_Type_STATUS{#FactoryGitHubConfiguration_Type_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [FactoryGitHubConfiguration_STATUS](#FactoryGitHubConfiguration_STATUS).
 
@@ -446,8 +446,8 @@ Used by: [FactoryGitHubConfiguration_STATUS](#FactoryGitHubConfiguration_STATUS)
 |------------------------------|-------------|
 | "FactoryGitHubConfiguration" |             |
 
-<a id="FactoryVSTSConfiguration_Type"></a>FactoryVSTSConfiguration_Type
------------------------------------------------------------------------
+FactoryVSTSConfiguration_Type{#FactoryVSTSConfiguration_Type}
+-------------------------------------------------------------
 
 Used by: [FactoryVSTSConfiguration](#FactoryVSTSConfiguration).
 
@@ -455,8 +455,8 @@ Used by: [FactoryVSTSConfiguration](#FactoryVSTSConfiguration).
 |----------------------------|-------------|
 | "FactoryVSTSConfiguration" |             |
 
-<a id="FactoryVSTSConfiguration_Type_STATUS"></a>FactoryVSTSConfiguration_Type_STATUS
--------------------------------------------------------------------------------------
+FactoryVSTSConfiguration_Type_STATUS{#FactoryVSTSConfiguration_Type_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [FactoryVSTSConfiguration_STATUS](#FactoryVSTSConfiguration_STATUS).
 
@@ -464,8 +464,8 @@ Used by: [FactoryVSTSConfiguration_STATUS](#FactoryVSTSConfiguration_STATUS).
 |----------------------------|-------------|
 | "FactoryVSTSConfiguration" |             |
 
-<a id="GitHubClientSecret"></a>GitHubClientSecret
--------------------------------------------------
+GitHubClientSecret{#GitHubClientSecret}
+---------------------------------------
 
 Client secret information for factory's bring your own app repository configuration.
 
@@ -476,8 +476,8 @@ Used by: [FactoryGitHubConfiguration](#FactoryGitHubConfiguration).
 | byoaSecretAkvUrl | Bring your own app client secret AKV URL.     | string<br/><small>Optional</small> |
 | byoaSecretName   | Bring your own app client secret name in AKV. | string<br/><small>Optional</small> |
 
-<a id="GitHubClientSecret_STATUS"></a>GitHubClientSecret_STATUS
----------------------------------------------------------------
+GitHubClientSecret_STATUS{#GitHubClientSecret_STATUS}
+-----------------------------------------------------
 
 Client secret information for factory's bring your own app repository configuration.
 

--- a/docs/hugo/content/reference/dataprotection/v1api20230101.md
+++ b/docs/hugo/content/reference/dataprotection/v1api20230101.md
@@ -5,15 +5,15 @@ title: dataprotection.azure.com/v1api20230101
 linktitle: v1api20230101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-01-01" |             |
 
-<a id="BackupVault"></a>BackupVault
------------------------------------
+BackupVault{#BackupVault}
+-------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}
 
@@ -26,7 +26,7 @@ Used by: [BackupVaultList](#BackupVaultList).
 | spec                                                                                    |             | [BackupVault_Spec](#BackupVault_Spec)<br/><small>Optional</small>                     |
 | status                                                                                  |             | [BackupVaultResource_STATUS](#BackupVaultResource_STATUS)<br/><small>Optional</small> |
 
-### <a id="BackupVault_Spec"></a>BackupVault_Spec
+### BackupVault_Spec {#BackupVault_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,7 +38,7 @@ Used by: [BackupVaultList](#BackupVaultList).
 | properties   | BackupVaultResource properties                                                                                                                                                                                                                                                               | [BackupVaultSpec](#BackupVaultSpec)<br/><small>Required</small>                                                                                                      |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="BackupVaultResource_STATUS"></a>BackupVaultResource_STATUS
+### BackupVaultResource_STATUS{#BackupVaultResource_STATUS}
 
 | Property   | Description                                                                                    | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,8 +53,8 @@ Used by: [BackupVaultList](#BackupVaultList).
 | tags       | Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultList"></a>BackupVaultList
--------------------------------------------
+BackupVaultList{#BackupVaultList}
+---------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}
 
@@ -64,8 +64,8 @@ Generator information: - Generated from: /dataprotection/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [BackupVault[]](#BackupVault)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupPolicy"></a>BackupVaultsBackupPolicy
--------------------------------------------------------------
+BackupVaultsBackupPolicy{#BackupVaultsBackupPolicy}
+---------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies/{backupPolicyName}
 
@@ -78,7 +78,7 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | spec                                                                                    |             | [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="BackupVaultsBackupPolicy_Spec"></a>BackupVaultsBackupPolicy_Spec
+### BackupVaultsBackupPolicy_Spec {#BackupVaultsBackupPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -87,7 +87,7 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dataprotection.azure.com/BackupVault resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   | BaseBackupPolicyResource properties                                                                                                                                                                                                                                                             | [BaseBackupPolicy](#BaseBackupPolicy)<br/><small>Optional</small>                                                                                                    |
 
-### <a id="BackupVaultsBackupPolicy_STATUS"></a>BackupVaultsBackupPolicy_STATUS
+### BackupVaultsBackupPolicy_STATUS{#BackupVaultsBackupPolicy_STATUS}
 
 | Property   | Description                                                                                    | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -98,8 +98,8 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | systemData | Metadata pertaining to creation and last modification of the resource.                         | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupPolicyList"></a>BackupVaultsBackupPolicyList
----------------------------------------------------------------------
+BackupVaultsBackupPolicyList{#BackupVaultsBackupPolicyList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies/{backupPolicyName}
 
@@ -109,8 +109,8 @@ Generator information: - Generated from: /dataprotection/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [BackupVaultsBackupPolicy[]](#BackupVaultsBackupPolicy)<br/><small>Optional</small> |
 
-<a id="BackupVault_Spec"></a>BackupVault_Spec
----------------------------------------------
+BackupVault_Spec{#BackupVault_Spec}
+-----------------------------------
 
 Used by: [BackupVault](#BackupVault).
 
@@ -124,8 +124,8 @@ Used by: [BackupVault](#BackupVault).
 | properties   | BackupVaultResource properties                                                                                                                                                                                                                                                               | [BackupVaultSpec](#BackupVaultSpec)<br/><small>Required</small>                                                                                                      |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="BackupVaultResource_STATUS"></a>BackupVaultResource_STATUS
------------------------------------------------------------------
+BackupVaultResource_STATUS{#BackupVaultResource_STATUS}
+-------------------------------------------------------
 
 Backup Vault Resource
 
@@ -144,8 +144,8 @@ Used by: [BackupVault](#BackupVault).
 | tags       | Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupPolicy_Spec"></a>BackupVaultsBackupPolicy_Spec
------------------------------------------------------------------------
+BackupVaultsBackupPolicy_Spec{#BackupVaultsBackupPolicy_Spec}
+-------------------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 
@@ -156,8 +156,8 @@ Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dataprotection.azure.com/BackupVault resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   | BaseBackupPolicyResource properties                                                                                                                                                                                                                                                             | [BaseBackupPolicy](#BaseBackupPolicy)<br/><small>Optional</small>                                                                                                    |
 
-<a id="BackupVaultsBackupPolicy_STATUS"></a>BackupVaultsBackupPolicy_STATUS
----------------------------------------------------------------------------
+BackupVaultsBackupPolicy_STATUS{#BackupVaultsBackupPolicy_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 
@@ -170,8 +170,8 @@ Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 | systemData | Metadata pertaining to creation and last modification of the resource.                         | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVault_STATUS"></a>BackupVault_STATUS
--------------------------------------------------
+BackupVault_STATUS{#BackupVault_STATUS}
+---------------------------------------
 
 Backup Vault
 
@@ -188,8 +188,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS).
 | securitySettings                | Security Settings                              | [SecuritySettings_STATUS](#SecuritySettings_STATUS)<br/><small>Optional</small>                           |
 | storageSettings                 | Storage Settings                               | [StorageSetting_STATUS[]](#StorageSetting_STATUS)<br/><small>Optional</small>                             |
 
-<a id="BackupVaultOperatorSpec"></a>BackupVaultOperatorSpec
------------------------------------------------------------
+BackupVaultOperatorSpec{#BackupVaultOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -201,8 +201,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [BackupVaultOperatorConfigMaps](#BackupVaultOperatorConfigMaps)<br/><small>Optional</small>                                                                         |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupPolicyOperatorSpec"></a>BackupVaultsBackupPolicyOperatorSpec
--------------------------------------------------------------------------------------
+BackupVaultsBackupPolicyOperatorSpec{#BackupVaultsBackupPolicyOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -213,8 +213,8 @@ Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackupVaultSpec"></a>BackupVaultSpec
--------------------------------------------
+BackupVaultSpec{#BackupVaultSpec}
+---------------------------------
 
 Backup Vault
 
@@ -227,8 +227,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 | securitySettings   | Security Settings   | [SecuritySettings](#SecuritySettings)<br/><small>Optional</small>     |
 | storageSettings    | Storage Settings    | [StorageSetting[]](#StorageSetting)<br/><small>Required</small>       |
 
-<a id="BaseBackupPolicy"></a>BaseBackupPolicy
----------------------------------------------
+BaseBackupPolicy{#BaseBackupPolicy}
+-----------------------------------
 
 Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 
@@ -236,8 +236,8 @@ Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 |--------------|----------------------------------------------|-----------------------------------------------------------|
 | backupPolicy | Mutually exclusive with all other properties | [BackupPolicy](#BackupPolicy)<br/><small>Optional</small> |
 
-<a id="BaseBackupPolicy_STATUS"></a>BaseBackupPolicy_STATUS
------------------------------------------------------------
+BaseBackupPolicy_STATUS{#BaseBackupPolicy_STATUS}
+-------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS).
 
@@ -245,8 +245,8 @@ Used by: [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS).
 |--------------|----------------------------------------------|-------------------------------------------------------------------------|
 | backupPolicy | Mutually exclusive with all other properties | [BackupPolicy_STATUS](#BackupPolicy_STATUS)<br/><small>Optional</small> |
 
-<a id="DppIdentityDetails"></a>DppIdentityDetails
--------------------------------------------------
+DppIdentityDetails{#DppIdentityDetails}
+---------------------------------------
 
 Identity details
 
@@ -256,8 +256,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 |----------|-------------------------------------------------------------|------------------------------------|
 | type     | The identityType which can be either SystemAssigned or None | string<br/><small>Optional</small> |
 
-<a id="DppIdentityDetails_STATUS"></a>DppIdentityDetails_STATUS
----------------------------------------------------------------
+DppIdentityDetails_STATUS{#DppIdentityDetails_STATUS}
+-----------------------------------------------------
 
 Identity details
 
@@ -269,8 +269,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS).
 | tenantId    | A Globally Unique Identifier (GUID) that represents the Azure AD tenant where the resource is now a member.                          | string<br/><small>Optional</small> |
 | type        | The identityType which can be either SystemAssigned or None                                                                          | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -285,8 +285,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS), and [BackupV
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy"></a>BackupPolicy
--------------------------------------
+BackupPolicy{#BackupPolicy}
+---------------------------
 
 Used by: [BaseBackupPolicy](#BaseBackupPolicy).
 
@@ -296,8 +296,8 @@ Used by: [BaseBackupPolicy](#BaseBackupPolicy).
 | objectType      |                                                                                              | [BackupPolicy_ObjectType](#BackupPolicy_ObjectType)<br/><small>Required</small> |
 | policyRules     | Policy rule dictionary that contains rules for each backuptype i.e Full/Incremental/Logs etc | [BasePolicyRule[]](#BasePolicyRule)<br/><small>Required</small>                 |
 
-<a id="BackupPolicy_STATUS"></a>BackupPolicy_STATUS
----------------------------------------------------
+BackupPolicy_STATUS{#BackupPolicy_STATUS}
+-----------------------------------------
 
 Used by: [BaseBackupPolicy_STATUS](#BaseBackupPolicy_STATUS).
 
@@ -307,8 +307,8 @@ Used by: [BaseBackupPolicy_STATUS](#BaseBackupPolicy_STATUS).
 | objectType      |                                                                                              | [BackupPolicy_ObjectType_STATUS](#BackupPolicy_ObjectType_STATUS)<br/><small>Optional</small> |
 | policyRules     | Policy rule dictionary that contains rules for each backuptype i.e Full/Incremental/Logs etc | [BasePolicyRule_STATUS[]](#BasePolicyRule_STATUS)<br/><small>Optional</small>                 |
 
-<a id="BackupVault_ProvisioningState_STATUS"></a>BackupVault_ProvisioningState_STATUS
--------------------------------------------------------------------------------------
+BackupVault_ProvisioningState_STATUS{#BackupVault_ProvisioningState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 
@@ -320,8 +320,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | "Unknown"      |             |
 | "Updating"     |             |
 
-<a id="BackupVault_ResourceMoveState_STATUS"></a>BackupVault_ResourceMoveState_STATUS
--------------------------------------------------------------------------------------
+BackupVault_ResourceMoveState_STATUS{#BackupVault_ResourceMoveState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 
@@ -338,8 +338,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | "PrepareTimedout" |             |
 | "Unknown"         |             |
 
-<a id="BackupVaultOperatorConfigMaps"></a>BackupVaultOperatorConfigMaps
------------------------------------------------------------------------
+BackupVaultOperatorConfigMaps{#BackupVaultOperatorConfigMaps}
+-------------------------------------------------------------
 
 Used by: [BackupVaultOperatorSpec](#BackupVaultOperatorSpec).
 
@@ -347,8 +347,8 @@ Used by: [BackupVaultOperatorSpec](#BackupVaultOperatorSpec).
 |-------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | principalId | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FeatureSettings"></a>FeatureSettings
--------------------------------------------
+FeatureSettings{#FeatureSettings}
+---------------------------------
 
 Class containing feature settings of vault
 
@@ -358,8 +358,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 |----------------------------------|-----------------------------------|---------------------------------------------------------------------------------------------------|
 | crossSubscriptionRestoreSettings | CrossSubscriptionRestore Settings | [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings)<br/><small>Optional</small> |
 
-<a id="FeatureSettings_STATUS"></a>FeatureSettings_STATUS
----------------------------------------------------------
+FeatureSettings_STATUS{#FeatureSettings_STATUS}
+-----------------------------------------------
 
 Class containing feature settings of vault
 
@@ -369,8 +369,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 |----------------------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | crossSubscriptionRestoreSettings | CrossSubscriptionRestore Settings | [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="MonitoringSettings"></a>MonitoringSettings
--------------------------------------------------
+MonitoringSettings{#MonitoringSettings}
+---------------------------------------
 
 Monitoring Settings
 
@@ -380,8 +380,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 |---------------------------|-----------------------------------------|-------------------------------------------------------------------------------------|
 | azureMonitorAlertSettings | Settings for Azure Monitor based alerts | [AzureMonitorAlertSettings](#AzureMonitorAlertSettings)<br/><small>Optional</small> |
 
-<a id="MonitoringSettings_STATUS"></a>MonitoringSettings_STATUS
----------------------------------------------------------------
+MonitoringSettings_STATUS{#MonitoringSettings_STATUS}
+-----------------------------------------------------
 
 Monitoring Settings
 
@@ -391,8 +391,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 |---------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------|
 | azureMonitorAlertSettings | Settings for Azure Monitor based alerts | [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceMoveDetails_STATUS"></a>ResourceMoveDetails_STATUS
------------------------------------------------------------------
+ResourceMoveDetails_STATUS{#ResourceMoveDetails_STATUS}
+-------------------------------------------------------
 
 ResourceMoveDetails will be returned in response to GetResource call from ARM
 
@@ -406,8 +406,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | startTimeUtc       | Start time in UTC of latest ResourceMove operation attempted. ISO 8601 format.      | string<br/><small>Optional</small> |
 | targetResourcePath | ARM resource path of target resource used in latest ResourceMove operation          | string<br/><small>Optional</small> |
 
-<a id="SecuritySettings"></a>SecuritySettings
----------------------------------------------
+SecuritySettings{#SecuritySettings}
+-----------------------------------
 
 Class containing security settings of vault
 
@@ -418,8 +418,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 | immutabilitySettings | Immutability Settings at vault level | [ImmutabilitySettings](#ImmutabilitySettings)<br/><small>Optional</small> |
 | softDeleteSettings   | Soft delete related settings         | [SoftDeleteSettings](#SoftDeleteSettings)<br/><small>Optional</small>     |
 
-<a id="SecuritySettings_STATUS"></a>SecuritySettings_STATUS
------------------------------------------------------------
+SecuritySettings_STATUS{#SecuritySettings_STATUS}
+-------------------------------------------------
 
 Class containing security settings of vault
 
@@ -430,8 +430,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | immutabilitySettings | Immutability Settings at vault level | [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS)<br/><small>Optional</small> |
 | softDeleteSettings   | Soft delete related settings         | [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS)<br/><small>Optional</small>     |
 
-<a id="StorageSetting"></a>StorageSetting
------------------------------------------
+StorageSetting{#StorageSetting}
+-------------------------------
 
 Storage setting
 
@@ -442,8 +442,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 | datastoreType | Gets or sets the type of the datastore. | [StorageSetting_DatastoreType](#StorageSetting_DatastoreType)<br/><small>Optional</small> |
 | type          | Gets or sets the type.                  | [StorageSetting_Type](#StorageSetting_Type)<br/><small>Optional</small>                   |
 
-<a id="StorageSetting_STATUS"></a>StorageSetting_STATUS
--------------------------------------------------------
+StorageSetting_STATUS{#StorageSetting_STATUS}
+---------------------------------------------
 
 Storage setting
 
@@ -454,7 +454,19 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | datastoreType | Gets or sets the type of the datastore. | [StorageSetting_DatastoreType_STATUS](#StorageSetting_DatastoreType_STATUS)<br/><small>Optional</small> |
 | type          | Gets or sets the type.                  | [StorageSetting_Type_STATUS](#StorageSetting_Type_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -466,20 +478,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="AzureMonitorAlertSettings"></a>AzureMonitorAlertSettings
----------------------------------------------------------------
+AzureMonitorAlertSettings{#AzureMonitorAlertSettings}
+-----------------------------------------------------
 
 Settings for Azure Monitor based alerts
 
@@ -489,8 +489,8 @@ Used by: [MonitoringSettings](#MonitoringSettings).
 |-------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | alertsForAllJobFailures |             | [AzureMonitorAlertSettings_AlertsForAllJobFailures](#AzureMonitorAlertSettings_AlertsForAllJobFailures)<br/><small>Optional</small> |
 
-<a id="AzureMonitorAlertSettings_STATUS"></a>AzureMonitorAlertSettings_STATUS
------------------------------------------------------------------------------
+AzureMonitorAlertSettings_STATUS{#AzureMonitorAlertSettings_STATUS}
+-------------------------------------------------------------------
 
 Settings for Azure Monitor based alerts
 
@@ -500,8 +500,8 @@ Used by: [MonitoringSettings_STATUS](#MonitoringSettings_STATUS).
 |-------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | alertsForAllJobFailures |             | [AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS](#AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy_ObjectType"></a>BackupPolicy_ObjectType
------------------------------------------------------------
+BackupPolicy_ObjectType{#BackupPolicy_ObjectType}
+-------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -509,8 +509,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 |----------------|-------------|
 | "BackupPolicy" |             |
 
-<a id="BackupPolicy_ObjectType_STATUS"></a>BackupPolicy_ObjectType_STATUS
--------------------------------------------------------------------------
+BackupPolicy_ObjectType_STATUS{#BackupPolicy_ObjectType_STATUS}
+---------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -518,8 +518,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 |----------------|-------------|
 | "BackupPolicy" |             |
 
-<a id="BasePolicyRule"></a>BasePolicyRule
------------------------------------------
+BasePolicyRule{#BasePolicyRule}
+-------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -528,8 +528,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | azureBackupRule    | Mutually exclusive with all other properties | [AzureBackupRule](#AzureBackupRule)<br/><small>Optional</small>       |
 | azureRetentionRule | Mutually exclusive with all other properties | [AzureRetentionRule](#AzureRetentionRule)<br/><small>Optional</small> |
 
-<a id="BasePolicyRule_STATUS"></a>BasePolicyRule_STATUS
--------------------------------------------------------
+BasePolicyRule_STATUS{#BasePolicyRule_STATUS}
+---------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -538,8 +538,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | azureBackupRule    | Mutually exclusive with all other properties | [AzureBackupRule_STATUS](#AzureBackupRule_STATUS)<br/><small>Optional</small>       |
 | azureRetentionRule | Mutually exclusive with all other properties | [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS)<br/><small>Optional</small> |
 
-<a id="CrossSubscriptionRestoreSettings"></a>CrossSubscriptionRestoreSettings
------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings{#CrossSubscriptionRestoreSettings}
+-------------------------------------------------------------------
 
 CrossSubscriptionRestore Settings
 
@@ -549,8 +549,8 @@ Used by: [FeatureSettings](#FeatureSettings).
 |----------|--------------------------------|---------------------------------------------------------------------------------------------------------------|
 | state    | CrossSubscriptionRestore state | [CrossSubscriptionRestoreSettings_State](#CrossSubscriptionRestoreSettings_State)<br/><small>Optional</small> |
 
-<a id="CrossSubscriptionRestoreSettings_STATUS"></a>CrossSubscriptionRestoreSettings_STATUS
--------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_STATUS{#CrossSubscriptionRestoreSettings_STATUS}
+---------------------------------------------------------------------------------
 
 CrossSubscriptionRestore Settings
 
@@ -560,8 +560,8 @@ Used by: [FeatureSettings_STATUS](#FeatureSettings_STATUS).
 |----------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | state    | CrossSubscriptionRestore state | [CrossSubscriptionRestoreSettings_State_STATUS](#CrossSubscriptionRestoreSettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilitySettings"></a>ImmutabilitySettings
------------------------------------------------------
+ImmutabilitySettings{#ImmutabilitySettings}
+-------------------------------------------
 
 Immutability Settings at vault level
 
@@ -571,8 +571,8 @@ Used by: [SecuritySettings](#SecuritySettings).
 |----------|--------------------|---------------------------------------------------------------------------------------|
 | state    | Immutability state | [ImmutabilitySettings_State](#ImmutabilitySettings_State)<br/><small>Optional</small> |
 
-<a id="ImmutabilitySettings_STATUS"></a>ImmutabilitySettings_STATUS
--------------------------------------------------------------------
+ImmutabilitySettings_STATUS{#ImmutabilitySettings_STATUS}
+---------------------------------------------------------
 
 Immutability Settings at vault level
 
@@ -582,8 +582,8 @@ Used by: [SecuritySettings_STATUS](#SecuritySettings_STATUS).
 |----------|--------------------|-----------------------------------------------------------------------------------------------------|
 | state    | Immutability state | [ImmutabilitySettings_State_STATUS](#ImmutabilitySettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="SoftDeleteSettings"></a>SoftDeleteSettings
--------------------------------------------------
+SoftDeleteSettings{#SoftDeleteSettings}
+---------------------------------------
 
 Soft delete related settings
 
@@ -594,8 +594,8 @@ Used by: [SecuritySettings](#SecuritySettings).
 | retentionDurationInDays | Soft delete retention duration | float64<br/><small>Optional</small>                                               |
 | state                   | State of soft delete           | [SoftDeleteSettings_State](#SoftDeleteSettings_State)<br/><small>Optional</small> |
 
-<a id="SoftDeleteSettings_STATUS"></a>SoftDeleteSettings_STATUS
----------------------------------------------------------------
+SoftDeleteSettings_STATUS{#SoftDeleteSettings_STATUS}
+-----------------------------------------------------
 
 Soft delete related settings
 
@@ -606,8 +606,8 @@ Used by: [SecuritySettings_STATUS](#SecuritySettings_STATUS).
 | retentionDurationInDays | Soft delete retention duration | float64<br/><small>Optional</small>                                                             |
 | state                   | State of soft delete           | [SoftDeleteSettings_State_STATUS](#SoftDeleteSettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="StorageSetting_DatastoreType"></a>StorageSetting_DatastoreType
----------------------------------------------------------------------
+StorageSetting_DatastoreType{#StorageSetting_DatastoreType}
+-----------------------------------------------------------
 
 Used by: [StorageSetting](#StorageSetting).
 
@@ -617,8 +617,8 @@ Used by: [StorageSetting](#StorageSetting).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="StorageSetting_DatastoreType_STATUS"></a>StorageSetting_DatastoreType_STATUS
------------------------------------------------------------------------------------
+StorageSetting_DatastoreType_STATUS{#StorageSetting_DatastoreType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 
@@ -628,8 +628,8 @@ Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="StorageSetting_Type"></a>StorageSetting_Type
----------------------------------------------------
+StorageSetting_Type{#StorageSetting_Type}
+-----------------------------------------
 
 Used by: [StorageSetting](#StorageSetting).
 
@@ -639,8 +639,8 @@ Used by: [StorageSetting](#StorageSetting).
 | "LocallyRedundant" |             |
 | "ZoneRedundant"    |             |
 
-<a id="StorageSetting_Type_STATUS"></a>StorageSetting_Type_STATUS
------------------------------------------------------------------
+StorageSetting_Type_STATUS{#StorageSetting_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 
@@ -650,8 +650,8 @@ Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 | "LocallyRedundant" |             |
 | "ZoneRedundant"    |             |
 
-<a id="AzureBackupRule"></a>AzureBackupRule
--------------------------------------------
+AzureBackupRule{#AzureBackupRule}
+---------------------------------
 
 Used by: [BasePolicyRule](#BasePolicyRule).
 
@@ -663,8 +663,8 @@ Used by: [BasePolicyRule](#BasePolicyRule).
 | objectType       |                    | [AzureBackupRule_ObjectType](#AzureBackupRule_ObjectType)<br/><small>Required</small> |
 | trigger          |                    | [TriggerContext](#TriggerContext)<br/><small>Required</small>                         |
 
-<a id="AzureBackupRule_STATUS"></a>AzureBackupRule_STATUS
----------------------------------------------------------
+AzureBackupRule_STATUS{#AzureBackupRule_STATUS}
+-----------------------------------------------
 
 Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 
@@ -676,8 +676,8 @@ Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 | objectType       |                    | [AzureBackupRule_ObjectType_STATUS](#AzureBackupRule_ObjectType_STATUS)<br/><small>Optional</small> |
 | trigger          |                    | [TriggerContext_STATUS](#TriggerContext_STATUS)<br/><small>Optional</small>                         |
 
-<a id="AzureMonitorAlertSettings_AlertsForAllJobFailures"></a>AzureMonitorAlertSettings_AlertsForAllJobFailures
----------------------------------------------------------------------------------------------------------------
+AzureMonitorAlertSettings_AlertsForAllJobFailures{#AzureMonitorAlertSettings_AlertsForAllJobFailures}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [AzureMonitorAlertSettings](#AzureMonitorAlertSettings).
 
@@ -686,8 +686,8 @@ Used by: [AzureMonitorAlertSettings](#AzureMonitorAlertSettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS"></a>AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS
------------------------------------------------------------------------------------------------------------------------------
+AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS{#AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS).
 
@@ -696,8 +696,8 @@ Used by: [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AzureRetentionRule"></a>AzureRetentionRule
--------------------------------------------------
+AzureRetentionRule{#AzureRetentionRule}
+---------------------------------------
 
 Used by: [BasePolicyRule](#BasePolicyRule).
 
@@ -708,8 +708,8 @@ Used by: [BasePolicyRule](#BasePolicyRule).
 | name       |             | string<br/><small>Required</small>                                                          |
 | objectType |             | [AzureRetentionRule_ObjectType](#AzureRetentionRule_ObjectType)<br/><small>Required</small> |
 
-<a id="AzureRetentionRule_STATUS"></a>AzureRetentionRule_STATUS
----------------------------------------------------------------
+AzureRetentionRule_STATUS{#AzureRetentionRule_STATUS}
+-----------------------------------------------------
 
 Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 
@@ -720,8 +720,8 @@ Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 | name       |             | string<br/><small>Optional</small>                                                                        |
 | objectType |             | [AzureRetentionRule_ObjectType_STATUS](#AzureRetentionRule_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="CrossSubscriptionRestoreSettings_State"></a>CrossSubscriptionRestoreSettings_State
------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_State{#CrossSubscriptionRestoreSettings_State}
+-------------------------------------------------------------------------------
 
 Used by: [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings).
 
@@ -731,8 +731,8 @@ Used by: [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings).
 | "Enabled"             |             |
 | "PermanentlyDisabled" |             |
 
-<a id="CrossSubscriptionRestoreSettings_State_STATUS"></a>CrossSubscriptionRestoreSettings_State_STATUS
--------------------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_State_STATUS{#CrossSubscriptionRestoreSettings_State_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSettings_STATUS).
 
@@ -742,8 +742,8 @@ Used by: [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSett
 | "Enabled"             |             |
 | "PermanentlyDisabled" |             |
 
-<a id="ImmutabilitySettings_State"></a>ImmutabilitySettings_State
------------------------------------------------------------------
+ImmutabilitySettings_State{#ImmutabilitySettings_State}
+-------------------------------------------------------
 
 Used by: [ImmutabilitySettings](#ImmutabilitySettings).
 
@@ -753,8 +753,8 @@ Used by: [ImmutabilitySettings](#ImmutabilitySettings).
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ImmutabilitySettings_State_STATUS"></a>ImmutabilitySettings_State_STATUS
--------------------------------------------------------------------------------
+ImmutabilitySettings_State_STATUS{#ImmutabilitySettings_State_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS).
 
@@ -764,8 +764,8 @@ Used by: [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS).
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="SoftDeleteSettings_State"></a>SoftDeleteSettings_State
--------------------------------------------------------------
+SoftDeleteSettings_State{#SoftDeleteSettings_State}
+---------------------------------------------------
 
 Used by: [SoftDeleteSettings](#SoftDeleteSettings).
 
@@ -775,8 +775,8 @@ Used by: [SoftDeleteSettings](#SoftDeleteSettings).
 | "Off"      |             |
 | "On"       |             |
 
-<a id="SoftDeleteSettings_State_STATUS"></a>SoftDeleteSettings_State_STATUS
----------------------------------------------------------------------------
+SoftDeleteSettings_State_STATUS{#SoftDeleteSettings_State_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS).
 
@@ -786,8 +786,8 @@ Used by: [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS).
 | "Off"      |             |
 | "On"       |             |
 
-<a id="AzureBackupRule_ObjectType"></a>AzureBackupRule_ObjectType
------------------------------------------------------------------
+AzureBackupRule_ObjectType{#AzureBackupRule_ObjectType}
+-------------------------------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -795,8 +795,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 |-------------------|-------------|
 | "AzureBackupRule" |             |
 
-<a id="AzureBackupRule_ObjectType_STATUS"></a>AzureBackupRule_ObjectType_STATUS
--------------------------------------------------------------------------------
+AzureBackupRule_ObjectType_STATUS{#AzureBackupRule_ObjectType_STATUS}
+---------------------------------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -804,8 +804,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 |-------------------|-------------|
 | "AzureBackupRule" |             |
 
-<a id="AzureRetentionRule_ObjectType"></a>AzureRetentionRule_ObjectType
------------------------------------------------------------------------
+AzureRetentionRule_ObjectType{#AzureRetentionRule_ObjectType}
+-------------------------------------------------------------
 
 Used by: [AzureRetentionRule](#AzureRetentionRule).
 
@@ -813,8 +813,8 @@ Used by: [AzureRetentionRule](#AzureRetentionRule).
 |----------------------|-------------|
 | "AzureRetentionRule" |             |
 
-<a id="AzureRetentionRule_ObjectType_STATUS"></a>AzureRetentionRule_ObjectType_STATUS
--------------------------------------------------------------------------------------
+AzureRetentionRule_ObjectType_STATUS{#AzureRetentionRule_ObjectType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 
@@ -822,8 +822,8 @@ Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 |----------------------|-------------|
 | "AzureRetentionRule" |             |
 
-<a id="BackupParameters"></a>BackupParameters
----------------------------------------------
+BackupParameters{#BackupParameters}
+-----------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -831,8 +831,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 |-------------------|----------------------------------------------|---------------------------------------------------------------------|
 | azureBackupParams | Mutually exclusive with all other properties | [AzureBackupParams](#AzureBackupParams)<br/><small>Optional</small> |
 
-<a id="BackupParameters_STATUS"></a>BackupParameters_STATUS
------------------------------------------------------------
+BackupParameters_STATUS{#BackupParameters_STATUS}
+-------------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -840,8 +840,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 |-------------------|----------------------------------------------|-----------------------------------------------------------------------------------|
 | azureBackupParams | Mutually exclusive with all other properties | [AzureBackupParams_STATUS](#AzureBackupParams_STATUS)<br/><small>Optional</small> |
 
-<a id="DataStoreInfoBase"></a>DataStoreInfoBase
------------------------------------------------
+DataStoreInfoBase{#DataStoreInfoBase}
+-------------------------------------
 
 DataStoreInfo base
 
@@ -852,8 +852,8 @@ Used by: [AzureBackupRule](#AzureBackupRule), [SourceLifeCycle](#SourceLifeCycle
 | dataStoreType | type of datastore; Operational/Vault/Archive                           | [DataStoreInfoBase_DataStoreType](#DataStoreInfoBase_DataStoreType)<br/><small>Required</small> |
 | objectType    | Type of Datasource object, used to initialize the right inherited type | string<br/><small>Required</small>                                                              |
 
-<a id="DataStoreInfoBase_STATUS"></a>DataStoreInfoBase_STATUS
--------------------------------------------------------------
+DataStoreInfoBase_STATUS{#DataStoreInfoBase_STATUS}
+---------------------------------------------------
 
 DataStoreInfo base
 
@@ -864,8 +864,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS), [SourceLifeCycle_STA
 | dataStoreType | type of datastore; Operational/Vault/Archive                           | [DataStoreInfoBase_DataStoreType_STATUS](#DataStoreInfoBase_DataStoreType_STATUS)<br/><small>Optional</small> |
 | objectType    | Type of Datasource object, used to initialize the right inherited type | string<br/><small>Optional</small>                                                                            |
 
-<a id="SourceLifeCycle"></a>SourceLifeCycle
--------------------------------------------
+SourceLifeCycle{#SourceLifeCycle}
+---------------------------------
 
 Source LifeCycle
 
@@ -877,8 +877,8 @@ Used by: [AzureRetentionRule](#AzureRetentionRule).
 | sourceDataStore             | DataStoreInfo base | [DataStoreInfoBase](#DataStoreInfoBase)<br/><small>Required</small>   |
 | targetDataStoreCopySettings |                    | [TargetCopySetting[]](#TargetCopySetting)<br/><small>Optional</small> |
 
-<a id="SourceLifeCycle_STATUS"></a>SourceLifeCycle_STATUS
----------------------------------------------------------
+SourceLifeCycle_STATUS{#SourceLifeCycle_STATUS}
+-----------------------------------------------
 
 Source LifeCycle
 
@@ -890,8 +890,8 @@ Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 | sourceDataStore             | DataStoreInfo base | [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS)<br/><small>Optional</small>   |
 | targetDataStoreCopySettings |                    | [TargetCopySetting_STATUS[]](#TargetCopySetting_STATUS)<br/><small>Optional</small> |
 
-<a id="TriggerContext"></a>TriggerContext
------------------------------------------
+TriggerContext{#TriggerContext}
+-------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -900,8 +900,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 | adhocBasedTriggerContext    | Mutually exclusive with all other properties | [AdhocBasedTriggerContext](#AdhocBasedTriggerContext)<br/><small>Optional</small>       |
 | scheduleBasedTriggerContext | Mutually exclusive with all other properties | [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext)<br/><small>Optional</small> |
 
-<a id="TriggerContext_STATUS"></a>TriggerContext_STATUS
--------------------------------------------------------
+TriggerContext_STATUS{#TriggerContext_STATUS}
+---------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -910,8 +910,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 | adhocBasedTriggerContext    | Mutually exclusive with all other properties | [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS)<br/><small>Optional</small>       |
 | scheduleBasedTriggerContext | Mutually exclusive with all other properties | [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTriggerContext"></a>AdhocBasedTriggerContext
--------------------------------------------------------------
+AdhocBasedTriggerContext{#AdhocBasedTriggerContext}
+---------------------------------------------------
 
 Used by: [TriggerContext](#TriggerContext).
 
@@ -920,8 +920,8 @@ Used by: [TriggerContext](#TriggerContext).
 | objectType      | Type of the specific object - used for deserializing        | [AdhocBasedTriggerContext_ObjectType](#AdhocBasedTriggerContext_ObjectType)<br/><small>Required</small> |
 | taggingCriteria | Tagging Criteria containing retention tag for adhoc backup. | [AdhocBasedTaggingCriteria](#AdhocBasedTaggingCriteria)<br/><small>Required</small>                     |
 
-<a id="AdhocBasedTriggerContext_STATUS"></a>AdhocBasedTriggerContext_STATUS
----------------------------------------------------------------------------
+AdhocBasedTriggerContext_STATUS{#AdhocBasedTriggerContext_STATUS}
+-----------------------------------------------------------------
 
 Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 
@@ -930,8 +930,8 @@ Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 | objectType      | Type of the specific object - used for deserializing        | [AdhocBasedTriggerContext_ObjectType_STATUS](#AdhocBasedTriggerContext_ObjectType_STATUS)<br/><small>Optional</small> |
 | taggingCriteria | Tagging Criteria containing retention tag for adhoc backup. | [AdhocBasedTaggingCriteria_STATUS](#AdhocBasedTaggingCriteria_STATUS)<br/><small>Optional</small>                     |
 
-<a id="AzureBackupParams"></a>AzureBackupParams
------------------------------------------------
+AzureBackupParams{#AzureBackupParams}
+-------------------------------------
 
 Used by: [BackupParameters](#BackupParameters).
 
@@ -940,8 +940,8 @@ Used by: [BackupParameters](#BackupParameters).
 | backupType | BackupType ; Full/Incremental etc                    | string<br/><small>Required</small>                                                        |
 | objectType | Type of the specific object - used for deserializing | [AzureBackupParams_ObjectType](#AzureBackupParams_ObjectType)<br/><small>Required</small> |
 
-<a id="AzureBackupParams_STATUS"></a>AzureBackupParams_STATUS
--------------------------------------------------------------
+AzureBackupParams_STATUS{#AzureBackupParams_STATUS}
+---------------------------------------------------
 
 Used by: [BackupParameters_STATUS](#BackupParameters_STATUS).
 
@@ -950,8 +950,8 @@ Used by: [BackupParameters_STATUS](#BackupParameters_STATUS).
 | backupType | BackupType ; Full/Incremental etc                    | string<br/><small>Optional</small>                                                                      |
 | objectType | Type of the specific object - used for deserializing | [AzureBackupParams_ObjectType_STATUS](#AzureBackupParams_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="DataStoreInfoBase_DataStoreType"></a>DataStoreInfoBase_DataStoreType
----------------------------------------------------------------------------
+DataStoreInfoBase_DataStoreType{#DataStoreInfoBase_DataStoreType}
+-----------------------------------------------------------------
 
 Used by: [DataStoreInfoBase](#DataStoreInfoBase).
 
@@ -961,8 +961,8 @@ Used by: [DataStoreInfoBase](#DataStoreInfoBase).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="DataStoreInfoBase_DataStoreType_STATUS"></a>DataStoreInfoBase_DataStoreType_STATUS
------------------------------------------------------------------------------------------
+DataStoreInfoBase_DataStoreType_STATUS{#DataStoreInfoBase_DataStoreType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS).
 
@@ -972,8 +972,8 @@ Used by: [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="DeleteOption"></a>DeleteOption
--------------------------------------
+DeleteOption{#DeleteOption}
+---------------------------
 
 Used by: [SourceLifeCycle](#SourceLifeCycle).
 
@@ -981,8 +981,8 @@ Used by: [SourceLifeCycle](#SourceLifeCycle).
 |----------------------|----------------------------------------------|---------------------------------------------------------------------------|
 | absoluteDeleteOption | Mutually exclusive with all other properties | [AbsoluteDeleteOption](#AbsoluteDeleteOption)<br/><small>Optional</small> |
 
-<a id="DeleteOption_STATUS"></a>DeleteOption_STATUS
----------------------------------------------------
+DeleteOption_STATUS{#DeleteOption_STATUS}
+-----------------------------------------
 
 Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 
@@ -990,8 +990,8 @@ Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 |----------------------|----------------------------------------------|-----------------------------------------------------------------------------------------|
 | absoluteDeleteOption | Mutually exclusive with all other properties | [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduleBasedTriggerContext"></a>ScheduleBasedTriggerContext
--------------------------------------------------------------------
+ScheduleBasedTriggerContext{#ScheduleBasedTriggerContext}
+---------------------------------------------------------
 
 Used by: [TriggerContext](#TriggerContext).
 
@@ -1001,8 +1001,8 @@ Used by: [TriggerContext](#TriggerContext).
 | schedule        | Schedule for this backup                                | [BackupSchedule](#BackupSchedule)<br/><small>Required</small>                                                 |
 | taggingCriteria | List of tags that can be applicable for given schedule. | [TaggingCriteria[]](#TaggingCriteria)<br/><small>Required</small>                                             |
 
-<a id="ScheduleBasedTriggerContext_STATUS"></a>ScheduleBasedTriggerContext_STATUS
----------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_STATUS{#ScheduleBasedTriggerContext_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 
@@ -1012,8 +1012,8 @@ Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 | schedule        | Schedule for this backup                                | [BackupSchedule_STATUS](#BackupSchedule_STATUS)<br/><small>Optional</small>                                                 |
 | taggingCriteria | List of tags that can be applicable for given schedule. | [TaggingCriteria_STATUS[]](#TaggingCriteria_STATUS)<br/><small>Optional</small>                                             |
 
-<a id="TargetCopySetting"></a>TargetCopySetting
------------------------------------------------
+TargetCopySetting{#TargetCopySetting}
+-------------------------------------
 
 Target copy settings
 
@@ -1024,8 +1024,8 @@ Used by: [SourceLifeCycle](#SourceLifeCycle).
 | copyAfter | It can be CustomCopyOption or ImmediateCopyOption. | [CopyOption](#CopyOption)<br/><small>Required</small>               |
 | dataStore | Info of target datastore                           | [DataStoreInfoBase](#DataStoreInfoBase)<br/><small>Required</small> |
 
-<a id="TargetCopySetting_STATUS"></a>TargetCopySetting_STATUS
--------------------------------------------------------------
+TargetCopySetting_STATUS{#TargetCopySetting_STATUS}
+---------------------------------------------------
 
 Target copy settings
 
@@ -1036,8 +1036,8 @@ Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 | copyAfter | It can be CustomCopyOption or ImmediateCopyOption. | [CopyOption_STATUS](#CopyOption_STATUS)<br/><small>Optional</small>               |
 | dataStore | Info of target datastore                           | [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS)<br/><small>Optional</small> |
 
-<a id="AbsoluteDeleteOption"></a>AbsoluteDeleteOption
------------------------------------------------------
+AbsoluteDeleteOption{#AbsoluteDeleteOption}
+-------------------------------------------
 
 Used by: [DeleteOption](#DeleteOption).
 
@@ -1046,8 +1046,8 @@ Used by: [DeleteOption](#DeleteOption).
 | duration   | Duration of deletion after given timespan            | string<br/><small>Required</small>                                                              |
 | objectType | Type of the specific object - used for deserializing | [AbsoluteDeleteOption_ObjectType](#AbsoluteDeleteOption_ObjectType)<br/><small>Required</small> |
 
-<a id="AbsoluteDeleteOption_STATUS"></a>AbsoluteDeleteOption_STATUS
--------------------------------------------------------------------
+AbsoluteDeleteOption_STATUS{#AbsoluteDeleteOption_STATUS}
+---------------------------------------------------------
 
 Used by: [DeleteOption_STATUS](#DeleteOption_STATUS).
 
@@ -1056,8 +1056,8 @@ Used by: [DeleteOption_STATUS](#DeleteOption_STATUS).
 | duration   | Duration of deletion after given timespan            | string<br/><small>Optional</small>                                                                            |
 | objectType | Type of the specific object - used for deserializing | [AbsoluteDeleteOption_ObjectType_STATUS](#AbsoluteDeleteOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTaggingCriteria"></a>AdhocBasedTaggingCriteria
----------------------------------------------------------------
+AdhocBasedTaggingCriteria{#AdhocBasedTaggingCriteria}
+-----------------------------------------------------
 
 Adhoc backup tagging criteria
 
@@ -1067,8 +1067,8 @@ Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 |----------|---------------------------|-----------------------------------------------------------|
 | tagInfo  | Retention tag information | [RetentionTag](#RetentionTag)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTaggingCriteria_STATUS"></a>AdhocBasedTaggingCriteria_STATUS
------------------------------------------------------------------------------
+AdhocBasedTaggingCriteria_STATUS{#AdhocBasedTaggingCriteria_STATUS}
+-------------------------------------------------------------------
 
 Adhoc backup tagging criteria
 
@@ -1078,8 +1078,8 @@ Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 |----------|---------------------------|-------------------------------------------------------------------------|
 | tagInfo  | Retention tag information | [RetentionTag_STATUS](#RetentionTag_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTriggerContext_ObjectType"></a>AdhocBasedTriggerContext_ObjectType
------------------------------------------------------------------------------------
+AdhocBasedTriggerContext_ObjectType{#AdhocBasedTriggerContext_ObjectType}
+-------------------------------------------------------------------------
 
 Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 
@@ -1087,8 +1087,8 @@ Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 |----------------------------|-------------|
 | "AdhocBasedTriggerContext" |             |
 
-<a id="AdhocBasedTriggerContext_ObjectType_STATUS"></a>AdhocBasedTriggerContext_ObjectType_STATUS
--------------------------------------------------------------------------------------------------
+AdhocBasedTriggerContext_ObjectType_STATUS{#AdhocBasedTriggerContext_ObjectType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 
@@ -1096,8 +1096,8 @@ Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 |----------------------------|-------------|
 | "AdhocBasedTriggerContext" |             |
 
-<a id="AzureBackupParams_ObjectType"></a>AzureBackupParams_ObjectType
----------------------------------------------------------------------
+AzureBackupParams_ObjectType{#AzureBackupParams_ObjectType}
+-----------------------------------------------------------
 
 Used by: [AzureBackupParams](#AzureBackupParams).
 
@@ -1105,8 +1105,8 @@ Used by: [AzureBackupParams](#AzureBackupParams).
 |---------------------|-------------|
 | "AzureBackupParams" |             |
 
-<a id="AzureBackupParams_ObjectType_STATUS"></a>AzureBackupParams_ObjectType_STATUS
------------------------------------------------------------------------------------
+AzureBackupParams_ObjectType_STATUS{#AzureBackupParams_ObjectType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AzureBackupParams_STATUS](#AzureBackupParams_STATUS).
 
@@ -1114,8 +1114,8 @@ Used by: [AzureBackupParams_STATUS](#AzureBackupParams_STATUS).
 |---------------------|-------------|
 | "AzureBackupParams" |             |
 
-<a id="BackupSchedule"></a>BackupSchedule
------------------------------------------
+BackupSchedule{#BackupSchedule}
+-------------------------------
 
 Schedule for backup
 
@@ -1126,8 +1126,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 | repeatingTimeIntervals | ISO 8601 repeating time interval format                  | string[]<br/><small>Required</small> |
 | timeZone               | Time zone for a schedule. Example: Pacific Standard Time | string<br/><small>Optional</small>   |
 
-<a id="BackupSchedule_STATUS"></a>BackupSchedule_STATUS
--------------------------------------------------------
+BackupSchedule_STATUS{#BackupSchedule_STATUS}
+---------------------------------------------
 
 Schedule for backup
 
@@ -1138,8 +1138,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 | repeatingTimeIntervals | ISO 8601 repeating time interval format                  | string[]<br/><small>Optional</small> |
 | timeZone               | Time zone for a schedule. Example: Pacific Standard Time | string<br/><small>Optional</small>   |
 
-<a id="CopyOption"></a>CopyOption
----------------------------------
+CopyOption{#CopyOption}
+-----------------------
 
 Used by: [TargetCopySetting](#TargetCopySetting).
 
@@ -1149,8 +1149,8 @@ Used by: [TargetCopySetting](#TargetCopySetting).
 | customCopyOption    | Mutually exclusive with all other properties | [CustomCopyOption](#CustomCopyOption)<br/><small>Optional</small>       |
 | immediateCopyOption | Mutually exclusive with all other properties | [ImmediateCopyOption](#ImmediateCopyOption)<br/><small>Optional</small> |
 
-<a id="CopyOption_STATUS"></a>CopyOption_STATUS
------------------------------------------------
+CopyOption_STATUS{#CopyOption_STATUS}
+-------------------------------------
 
 Used by: [TargetCopySetting_STATUS](#TargetCopySetting_STATUS).
 
@@ -1160,8 +1160,8 @@ Used by: [TargetCopySetting_STATUS](#TargetCopySetting_STATUS).
 | customCopyOption    | Mutually exclusive with all other properties | [CustomCopyOption_STATUS](#CustomCopyOption_STATUS)<br/><small>Optional</small>       |
 | immediateCopyOption | Mutually exclusive with all other properties | [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduleBasedTriggerContext_ObjectType"></a>ScheduleBasedTriggerContext_ObjectType
------------------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_ObjectType{#ScheduleBasedTriggerContext_ObjectType}
+-------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 
@@ -1169,8 +1169,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 |-------------------------------|-------------|
 | "ScheduleBasedTriggerContext" |             |
 
-<a id="ScheduleBasedTriggerContext_ObjectType_STATUS"></a>ScheduleBasedTriggerContext_ObjectType_STATUS
--------------------------------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_ObjectType_STATUS{#ScheduleBasedTriggerContext_ObjectType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATUS).
 
@@ -1178,8 +1178,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 |-------------------------------|-------------|
 | "ScheduleBasedTriggerContext" |             |
 
-<a id="TaggingCriteria"></a>TaggingCriteria
--------------------------------------------
+TaggingCriteria{#TaggingCriteria}
+---------------------------------
 
 Tagging criteria
 
@@ -1192,8 +1192,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 | taggingPriority | Retention Tag priority.                                                      | int<br/><small>Required</small>                                 |
 | tagInfo         | Retention tag information                                                    | [RetentionTag](#RetentionTag)<br/><small>Required</small>       |
 
-<a id="TaggingCriteria_STATUS"></a>TaggingCriteria_STATUS
----------------------------------------------------------
+TaggingCriteria_STATUS{#TaggingCriteria_STATUS}
+-----------------------------------------------
 
 Tagging criteria
 
@@ -1206,8 +1206,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 | taggingPriority | Retention Tag priority.                                                      | int<br/><small>Optional</small>                                               |
 | tagInfo         | Retention tag information                                                    | [RetentionTag_STATUS](#RetentionTag_STATUS)<br/><small>Optional</small>       |
 
-<a id="AbsoluteDeleteOption_ObjectType"></a>AbsoluteDeleteOption_ObjectType
----------------------------------------------------------------------------
+AbsoluteDeleteOption_ObjectType{#AbsoluteDeleteOption_ObjectType}
+-----------------------------------------------------------------
 
 Used by: [AbsoluteDeleteOption](#AbsoluteDeleteOption).
 
@@ -1215,8 +1215,8 @@ Used by: [AbsoluteDeleteOption](#AbsoluteDeleteOption).
 |------------------------|-------------|
 | "AbsoluteDeleteOption" |             |
 
-<a id="AbsoluteDeleteOption_ObjectType_STATUS"></a>AbsoluteDeleteOption_ObjectType_STATUS
------------------------------------------------------------------------------------------
+AbsoluteDeleteOption_ObjectType_STATUS{#AbsoluteDeleteOption_ObjectType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS).
 
@@ -1224,8 +1224,8 @@ Used by: [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS).
 |------------------------|-------------|
 | "AbsoluteDeleteOption" |             |
 
-<a id="BackupCriteria"></a>BackupCriteria
------------------------------------------
+BackupCriteria{#BackupCriteria}
+-------------------------------
 
 Used by: [TaggingCriteria](#TaggingCriteria).
 
@@ -1233,8 +1233,8 @@ Used by: [TaggingCriteria](#TaggingCriteria).
 |-----------------------------|----------------------------------------------|-----------------------------------------------------------------------------------------|
 | scheduleBasedBackupCriteria | Mutually exclusive with all other properties | [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria)<br/><small>Optional</small> |
 
-<a id="BackupCriteria_STATUS"></a>BackupCriteria_STATUS
--------------------------------------------------------
+BackupCriteria_STATUS{#BackupCriteria_STATUS}
+---------------------------------------------
 
 Used by: [TaggingCriteria_STATUS](#TaggingCriteria_STATUS).
 
@@ -1242,8 +1242,8 @@ Used by: [TaggingCriteria_STATUS](#TaggingCriteria_STATUS).
 |-----------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | scheduleBasedBackupCriteria | Mutually exclusive with all other properties | [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS)<br/><small>Optional</small> |
 
-<a id="CopyOnExpiryOption"></a>CopyOnExpiryOption
--------------------------------------------------
+CopyOnExpiryOption{#CopyOnExpiryOption}
+---------------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -1251,8 +1251,8 @@ Used by: [CopyOption](#CopyOption).
 |------------|------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [CopyOnExpiryOption_ObjectType](#CopyOnExpiryOption_ObjectType)<br/><small>Required</small> |
 
-<a id="CopyOnExpiryOption_STATUS"></a>CopyOnExpiryOption_STATUS
----------------------------------------------------------------
+CopyOnExpiryOption_STATUS{#CopyOnExpiryOption_STATUS}
+-----------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -1260,8 +1260,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 |------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [CopyOnExpiryOption_ObjectType_STATUS](#CopyOnExpiryOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomCopyOption"></a>CustomCopyOption
----------------------------------------------
+CustomCopyOption{#CustomCopyOption}
+-----------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -1270,8 +1270,8 @@ Used by: [CopyOption](#CopyOption).
 | duration   | Data copied after given timespan                     | string<br/><small>Optional</small>                                                      |
 | objectType | Type of the specific object - used for deserializing | [CustomCopyOption_ObjectType](#CustomCopyOption_ObjectType)<br/><small>Required</small> |
 
-<a id="CustomCopyOption_STATUS"></a>CustomCopyOption_STATUS
------------------------------------------------------------
+CustomCopyOption_STATUS{#CustomCopyOption_STATUS}
+-------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -1280,8 +1280,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 | duration   | Data copied after given timespan                     | string<br/><small>Optional</small>                                                                    |
 | objectType | Type of the specific object - used for deserializing | [CustomCopyOption_ObjectType_STATUS](#CustomCopyOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmediateCopyOption"></a>ImmediateCopyOption
----------------------------------------------------
+ImmediateCopyOption{#ImmediateCopyOption}
+-----------------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -1289,8 +1289,8 @@ Used by: [CopyOption](#CopyOption).
 |------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [ImmediateCopyOption_ObjectType](#ImmediateCopyOption_ObjectType)<br/><small>Required</small> |
 
-<a id="ImmediateCopyOption_STATUS"></a>ImmediateCopyOption_STATUS
------------------------------------------------------------------
+ImmediateCopyOption_STATUS{#ImmediateCopyOption_STATUS}
+-------------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -1298,8 +1298,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 |------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [ImmediateCopyOption_ObjectType_STATUS](#ImmediateCopyOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="RetentionTag"></a>RetentionTag
--------------------------------------
+RetentionTag{#RetentionTag}
+---------------------------
 
 Retention tag
 
@@ -1309,8 +1309,8 @@ Used by: [AdhocBasedTaggingCriteria](#AdhocBasedTaggingCriteria), and [TaggingCr
 |----------|----------------------------------------------------|------------------------------------|
 | tagName  | Retention Tag Name to relate it to retention rule. | string<br/><small>Required</small> |
 
-<a id="RetentionTag_STATUS"></a>RetentionTag_STATUS
----------------------------------------------------
+RetentionTag_STATUS{#RetentionTag_STATUS}
+-----------------------------------------
 
 Retention tag
 
@@ -1322,8 +1322,8 @@ Used by: [AdhocBasedTaggingCriteria_STATUS](#AdhocBasedTaggingCriteria_STATUS), 
 | id       | Retention Tag version.                             | string<br/><small>Optional</small> |
 | tagName  | Retention Tag Name to relate it to retention rule. | string<br/><small>Optional</small> |
 
-<a id="CopyOnExpiryOption_ObjectType"></a>CopyOnExpiryOption_ObjectType
------------------------------------------------------------------------
+CopyOnExpiryOption_ObjectType{#CopyOnExpiryOption_ObjectType}
+-------------------------------------------------------------
 
 Used by: [CopyOnExpiryOption](#CopyOnExpiryOption).
 
@@ -1331,8 +1331,8 @@ Used by: [CopyOnExpiryOption](#CopyOnExpiryOption).
 |----------------------|-------------|
 | "CopyOnExpiryOption" |             |
 
-<a id="CopyOnExpiryOption_ObjectType_STATUS"></a>CopyOnExpiryOption_ObjectType_STATUS
--------------------------------------------------------------------------------------
+CopyOnExpiryOption_ObjectType_STATUS{#CopyOnExpiryOption_ObjectType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [CopyOnExpiryOption_STATUS](#CopyOnExpiryOption_STATUS).
 
@@ -1340,8 +1340,8 @@ Used by: [CopyOnExpiryOption_STATUS](#CopyOnExpiryOption_STATUS).
 |----------------------|-------------|
 | "CopyOnExpiryOption" |             |
 
-<a id="CustomCopyOption_ObjectType"></a>CustomCopyOption_ObjectType
--------------------------------------------------------------------
+CustomCopyOption_ObjectType{#CustomCopyOption_ObjectType}
+---------------------------------------------------------
 
 Used by: [CustomCopyOption](#CustomCopyOption).
 
@@ -1349,8 +1349,8 @@ Used by: [CustomCopyOption](#CustomCopyOption).
 |--------------------|-------------|
 | "CustomCopyOption" |             |
 
-<a id="CustomCopyOption_ObjectType_STATUS"></a>CustomCopyOption_ObjectType_STATUS
----------------------------------------------------------------------------------
+CustomCopyOption_ObjectType_STATUS{#CustomCopyOption_ObjectType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [CustomCopyOption_STATUS](#CustomCopyOption_STATUS).
 
@@ -1358,8 +1358,8 @@ Used by: [CustomCopyOption_STATUS](#CustomCopyOption_STATUS).
 |--------------------|-------------|
 | "CustomCopyOption" |             |
 
-<a id="ImmediateCopyOption_ObjectType"></a>ImmediateCopyOption_ObjectType
--------------------------------------------------------------------------
+ImmediateCopyOption_ObjectType{#ImmediateCopyOption_ObjectType}
+---------------------------------------------------------------
 
 Used by: [ImmediateCopyOption](#ImmediateCopyOption).
 
@@ -1367,8 +1367,8 @@ Used by: [ImmediateCopyOption](#ImmediateCopyOption).
 |-----------------------|-------------|
 | "ImmediateCopyOption" |             |
 
-<a id="ImmediateCopyOption_ObjectType_STATUS"></a>ImmediateCopyOption_ObjectType_STATUS
----------------------------------------------------------------------------------------
+ImmediateCopyOption_ObjectType_STATUS{#ImmediateCopyOption_ObjectType_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS).
 
@@ -1376,8 +1376,8 @@ Used by: [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS).
 |-----------------------|-------------|
 | "ImmediateCopyOption" |             |
 
-<a id="ScheduleBasedBackupCriteria"></a>ScheduleBasedBackupCriteria
--------------------------------------------------------------------
+ScheduleBasedBackupCriteria{#ScheduleBasedBackupCriteria}
+---------------------------------------------------------
 
 Used by: [BackupCriteria](#BackupCriteria).
 
@@ -1391,8 +1391,8 @@ Used by: [BackupCriteria](#BackupCriteria).
 | scheduleTimes    | List of schedule times for backup                                                                                                      | string[]<br/><small>Optional</small>                                                                                        |
 | weeksOfTheMonth  | It should be First/Second/Third/Fourth/Last                                                                                            | [ScheduleBasedBackupCriteria_WeeksOfTheMonth[]](#ScheduleBasedBackupCriteria_WeeksOfTheMonth)<br/><small>Optional</small>   |
 
-<a id="ScheduleBasedBackupCriteria_STATUS"></a>ScheduleBasedBackupCriteria_STATUS
----------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_STATUS{#ScheduleBasedBackupCriteria_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [BackupCriteria_STATUS](#BackupCriteria_STATUS).
 
@@ -1406,8 +1406,8 @@ Used by: [BackupCriteria_STATUS](#BackupCriteria_STATUS).
 | scheduleTimes    | List of schedule times for backup                                                                                                      | string[]<br/><small>Optional</small>                                                                                                      |
 | weeksOfTheMonth  | It should be First/Second/Third/Fourth/Last                                                                                            | [ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS[]](#ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS)<br/><small>Optional</small>   |
 
-<a id="Day"></a>Day
--------------------
+Day{#Day}
+---------
 
 Day of the week
 
@@ -1418,8 +1418,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | date     | Date of the month                  | int<br/><small>Optional</small>  |
 | isLast   | Whether Date is last date of month | bool<br/><small>Optional</small> |
 
-<a id="Day_STATUS"></a>Day_STATUS
----------------------------------
+Day_STATUS{#Day_STATUS}
+-----------------------
 
 Day of the week
 
@@ -1430,8 +1430,8 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | date     | Date of the month                  | int<br/><small>Optional</small>  |
 | isLast   | Whether Date is last date of month | bool<br/><small>Optional</small> |
 
-<a id="ScheduleBasedBackupCriteria_AbsoluteCriteria"></a>ScheduleBasedBackupCriteria_AbsoluteCriteria
------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_AbsoluteCriteria{#ScheduleBasedBackupCriteria_AbsoluteCriteria}
+-------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -1443,8 +1443,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "FirstOfWeek"  |             |
 | "FirstOfYear"  |             |
 
-<a id="ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS"></a>ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS
--------------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS{#ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
@@ -1456,8 +1456,8 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | "FirstOfWeek"  |             |
 | "FirstOfYear"  |             |
 
-<a id="ScheduleBasedBackupCriteria_DaysOfTheWeek"></a>ScheduleBasedBackupCriteria_DaysOfTheWeek
------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_DaysOfTheWeek{#ScheduleBasedBackupCriteria_DaysOfTheWeek}
+-------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -1471,8 +1471,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS"></a>ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS
--------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS{#ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
@@ -1486,66 +1486,66 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="ScheduleBasedBackupCriteria_MonthsOfYear"></a>ScheduleBasedBackupCriteria_MonthsOfYear
+ScheduleBasedBackupCriteria_MonthsOfYear{#ScheduleBasedBackupCriteria_MonthsOfYear}
+-----------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
+
+| Value       | Description |
+|-------------|-------------|
+| "April"     |             |
+| "August"    |             |
+| "December"  |             |
+| "February"  |             |
+| "January"   |             |
+| "July"      |             |
+| "June"      |             |
+| "March"     |             |
+| "May"       |             |
+| "November"  |             |
+| "October"   |             |
+| "September" |             |
+
+ScheduleBasedBackupCriteria_MonthsOfYear_STATUS{#ScheduleBasedBackupCriteria_MonthsOfYear_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "April"     |             |
+| "August"    |             |
+| "December"  |             |
+| "February"  |             |
+| "January"   |             |
+| "July"      |             |
+| "June"      |             |
+| "March"     |             |
+| "May"       |             |
+| "November"  |             |
+| "October"   |             |
+| "September" |             |
+
+ScheduleBasedBackupCriteria_ObjectType{#ScheduleBasedBackupCriteria_ObjectType}
+-------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
+
+| Value                         | Description |
+|-------------------------------|-------------|
+| "ScheduleBasedBackupCriteria" |             |
+
+ScheduleBasedBackupCriteria_ObjectType_STATUS{#ScheduleBasedBackupCriteria_ObjectType_STATUS}
 ---------------------------------------------------------------------------------------------
 
-Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
-
-| Value       | Description |
-|-------------|-------------|
-| "April"     |             |
-| "August"    |             |
-| "December"  |             |
-| "February"  |             |
-| "January"   |             |
-| "July"      |             |
-| "June"      |             |
-| "March"     |             |
-| "May"       |             |
-| "November"  |             |
-| "October"   |             |
-| "September" |             |
-
-<a id="ScheduleBasedBackupCriteria_MonthsOfYear_STATUS"></a>ScheduleBasedBackupCriteria_MonthsOfYear_STATUS
------------------------------------------------------------------------------------------------------------
-
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
-| Value       | Description |
-|-------------|-------------|
-| "April"     |             |
-| "August"    |             |
-| "December"  |             |
-| "February"  |             |
-| "January"   |             |
-| "July"      |             |
-| "June"      |             |
-| "March"     |             |
-| "May"       |             |
-| "November"  |             |
-| "October"   |             |
-| "September" |             |
+| Value                         | Description |
+|-------------------------------|-------------|
+| "ScheduleBasedBackupCriteria" |             |
 
-<a id="ScheduleBasedBackupCriteria_ObjectType"></a>ScheduleBasedBackupCriteria_ObjectType
+ScheduleBasedBackupCriteria_WeeksOfTheMonth{#ScheduleBasedBackupCriteria_WeeksOfTheMonth}
 -----------------------------------------------------------------------------------------
-
-Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
-
-| Value                         | Description |
-|-------------------------------|-------------|
-| "ScheduleBasedBackupCriteria" |             |
-
-<a id="ScheduleBasedBackupCriteria_ObjectType_STATUS"></a>ScheduleBasedBackupCriteria_ObjectType_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
-
-| Value                         | Description |
-|-------------------------------|-------------|
-| "ScheduleBasedBackupCriteria" |             |
-
-<a id="ScheduleBasedBackupCriteria_WeeksOfTheMonth"></a>ScheduleBasedBackupCriteria_WeeksOfTheMonth
----------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -1557,8 +1557,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "Second" |             |
 | "Third"  |             |
 
-<a id="ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS"></a>ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS
------------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS{#ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 

--- a/docs/hugo/content/reference/dataprotection/v1api20231101.md
+++ b/docs/hugo/content/reference/dataprotection/v1api20231101.md
@@ -5,15 +5,15 @@ title: dataprotection.azure.com/v1api20231101
 linktitle: v1api20231101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-11-01" |             |
 
-<a id="BackupVault"></a>BackupVault
------------------------------------
+BackupVault{#BackupVault}
+-------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}
 
@@ -26,7 +26,7 @@ Used by: [BackupVaultList](#BackupVaultList).
 | spec                                                                                    |             | [BackupVault_Spec](#BackupVault_Spec)<br/><small>Optional</small>                     |
 | status                                                                                  |             | [BackupVaultResource_STATUS](#BackupVaultResource_STATUS)<br/><small>Optional</small> |
 
-### <a id="BackupVault_Spec"></a>BackupVault_Spec
+### BackupVault_Spec {#BackupVault_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,7 +38,7 @@ Used by: [BackupVaultList](#BackupVaultList).
 | properties   | BackupVaultResource properties                                                                                                                                                                                                                                                               | [BackupVaultSpec](#BackupVaultSpec)<br/><small>Required</small>                                                                                                      |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="BackupVaultResource_STATUS"></a>BackupVaultResource_STATUS
+### BackupVaultResource_STATUS{#BackupVaultResource_STATUS}
 
 | Property   | Description                                                                                    | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,8 +53,8 @@ Used by: [BackupVaultList](#BackupVaultList).
 | tags       | Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultList"></a>BackupVaultList
--------------------------------------------
+BackupVaultList{#BackupVaultList}
+---------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}
 
@@ -64,8 +64,8 @@ Generator information: - Generated from: /dataprotection/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [BackupVault[]](#BackupVault)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupInstance"></a>BackupVaultsBackupInstance
------------------------------------------------------------------
+BackupVaultsBackupInstance{#BackupVaultsBackupInstance}
+-------------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}
 
@@ -78,7 +78,7 @@ Used by: [BackupVaultsBackupInstanceList](#BackupVaultsBackupInstanceList).
 | spec                                                                                    |             | [BackupVaultsBackupInstance_Spec](#BackupVaultsBackupInstance_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BackupVaultsBackupInstance_STATUS](#BackupVaultsBackupInstance_STATUS)<br/><small>Optional</small> |
 
-### <a id="BackupVaultsBackupInstance_Spec"></a>BackupVaultsBackupInstance_Spec
+### BackupVaultsBackupInstance_Spec {#BackupVaultsBackupInstance_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -88,7 +88,7 @@ Used by: [BackupVaultsBackupInstanceList](#BackupVaultsBackupInstanceList).
 | properties   | BackupInstanceResource properties                                                                                                                                                                                                                                                               | [BackupInstance](#BackupInstance)<br/><small>Optional</small>                                                                                                        |
 | tags         | Proxy Resource tags.                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="BackupVaultsBackupInstance_STATUS"></a>BackupVaultsBackupInstance_STATUS
+### BackupVaultsBackupInstance_STATUS{#BackupVaultsBackupInstance_STATUS}
 
 | Property   | Description                                                                                          | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -100,8 +100,8 @@ Used by: [BackupVaultsBackupInstanceList](#BackupVaultsBackupInstanceList).
 | tags       | Proxy Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Proxy Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupInstanceList"></a>BackupVaultsBackupInstanceList
--------------------------------------------------------------------------
+BackupVaultsBackupInstanceList{#BackupVaultsBackupInstanceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}
 
@@ -111,8 +111,8 @@ Generator information: - Generated from: /dataprotection/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [BackupVaultsBackupInstance[]](#BackupVaultsBackupInstance)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupPolicy"></a>BackupVaultsBackupPolicy
--------------------------------------------------------------
+BackupVaultsBackupPolicy{#BackupVaultsBackupPolicy}
+---------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies/{backupPolicyName}
 
@@ -125,7 +125,7 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | spec                                                                                    |             | [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="BackupVaultsBackupPolicy_Spec"></a>BackupVaultsBackupPolicy_Spec
+### BackupVaultsBackupPolicy_Spec {#BackupVaultsBackupPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -134,7 +134,7 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dataprotection.azure.com/BackupVault resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   | BaseBackupPolicyResource properties                                                                                                                                                                                                                                                             | [BaseBackupPolicy](#BaseBackupPolicy)<br/><small>Optional</small>                                                                                                    |
 
-### <a id="BackupVaultsBackupPolicy_STATUS"></a>BackupVaultsBackupPolicy_STATUS
+### BackupVaultsBackupPolicy_STATUS{#BackupVaultsBackupPolicy_STATUS}
 
 | Property   | Description                                                                                    | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -145,8 +145,8 @@ Used by: [BackupVaultsBackupPolicyList](#BackupVaultsBackupPolicyList).
 | systemData | Metadata pertaining to creation and last modification of the resource.                         | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupPolicyList"></a>BackupVaultsBackupPolicyList
----------------------------------------------------------------------
+BackupVaultsBackupPolicyList{#BackupVaultsBackupPolicyList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-11-01/dataprotection.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies/{backupPolicyName}
 
@@ -156,8 +156,8 @@ Generator information: - Generated from: /dataprotection/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [BackupVaultsBackupPolicy[]](#BackupVaultsBackupPolicy)<br/><small>Optional</small> |
 
-<a id="BackupVault_Spec"></a>BackupVault_Spec
----------------------------------------------
+BackupVault_Spec{#BackupVault_Spec}
+-----------------------------------
 
 Used by: [BackupVault](#BackupVault).
 
@@ -171,8 +171,8 @@ Used by: [BackupVault](#BackupVault).
 | properties   | BackupVaultResource properties                                                                                                                                                                                                                                                               | [BackupVaultSpec](#BackupVaultSpec)<br/><small>Required</small>                                                                                                      |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="BackupVaultResource_STATUS"></a>BackupVaultResource_STATUS
------------------------------------------------------------------
+BackupVaultResource_STATUS{#BackupVaultResource_STATUS}
+-------------------------------------------------------
 
 Backup Vault Resource
 
@@ -191,8 +191,8 @@ Used by: [BackupVault](#BackupVault).
 | tags       | Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupInstance_Spec"></a>BackupVaultsBackupInstance_Spec
----------------------------------------------------------------------------
+BackupVaultsBackupInstance_Spec{#BackupVaultsBackupInstance_Spec}
+-----------------------------------------------------------------
 
 Used by: [BackupVaultsBackupInstance](#BackupVaultsBackupInstance).
 
@@ -204,8 +204,8 @@ Used by: [BackupVaultsBackupInstance](#BackupVaultsBackupInstance).
 | properties   | BackupInstanceResource properties                                                                                                                                                                                                                                                               | [BackupInstance](#BackupInstance)<br/><small>Optional</small>                                                                                                        |
 | tags         | Proxy Resource tags.                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="BackupVaultsBackupInstance_STATUS"></a>BackupVaultsBackupInstance_STATUS
--------------------------------------------------------------------------------
+BackupVaultsBackupInstance_STATUS{#BackupVaultsBackupInstance_STATUS}
+---------------------------------------------------------------------
 
 Used by: [BackupVaultsBackupInstance](#BackupVaultsBackupInstance).
 
@@ -219,8 +219,8 @@ Used by: [BackupVaultsBackupInstance](#BackupVaultsBackupInstance).
 | tags       | Proxy Resource tags.                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Proxy Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupVaultsBackupPolicy_Spec"></a>BackupVaultsBackupPolicy_Spec
------------------------------------------------------------------------
+BackupVaultsBackupPolicy_Spec{#BackupVaultsBackupPolicy_Spec}
+-------------------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 
@@ -231,8 +231,8 @@ Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dataprotection.azure.com/BackupVault resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   | BaseBackupPolicyResource properties                                                                                                                                                                                                                                                             | [BaseBackupPolicy](#BaseBackupPolicy)<br/><small>Optional</small>                                                                                                    |
 
-<a id="BackupVaultsBackupPolicy_STATUS"></a>BackupVaultsBackupPolicy_STATUS
----------------------------------------------------------------------------
+BackupVaultsBackupPolicy_STATUS{#BackupVaultsBackupPolicy_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 
@@ -245,8 +245,8 @@ Used by: [BackupVaultsBackupPolicy](#BackupVaultsBackupPolicy).
 | systemData | Metadata pertaining to creation and last modification of the resource.                         | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/... | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BackupInstance"></a>BackupInstance
------------------------------------------
+BackupInstance{#BackupInstance}
+-------------------------------
 
 Backup Instance
 
@@ -263,8 +263,8 @@ Used by: [BackupVaultsBackupInstance_Spec](#BackupVaultsBackupInstance_Spec).
 | policyInfo                | Gets or sets the policy information.                                                                                     | [PolicyInfo](#PolicyInfo)<br/><small>Required</small>                                       |
 | validationType            | Specifies the type of validation. In case of DeepValidation, all validations from /validateForBackup API will run again. | [BackupInstance_ValidationType](#BackupInstance_ValidationType)<br/><small>Optional</small> |
 
-<a id="BackupInstance_STATUS"></a>BackupInstance_STATUS
--------------------------------------------------------
+BackupInstance_STATUS{#BackupInstance_STATUS}
+---------------------------------------------
 
 Backup Instance
 
@@ -285,8 +285,8 @@ Used by: [BackupVaultsBackupInstance_STATUS](#BackupVaultsBackupInstance_STATUS)
 | provisioningState         | Specifies the provisioning state of the resource i.e. provisioning/updating/Succeeded/Failed                             | string<br/><small>Optional</small>                                                                                        |
 | validationType            | Specifies the type of validation. In case of DeepValidation, all validations from /validateForBackup API will run again. | [BackupInstance_ValidationType_STATUS](#BackupInstance_ValidationType_STATUS)<br/><small>Optional</small>                 |
 
-<a id="BackupVault_STATUS"></a>BackupVault_STATUS
--------------------------------------------------
+BackupVault_STATUS{#BackupVault_STATUS}
+---------------------------------------
 
 Backup Vault
 
@@ -305,8 +305,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS).
 | securitySettings                | Security Settings                              | [SecuritySettings_STATUS](#SecuritySettings_STATUS)<br/><small>Optional</small>                           |
 | storageSettings                 | Storage Settings                               | [StorageSetting_STATUS[]](#StorageSetting_STATUS)<br/><small>Optional</small>                             |
 
-<a id="BackupVaultOperatorSpec"></a>BackupVaultOperatorSpec
------------------------------------------------------------
+BackupVaultOperatorSpec{#BackupVaultOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -318,8 +318,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [BackupVaultOperatorConfigMaps](#BackupVaultOperatorConfigMaps)<br/><small>Optional</small>                                                                         |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupInstanceOperatorSpec"></a>BackupVaultsBackupInstanceOperatorSpec
------------------------------------------------------------------------------------------
+BackupVaultsBackupInstanceOperatorSpec{#BackupVaultsBackupInstanceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -330,8 +330,8 @@ Used by: [BackupVaultsBackupInstance_Spec](#BackupVaultsBackupInstance_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackupVaultsBackupPolicyOperatorSpec"></a>BackupVaultsBackupPolicyOperatorSpec
--------------------------------------------------------------------------------------
+BackupVaultsBackupPolicyOperatorSpec{#BackupVaultsBackupPolicyOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -342,8 +342,8 @@ Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BackupVaultSpec"></a>BackupVaultSpec
--------------------------------------------
+BackupVaultSpec{#BackupVaultSpec}
+---------------------------------
 
 Backup Vault
 
@@ -357,8 +357,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 | securitySettings   | Security Settings                           | [SecuritySettings](#SecuritySettings)<br/><small>Optional</small>     |
 | storageSettings    | Storage Settings                            | [StorageSetting[]](#StorageSetting)<br/><small>Required</small>       |
 
-<a id="BaseBackupPolicy"></a>BaseBackupPolicy
----------------------------------------------
+BaseBackupPolicy{#BaseBackupPolicy}
+-----------------------------------
 
 Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 
@@ -366,8 +366,8 @@ Used by: [BackupVaultsBackupPolicy_Spec](#BackupVaultsBackupPolicy_Spec).
 |--------------|----------------------------------------------|-----------------------------------------------------------|
 | backupPolicy | Mutually exclusive with all other properties | [BackupPolicy](#BackupPolicy)<br/><small>Optional</small> |
 
-<a id="BaseBackupPolicy_STATUS"></a>BaseBackupPolicy_STATUS
------------------------------------------------------------
+BaseBackupPolicy_STATUS{#BaseBackupPolicy_STATUS}
+-------------------------------------------------
 
 Used by: [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS).
 
@@ -375,8 +375,8 @@ Used by: [BackupVaultsBackupPolicy_STATUS](#BackupVaultsBackupPolicy_STATUS).
 |--------------|----------------------------------------------|-------------------------------------------------------------------------|
 | backupPolicy | Mutually exclusive with all other properties | [BackupPolicy_STATUS](#BackupPolicy_STATUS)<br/><small>Optional</small> |
 
-<a id="DppIdentityDetails"></a>DppIdentityDetails
--------------------------------------------------
+DppIdentityDetails{#DppIdentityDetails}
+---------------------------------------
 
 Identity details
 
@@ -387,8 +387,8 @@ Used by: [BackupVault_Spec](#BackupVault_Spec).
 | type                   | The identityType which can be either SystemAssigned, UserAssigned, 'SystemAssigned,UserAssigned' or None | string<br/><small>Optional</small>                                                        |
 | userAssignedIdentities | Gets or sets the user assigned identities.                                                               | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="DppIdentityDetails_STATUS"></a>DppIdentityDetails_STATUS
----------------------------------------------------------------
+DppIdentityDetails_STATUS{#DppIdentityDetails_STATUS}
+-----------------------------------------------------
 
 Identity details
 
@@ -401,8 +401,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS).
 | type                   | The identityType which can be either SystemAssigned, UserAssigned, 'SystemAssigned,UserAssigned' or None                             | string<br/><small>Optional</small>                                                                 |
 | userAssignedIdentities | Gets or sets the user assigned identities.                                                                                           | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -417,8 +417,8 @@ Used by: [BackupVaultResource_STATUS](#BackupVaultResource_STATUS), [BackupVault
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="AuthCredentials"></a>AuthCredentials
--------------------------------------------
+AuthCredentials{#AuthCredentials}
+---------------------------------
 
 Used by: [BackupInstance](#BackupInstance).
 
@@ -426,8 +426,8 @@ Used by: [BackupInstance](#BackupInstance).
 |---------------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------|
 | secretStoreBasedAuthCredentials | Mutually exclusive with all other properties | [SecretStoreBasedAuthCredentials](#SecretStoreBasedAuthCredentials)<br/><small>Optional</small> |
 
-<a id="AuthCredentials_STATUS"></a>AuthCredentials_STATUS
----------------------------------------------------------
+AuthCredentials_STATUS{#AuthCredentials_STATUS}
+-----------------------------------------------
 
 Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 
@@ -435,8 +435,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 |---------------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | secretStoreBasedAuthCredentials | Mutually exclusive with all other properties | [SecretStoreBasedAuthCredentials_STATUS](#SecretStoreBasedAuthCredentials_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupInstance_CurrentProtectionState_STATUS"></a>BackupInstance_CurrentProtectionState_STATUS
------------------------------------------------------------------------------------------------------
+BackupInstance_CurrentProtectionState_STATUS{#BackupInstance_CurrentProtectionState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 
@@ -455,8 +455,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | "SoftDeleting"                |             |
 | "UpdatingProtection"          |             |
 
-<a id="BackupInstance_ValidationType"></a>BackupInstance_ValidationType
------------------------------------------------------------------------
+BackupInstance_ValidationType{#BackupInstance_ValidationType}
+-------------------------------------------------------------
 
 Used by: [BackupInstance](#BackupInstance).
 
@@ -465,8 +465,8 @@ Used by: [BackupInstance](#BackupInstance).
 | "DeepValidation"    |             |
 | "ShallowValidation" |             |
 
-<a id="BackupInstance_ValidationType_STATUS"></a>BackupInstance_ValidationType_STATUS
--------------------------------------------------------------------------------------
+BackupInstance_ValidationType_STATUS{#BackupInstance_ValidationType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 
@@ -475,8 +475,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | "DeepValidation"    |             |
 | "ShallowValidation" |             |
 
-<a id="BackupPolicy"></a>BackupPolicy
--------------------------------------
+BackupPolicy{#BackupPolicy}
+---------------------------
 
 Used by: [BaseBackupPolicy](#BaseBackupPolicy).
 
@@ -486,8 +486,8 @@ Used by: [BaseBackupPolicy](#BaseBackupPolicy).
 | objectType      |                                                                                              | [BackupPolicy_ObjectType](#BackupPolicy_ObjectType)<br/><small>Required</small> |
 | policyRules     | Policy rule dictionary that contains rules for each backuptype i.e Full/Incremental/Logs etc | [BasePolicyRule[]](#BasePolicyRule)<br/><small>Required</small>                 |
 
-<a id="BackupPolicy_STATUS"></a>BackupPolicy_STATUS
----------------------------------------------------
+BackupPolicy_STATUS{#BackupPolicy_STATUS}
+-----------------------------------------
 
 Used by: [BaseBackupPolicy_STATUS](#BaseBackupPolicy_STATUS).
 
@@ -497,8 +497,8 @@ Used by: [BaseBackupPolicy_STATUS](#BaseBackupPolicy_STATUS).
 | objectType      |                                                                                              | [BackupPolicy_ObjectType_STATUS](#BackupPolicy_ObjectType_STATUS)<br/><small>Optional</small> |
 | policyRules     | Policy rule dictionary that contains rules for each backuptype i.e Full/Incremental/Logs etc | [BasePolicyRule_STATUS[]](#BasePolicyRule_STATUS)<br/><small>Optional</small>                 |
 
-<a id="BackupVault_ProvisioningState_STATUS"></a>BackupVault_ProvisioningState_STATUS
--------------------------------------------------------------------------------------
+BackupVault_ProvisioningState_STATUS{#BackupVault_ProvisioningState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 
@@ -510,8 +510,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | "Unknown"      |             |
 | "Updating"     |             |
 
-<a id="BackupVault_ResourceMoveState_STATUS"></a>BackupVault_ResourceMoveState_STATUS
--------------------------------------------------------------------------------------
+BackupVault_ResourceMoveState_STATUS{#BackupVault_ResourceMoveState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 
@@ -528,8 +528,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | "PrepareTimedout" |             |
 | "Unknown"         |             |
 
-<a id="BackupVault_SecureScore_STATUS"></a>BackupVault_SecureScore_STATUS
--------------------------------------------------------------------------
+BackupVault_SecureScore_STATUS{#BackupVault_SecureScore_STATUS}
+---------------------------------------------------------------
 
 Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 
@@ -541,8 +541,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | "None"         |             |
 | "NotSupported" |             |
 
-<a id="BackupVaultOperatorConfigMaps"></a>BackupVaultOperatorConfigMaps
------------------------------------------------------------------------
+BackupVaultOperatorConfigMaps{#BackupVaultOperatorConfigMaps}
+-------------------------------------------------------------
 
 Used by: [BackupVaultOperatorSpec](#BackupVaultOperatorSpec).
 
@@ -550,8 +550,8 @@ Used by: [BackupVaultOperatorSpec](#BackupVaultOperatorSpec).
 |-------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | principalId | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="Datasource"></a>Datasource
----------------------------------
+Datasource{#Datasource}
+-----------------------
 
 Datasource to be backed up
 
@@ -568,8 +568,8 @@ Used by: [BackupInstance](#BackupInstance).
 | resourceType       | Resource Type of Datasource.                                                                                                                               | string<br/><small>Optional</small>                                                                                                                         |
 | resourceUri        | Uri of the resource.                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="Datasource_STATUS"></a>Datasource_STATUS
------------------------------------------------
+Datasource_STATUS{#Datasource_STATUS}
+-------------------------------------
 
 Datasource to be backed up
 
@@ -586,8 +586,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | resourceType       | Resource Type of Datasource.                                                                                                                               | string<br/><small>Optional</small>                                                          |
 | resourceUri        | Uri of the resource.                                                                                                                                       | string<br/><small>Optional</small>                                                          |
 
-<a id="DatasourceSet"></a>DatasourceSet
----------------------------------------
+DatasourceSet{#DatasourceSet}
+-----------------------------
 
 DatasourceSet details of datasource to be backed up
 
@@ -604,8 +604,8 @@ Used by: [BackupInstance](#BackupInstance).
 | resourceType       | Resource Type of Datasource.                                                                                                                               | string<br/><small>Optional</small>                                                                                                                         |
 | resourceUri        | Uri of the resource.                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="DatasourceSet_STATUS"></a>DatasourceSet_STATUS
------------------------------------------------------
+DatasourceSet_STATUS{#DatasourceSet_STATUS}
+-------------------------------------------
 
 DatasourceSet details of datasource to be backed up
 
@@ -622,8 +622,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | resourceType       | Resource Type of Datasource.                                                                                                                               | string<br/><small>Optional</small>                                                          |
 | resourceUri        | Uri of the resource.                                                                                                                                       | string<br/><small>Optional</small>                                                          |
 
-<a id="FeatureSettings"></a>FeatureSettings
--------------------------------------------
+FeatureSettings{#FeatureSettings}
+---------------------------------
 
 Class containing feature settings of vault
 
@@ -634,8 +634,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 | crossRegionRestoreSettings       |                                   | [CrossRegionRestoreSettings](#CrossRegionRestoreSettings)<br/><small>Optional</small>             |
 | crossSubscriptionRestoreSettings | CrossSubscriptionRestore Settings | [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings)<br/><small>Optional</small> |
 
-<a id="FeatureSettings_STATUS"></a>FeatureSettings_STATUS
----------------------------------------------------------
+FeatureSettings_STATUS{#FeatureSettings_STATUS}
+-----------------------------------------------
 
 Class containing feature settings of vault
 
@@ -646,8 +646,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | crossRegionRestoreSettings       |                                   | [CrossRegionRestoreSettings_STATUS](#CrossRegionRestoreSettings_STATUS)<br/><small>Optional</small>             |
 | crossSubscriptionRestoreSettings | CrossSubscriptionRestore Settings | [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="IdentityDetails"></a>IdentityDetails
--------------------------------------------
+IdentityDetails{#IdentityDetails}
+---------------------------------
 
 Used by: [BackupInstance](#BackupInstance).
 
@@ -656,8 +656,8 @@ Used by: [BackupInstance](#BackupInstance).
 | userAssignedIdentityArmUrl | ARM URL for User Assigned Identity.                  | string<br/><small>Optional</small> |
 | useSystemAssignedIdentity  | Specifies if the BI is protected by System Identity. | bool<br/><small>Optional</small>   |
 
-<a id="IdentityDetails_STATUS"></a>IdentityDetails_STATUS
----------------------------------------------------------
+IdentityDetails_STATUS{#IdentityDetails_STATUS}
+-----------------------------------------------
 
 Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 
@@ -666,8 +666,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | userAssignedIdentityArmUrl | ARM URL for User Assigned Identity.                  | string<br/><small>Optional</small> |
 | useSystemAssignedIdentity  | Specifies if the BI is protected by System Identity. | bool<br/><small>Optional</small>   |
 
-<a id="MonitoringSettings"></a>MonitoringSettings
--------------------------------------------------
+MonitoringSettings{#MonitoringSettings}
+---------------------------------------
 
 Monitoring Settings
 
@@ -677,8 +677,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 |---------------------------|-----------------------------------------|-------------------------------------------------------------------------------------|
 | azureMonitorAlertSettings | Settings for Azure Monitor based alerts | [AzureMonitorAlertSettings](#AzureMonitorAlertSettings)<br/><small>Optional</small> |
 
-<a id="MonitoringSettings_STATUS"></a>MonitoringSettings_STATUS
----------------------------------------------------------------
+MonitoringSettings_STATUS{#MonitoringSettings_STATUS}
+-----------------------------------------------------
 
 Monitoring Settings
 
@@ -688,8 +688,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 |---------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------|
 | azureMonitorAlertSettings | Settings for Azure Monitor based alerts | [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="PolicyInfo"></a>PolicyInfo
----------------------------------
+PolicyInfo{#PolicyInfo}
+-----------------------
 
 Policy Info in backupInstance
 
@@ -700,8 +700,8 @@ Used by: [BackupInstance](#BackupInstance).
 | policyParameters | Policy parameters for the backup instance | [PolicyParameters](#PolicyParameters)<br/><small>Optional</small>                                                                                          |
 | policyReference  |                                           | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="PolicyInfo_STATUS"></a>PolicyInfo_STATUS
------------------------------------------------
+PolicyInfo_STATUS{#PolicyInfo_STATUS}
+-------------------------------------
 
 Policy Info in backupInstance
 
@@ -713,8 +713,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | policyParameters | Policy parameters for the backup instance | [PolicyParameters_STATUS](#PolicyParameters_STATUS)<br/><small>Optional</small> |
 | policyVersion    |                                           | string<br/><small>Optional</small>                                              |
 
-<a id="ProtectionStatusDetails_STATUS"></a>ProtectionStatusDetails_STATUS
--------------------------------------------------------------------------
+ProtectionStatusDetails_STATUS{#ProtectionStatusDetails_STATUS}
+---------------------------------------------------------------
 
 Protection status details
 
@@ -725,8 +725,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS).
 | errorDetails | Specifies the protection status error of the resource | [UserFacingError_STATUS](#UserFacingError_STATUS)<br/><small>Optional</small>                               |
 | status       | Specifies the protection status of the resource       | [ProtectionStatusDetails_Status_STATUS](#ProtectionStatusDetails_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceMoveDetails_STATUS"></a>ResourceMoveDetails_STATUS
------------------------------------------------------------------
+ResourceMoveDetails_STATUS{#ResourceMoveDetails_STATUS}
+-------------------------------------------------------
 
 ResourceMoveDetails will be returned in response to GetResource call from ARM
 
@@ -740,8 +740,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | startTimeUtc       | Start time in UTC of latest ResourceMove operation attempted. ISO 8601 format.      | string<br/><small>Optional</small> |
 | targetResourcePath | ARM resource path of target resource used in latest ResourceMove operation          | string<br/><small>Optional</small> |
 
-<a id="SecuritySettings"></a>SecuritySettings
----------------------------------------------
+SecuritySettings{#SecuritySettings}
+-----------------------------------
 
 Class containing security settings of vault
 
@@ -752,8 +752,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 | immutabilitySettings | Immutability Settings at vault level | [ImmutabilitySettings](#ImmutabilitySettings)<br/><small>Optional</small> |
 | softDeleteSettings   | Soft delete related settings         | [SoftDeleteSettings](#SoftDeleteSettings)<br/><small>Optional</small>     |
 
-<a id="SecuritySettings_STATUS"></a>SecuritySettings_STATUS
------------------------------------------------------------
+SecuritySettings_STATUS{#SecuritySettings_STATUS}
+-------------------------------------------------
 
 Class containing security settings of vault
 
@@ -764,8 +764,8 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | immutabilitySettings | Immutability Settings at vault level | [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS)<br/><small>Optional</small> |
 | softDeleteSettings   | Soft delete related settings         | [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS)<br/><small>Optional</small>     |
 
-<a id="StorageSetting"></a>StorageSetting
------------------------------------------
+StorageSetting{#StorageSetting}
+-------------------------------
 
 Storage setting
 
@@ -776,8 +776,8 @@ Used by: [BackupVaultSpec](#BackupVaultSpec).
 | datastoreType | Gets or sets the type of the datastore. | [StorageSetting_DatastoreType](#StorageSetting_DatastoreType)<br/><small>Optional</small> |
 | type          | Gets or sets the type.                  | [StorageSetting_Type](#StorageSetting_Type)<br/><small>Optional</small>                   |
 
-<a id="StorageSetting_STATUS"></a>StorageSetting_STATUS
--------------------------------------------------------
+StorageSetting_STATUS{#StorageSetting_STATUS}
+---------------------------------------------
 
 Storage setting
 
@@ -788,7 +788,19 @@ Used by: [BackupVault_STATUS](#BackupVault_STATUS).
 | datastoreType | Gets or sets the type of the datastore. | [StorageSetting_DatastoreType_STATUS](#StorageSetting_DatastoreType_STATUS)<br/><small>Optional</small> |
 | type          | Gets or sets the type.                  | [StorageSetting_Type_STATUS](#StorageSetting_Type_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -800,20 +812,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -824,8 +824,8 @@ Used by: [DppIdentityDetails_STATUS](#DppIdentityDetails_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -835,8 +835,8 @@ Used by: [DppIdentityDetails](#DppIdentityDetails).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserFacingError_STATUS"></a>UserFacingError_STATUS
----------------------------------------------------------
+UserFacingError_STATUS{#UserFacingError_STATUS}
+-----------------------------------------------
 
 Error object used by layers that have access to localized content, and propagate that to user
 
@@ -854,8 +854,8 @@ Used by: [BackupInstance_STATUS](#BackupInstance_STATUS), and [ProtectionStatusD
 | recommendedAction | RecommendedAction � localized.                                | string[]<br/><small>Optional</small>                                                              |
 | target            | Target of the error.                                          | string<br/><small>Optional</small>                                                                |
 
-<a id="AzureMonitorAlertSettings"></a>AzureMonitorAlertSettings
----------------------------------------------------------------
+AzureMonitorAlertSettings{#AzureMonitorAlertSettings}
+-----------------------------------------------------
 
 Settings for Azure Monitor based alerts
 
@@ -865,8 +865,8 @@ Used by: [MonitoringSettings](#MonitoringSettings).
 |-------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | alertsForAllJobFailures |             | [AzureMonitorAlertSettings_AlertsForAllJobFailures](#AzureMonitorAlertSettings_AlertsForAllJobFailures)<br/><small>Optional</small> |
 
-<a id="AzureMonitorAlertSettings_STATUS"></a>AzureMonitorAlertSettings_STATUS
------------------------------------------------------------------------------
+AzureMonitorAlertSettings_STATUS{#AzureMonitorAlertSettings_STATUS}
+-------------------------------------------------------------------
 
 Settings for Azure Monitor based alerts
 
@@ -876,8 +876,8 @@ Used by: [MonitoringSettings_STATUS](#MonitoringSettings_STATUS).
 |-------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | alertsForAllJobFailures |             | [AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS](#AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy_ObjectType"></a>BackupPolicy_ObjectType
------------------------------------------------------------
+BackupPolicy_ObjectType{#BackupPolicy_ObjectType}
+-------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -885,8 +885,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 |----------------|-------------|
 | "BackupPolicy" |             |
 
-<a id="BackupPolicy_ObjectType_STATUS"></a>BackupPolicy_ObjectType_STATUS
--------------------------------------------------------------------------
+BackupPolicy_ObjectType_STATUS{#BackupPolicy_ObjectType_STATUS}
+---------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -894,8 +894,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 |----------------|-------------|
 | "BackupPolicy" |             |
 
-<a id="BasePolicyRule"></a>BasePolicyRule
------------------------------------------
+BasePolicyRule{#BasePolicyRule}
+-------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -904,8 +904,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | azureBackupRule    | Mutually exclusive with all other properties | [AzureBackupRule](#AzureBackupRule)<br/><small>Optional</small>       |
 | azureRetentionRule | Mutually exclusive with all other properties | [AzureRetentionRule](#AzureRetentionRule)<br/><small>Optional</small> |
 
-<a id="BasePolicyRule_STATUS"></a>BasePolicyRule_STATUS
--------------------------------------------------------
+BasePolicyRule_STATUS{#BasePolicyRule_STATUS}
+---------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -914,8 +914,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | azureBackupRule    | Mutually exclusive with all other properties | [AzureBackupRule_STATUS](#AzureBackupRule_STATUS)<br/><small>Optional</small>       |
 | azureRetentionRule | Mutually exclusive with all other properties | [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS)<br/><small>Optional</small> |
 
-<a id="BaseResourceProperties"></a>BaseResourceProperties
----------------------------------------------------------
+BaseResourceProperties{#BaseResourceProperties}
+-----------------------------------------------
 
 Used by: [Datasource](#Datasource), and [DatasourceSet](#DatasourceSet).
 
@@ -923,8 +923,8 @@ Used by: [Datasource](#Datasource), and [DatasourceSet](#DatasourceSet).
 |---------------------------|----------------------------------------------|-------------------------------------------------------------------------------------|
 | defaultResourceProperties | Mutually exclusive with all other properties | [DefaultResourceProperties](#DefaultResourceProperties)<br/><small>Optional</small> |
 
-<a id="BaseResourceProperties_STATUS"></a>BaseResourceProperties_STATUS
------------------------------------------------------------------------
+BaseResourceProperties_STATUS{#BaseResourceProperties_STATUS}
+-------------------------------------------------------------
 
 Used by: [Datasource_STATUS](#Datasource_STATUS), and [DatasourceSet_STATUS](#DatasourceSet_STATUS).
 
@@ -932,8 +932,8 @@ Used by: [Datasource_STATUS](#Datasource_STATUS), and [DatasourceSet_STATUS](#Da
 |---------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------|
 | defaultResourceProperties | Mutually exclusive with all other properties | [DefaultResourceProperties_STATUS](#DefaultResourceProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="CrossRegionRestoreSettings"></a>CrossRegionRestoreSettings
------------------------------------------------------------------
+CrossRegionRestoreSettings{#CrossRegionRestoreSettings}
+-------------------------------------------------------
 
 Used by: [FeatureSettings](#FeatureSettings).
 
@@ -941,8 +941,8 @@ Used by: [FeatureSettings](#FeatureSettings).
 |----------|--------------------------|---------------------------------------------------------------------------------------------------|
 | state    | CrossRegionRestore state | [CrossRegionRestoreSettings_State](#CrossRegionRestoreSettings_State)<br/><small>Optional</small> |
 
-<a id="CrossRegionRestoreSettings_STATUS"></a>CrossRegionRestoreSettings_STATUS
--------------------------------------------------------------------------------
+CrossRegionRestoreSettings_STATUS{#CrossRegionRestoreSettings_STATUS}
+---------------------------------------------------------------------
 
 Used by: [FeatureSettings_STATUS](#FeatureSettings_STATUS).
 
@@ -950,8 +950,8 @@ Used by: [FeatureSettings_STATUS](#FeatureSettings_STATUS).
 |----------|--------------------------|-----------------------------------------------------------------------------------------------------------------|
 | state    | CrossRegionRestore state | [CrossRegionRestoreSettings_State_STATUS](#CrossRegionRestoreSettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="CrossSubscriptionRestoreSettings"></a>CrossSubscriptionRestoreSettings
------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings{#CrossSubscriptionRestoreSettings}
+-------------------------------------------------------------------
 
 CrossSubscriptionRestore Settings
 
@@ -961,8 +961,8 @@ Used by: [FeatureSettings](#FeatureSettings).
 |----------|--------------------------------|---------------------------------------------------------------------------------------------------------------|
 | state    | CrossSubscriptionRestore state | [CrossSubscriptionRestoreSettings_State](#CrossSubscriptionRestoreSettings_State)<br/><small>Optional</small> |
 
-<a id="CrossSubscriptionRestoreSettings_STATUS"></a>CrossSubscriptionRestoreSettings_STATUS
--------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_STATUS{#CrossSubscriptionRestoreSettings_STATUS}
+---------------------------------------------------------------------------------
 
 CrossSubscriptionRestore Settings
 
@@ -972,8 +972,8 @@ Used by: [FeatureSettings_STATUS](#FeatureSettings_STATUS).
 |----------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | state    | CrossSubscriptionRestore state | [CrossSubscriptionRestoreSettings_State_STATUS](#CrossSubscriptionRestoreSettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilitySettings"></a>ImmutabilitySettings
------------------------------------------------------
+ImmutabilitySettings{#ImmutabilitySettings}
+-------------------------------------------
 
 Immutability Settings at vault level
 
@@ -983,8 +983,8 @@ Used by: [SecuritySettings](#SecuritySettings).
 |----------|--------------------|---------------------------------------------------------------------------------------|
 | state    | Immutability state | [ImmutabilitySettings_State](#ImmutabilitySettings_State)<br/><small>Optional</small> |
 
-<a id="ImmutabilitySettings_STATUS"></a>ImmutabilitySettings_STATUS
--------------------------------------------------------------------
+ImmutabilitySettings_STATUS{#ImmutabilitySettings_STATUS}
+---------------------------------------------------------
 
 Immutability Settings at vault level
 
@@ -994,8 +994,8 @@ Used by: [SecuritySettings_STATUS](#SecuritySettings_STATUS).
 |----------|--------------------|-----------------------------------------------------------------------------------------------------|
 | state    | Immutability state | [ImmutabilitySettings_State_STATUS](#ImmutabilitySettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="InnerError_STATUS"></a>InnerError_STATUS
------------------------------------------------
+InnerError_STATUS{#InnerError_STATUS}
+-------------------------------------
 
 Inner Error
 
@@ -1007,8 +1007,8 @@ Used by: [UserFacingError_STATUS](#UserFacingError_STATUS), and [UserFacingError
 | code               | Unique code for this error                                                                 | string<br/><small>Optional</small>                                                    |
 | embeddedInnerError | Child Inner Error, to allow Nesting.                                                       | [InnerError_STATUS_Unrolled](#InnerError_STATUS_Unrolled)<br/><small>Optional</small> |
 
-<a id="PolicyParameters"></a>PolicyParameters
----------------------------------------------
+PolicyParameters{#PolicyParameters}
+-----------------------------------
 
 Parameters in Policy
 
@@ -1019,8 +1019,8 @@ Used by: [PolicyInfo](#PolicyInfo).
 | backupDatasourceParametersList | Gets or sets the Backup Data Source Parameters | [BackupDatasourceParameters[]](#BackupDatasourceParameters)<br/><small>Optional</small> |
 | dataStoreParametersList        | Gets or sets the DataStore Parameters          | [DataStoreParameters[]](#DataStoreParameters)<br/><small>Optional</small>               |
 
-<a id="PolicyParameters_STATUS"></a>PolicyParameters_STATUS
------------------------------------------------------------
+PolicyParameters_STATUS{#PolicyParameters_STATUS}
+-------------------------------------------------
 
 Parameters in Policy
 
@@ -1031,8 +1031,8 @@ Used by: [PolicyInfo_STATUS](#PolicyInfo_STATUS).
 | backupDatasourceParametersList | Gets or sets the Backup Data Source Parameters | [BackupDatasourceParameters_STATUS[]](#BackupDatasourceParameters_STATUS)<br/><small>Optional</small> |
 | dataStoreParametersList        | Gets or sets the DataStore Parameters          | [DataStoreParameters_STATUS[]](#DataStoreParameters_STATUS)<br/><small>Optional</small>               |
 
-<a id="ProtectionStatusDetails_Status_STATUS"></a>ProtectionStatusDetails_Status_STATUS
----------------------------------------------------------------------------------------
+ProtectionStatusDetails_Status_STATUS{#ProtectionStatusDetails_Status_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ProtectionStatusDetails_STATUS](#ProtectionStatusDetails_STATUS).
 
@@ -1045,8 +1045,8 @@ Used by: [ProtectionStatusDetails_STATUS](#ProtectionStatusDetails_STATUS).
 | "SoftDeleted"                 |             |
 | "SoftDeleting"                |             |
 
-<a id="SecretStoreBasedAuthCredentials"></a>SecretStoreBasedAuthCredentials
----------------------------------------------------------------------------
+SecretStoreBasedAuthCredentials{#SecretStoreBasedAuthCredentials}
+-----------------------------------------------------------------
 
 Used by: [AuthCredentials](#AuthCredentials).
 
@@ -1055,8 +1055,8 @@ Used by: [AuthCredentials](#AuthCredentials).
 | objectType          | Type of the specific object - used for deserializing | [SecretStoreBasedAuthCredentials_ObjectType](#SecretStoreBasedAuthCredentials_ObjectType)<br/><small>Required</small> |
 | secretStoreResource | Secret store resource                                | [SecretStoreResource](#SecretStoreResource)<br/><small>Optional</small>                                               |
 
-<a id="SecretStoreBasedAuthCredentials_STATUS"></a>SecretStoreBasedAuthCredentials_STATUS
------------------------------------------------------------------------------------------
+SecretStoreBasedAuthCredentials_STATUS{#SecretStoreBasedAuthCredentials_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AuthCredentials_STATUS](#AuthCredentials_STATUS).
 
@@ -1065,8 +1065,8 @@ Used by: [AuthCredentials_STATUS](#AuthCredentials_STATUS).
 | objectType          | Type of the specific object - used for deserializing | [SecretStoreBasedAuthCredentials_ObjectType_STATUS](#SecretStoreBasedAuthCredentials_ObjectType_STATUS)<br/><small>Optional</small> |
 | secretStoreResource | Secret store resource                                | [SecretStoreResource_STATUS](#SecretStoreResource_STATUS)<br/><small>Optional</small>                                               |
 
-<a id="SoftDeleteSettings"></a>SoftDeleteSettings
--------------------------------------------------
+SoftDeleteSettings{#SoftDeleteSettings}
+---------------------------------------
 
 Soft delete related settings
 
@@ -1077,8 +1077,8 @@ Used by: [SecuritySettings](#SecuritySettings).
 | retentionDurationInDays | Soft delete retention duration | float64<br/><small>Optional</small>                                               |
 | state                   | State of soft delete           | [SoftDeleteSettings_State](#SoftDeleteSettings_State)<br/><small>Optional</small> |
 
-<a id="SoftDeleteSettings_STATUS"></a>SoftDeleteSettings_STATUS
----------------------------------------------------------------
+SoftDeleteSettings_STATUS{#SoftDeleteSettings_STATUS}
+-----------------------------------------------------
 
 Soft delete related settings
 
@@ -1089,8 +1089,8 @@ Used by: [SecuritySettings_STATUS](#SecuritySettings_STATUS).
 | retentionDurationInDays | Soft delete retention duration | float64<br/><small>Optional</small>                                                             |
 | state                   | State of soft delete           | [SoftDeleteSettings_State_STATUS](#SoftDeleteSettings_State_STATUS)<br/><small>Optional</small> |
 
-<a id="StorageSetting_DatastoreType"></a>StorageSetting_DatastoreType
----------------------------------------------------------------------
+StorageSetting_DatastoreType{#StorageSetting_DatastoreType}
+-----------------------------------------------------------
 
 Used by: [StorageSetting](#StorageSetting).
 
@@ -1100,8 +1100,8 @@ Used by: [StorageSetting](#StorageSetting).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="StorageSetting_DatastoreType_STATUS"></a>StorageSetting_DatastoreType_STATUS
------------------------------------------------------------------------------------
+StorageSetting_DatastoreType_STATUS{#StorageSetting_DatastoreType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 
@@ -1111,8 +1111,8 @@ Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="StorageSetting_Type"></a>StorageSetting_Type
----------------------------------------------------
+StorageSetting_Type{#StorageSetting_Type}
+-----------------------------------------
 
 Used by: [StorageSetting](#StorageSetting).
 
@@ -1122,19 +1122,19 @@ Used by: [StorageSetting](#StorageSetting).
 | "LocallyRedundant" |             |
 | "ZoneRedundant"    |             |
 
-<a id="StorageSetting_Type_STATUS"></a>StorageSetting_Type_STATUS
+StorageSetting_Type_STATUS{#StorageSetting_Type_STATUS}
+-------------------------------------------------------
+
+Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
+
+| Value              | Description |
+|--------------------|-------------|
+| "GeoRedundant"     |             |
+| "LocallyRedundant" |             |
+| "ZoneRedundant"    |             |
+
+UserFacingError_STATUS_Unrolled{#UserFacingError_STATUS_Unrolled}
 -----------------------------------------------------------------
-
-Used by: [StorageSetting_STATUS](#StorageSetting_STATUS).
-
-| Value              | Description |
-|--------------------|-------------|
-| "GeoRedundant"     |             |
-| "LocallyRedundant" |             |
-| "ZoneRedundant"    |             |
-
-<a id="UserFacingError_STATUS_Unrolled"></a>UserFacingError_STATUS_Unrolled
----------------------------------------------------------------------------
 
 Used by: [UserFacingError_STATUS](#UserFacingError_STATUS).
 
@@ -1149,8 +1149,8 @@ Used by: [UserFacingError_STATUS](#UserFacingError_STATUS).
 | recommendedAction | RecommendedAction � localized.                                | string[]<br/><small>Optional</small>                                |
 | target            | Target of the error.                                          | string<br/><small>Optional</small>                                  |
 
-<a id="AzureBackupRule"></a>AzureBackupRule
--------------------------------------------
+AzureBackupRule{#AzureBackupRule}
+---------------------------------
 
 Used by: [BasePolicyRule](#BasePolicyRule).
 
@@ -1162,8 +1162,8 @@ Used by: [BasePolicyRule](#BasePolicyRule).
 | objectType       |                    | [AzureBackupRule_ObjectType](#AzureBackupRule_ObjectType)<br/><small>Required</small> |
 | trigger          |                    | [TriggerContext](#TriggerContext)<br/><small>Required</small>                         |
 
-<a id="AzureBackupRule_STATUS"></a>AzureBackupRule_STATUS
----------------------------------------------------------
+AzureBackupRule_STATUS{#AzureBackupRule_STATUS}
+-----------------------------------------------
 
 Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 
@@ -1175,8 +1175,8 @@ Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 | objectType       |                    | [AzureBackupRule_ObjectType_STATUS](#AzureBackupRule_ObjectType_STATUS)<br/><small>Optional</small> |
 | trigger          |                    | [TriggerContext_STATUS](#TriggerContext_STATUS)<br/><small>Optional</small>                         |
 
-<a id="AzureMonitorAlertSettings_AlertsForAllJobFailures"></a>AzureMonitorAlertSettings_AlertsForAllJobFailures
----------------------------------------------------------------------------------------------------------------
+AzureMonitorAlertSettings_AlertsForAllJobFailures{#AzureMonitorAlertSettings_AlertsForAllJobFailures}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [AzureMonitorAlertSettings](#AzureMonitorAlertSettings).
 
@@ -1185,8 +1185,8 @@ Used by: [AzureMonitorAlertSettings](#AzureMonitorAlertSettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS"></a>AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS
------------------------------------------------------------------------------------------------------------------------------
+AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS{#AzureMonitorAlertSettings_AlertsForAllJobFailures_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS).
 
@@ -1195,8 +1195,8 @@ Used by: [AzureMonitorAlertSettings_STATUS](#AzureMonitorAlertSettings_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AzureRetentionRule"></a>AzureRetentionRule
--------------------------------------------------
+AzureRetentionRule{#AzureRetentionRule}
+---------------------------------------
 
 Used by: [BasePolicyRule](#BasePolicyRule).
 
@@ -1207,8 +1207,8 @@ Used by: [BasePolicyRule](#BasePolicyRule).
 | name       |             | string<br/><small>Required</small>                                                          |
 | objectType |             | [AzureRetentionRule_ObjectType](#AzureRetentionRule_ObjectType)<br/><small>Required</small> |
 
-<a id="AzureRetentionRule_STATUS"></a>AzureRetentionRule_STATUS
----------------------------------------------------------------
+AzureRetentionRule_STATUS{#AzureRetentionRule_STATUS}
+-----------------------------------------------------
 
 Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 
@@ -1219,8 +1219,8 @@ Used by: [BasePolicyRule_STATUS](#BasePolicyRule_STATUS).
 | name       |             | string<br/><small>Optional</small>                                                                        |
 | objectType |             | [AzureRetentionRule_ObjectType_STATUS](#AzureRetentionRule_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupDatasourceParameters"></a>BackupDatasourceParameters
------------------------------------------------------------------
+BackupDatasourceParameters{#BackupDatasourceParameters}
+-------------------------------------------------------
 
 Used by: [PolicyParameters](#PolicyParameters).
 
@@ -1229,8 +1229,8 @@ Used by: [PolicyParameters](#PolicyParameters).
 | blobBackupDatasourceParameters              | Mutually exclusive with all other properties | [BlobBackupDatasourceParameters](#BlobBackupDatasourceParameters)<br/><small>Optional</small>                           |
 | kubernetesClusterBackupDatasourceParameters | Mutually exclusive with all other properties | [KubernetesClusterBackupDatasourceParameters](#KubernetesClusterBackupDatasourceParameters)<br/><small>Optional</small> |
 
-<a id="BackupDatasourceParameters_STATUS"></a>BackupDatasourceParameters_STATUS
--------------------------------------------------------------------------------
+BackupDatasourceParameters_STATUS{#BackupDatasourceParameters_STATUS}
+---------------------------------------------------------------------
 
 Used by: [PolicyParameters_STATUS](#PolicyParameters_STATUS).
 
@@ -1239,8 +1239,8 @@ Used by: [PolicyParameters_STATUS](#PolicyParameters_STATUS).
 | blobBackupDatasourceParameters              | Mutually exclusive with all other properties | [BlobBackupDatasourceParameters_STATUS](#BlobBackupDatasourceParameters_STATUS)<br/><small>Optional</small>                           |
 | kubernetesClusterBackupDatasourceParameters | Mutually exclusive with all other properties | [KubernetesClusterBackupDatasourceParameters_STATUS](#KubernetesClusterBackupDatasourceParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="CrossRegionRestoreSettings_State"></a>CrossRegionRestoreSettings_State
------------------------------------------------------------------------------
+CrossRegionRestoreSettings_State{#CrossRegionRestoreSettings_State}
+-------------------------------------------------------------------
 
 Used by: [CrossRegionRestoreSettings](#CrossRegionRestoreSettings).
 
@@ -1249,8 +1249,8 @@ Used by: [CrossRegionRestoreSettings](#CrossRegionRestoreSettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CrossRegionRestoreSettings_State_STATUS"></a>CrossRegionRestoreSettings_State_STATUS
--------------------------------------------------------------------------------------------
+CrossRegionRestoreSettings_State_STATUS{#CrossRegionRestoreSettings_State_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [CrossRegionRestoreSettings_STATUS](#CrossRegionRestoreSettings_STATUS).
 
@@ -1259,8 +1259,8 @@ Used by: [CrossRegionRestoreSettings_STATUS](#CrossRegionRestoreSettings_STATUS)
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CrossSubscriptionRestoreSettings_State"></a>CrossSubscriptionRestoreSettings_State
------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_State{#CrossSubscriptionRestoreSettings_State}
+-------------------------------------------------------------------------------
 
 Used by: [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings).
 
@@ -1270,8 +1270,8 @@ Used by: [CrossSubscriptionRestoreSettings](#CrossSubscriptionRestoreSettings).
 | "Enabled"             |             |
 | "PermanentlyDisabled" |             |
 
-<a id="CrossSubscriptionRestoreSettings_State_STATUS"></a>CrossSubscriptionRestoreSettings_State_STATUS
--------------------------------------------------------------------------------------------------------
+CrossSubscriptionRestoreSettings_State_STATUS{#CrossSubscriptionRestoreSettings_State_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSettings_STATUS).
 
@@ -1281,8 +1281,8 @@ Used by: [CrossSubscriptionRestoreSettings_STATUS](#CrossSubscriptionRestoreSett
 | "Enabled"             |             |
 | "PermanentlyDisabled" |             |
 
-<a id="DataStoreParameters"></a>DataStoreParameters
----------------------------------------------------
+DataStoreParameters{#DataStoreParameters}
+-----------------------------------------
 
 Used by: [PolicyParameters](#PolicyParameters).
 
@@ -1290,8 +1290,8 @@ Used by: [PolicyParameters](#PolicyParameters).
 |---------------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------|
 | azureOperationalStoreParameters | Mutually exclusive with all other properties | [AzureOperationalStoreParameters](#AzureOperationalStoreParameters)<br/><small>Optional</small> |
 
-<a id="DataStoreParameters_STATUS"></a>DataStoreParameters_STATUS
------------------------------------------------------------------
+DataStoreParameters_STATUS{#DataStoreParameters_STATUS}
+-------------------------------------------------------
 
 Used by: [PolicyParameters_STATUS](#PolicyParameters_STATUS).
 
@@ -1299,8 +1299,8 @@ Used by: [PolicyParameters_STATUS](#PolicyParameters_STATUS).
 |---------------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | azureOperationalStoreParameters | Mutually exclusive with all other properties | [AzureOperationalStoreParameters_STATUS](#AzureOperationalStoreParameters_STATUS)<br/><small>Optional</small> |
 
-<a id="DefaultResourceProperties"></a>DefaultResourceProperties
----------------------------------------------------------------
+DefaultResourceProperties{#DefaultResourceProperties}
+-----------------------------------------------------
 
 Used by: [BaseResourceProperties](#BaseResourceProperties).
 
@@ -1308,8 +1308,8 @@ Used by: [BaseResourceProperties](#BaseResourceProperties).
 |------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [DefaultResourceProperties_ObjectType](#DefaultResourceProperties_ObjectType)<br/><small>Required</small> |
 
-<a id="DefaultResourceProperties_STATUS"></a>DefaultResourceProperties_STATUS
------------------------------------------------------------------------------
+DefaultResourceProperties_STATUS{#DefaultResourceProperties_STATUS}
+-------------------------------------------------------------------
 
 Used by: [BaseResourceProperties_STATUS](#BaseResourceProperties_STATUS).
 
@@ -1317,8 +1317,8 @@ Used by: [BaseResourceProperties_STATUS](#BaseResourceProperties_STATUS).
 |------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [DefaultResourceProperties_ObjectType_STATUS](#DefaultResourceProperties_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilitySettings_State"></a>ImmutabilitySettings_State
------------------------------------------------------------------
+ImmutabilitySettings_State{#ImmutabilitySettings_State}
+-------------------------------------------------------
 
 Used by: [ImmutabilitySettings](#ImmutabilitySettings).
 
@@ -1328,8 +1328,8 @@ Used by: [ImmutabilitySettings](#ImmutabilitySettings).
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ImmutabilitySettings_State_STATUS"></a>ImmutabilitySettings_State_STATUS
--------------------------------------------------------------------------------
+ImmutabilitySettings_State_STATUS{#ImmutabilitySettings_State_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS).
 
@@ -1339,8 +1339,8 @@ Used by: [ImmutabilitySettings_STATUS](#ImmutabilitySettings_STATUS).
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="InnerError_STATUS_Unrolled"></a>InnerError_STATUS_Unrolled
------------------------------------------------------------------
+InnerError_STATUS_Unrolled{#InnerError_STATUS_Unrolled}
+-------------------------------------------------------
 
 Used by: [InnerError_STATUS](#InnerError_STATUS).
 
@@ -1349,8 +1349,8 @@ Used by: [InnerError_STATUS](#InnerError_STATUS).
 | additionalInfo | Any Key value pairs that can be provided to the client for additional verbose information. | map[string]string<br/><small>Optional</small> |
 | code           | Unique code for this error                                                                 | string<br/><small>Optional</small>            |
 
-<a id="SecretStoreBasedAuthCredentials_ObjectType"></a>SecretStoreBasedAuthCredentials_ObjectType
--------------------------------------------------------------------------------------------------
+SecretStoreBasedAuthCredentials_ObjectType{#SecretStoreBasedAuthCredentials_ObjectType}
+---------------------------------------------------------------------------------------
 
 Used by: [SecretStoreBasedAuthCredentials](#SecretStoreBasedAuthCredentials).
 
@@ -1358,8 +1358,8 @@ Used by: [SecretStoreBasedAuthCredentials](#SecretStoreBasedAuthCredentials).
 |-----------------------------------|-------------|
 | "SecretStoreBasedAuthCredentials" |             |
 
-<a id="SecretStoreBasedAuthCredentials_ObjectType_STATUS"></a>SecretStoreBasedAuthCredentials_ObjectType_STATUS
----------------------------------------------------------------------------------------------------------------
+SecretStoreBasedAuthCredentials_ObjectType_STATUS{#SecretStoreBasedAuthCredentials_ObjectType_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [SecretStoreBasedAuthCredentials_STATUS](#SecretStoreBasedAuthCredentials_STATUS).
 
@@ -1367,8 +1367,8 @@ Used by: [SecretStoreBasedAuthCredentials_STATUS](#SecretStoreBasedAuthCredentia
 |-----------------------------------|-------------|
 | "SecretStoreBasedAuthCredentials" |             |
 
-<a id="SecretStoreResource"></a>SecretStoreResource
----------------------------------------------------
+SecretStoreResource{#SecretStoreResource}
+-----------------------------------------
 
 Class representing a secret store resource.
 
@@ -1380,8 +1380,8 @@ Used by: [SecretStoreBasedAuthCredentials](#SecretStoreBasedAuthCredentials).
 | uri             | Uri to get to the resource                         | string<br/><small>Optional</small>                                                                      |
 | value           | Gets or sets value stored in secret store resource | string<br/><small>Optional</small>                                                                      |
 
-<a id="SecretStoreResource_STATUS"></a>SecretStoreResource_STATUS
------------------------------------------------------------------
+SecretStoreResource_STATUS{#SecretStoreResource_STATUS}
+-------------------------------------------------------
 
 Class representing a secret store resource.
 
@@ -1393,8 +1393,8 @@ Used by: [SecretStoreBasedAuthCredentials_STATUS](#SecretStoreBasedAuthCredentia
 | uri             | Uri to get to the resource                         | string<br/><small>Optional</small>                                                                                    |
 | value           | Gets or sets value stored in secret store resource | string<br/><small>Optional</small>                                                                                    |
 
-<a id="SoftDeleteSettings_State"></a>SoftDeleteSettings_State
--------------------------------------------------------------
+SoftDeleteSettings_State{#SoftDeleteSettings_State}
+---------------------------------------------------
 
 Used by: [SoftDeleteSettings](#SoftDeleteSettings).
 
@@ -1404,8 +1404,8 @@ Used by: [SoftDeleteSettings](#SoftDeleteSettings).
 | "Off"      |             |
 | "On"       |             |
 
-<a id="SoftDeleteSettings_State_STATUS"></a>SoftDeleteSettings_State_STATUS
----------------------------------------------------------------------------
+SoftDeleteSettings_State_STATUS{#SoftDeleteSettings_State_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS).
 
@@ -1415,8 +1415,8 @@ Used by: [SoftDeleteSettings_STATUS](#SoftDeleteSettings_STATUS).
 | "Off"      |             |
 | "On"       |             |
 
-<a id="AzureBackupRule_ObjectType"></a>AzureBackupRule_ObjectType
------------------------------------------------------------------
+AzureBackupRule_ObjectType{#AzureBackupRule_ObjectType}
+-------------------------------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -1424,8 +1424,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 |-------------------|-------------|
 | "AzureBackupRule" |             |
 
-<a id="AzureBackupRule_ObjectType_STATUS"></a>AzureBackupRule_ObjectType_STATUS
--------------------------------------------------------------------------------
+AzureBackupRule_ObjectType_STATUS{#AzureBackupRule_ObjectType_STATUS}
+---------------------------------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -1433,8 +1433,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 |-------------------|-------------|
 | "AzureBackupRule" |             |
 
-<a id="AzureOperationalStoreParameters"></a>AzureOperationalStoreParameters
----------------------------------------------------------------------------
+AzureOperationalStoreParameters{#AzureOperationalStoreParameters}
+-----------------------------------------------------------------
 
 Used by: [DataStoreParameters](#DataStoreParameters).
 
@@ -1444,8 +1444,8 @@ Used by: [DataStoreParameters](#DataStoreParameters).
 | objectType             | Type of the specific object - used for deserializing | [AzureOperationalStoreParameters_ObjectType](#AzureOperationalStoreParameters_ObjectType)<br/><small>Required</small>                                      |
 | resourceGroupReference | Gets or sets the Snapshot Resource Group Uri.        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureOperationalStoreParameters_STATUS"></a>AzureOperationalStoreParameters_STATUS
------------------------------------------------------------------------------------------
+AzureOperationalStoreParameters_STATUS{#AzureOperationalStoreParameters_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DataStoreParameters_STATUS](#DataStoreParameters_STATUS).
 
@@ -1455,8 +1455,8 @@ Used by: [DataStoreParameters_STATUS](#DataStoreParameters_STATUS).
 | objectType      | Type of the specific object - used for deserializing | [AzureOperationalStoreParameters_ObjectType_STATUS](#AzureOperationalStoreParameters_ObjectType_STATUS)<br/><small>Optional</small>       |
 | resourceGroupId | Gets or sets the Snapshot Resource Group Uri.        | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="AzureRetentionRule_ObjectType"></a>AzureRetentionRule_ObjectType
------------------------------------------------------------------------
+AzureRetentionRule_ObjectType{#AzureRetentionRule_ObjectType}
+-------------------------------------------------------------
 
 Used by: [AzureRetentionRule](#AzureRetentionRule).
 
@@ -1464,8 +1464,8 @@ Used by: [AzureRetentionRule](#AzureRetentionRule).
 |----------------------|-------------|
 | "AzureRetentionRule" |             |
 
-<a id="AzureRetentionRule_ObjectType_STATUS"></a>AzureRetentionRule_ObjectType_STATUS
--------------------------------------------------------------------------------------
+AzureRetentionRule_ObjectType_STATUS{#AzureRetentionRule_ObjectType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 
@@ -1473,8 +1473,8 @@ Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 |----------------------|-------------|
 | "AzureRetentionRule" |             |
 
-<a id="BackupParameters"></a>BackupParameters
----------------------------------------------
+BackupParameters{#BackupParameters}
+-----------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -1482,8 +1482,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 |-------------------|----------------------------------------------|---------------------------------------------------------------------|
 | azureBackupParams | Mutually exclusive with all other properties | [AzureBackupParams](#AzureBackupParams)<br/><small>Optional</small> |
 
-<a id="BackupParameters_STATUS"></a>BackupParameters_STATUS
------------------------------------------------------------
+BackupParameters_STATUS{#BackupParameters_STATUS}
+-------------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -1491,8 +1491,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 |-------------------|----------------------------------------------|-----------------------------------------------------------------------------------|
 | azureBackupParams | Mutually exclusive with all other properties | [AzureBackupParams_STATUS](#AzureBackupParams_STATUS)<br/><small>Optional</small> |
 
-<a id="BlobBackupDatasourceParameters"></a>BlobBackupDatasourceParameters
--------------------------------------------------------------------------
+BlobBackupDatasourceParameters{#BlobBackupDatasourceParameters}
+---------------------------------------------------------------
 
 Used by: [BackupDatasourceParameters](#BackupDatasourceParameters).
 
@@ -1501,8 +1501,8 @@ Used by: [BackupDatasourceParameters](#BackupDatasourceParameters).
 | containersList | List of containers to be backed up during configuration of backup of blobs | string[]<br/><small>Required</small>                                                                                |
 | objectType     | Type of the specific object - used for deserializing                       | [BlobBackupDatasourceParameters_ObjectType](#BlobBackupDatasourceParameters_ObjectType)<br/><small>Required</small> |
 
-<a id="BlobBackupDatasourceParameters_STATUS"></a>BlobBackupDatasourceParameters_STATUS
----------------------------------------------------------------------------------------
+BlobBackupDatasourceParameters_STATUS{#BlobBackupDatasourceParameters_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [BackupDatasourceParameters_STATUS](#BackupDatasourceParameters_STATUS).
 
@@ -1511,8 +1511,8 @@ Used by: [BackupDatasourceParameters_STATUS](#BackupDatasourceParameters_STATUS)
 | containersList | List of containers to be backed up during configuration of backup of blobs | string[]<br/><small>Optional</small>                                                                                              |
 | objectType     | Type of the specific object - used for deserializing                       | [BlobBackupDatasourceParameters_ObjectType_STATUS](#BlobBackupDatasourceParameters_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="DataStoreInfoBase"></a>DataStoreInfoBase
------------------------------------------------
+DataStoreInfoBase{#DataStoreInfoBase}
+-------------------------------------
 
 DataStoreInfo base
 
@@ -1523,8 +1523,8 @@ Used by: [AzureBackupRule](#AzureBackupRule), [SourceLifeCycle](#SourceLifeCycle
 | dataStoreType | type of datastore; Operational/Vault/Archive                           | [DataStoreInfoBase_DataStoreType](#DataStoreInfoBase_DataStoreType)<br/><small>Required</small> |
 | objectType    | Type of Datasource object, used to initialize the right inherited type | string<br/><small>Required</small>                                                              |
 
-<a id="DataStoreInfoBase_STATUS"></a>DataStoreInfoBase_STATUS
--------------------------------------------------------------
+DataStoreInfoBase_STATUS{#DataStoreInfoBase_STATUS}
+---------------------------------------------------
 
 DataStoreInfo base
 
@@ -1535,8 +1535,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS), [SourceLifeCycle_STA
 | dataStoreType | type of datastore; Operational/Vault/Archive                           | [DataStoreInfoBase_DataStoreType_STATUS](#DataStoreInfoBase_DataStoreType_STATUS)<br/><small>Optional</small> |
 | objectType    | Type of Datasource object, used to initialize the right inherited type | string<br/><small>Optional</small>                                                                            |
 
-<a id="DefaultResourceProperties_ObjectType"></a>DefaultResourceProperties_ObjectType
--------------------------------------------------------------------------------------
+DefaultResourceProperties_ObjectType{#DefaultResourceProperties_ObjectType}
+---------------------------------------------------------------------------
 
 Used by: [DefaultResourceProperties](#DefaultResourceProperties).
 
@@ -1544,8 +1544,8 @@ Used by: [DefaultResourceProperties](#DefaultResourceProperties).
 |-----------------------------|-------------|
 | "DefaultResourceProperties" |             |
 
-<a id="DefaultResourceProperties_ObjectType_STATUS"></a>DefaultResourceProperties_ObjectType_STATUS
----------------------------------------------------------------------------------------------------
+DefaultResourceProperties_ObjectType_STATUS{#DefaultResourceProperties_ObjectType_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [DefaultResourceProperties_STATUS](#DefaultResourceProperties_STATUS).
 
@@ -1553,8 +1553,8 @@ Used by: [DefaultResourceProperties_STATUS](#DefaultResourceProperties_STATUS).
 |-----------------------------|-------------|
 | "DefaultResourceProperties" |             |
 
-<a id="KubernetesClusterBackupDatasourceParameters"></a>KubernetesClusterBackupDatasourceParameters
----------------------------------------------------------------------------------------------------
+KubernetesClusterBackupDatasourceParameters{#KubernetesClusterBackupDatasourceParameters}
+-----------------------------------------------------------------------------------------
 
 Used by: [BackupDatasourceParameters](#BackupDatasourceParameters).
 
@@ -1570,8 +1570,8 @@ Used by: [BackupDatasourceParameters](#BackupDatasourceParameters).
 | objectType                   | Type of the specific object - used for deserializing                                                                              | [KubernetesClusterBackupDatasourceParameters_ObjectType](#KubernetesClusterBackupDatasourceParameters_ObjectType)<br/><small>Required</small> |
 | snapshotVolumes              | Gets or sets the volume snapshot property. This property if enabled will take volume snapshots during backup.                     | bool<br/><small>Required</small>                                                                                                              |
 
-<a id="KubernetesClusterBackupDatasourceParameters_STATUS"></a>KubernetesClusterBackupDatasourceParameters_STATUS
------------------------------------------------------------------------------------------------------------------
+KubernetesClusterBackupDatasourceParameters_STATUS{#KubernetesClusterBackupDatasourceParameters_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [BackupDatasourceParameters_STATUS](#BackupDatasourceParameters_STATUS).
 
@@ -1587,8 +1587,8 @@ Used by: [BackupDatasourceParameters_STATUS](#BackupDatasourceParameters_STATUS)
 | objectType                   | Type of the specific object - used for deserializing                                                                              | [KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS](#KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS)<br/><small>Optional</small> |
 | snapshotVolumes              | Gets or sets the volume snapshot property. This property if enabled will take volume snapshots during backup.                     | bool<br/><small>Optional</small>                                                                                                                            |
 
-<a id="SecretStoreResource_SecretStoreType"></a>SecretStoreResource_SecretStoreType
------------------------------------------------------------------------------------
+SecretStoreResource_SecretStoreType{#SecretStoreResource_SecretStoreType}
+-------------------------------------------------------------------------
 
 Used by: [SecretStoreResource](#SecretStoreResource).
 
@@ -1597,8 +1597,8 @@ Used by: [SecretStoreResource](#SecretStoreResource).
 | "AzureKeyVault" |             |
 | "Invalid"       |             |
 
-<a id="SecretStoreResource_SecretStoreType_STATUS"></a>SecretStoreResource_SecretStoreType_STATUS
--------------------------------------------------------------------------------------------------
+SecretStoreResource_SecretStoreType_STATUS{#SecretStoreResource_SecretStoreType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [SecretStoreResource_STATUS](#SecretStoreResource_STATUS).
 
@@ -1607,8 +1607,8 @@ Used by: [SecretStoreResource_STATUS](#SecretStoreResource_STATUS).
 | "AzureKeyVault" |             |
 | "Invalid"       |             |
 
-<a id="SourceLifeCycle"></a>SourceLifeCycle
--------------------------------------------
+SourceLifeCycle{#SourceLifeCycle}
+---------------------------------
 
 Source LifeCycle
 
@@ -1620,8 +1620,8 @@ Used by: [AzureRetentionRule](#AzureRetentionRule).
 | sourceDataStore             | DataStoreInfo base | [DataStoreInfoBase](#DataStoreInfoBase)<br/><small>Required</small>   |
 | targetDataStoreCopySettings |                    | [TargetCopySetting[]](#TargetCopySetting)<br/><small>Optional</small> |
 
-<a id="SourceLifeCycle_STATUS"></a>SourceLifeCycle_STATUS
----------------------------------------------------------
+SourceLifeCycle_STATUS{#SourceLifeCycle_STATUS}
+-----------------------------------------------
 
 Source LifeCycle
 
@@ -1633,8 +1633,8 @@ Used by: [AzureRetentionRule_STATUS](#AzureRetentionRule_STATUS).
 | sourceDataStore             | DataStoreInfo base | [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS)<br/><small>Optional</small>   |
 | targetDataStoreCopySettings |                    | [TargetCopySetting_STATUS[]](#TargetCopySetting_STATUS)<br/><small>Optional</small> |
 
-<a id="TriggerContext"></a>TriggerContext
------------------------------------------
+TriggerContext{#TriggerContext}
+-------------------------------
 
 Used by: [AzureBackupRule](#AzureBackupRule).
 
@@ -1643,8 +1643,8 @@ Used by: [AzureBackupRule](#AzureBackupRule).
 | adhocBasedTriggerContext    | Mutually exclusive with all other properties | [AdhocBasedTriggerContext](#AdhocBasedTriggerContext)<br/><small>Optional</small>       |
 | scheduleBasedTriggerContext | Mutually exclusive with all other properties | [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext)<br/><small>Optional</small> |
 
-<a id="TriggerContext_STATUS"></a>TriggerContext_STATUS
--------------------------------------------------------
+TriggerContext_STATUS{#TriggerContext_STATUS}
+---------------------------------------------
 
 Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 
@@ -1653,8 +1653,8 @@ Used by: [AzureBackupRule_STATUS](#AzureBackupRule_STATUS).
 | adhocBasedTriggerContext    | Mutually exclusive with all other properties | [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS)<br/><small>Optional</small>       |
 | scheduleBasedTriggerContext | Mutually exclusive with all other properties | [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTriggerContext"></a>AdhocBasedTriggerContext
--------------------------------------------------------------
+AdhocBasedTriggerContext{#AdhocBasedTriggerContext}
+---------------------------------------------------
 
 Used by: [TriggerContext](#TriggerContext).
 
@@ -1663,8 +1663,8 @@ Used by: [TriggerContext](#TriggerContext).
 | objectType      | Type of the specific object - used for deserializing        | [AdhocBasedTriggerContext_ObjectType](#AdhocBasedTriggerContext_ObjectType)<br/><small>Required</small> |
 | taggingCriteria | Tagging Criteria containing retention tag for adhoc backup. | [AdhocBasedTaggingCriteria](#AdhocBasedTaggingCriteria)<br/><small>Required</small>                     |
 
-<a id="AdhocBasedTriggerContext_STATUS"></a>AdhocBasedTriggerContext_STATUS
----------------------------------------------------------------------------
+AdhocBasedTriggerContext_STATUS{#AdhocBasedTriggerContext_STATUS}
+-----------------------------------------------------------------
 
 Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 
@@ -1673,8 +1673,8 @@ Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 | objectType      | Type of the specific object - used for deserializing        | [AdhocBasedTriggerContext_ObjectType_STATUS](#AdhocBasedTriggerContext_ObjectType_STATUS)<br/><small>Optional</small> |
 | taggingCriteria | Tagging Criteria containing retention tag for adhoc backup. | [AdhocBasedTaggingCriteria_STATUS](#AdhocBasedTaggingCriteria_STATUS)<br/><small>Optional</small>                     |
 
-<a id="AzureBackupParams"></a>AzureBackupParams
------------------------------------------------
+AzureBackupParams{#AzureBackupParams}
+-------------------------------------
 
 Used by: [BackupParameters](#BackupParameters).
 
@@ -1683,8 +1683,8 @@ Used by: [BackupParameters](#BackupParameters).
 | backupType | BackupType ; Full/Incremental etc                    | string<br/><small>Required</small>                                                        |
 | objectType | Type of the specific object - used for deserializing | [AzureBackupParams_ObjectType](#AzureBackupParams_ObjectType)<br/><small>Required</small> |
 
-<a id="AzureBackupParams_STATUS"></a>AzureBackupParams_STATUS
--------------------------------------------------------------
+AzureBackupParams_STATUS{#AzureBackupParams_STATUS}
+---------------------------------------------------
 
 Used by: [BackupParameters_STATUS](#BackupParameters_STATUS).
 
@@ -1693,8 +1693,8 @@ Used by: [BackupParameters_STATUS](#BackupParameters_STATUS).
 | backupType | BackupType ; Full/Incremental etc                    | string<br/><small>Optional</small>                                                                      |
 | objectType | Type of the specific object - used for deserializing | [AzureBackupParams_ObjectType_STATUS](#AzureBackupParams_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="AzureOperationalStoreParameters_DataStoreType"></a>AzureOperationalStoreParameters_DataStoreType
--------------------------------------------------------------------------------------------------------
+AzureOperationalStoreParameters_DataStoreType{#AzureOperationalStoreParameters_DataStoreType}
+---------------------------------------------------------------------------------------------
 
 Used by: [AzureOperationalStoreParameters](#AzureOperationalStoreParameters).
 
@@ -1704,8 +1704,8 @@ Used by: [AzureOperationalStoreParameters](#AzureOperationalStoreParameters).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="AzureOperationalStoreParameters_DataStoreType_STATUS"></a>AzureOperationalStoreParameters_DataStoreType_STATUS
----------------------------------------------------------------------------------------------------------------------
+AzureOperationalStoreParameters_DataStoreType_STATUS{#AzureOperationalStoreParameters_DataStoreType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [AzureOperationalStoreParameters_STATUS](#AzureOperationalStoreParameters_STATUS).
 
@@ -1715,8 +1715,8 @@ Used by: [AzureOperationalStoreParameters_STATUS](#AzureOperationalStoreParamete
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="AzureOperationalStoreParameters_ObjectType"></a>AzureOperationalStoreParameters_ObjectType
--------------------------------------------------------------------------------------------------
+AzureOperationalStoreParameters_ObjectType{#AzureOperationalStoreParameters_ObjectType}
+---------------------------------------------------------------------------------------
 
 Used by: [AzureOperationalStoreParameters](#AzureOperationalStoreParameters).
 
@@ -1724,8 +1724,8 @@ Used by: [AzureOperationalStoreParameters](#AzureOperationalStoreParameters).
 |-----------------------------------|-------------|
 | "AzureOperationalStoreParameters" |             |
 
-<a id="AzureOperationalStoreParameters_ObjectType_STATUS"></a>AzureOperationalStoreParameters_ObjectType_STATUS
----------------------------------------------------------------------------------------------------------------
+AzureOperationalStoreParameters_ObjectType_STATUS{#AzureOperationalStoreParameters_ObjectType_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [AzureOperationalStoreParameters_STATUS](#AzureOperationalStoreParameters_STATUS).
 
@@ -1733,8 +1733,8 @@ Used by: [AzureOperationalStoreParameters_STATUS](#AzureOperationalStoreParamete
 |-----------------------------------|-------------|
 | "AzureOperationalStoreParameters" |             |
 
-<a id="BlobBackupDatasourceParameters_ObjectType"></a>BlobBackupDatasourceParameters_ObjectType
------------------------------------------------------------------------------------------------
+BlobBackupDatasourceParameters_ObjectType{#BlobBackupDatasourceParameters_ObjectType}
+-------------------------------------------------------------------------------------
 
 Used by: [BlobBackupDatasourceParameters](#BlobBackupDatasourceParameters).
 
@@ -1742,8 +1742,8 @@ Used by: [BlobBackupDatasourceParameters](#BlobBackupDatasourceParameters).
 |----------------------------------|-------------|
 | "BlobBackupDatasourceParameters" |             |
 
-<a id="BlobBackupDatasourceParameters_ObjectType_STATUS"></a>BlobBackupDatasourceParameters_ObjectType_STATUS
--------------------------------------------------------------------------------------------------------------
+BlobBackupDatasourceParameters_ObjectType_STATUS{#BlobBackupDatasourceParameters_ObjectType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [BlobBackupDatasourceParameters_STATUS](#BlobBackupDatasourceParameters_STATUS).
 
@@ -1751,8 +1751,8 @@ Used by: [BlobBackupDatasourceParameters_STATUS](#BlobBackupDatasourceParameters
 |----------------------------------|-------------|
 | "BlobBackupDatasourceParameters" |             |
 
-<a id="DataStoreInfoBase_DataStoreType"></a>DataStoreInfoBase_DataStoreType
----------------------------------------------------------------------------
+DataStoreInfoBase_DataStoreType{#DataStoreInfoBase_DataStoreType}
+-----------------------------------------------------------------
 
 Used by: [DataStoreInfoBase](#DataStoreInfoBase).
 
@@ -1762,8 +1762,8 @@ Used by: [DataStoreInfoBase](#DataStoreInfoBase).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="DataStoreInfoBase_DataStoreType_STATUS"></a>DataStoreInfoBase_DataStoreType_STATUS
------------------------------------------------------------------------------------------
+DataStoreInfoBase_DataStoreType_STATUS{#DataStoreInfoBase_DataStoreType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS).
 
@@ -1773,8 +1773,8 @@ Used by: [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS).
 | "OperationalStore" |             |
 | "VaultStore"       |             |
 
-<a id="DeleteOption"></a>DeleteOption
--------------------------------------
+DeleteOption{#DeleteOption}
+---------------------------
 
 Used by: [SourceLifeCycle](#SourceLifeCycle).
 
@@ -1782,8 +1782,8 @@ Used by: [SourceLifeCycle](#SourceLifeCycle).
 |----------------------|----------------------------------------------|---------------------------------------------------------------------------|
 | absoluteDeleteOption | Mutually exclusive with all other properties | [AbsoluteDeleteOption](#AbsoluteDeleteOption)<br/><small>Optional</small> |
 
-<a id="DeleteOption_STATUS"></a>DeleteOption_STATUS
----------------------------------------------------
+DeleteOption_STATUS{#DeleteOption_STATUS}
+-----------------------------------------
 
 Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 
@@ -1791,8 +1791,8 @@ Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 |----------------------|----------------------------------------------|-----------------------------------------------------------------------------------------|
 | absoluteDeleteOption | Mutually exclusive with all other properties | [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS)<br/><small>Optional</small> |
 
-<a id="KubernetesClusterBackupDatasourceParameters_ObjectType"></a>KubernetesClusterBackupDatasourceParameters_ObjectType
--------------------------------------------------------------------------------------------------------------------------
+KubernetesClusterBackupDatasourceParameters_ObjectType{#KubernetesClusterBackupDatasourceParameters_ObjectType}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [KubernetesClusterBackupDatasourceParameters](#KubernetesClusterBackupDatasourceParameters).
 
@@ -1800,8 +1800,8 @@ Used by: [KubernetesClusterBackupDatasourceParameters](#KubernetesClusterBackupD
 |-----------------------------------------------|-------------|
 | "KubernetesClusterBackupDatasourceParameters" |             |
 
-<a id="KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS"></a>KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS{#KubernetesClusterBackupDatasourceParameters_ObjectType_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [KubernetesClusterBackupDatasourceParameters_STATUS](#KubernetesClusterBackupDatasourceParameters_STATUS).
 
@@ -1809,32 +1809,32 @@ Used by: [KubernetesClusterBackupDatasourceParameters_STATUS](#KubernetesCluster
 |-----------------------------------------------|-------------|
 | "KubernetesClusterBackupDatasourceParameters" |             |
 
-<a id="NamespacedNameResource"></a>NamespacedNameResource
+NamespacedNameResource{#NamespacedNameResource}
+-----------------------------------------------
+
+Class to refer resources which contains namespace and name
+
+Used by: [KubernetesClusterBackupDatasourceParameters](#KubernetesClusterBackupDatasourceParameters).
+
+| Property  | Description                            | Type                               |
+|-----------|----------------------------------------|------------------------------------|
+| name      | Name of the resource                   | string<br/><small>Optional</small> |
+| namespace | Namespace in which the resource exists | string<br/><small>Optional</small> |
+
+NamespacedNameResource_STATUS{#NamespacedNameResource_STATUS}
+-------------------------------------------------------------
+
+Class to refer resources which contains namespace and name
+
+Used by: [KubernetesClusterBackupDatasourceParameters_STATUS](#KubernetesClusterBackupDatasourceParameters_STATUS).
+
+| Property  | Description                            | Type                               |
+|-----------|----------------------------------------|------------------------------------|
+| name      | Name of the resource                   | string<br/><small>Optional</small> |
+| namespace | Namespace in which the resource exists | string<br/><small>Optional</small> |
+
+ScheduleBasedTriggerContext{#ScheduleBasedTriggerContext}
 ---------------------------------------------------------
-
-Class to refer resources which contains namespace and name
-
-Used by: [KubernetesClusterBackupDatasourceParameters](#KubernetesClusterBackupDatasourceParameters).
-
-| Property  | Description                            | Type                               |
-|-----------|----------------------------------------|------------------------------------|
-| name      | Name of the resource                   | string<br/><small>Optional</small> |
-| namespace | Namespace in which the resource exists | string<br/><small>Optional</small> |
-
-<a id="NamespacedNameResource_STATUS"></a>NamespacedNameResource_STATUS
------------------------------------------------------------------------
-
-Class to refer resources which contains namespace and name
-
-Used by: [KubernetesClusterBackupDatasourceParameters_STATUS](#KubernetesClusterBackupDatasourceParameters_STATUS).
-
-| Property  | Description                            | Type                               |
-|-----------|----------------------------------------|------------------------------------|
-| name      | Name of the resource                   | string<br/><small>Optional</small> |
-| namespace | Namespace in which the resource exists | string<br/><small>Optional</small> |
-
-<a id="ScheduleBasedTriggerContext"></a>ScheduleBasedTriggerContext
--------------------------------------------------------------------
 
 Used by: [TriggerContext](#TriggerContext).
 
@@ -1844,8 +1844,8 @@ Used by: [TriggerContext](#TriggerContext).
 | schedule        | Schedule for this backup                                | [BackupSchedule](#BackupSchedule)<br/><small>Required</small>                                                 |
 | taggingCriteria | List of tags that can be applicable for given schedule. | [TaggingCriteria[]](#TaggingCriteria)<br/><small>Required</small>                                             |
 
-<a id="ScheduleBasedTriggerContext_STATUS"></a>ScheduleBasedTriggerContext_STATUS
----------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_STATUS{#ScheduleBasedTriggerContext_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 
@@ -1855,8 +1855,8 @@ Used by: [TriggerContext_STATUS](#TriggerContext_STATUS).
 | schedule        | Schedule for this backup                                | [BackupSchedule_STATUS](#BackupSchedule_STATUS)<br/><small>Optional</small>                                                 |
 | taggingCriteria | List of tags that can be applicable for given schedule. | [TaggingCriteria_STATUS[]](#TaggingCriteria_STATUS)<br/><small>Optional</small>                                             |
 
-<a id="TargetCopySetting"></a>TargetCopySetting
------------------------------------------------
+TargetCopySetting{#TargetCopySetting}
+-------------------------------------
 
 Target copy settings
 
@@ -1867,8 +1867,8 @@ Used by: [SourceLifeCycle](#SourceLifeCycle).
 | copyAfter | It can be CustomCopyOption or ImmediateCopyOption. | [CopyOption](#CopyOption)<br/><small>Required</small>               |
 | dataStore | Info of target datastore                           | [DataStoreInfoBase](#DataStoreInfoBase)<br/><small>Required</small> |
 
-<a id="TargetCopySetting_STATUS"></a>TargetCopySetting_STATUS
--------------------------------------------------------------
+TargetCopySetting_STATUS{#TargetCopySetting_STATUS}
+---------------------------------------------------
 
 Target copy settings
 
@@ -1879,8 +1879,8 @@ Used by: [SourceLifeCycle_STATUS](#SourceLifeCycle_STATUS).
 | copyAfter | It can be CustomCopyOption or ImmediateCopyOption. | [CopyOption_STATUS](#CopyOption_STATUS)<br/><small>Optional</small>               |
 | dataStore | Info of target datastore                           | [DataStoreInfoBase_STATUS](#DataStoreInfoBase_STATUS)<br/><small>Optional</small> |
 
-<a id="AbsoluteDeleteOption"></a>AbsoluteDeleteOption
------------------------------------------------------
+AbsoluteDeleteOption{#AbsoluteDeleteOption}
+-------------------------------------------
 
 Used by: [DeleteOption](#DeleteOption).
 
@@ -1889,8 +1889,8 @@ Used by: [DeleteOption](#DeleteOption).
 | duration   | Duration of deletion after given timespan            | string<br/><small>Required</small>                                                              |
 | objectType | Type of the specific object - used for deserializing | [AbsoluteDeleteOption_ObjectType](#AbsoluteDeleteOption_ObjectType)<br/><small>Required</small> |
 
-<a id="AbsoluteDeleteOption_STATUS"></a>AbsoluteDeleteOption_STATUS
--------------------------------------------------------------------
+AbsoluteDeleteOption_STATUS{#AbsoluteDeleteOption_STATUS}
+---------------------------------------------------------
 
 Used by: [DeleteOption_STATUS](#DeleteOption_STATUS).
 
@@ -1899,8 +1899,8 @@ Used by: [DeleteOption_STATUS](#DeleteOption_STATUS).
 | duration   | Duration of deletion after given timespan            | string<br/><small>Optional</small>                                                                            |
 | objectType | Type of the specific object - used for deserializing | [AbsoluteDeleteOption_ObjectType_STATUS](#AbsoluteDeleteOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTaggingCriteria"></a>AdhocBasedTaggingCriteria
----------------------------------------------------------------
+AdhocBasedTaggingCriteria{#AdhocBasedTaggingCriteria}
+-----------------------------------------------------
 
 Adhoc backup tagging criteria
 
@@ -1910,8 +1910,8 @@ Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 |----------|---------------------------|-----------------------------------------------------------|
 | tagInfo  | Retention tag information | [RetentionTag](#RetentionTag)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTaggingCriteria_STATUS"></a>AdhocBasedTaggingCriteria_STATUS
------------------------------------------------------------------------------
+AdhocBasedTaggingCriteria_STATUS{#AdhocBasedTaggingCriteria_STATUS}
+-------------------------------------------------------------------
 
 Adhoc backup tagging criteria
 
@@ -1921,8 +1921,8 @@ Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 |----------|---------------------------|-------------------------------------------------------------------------|
 | tagInfo  | Retention tag information | [RetentionTag_STATUS](#RetentionTag_STATUS)<br/><small>Optional</small> |
 
-<a id="AdhocBasedTriggerContext_ObjectType"></a>AdhocBasedTriggerContext_ObjectType
------------------------------------------------------------------------------------
+AdhocBasedTriggerContext_ObjectType{#AdhocBasedTriggerContext_ObjectType}
+-------------------------------------------------------------------------
 
 Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 
@@ -1930,8 +1930,8 @@ Used by: [AdhocBasedTriggerContext](#AdhocBasedTriggerContext).
 |----------------------------|-------------|
 | "AdhocBasedTriggerContext" |             |
 
-<a id="AdhocBasedTriggerContext_ObjectType_STATUS"></a>AdhocBasedTriggerContext_ObjectType_STATUS
--------------------------------------------------------------------------------------------------
+AdhocBasedTriggerContext_ObjectType_STATUS{#AdhocBasedTriggerContext_ObjectType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 
@@ -1939,8 +1939,8 @@ Used by: [AdhocBasedTriggerContext_STATUS](#AdhocBasedTriggerContext_STATUS).
 |----------------------------|-------------|
 | "AdhocBasedTriggerContext" |             |
 
-<a id="AzureBackupParams_ObjectType"></a>AzureBackupParams_ObjectType
----------------------------------------------------------------------
+AzureBackupParams_ObjectType{#AzureBackupParams_ObjectType}
+-----------------------------------------------------------
 
 Used by: [AzureBackupParams](#AzureBackupParams).
 
@@ -1948,8 +1948,8 @@ Used by: [AzureBackupParams](#AzureBackupParams).
 |---------------------|-------------|
 | "AzureBackupParams" |             |
 
-<a id="AzureBackupParams_ObjectType_STATUS"></a>AzureBackupParams_ObjectType_STATUS
------------------------------------------------------------------------------------
+AzureBackupParams_ObjectType_STATUS{#AzureBackupParams_ObjectType_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AzureBackupParams_STATUS](#AzureBackupParams_STATUS).
 
@@ -1957,8 +1957,8 @@ Used by: [AzureBackupParams_STATUS](#AzureBackupParams_STATUS).
 |---------------------|-------------|
 | "AzureBackupParams" |             |
 
-<a id="BackupSchedule"></a>BackupSchedule
------------------------------------------
+BackupSchedule{#BackupSchedule}
+-------------------------------
 
 Schedule for backup
 
@@ -1969,8 +1969,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 | repeatingTimeIntervals | ISO 8601 repeating time interval format                  | string[]<br/><small>Required</small> |
 | timeZone               | Time zone for a schedule. Example: Pacific Standard Time | string<br/><small>Optional</small>   |
 
-<a id="BackupSchedule_STATUS"></a>BackupSchedule_STATUS
--------------------------------------------------------
+BackupSchedule_STATUS{#BackupSchedule_STATUS}
+---------------------------------------------
 
 Schedule for backup
 
@@ -1981,8 +1981,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 | repeatingTimeIntervals | ISO 8601 repeating time interval format                  | string[]<br/><small>Optional</small> |
 | timeZone               | Time zone for a schedule. Example: Pacific Standard Time | string<br/><small>Optional</small>   |
 
-<a id="CopyOption"></a>CopyOption
----------------------------------
+CopyOption{#CopyOption}
+-----------------------
 
 Used by: [TargetCopySetting](#TargetCopySetting).
 
@@ -1992,8 +1992,8 @@ Used by: [TargetCopySetting](#TargetCopySetting).
 | customCopyOption    | Mutually exclusive with all other properties | [CustomCopyOption](#CustomCopyOption)<br/><small>Optional</small>       |
 | immediateCopyOption | Mutually exclusive with all other properties | [ImmediateCopyOption](#ImmediateCopyOption)<br/><small>Optional</small> |
 
-<a id="CopyOption_STATUS"></a>CopyOption_STATUS
------------------------------------------------
+CopyOption_STATUS{#CopyOption_STATUS}
+-------------------------------------
 
 Used by: [TargetCopySetting_STATUS](#TargetCopySetting_STATUS).
 
@@ -2003,8 +2003,8 @@ Used by: [TargetCopySetting_STATUS](#TargetCopySetting_STATUS).
 | customCopyOption    | Mutually exclusive with all other properties | [CustomCopyOption_STATUS](#CustomCopyOption_STATUS)<br/><small>Optional</small>       |
 | immediateCopyOption | Mutually exclusive with all other properties | [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduleBasedTriggerContext_ObjectType"></a>ScheduleBasedTriggerContext_ObjectType
------------------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_ObjectType{#ScheduleBasedTriggerContext_ObjectType}
+-------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 
@@ -2012,8 +2012,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 |-------------------------------|-------------|
 | "ScheduleBasedTriggerContext" |             |
 
-<a id="ScheduleBasedTriggerContext_ObjectType_STATUS"></a>ScheduleBasedTriggerContext_ObjectType_STATUS
--------------------------------------------------------------------------------------------------------
+ScheduleBasedTriggerContext_ObjectType_STATUS{#ScheduleBasedTriggerContext_ObjectType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATUS).
 
@@ -2021,8 +2021,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 |-------------------------------|-------------|
 | "ScheduleBasedTriggerContext" |             |
 
-<a id="TaggingCriteria"></a>TaggingCriteria
--------------------------------------------
+TaggingCriteria{#TaggingCriteria}
+---------------------------------
 
 Tagging criteria
 
@@ -2035,8 +2035,8 @@ Used by: [ScheduleBasedTriggerContext](#ScheduleBasedTriggerContext).
 | taggingPriority | Retention Tag priority.                                                      | int<br/><small>Required</small>                                 |
 | tagInfo         | Retention tag information                                                    | [RetentionTag](#RetentionTag)<br/><small>Required</small>       |
 
-<a id="TaggingCriteria_STATUS"></a>TaggingCriteria_STATUS
----------------------------------------------------------
+TaggingCriteria_STATUS{#TaggingCriteria_STATUS}
+-----------------------------------------------
 
 Tagging criteria
 
@@ -2049,8 +2049,8 @@ Used by: [ScheduleBasedTriggerContext_STATUS](#ScheduleBasedTriggerContext_STATU
 | taggingPriority | Retention Tag priority.                                                      | int<br/><small>Optional</small>                                               |
 | tagInfo         | Retention tag information                                                    | [RetentionTag_STATUS](#RetentionTag_STATUS)<br/><small>Optional</small>       |
 
-<a id="AbsoluteDeleteOption_ObjectType"></a>AbsoluteDeleteOption_ObjectType
----------------------------------------------------------------------------
+AbsoluteDeleteOption_ObjectType{#AbsoluteDeleteOption_ObjectType}
+-----------------------------------------------------------------
 
 Used by: [AbsoluteDeleteOption](#AbsoluteDeleteOption).
 
@@ -2058,8 +2058,8 @@ Used by: [AbsoluteDeleteOption](#AbsoluteDeleteOption).
 |------------------------|-------------|
 | "AbsoluteDeleteOption" |             |
 
-<a id="AbsoluteDeleteOption_ObjectType_STATUS"></a>AbsoluteDeleteOption_ObjectType_STATUS
------------------------------------------------------------------------------------------
+AbsoluteDeleteOption_ObjectType_STATUS{#AbsoluteDeleteOption_ObjectType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS).
 
@@ -2067,8 +2067,8 @@ Used by: [AbsoluteDeleteOption_STATUS](#AbsoluteDeleteOption_STATUS).
 |------------------------|-------------|
 | "AbsoluteDeleteOption" |             |
 
-<a id="BackupCriteria"></a>BackupCriteria
------------------------------------------
+BackupCriteria{#BackupCriteria}
+-------------------------------
 
 Used by: [TaggingCriteria](#TaggingCriteria).
 
@@ -2076,8 +2076,8 @@ Used by: [TaggingCriteria](#TaggingCriteria).
 |-----------------------------|----------------------------------------------|-----------------------------------------------------------------------------------------|
 | scheduleBasedBackupCriteria | Mutually exclusive with all other properties | [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria)<br/><small>Optional</small> |
 
-<a id="BackupCriteria_STATUS"></a>BackupCriteria_STATUS
--------------------------------------------------------
+BackupCriteria_STATUS{#BackupCriteria_STATUS}
+---------------------------------------------
 
 Used by: [TaggingCriteria_STATUS](#TaggingCriteria_STATUS).
 
@@ -2085,8 +2085,8 @@ Used by: [TaggingCriteria_STATUS](#TaggingCriteria_STATUS).
 |-----------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | scheduleBasedBackupCriteria | Mutually exclusive with all other properties | [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS)<br/><small>Optional</small> |
 
-<a id="CopyOnExpiryOption"></a>CopyOnExpiryOption
--------------------------------------------------
+CopyOnExpiryOption{#CopyOnExpiryOption}
+---------------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -2094,8 +2094,8 @@ Used by: [CopyOption](#CopyOption).
 |------------|------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [CopyOnExpiryOption_ObjectType](#CopyOnExpiryOption_ObjectType)<br/><small>Required</small> |
 
-<a id="CopyOnExpiryOption_STATUS"></a>CopyOnExpiryOption_STATUS
----------------------------------------------------------------
+CopyOnExpiryOption_STATUS{#CopyOnExpiryOption_STATUS}
+-----------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -2103,8 +2103,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 |------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [CopyOnExpiryOption_ObjectType_STATUS](#CopyOnExpiryOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomCopyOption"></a>CustomCopyOption
----------------------------------------------
+CustomCopyOption{#CustomCopyOption}
+-----------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -2113,8 +2113,8 @@ Used by: [CopyOption](#CopyOption).
 | duration   | Data copied after given timespan                     | string<br/><small>Optional</small>                                                      |
 | objectType | Type of the specific object - used for deserializing | [CustomCopyOption_ObjectType](#CustomCopyOption_ObjectType)<br/><small>Required</small> |
 
-<a id="CustomCopyOption_STATUS"></a>CustomCopyOption_STATUS
------------------------------------------------------------
+CustomCopyOption_STATUS{#CustomCopyOption_STATUS}
+-------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -2123,8 +2123,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 | duration   | Data copied after given timespan                     | string<br/><small>Optional</small>                                                                    |
 | objectType | Type of the specific object - used for deserializing | [CustomCopyOption_ObjectType_STATUS](#CustomCopyOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmediateCopyOption"></a>ImmediateCopyOption
----------------------------------------------------
+ImmediateCopyOption{#ImmediateCopyOption}
+-----------------------------------------
 
 Used by: [CopyOption](#CopyOption).
 
@@ -2132,8 +2132,8 @@ Used by: [CopyOption](#CopyOption).
 |------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [ImmediateCopyOption_ObjectType](#ImmediateCopyOption_ObjectType)<br/><small>Required</small> |
 
-<a id="ImmediateCopyOption_STATUS"></a>ImmediateCopyOption_STATUS
------------------------------------------------------------------
+ImmediateCopyOption_STATUS{#ImmediateCopyOption_STATUS}
+-------------------------------------------------------
 
 Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 
@@ -2141,8 +2141,8 @@ Used by: [CopyOption_STATUS](#CopyOption_STATUS).
 |------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | objectType | Type of the specific object - used for deserializing | [ImmediateCopyOption_ObjectType_STATUS](#ImmediateCopyOption_ObjectType_STATUS)<br/><small>Optional</small> |
 
-<a id="RetentionTag"></a>RetentionTag
--------------------------------------
+RetentionTag{#RetentionTag}
+---------------------------
 
 Retention tag
 
@@ -2152,8 +2152,8 @@ Used by: [AdhocBasedTaggingCriteria](#AdhocBasedTaggingCriteria), and [TaggingCr
 |----------|----------------------------------------------------|------------------------------------|
 | tagName  | Retention Tag Name to relate it to retention rule. | string<br/><small>Required</small> |
 
-<a id="RetentionTag_STATUS"></a>RetentionTag_STATUS
----------------------------------------------------
+RetentionTag_STATUS{#RetentionTag_STATUS}
+-----------------------------------------
 
 Retention tag
 
@@ -2165,8 +2165,8 @@ Used by: [AdhocBasedTaggingCriteria_STATUS](#AdhocBasedTaggingCriteria_STATUS), 
 | id       | Retention Tag version.                             | string<br/><small>Optional</small> |
 | tagName  | Retention Tag Name to relate it to retention rule. | string<br/><small>Optional</small> |
 
-<a id="CopyOnExpiryOption_ObjectType"></a>CopyOnExpiryOption_ObjectType
------------------------------------------------------------------------
+CopyOnExpiryOption_ObjectType{#CopyOnExpiryOption_ObjectType}
+-------------------------------------------------------------
 
 Used by: [CopyOnExpiryOption](#CopyOnExpiryOption).
 
@@ -2174,8 +2174,8 @@ Used by: [CopyOnExpiryOption](#CopyOnExpiryOption).
 |----------------------|-------------|
 | "CopyOnExpiryOption" |             |
 
-<a id="CopyOnExpiryOption_ObjectType_STATUS"></a>CopyOnExpiryOption_ObjectType_STATUS
--------------------------------------------------------------------------------------
+CopyOnExpiryOption_ObjectType_STATUS{#CopyOnExpiryOption_ObjectType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [CopyOnExpiryOption_STATUS](#CopyOnExpiryOption_STATUS).
 
@@ -2183,8 +2183,8 @@ Used by: [CopyOnExpiryOption_STATUS](#CopyOnExpiryOption_STATUS).
 |----------------------|-------------|
 | "CopyOnExpiryOption" |             |
 
-<a id="CustomCopyOption_ObjectType"></a>CustomCopyOption_ObjectType
--------------------------------------------------------------------
+CustomCopyOption_ObjectType{#CustomCopyOption_ObjectType}
+---------------------------------------------------------
 
 Used by: [CustomCopyOption](#CustomCopyOption).
 
@@ -2192,8 +2192,8 @@ Used by: [CustomCopyOption](#CustomCopyOption).
 |--------------------|-------------|
 | "CustomCopyOption" |             |
 
-<a id="CustomCopyOption_ObjectType_STATUS"></a>CustomCopyOption_ObjectType_STATUS
----------------------------------------------------------------------------------
+CustomCopyOption_ObjectType_STATUS{#CustomCopyOption_ObjectType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [CustomCopyOption_STATUS](#CustomCopyOption_STATUS).
 
@@ -2201,8 +2201,8 @@ Used by: [CustomCopyOption_STATUS](#CustomCopyOption_STATUS).
 |--------------------|-------------|
 | "CustomCopyOption" |             |
 
-<a id="ImmediateCopyOption_ObjectType"></a>ImmediateCopyOption_ObjectType
--------------------------------------------------------------------------
+ImmediateCopyOption_ObjectType{#ImmediateCopyOption_ObjectType}
+---------------------------------------------------------------
 
 Used by: [ImmediateCopyOption](#ImmediateCopyOption).
 
@@ -2210,8 +2210,8 @@ Used by: [ImmediateCopyOption](#ImmediateCopyOption).
 |-----------------------|-------------|
 | "ImmediateCopyOption" |             |
 
-<a id="ImmediateCopyOption_ObjectType_STATUS"></a>ImmediateCopyOption_ObjectType_STATUS
----------------------------------------------------------------------------------------
+ImmediateCopyOption_ObjectType_STATUS{#ImmediateCopyOption_ObjectType_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS).
 
@@ -2219,8 +2219,8 @@ Used by: [ImmediateCopyOption_STATUS](#ImmediateCopyOption_STATUS).
 |-----------------------|-------------|
 | "ImmediateCopyOption" |             |
 
-<a id="ScheduleBasedBackupCriteria"></a>ScheduleBasedBackupCriteria
--------------------------------------------------------------------
+ScheduleBasedBackupCriteria{#ScheduleBasedBackupCriteria}
+---------------------------------------------------------
 
 Used by: [BackupCriteria](#BackupCriteria).
 
@@ -2234,8 +2234,8 @@ Used by: [BackupCriteria](#BackupCriteria).
 | scheduleTimes    | List of schedule times for backup                                                                                                      | string[]<br/><small>Optional</small>                                                                                        |
 | weeksOfTheMonth  | It should be First/Second/Third/Fourth/Last                                                                                            | [ScheduleBasedBackupCriteria_WeeksOfTheMonth[]](#ScheduleBasedBackupCriteria_WeeksOfTheMonth)<br/><small>Optional</small>   |
 
-<a id="ScheduleBasedBackupCriteria_STATUS"></a>ScheduleBasedBackupCriteria_STATUS
----------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_STATUS{#ScheduleBasedBackupCriteria_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [BackupCriteria_STATUS](#BackupCriteria_STATUS).
 
@@ -2249,8 +2249,8 @@ Used by: [BackupCriteria_STATUS](#BackupCriteria_STATUS).
 | scheduleTimes    | List of schedule times for backup                                                                                                      | string[]<br/><small>Optional</small>                                                                                                      |
 | weeksOfTheMonth  | It should be First/Second/Third/Fourth/Last                                                                                            | [ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS[]](#ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS)<br/><small>Optional</small>   |
 
-<a id="Day"></a>Day
--------------------
+Day{#Day}
+---------
 
 Day of the week
 
@@ -2261,8 +2261,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | date     | Date of the month                  | int<br/><small>Optional</small>  |
 | isLast   | Whether Date is last date of month | bool<br/><small>Optional</small> |
 
-<a id="Day_STATUS"></a>Day_STATUS
----------------------------------
+Day_STATUS{#Day_STATUS}
+-----------------------
 
 Day of the week
 
@@ -2273,8 +2273,8 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | date     | Date of the month                  | int<br/><small>Optional</small>  |
 | isLast   | Whether Date is last date of month | bool<br/><small>Optional</small> |
 
-<a id="ScheduleBasedBackupCriteria_AbsoluteCriteria"></a>ScheduleBasedBackupCriteria_AbsoluteCriteria
------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_AbsoluteCriteria{#ScheduleBasedBackupCriteria_AbsoluteCriteria}
+-------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -2286,8 +2286,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "FirstOfWeek"  |             |
 | "FirstOfYear"  |             |
 
-<a id="ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS"></a>ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS
--------------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS{#ScheduleBasedBackupCriteria_AbsoluteCriteria_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
@@ -2299,8 +2299,8 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | "FirstOfWeek"  |             |
 | "FirstOfYear"  |             |
 
-<a id="ScheduleBasedBackupCriteria_DaysOfTheWeek"></a>ScheduleBasedBackupCriteria_DaysOfTheWeek
------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_DaysOfTheWeek{#ScheduleBasedBackupCriteria_DaysOfTheWeek}
+-------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -2314,8 +2314,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS"></a>ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS
--------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS{#ScheduleBasedBackupCriteria_DaysOfTheWeek_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
@@ -2329,66 +2329,66 @@ Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATU
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="ScheduleBasedBackupCriteria_MonthsOfYear"></a>ScheduleBasedBackupCriteria_MonthsOfYear
+ScheduleBasedBackupCriteria_MonthsOfYear{#ScheduleBasedBackupCriteria_MonthsOfYear}
+-----------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
+
+| Value       | Description |
+|-------------|-------------|
+| "April"     |             |
+| "August"    |             |
+| "December"  |             |
+| "February"  |             |
+| "January"   |             |
+| "July"      |             |
+| "June"      |             |
+| "March"     |             |
+| "May"       |             |
+| "November"  |             |
+| "October"   |             |
+| "September" |             |
+
+ScheduleBasedBackupCriteria_MonthsOfYear_STATUS{#ScheduleBasedBackupCriteria_MonthsOfYear_STATUS}
+-------------------------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "April"     |             |
+| "August"    |             |
+| "December"  |             |
+| "February"  |             |
+| "January"   |             |
+| "July"      |             |
+| "June"      |             |
+| "March"     |             |
+| "May"       |             |
+| "November"  |             |
+| "October"   |             |
+| "September" |             |
+
+ScheduleBasedBackupCriteria_ObjectType{#ScheduleBasedBackupCriteria_ObjectType}
+-------------------------------------------------------------------------------
+
+Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
+
+| Value                         | Description |
+|-------------------------------|-------------|
+| "ScheduleBasedBackupCriteria" |             |
+
+ScheduleBasedBackupCriteria_ObjectType_STATUS{#ScheduleBasedBackupCriteria_ObjectType_STATUS}
 ---------------------------------------------------------------------------------------------
 
-Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
-
-| Value       | Description |
-|-------------|-------------|
-| "April"     |             |
-| "August"    |             |
-| "December"  |             |
-| "February"  |             |
-| "January"   |             |
-| "July"      |             |
-| "June"      |             |
-| "March"     |             |
-| "May"       |             |
-| "November"  |             |
-| "October"   |             |
-| "September" |             |
-
-<a id="ScheduleBasedBackupCriteria_MonthsOfYear_STATUS"></a>ScheduleBasedBackupCriteria_MonthsOfYear_STATUS
------------------------------------------------------------------------------------------------------------
-
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 
-| Value       | Description |
-|-------------|-------------|
-| "April"     |             |
-| "August"    |             |
-| "December"  |             |
-| "February"  |             |
-| "January"   |             |
-| "July"      |             |
-| "June"      |             |
-| "March"     |             |
-| "May"       |             |
-| "November"  |             |
-| "October"   |             |
-| "September" |             |
+| Value                         | Description |
+|-------------------------------|-------------|
+| "ScheduleBasedBackupCriteria" |             |
 
-<a id="ScheduleBasedBackupCriteria_ObjectType"></a>ScheduleBasedBackupCriteria_ObjectType
+ScheduleBasedBackupCriteria_WeeksOfTheMonth{#ScheduleBasedBackupCriteria_WeeksOfTheMonth}
 -----------------------------------------------------------------------------------------
-
-Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
-
-| Value                         | Description |
-|-------------------------------|-------------|
-| "ScheduleBasedBackupCriteria" |             |
-
-<a id="ScheduleBasedBackupCriteria_ObjectType_STATUS"></a>ScheduleBasedBackupCriteria_ObjectType_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
-
-| Value                         | Description |
-|-------------------------------|-------------|
-| "ScheduleBasedBackupCriteria" |             |
-
-<a id="ScheduleBasedBackupCriteria_WeeksOfTheMonth"></a>ScheduleBasedBackupCriteria_WeeksOfTheMonth
----------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 
@@ -2400,8 +2400,8 @@ Used by: [ScheduleBasedBackupCriteria](#ScheduleBasedBackupCriteria).
 | "Second" |             |
 | "Third"  |             |
 
-<a id="ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS"></a>ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS
------------------------------------------------------------------------------------------------------------------
+ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS{#ScheduleBasedBackupCriteria_WeeksOfTheMonth_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ScheduleBasedBackupCriteria_STATUS](#ScheduleBasedBackupCriteria_STATUS).
 

--- a/docs/hugo/content/reference/dbformariadb/v1api20180601.md
+++ b/docs/hugo/content/reference/dbformariadb/v1api20180601.md
@@ -5,15 +5,15 @@ title: dbformariadb.azure.com/v1api20180601
 linktitle: v1api20180601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-06-01" |             |
 
-<a id="Configuration"></a>Configuration
----------------------------------------
+Configuration{#Configuration}
+-----------------------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}/configurations/{configurationName}
 
@@ -26,7 +26,7 @@ Used by: [ConfigurationList](#ConfigurationList).
 | spec                                                                                    |             | [Configuration_Spec](#Configuration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Configuration_STATUS](#Configuration_STATUS)<br/><small>Optional</small> |
 
-### <a id="Configuration_Spec"></a>Configuration_Spec
+### Configuration_Spec {#Configuration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -36,7 +36,7 @@ Used by: [ConfigurationList](#ConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="Configuration_STATUS"></a>Configuration_STATUS
+### Configuration_STATUS{#Configuration_STATUS}
 
 | Property      | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -51,8 +51,8 @@ Used by: [ConfigurationList](#ConfigurationList).
 | type          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value         | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ConfigurationList"></a>ConfigurationList
------------------------------------------------
+ConfigurationList{#ConfigurationList}
+-------------------------------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}/configurations/{configurationName}
 
@@ -62,8 +62,8 @@ Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBf
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [Configuration[]](#Configuration)<br/><small>Optional</small> |
 
-<a id="Database"></a>Database
------------------------------
+Database{#Database}
+-------------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}/databases/{databaseName}
 
@@ -76,7 +76,7 @@ Used by: [DatabaseList](#DatabaseList).
 | spec                                                                                    |             | [Database_Spec](#Database_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Database_STATUS](#Database_STATUS)<br/><small>Optional</small> |
 
-### <a id="Database_Spec"></a>Database_Spec
+### Database_Spec {#Database_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -86,7 +86,7 @@ Used by: [DatabaseList](#DatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                          | [DatabaseOperatorSpec](#DatabaseOperatorSpec)<br/><small>Optional</small>                                                                                            |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformariadb.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="Database_STATUS"></a>Database_STATUS
+### Database_STATUS{#Database_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -97,8 +97,8 @@ Used by: [DatabaseList](#DatabaseList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DatabaseList"></a>DatabaseList
--------------------------------------
+DatabaseList{#DatabaseList}
+---------------------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}/databases/{databaseName}
 
@@ -108,8 +108,8 @@ Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBf
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Database[]](#Database)<br/><small>Optional</small> |
 
-<a id="Server"></a>Server
--------------------------
+Server{#Server}
+---------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}
 
@@ -122,7 +122,7 @@ Used by: [ServerList](#ServerList).
 | spec                                                                                    |             | [Server_Spec](#Server_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Server_STATUS](#Server_STATUS)<br/><small>Optional</small> |
 
-### <a id="Server_Spec"></a>Server_Spec
+### Server_Spec {#Server_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -134,7 +134,7 @@ Used by: [ServerList](#ServerList).
 | sku          | The SKU (pricing tier) of the server.                                                                                                                                                                                                                                                        | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Application-specific metadata in the form of key-value pairs.                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Server_STATUS"></a>Server_STATUS
+### Server_STATUS{#Server_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -159,8 +159,8 @@ Used by: [ServerList](#ServerList).
 | userVisibleState           | A state of a server that is visible to user.                                                                                                                                                                                                                                                                              | [ServerProperties_UserVisibleState_STATUS](#ServerProperties_UserVisibleState_STATUS)<br/><small>Optional</small>                                       |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                           | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="ServerList"></a>ServerList
----------------------------------
+ServerList{#ServerList}
+-----------------------
 
 Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMariaDB/servers/{serverName}
 
@@ -170,8 +170,8 @@ Generator information: - Generated from: /mariadb/resource-manager/Microsoft.DBf
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Server[]](#Server)<br/><small>Optional</small> |
 
-<a id="Configuration_Spec"></a>Configuration_Spec
--------------------------------------------------
+Configuration_Spec{#Configuration_Spec}
+---------------------------------------
 
 Used by: [Configuration](#Configuration).
 
@@ -183,8 +183,8 @@ Used by: [Configuration](#Configuration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="Configuration_STATUS"></a>Configuration_STATUS
------------------------------------------------------
+Configuration_STATUS{#Configuration_STATUS}
+-------------------------------------------
 
 Used by: [Configuration](#Configuration).
 
@@ -201,8 +201,8 @@ Used by: [Configuration](#Configuration).
 | type          | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value         | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Database_Spec"></a>Database_Spec
----------------------------------------
+Database_Spec{#Database_Spec}
+-----------------------------
 
 Used by: [Database](#Database).
 
@@ -214,8 +214,8 @@ Used by: [Database](#Database).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                          | [DatabaseOperatorSpec](#DatabaseOperatorSpec)<br/><small>Optional</small>                                                                                            |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformariadb.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="Database_STATUS"></a>Database_STATUS
--------------------------------------------
+Database_STATUS{#Database_STATUS}
+---------------------------------
 
 Used by: [Database](#Database).
 
@@ -228,8 +228,8 @@ Used by: [Database](#Database).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Server_Spec"></a>Server_Spec
------------------------------------
+Server_Spec{#Server_Spec}
+-------------------------
 
 Used by: [Server](#Server).
 
@@ -243,8 +243,8 @@ Used by: [Server](#Server).
 | sku          | The SKU (pricing tier) of the server.                                                                                                                                                                                                                                                        | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Application-specific metadata in the form of key-value pairs.                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Server_STATUS"></a>Server_STATUS
----------------------------------------
+Server_STATUS{#Server_STATUS}
+-----------------------------
 
 Represents a server.
 
@@ -273,8 +273,8 @@ Used by: [Server](#Server).
 | userVisibleState           | A state of a server that is visible to user.                                                                                                                                                                                                                                                                              | [ServerProperties_UserVisibleState_STATUS](#ServerProperties_UserVisibleState_STATUS)<br/><small>Optional</small>                                       |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                           | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="ConfigurationOperatorSpec"></a>ConfigurationOperatorSpec
----------------------------------------------------------------
+ConfigurationOperatorSpec{#ConfigurationOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -285,8 +285,8 @@ Used by: [Configuration_Spec](#Configuration_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DatabaseOperatorSpec"></a>DatabaseOperatorSpec
------------------------------------------------------
+DatabaseOperatorSpec{#DatabaseOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -297,8 +297,8 @@ Used by: [Database_Spec](#Database_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MinimalTlsVersion_STATUS"></a>MinimalTlsVersion_STATUS
--------------------------------------------------------------
+MinimalTlsVersion_STATUS{#MinimalTlsVersion_STATUS}
+---------------------------------------------------
 
 Enforce a minimal Tls version for the server.
 
@@ -311,8 +311,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "TLS1_2"                 |             |
 | "TLSEnforcementDisabled" |             |
 
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
 
 Whether or not public network access is allowed for this server. Value is optional but if passed in, must be 'Enabled' or 'Disabled'
 
@@ -323,8 +323,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerOperatorSpec"></a>ServerOperatorSpec
--------------------------------------------------
+ServerOperatorSpec{#ServerOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -336,8 +336,8 @@ Used by: [Server_Spec](#Server_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [ServerOperatorSecrets](#ServerOperatorSecrets)<br/><small>Optional</small>                                                                                         |
 
-<a id="ServerPrivateEndpointConnection_STATUS"></a>ServerPrivateEndpointConnection_STATUS
------------------------------------------------------------------------------------------
+ServerPrivateEndpointConnection_STATUS{#ServerPrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------------------
 
 A private endpoint connection under a server
 
@@ -348,8 +348,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | id         | Resource Id of the private endpoint connection. | string<br/><small>Optional</small>                                                                                                |
 | properties | Private endpoint connection properties          | [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpointConnectionProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerProperties_UserVisibleState_STATUS"></a>ServerProperties_UserVisibleState_STATUS
----------------------------------------------------------------------------------------------
+ServerProperties_UserVisibleState_STATUS{#ServerProperties_UserVisibleState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Server_STATUS](#Server_STATUS).
 
@@ -359,8 +359,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Dropping" |             |
 | "Ready"    |             |
 
-<a id="ServerPropertiesForCreate"></a>ServerPropertiesForCreate
----------------------------------------------------------------
+ServerPropertiesForCreate{#ServerPropertiesForCreate}
+-----------------------------------------------------
 
 Used by: [Server_Spec](#Server_Spec).
 
@@ -371,8 +371,8 @@ Used by: [Server_Spec](#Server_Spec).
 | pointInTimeRestore | Mutually exclusive with all other properties | [ServerPropertiesForRestore](#ServerPropertiesForRestore)<br/><small>Optional</small>             |
 | replica            | Mutually exclusive with all other properties | [ServerPropertiesForReplica](#ServerPropertiesForReplica)<br/><small>Optional</small>             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -383,8 +383,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "10.2" |             |
 | "10.3" |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Billing information related properties of a server.
 
@@ -398,8 +398,8 @@ Used by: [Server_Spec](#Server_Spec).
 | size     | The size code, to be interpreted by resource as appropriate.                     | string<br/><small>Optional</small>                |
 | tier     | The tier of the particular SKU, e.g. Basic.                                      | [Sku_Tier](#Sku_Tier)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Billing information related properties of a server.
 
@@ -413,8 +413,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | size     | The size code, to be interpreted by resource as appropriate.                     | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. Basic.                                      | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SslEnforcement_STATUS"></a>SslEnforcement_STATUS
--------------------------------------------------------
+SslEnforcement_STATUS{#SslEnforcement_STATUS}
+---------------------------------------------
 
 Enable ssl enforcement or not when connect to server.
 
@@ -425,8 +425,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageProfile_STATUS"></a>StorageProfile_STATUS
--------------------------------------------------------
+StorageProfile_STATUS{#StorageProfile_STATUS}
+---------------------------------------------
 
 Storage Profile properties of a server
 
@@ -439,8 +439,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | storageAutogrow     | Enable Storage Auto Grow.                      | [StorageProfile_StorageAutogrow_STATUS](#StorageProfile_StorageAutogrow_STATUS)<br/><small>Optional</small>       |
 | storageMB           | Max storage allowed for a server.              | int<br/><small>Optional</small>                                                                                   |
 
-<a id="ServerOperatorSecrets"></a>ServerOperatorSecrets
--------------------------------------------------------
+ServerOperatorSecrets{#ServerOperatorSecrets}
+---------------------------------------------
 
 Used by: [ServerOperatorSpec](#ServerOperatorSpec).
 
@@ -448,8 +448,8 @@ Used by: [ServerOperatorSpec](#ServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="ServerPrivateEndpointConnectionProperties_STATUS"></a>ServerPrivateEndpointConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------
+ServerPrivateEndpointConnectionProperties_STATUS{#ServerPrivateEndpointConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Properties of a private endpoint connection.
 
@@ -461,8 +461,8 @@ Used by: [ServerPrivateEndpointConnection_STATUS](#ServerPrivateEndpointConnecti
 | privateLinkServiceConnectionState | Connection state of the private endpoint connection. | [ServerPrivateLinkServiceConnectionStateProperty_STATUS](#ServerPrivateLinkServiceConnectionStateProperty_STATUS)<br/><small>Optional</small>                         |
 | provisioningState                 | State of the private endpoint connection.            | [ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS](#ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerPropertiesForDefaultCreate"></a>ServerPropertiesForDefaultCreate
------------------------------------------------------------------------------
+ServerPropertiesForDefaultCreate{#ServerPropertiesForDefaultCreate}
+-------------------------------------------------------------------
 
 Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 
@@ -477,8 +477,8 @@ Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 | storageProfile             | Storage profile of a server.                                                                                                         | [StorageProfile](#StorageProfile)<br/><small>Optional</small>                                                                                          |
 | version                    | Server version.                                                                                                                      | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                            |
 
-<a id="ServerPropertiesForGeoRestore"></a>ServerPropertiesForGeoRestore
------------------------------------------------------------------------
+ServerPropertiesForGeoRestore{#ServerPropertiesForGeoRestore}
+-------------------------------------------------------------
 
 Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 
@@ -492,8 +492,8 @@ Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 | storageProfile      | Storage profile of a server.                                                                                                         | [StorageProfile](#StorageProfile)<br/><small>Optional</small>                                                     |
 | version             | Server version.                                                                                                                      | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                       |
 
-<a id="ServerPropertiesForReplica"></a>ServerPropertiesForReplica
------------------------------------------------------------------
+ServerPropertiesForReplica{#ServerPropertiesForReplica}
+-------------------------------------------------------
 
 Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 
@@ -507,8 +507,8 @@ Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 | storageProfile      | Storage profile of a server.                                                                                                         | [StorageProfile](#StorageProfile)<br/><small>Optional</small>                                               |
 | version             | Server version.                                                                                                                      | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                 |
 
-<a id="ServerPropertiesForRestore"></a>ServerPropertiesForRestore
------------------------------------------------------------------
+ServerPropertiesForRestore{#ServerPropertiesForRestore}
+-------------------------------------------------------
 
 Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 
@@ -523,8 +523,8 @@ Used by: [ServerPropertiesForCreate](#ServerPropertiesForCreate).
 | storageProfile      | Storage profile of a server.                                                                                                         | [StorageProfile](#StorageProfile)<br/><small>Optional</small>                                               |
 | version             | Server version.                                                                                                                      | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                 |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -534,8 +534,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -545,8 +545,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="StorageProfile_GeoRedundantBackup_STATUS"></a>StorageProfile_GeoRedundantBackup_STATUS
----------------------------------------------------------------------------------------------
+StorageProfile_GeoRedundantBackup_STATUS{#StorageProfile_GeoRedundantBackup_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 
@@ -555,8 +555,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageProfile_StorageAutogrow_STATUS"></a>StorageProfile_StorageAutogrow_STATUS
----------------------------------------------------------------------------------------
+StorageProfile_StorageAutogrow_STATUS{#StorageProfile_StorageAutogrow_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 
@@ -565,8 +565,8 @@ Used by: [StorageProfile_STATUS](#StorageProfile_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="MinimalTlsVersion"></a>MinimalTlsVersion
------------------------------------------------
+MinimalTlsVersion{#MinimalTlsVersion}
+-------------------------------------
 
 Enforce a minimal Tls version for the server.
 
@@ -579,8 +579,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate), 
 | "TLS1_2"                 |             |
 | "TLSEnforcementDisabled" |             |
 
-<a id="PrivateEndpointProperty_STATUS"></a>PrivateEndpointProperty_STATUS
--------------------------------------------------------------------------
+PrivateEndpointProperty_STATUS{#PrivateEndpointProperty_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpointConnectionProperties_STATUS).
 
@@ -588,8 +588,8 @@ Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpoi
 |----------|--------------------------------------|------------------------------------|
 | id       | Resource id of the private endpoint. | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
----------------------------------------------------
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
 
 Whether or not public network access is allowed for this server. Value is optional but if passed in, must be 'Enabled' or 'Disabled'
 
@@ -600,8 +600,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate), 
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS"></a>ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------
+ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS{#ServerPrivateEndpointConnectionProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpointConnectionProperties_STATUS).
 
@@ -613,8 +613,8 @@ Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpoi
 | "Ready"     |             |
 | "Rejecting" |             |
 
-<a id="ServerPrivateLinkServiceConnectionStateProperty_STATUS"></a>ServerPrivateLinkServiceConnectionStateProperty_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ServerPrivateLinkServiceConnectionStateProperty_STATUS{#ServerPrivateLinkServiceConnectionStateProperty_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpointConnectionProperties_STATUS).
 
@@ -624,8 +624,8 @@ Used by: [ServerPrivateEndpointConnectionProperties_STATUS](#ServerPrivateEndpoi
 | description     | The private link service connection description.          | string<br/><small>Optional</small>                                                                                                                                            |
 | status          | The private link service connection status.               | [ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS](#ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ServerPropertiesForDefaultCreate_CreateMode"></a>ServerPropertiesForDefaultCreate_CreateMode
----------------------------------------------------------------------------------------------------
+ServerPropertiesForDefaultCreate_CreateMode{#ServerPropertiesForDefaultCreate_CreateMode}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate).
 
@@ -633,8 +633,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate).
 |-----------|-------------|
 | "Default" |             |
 
-<a id="ServerPropertiesForGeoRestore_CreateMode"></a>ServerPropertiesForGeoRestore_CreateMode
----------------------------------------------------------------------------------------------
+ServerPropertiesForGeoRestore_CreateMode{#ServerPropertiesForGeoRestore_CreateMode}
+-----------------------------------------------------------------------------------
 
 Used by: [ServerPropertiesForGeoRestore](#ServerPropertiesForGeoRestore).
 
@@ -642,8 +642,8 @@ Used by: [ServerPropertiesForGeoRestore](#ServerPropertiesForGeoRestore).
 |--------------|-------------|
 | "GeoRestore" |             |
 
-<a id="ServerPropertiesForReplica_CreateMode"></a>ServerPropertiesForReplica_CreateMode
----------------------------------------------------------------------------------------
+ServerPropertiesForReplica_CreateMode{#ServerPropertiesForReplica_CreateMode}
+-----------------------------------------------------------------------------
 
 Used by: [ServerPropertiesForReplica](#ServerPropertiesForReplica).
 
@@ -651,8 +651,8 @@ Used by: [ServerPropertiesForReplica](#ServerPropertiesForReplica).
 |-----------|-------------|
 | "Replica" |             |
 
-<a id="ServerPropertiesForRestore_CreateMode"></a>ServerPropertiesForRestore_CreateMode
----------------------------------------------------------------------------------------
+ServerPropertiesForRestore_CreateMode{#ServerPropertiesForRestore_CreateMode}
+-----------------------------------------------------------------------------
 
 Used by: [ServerPropertiesForRestore](#ServerPropertiesForRestore).
 
@@ -660,8 +660,8 @@ Used by: [ServerPropertiesForRestore](#ServerPropertiesForRestore).
 |----------------------|-------------|
 | "PointInTimeRestore" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -672,8 +672,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate), 
 | "10.2" |             |
 | "10.3" |             |
 
-<a id="SslEnforcement"></a>SslEnforcement
------------------------------------------
+SslEnforcement{#SslEnforcement}
+-------------------------------
 
 Enable ssl enforcement or not when connect to server.
 
@@ -684,8 +684,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate), 
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageProfile"></a>StorageProfile
------------------------------------------
+StorageProfile{#StorageProfile}
+-------------------------------
 
 Storage Profile properties of a server
 
@@ -698,8 +698,8 @@ Used by: [ServerPropertiesForDefaultCreate](#ServerPropertiesForDefaultCreate), 
 | storageAutogrow     | Enable Storage Auto Grow.                      | [StorageProfile_StorageAutogrow](#StorageProfile_StorageAutogrow)<br/><small>Optional</small>       |
 | storageMB           | Max storage allowed for a server.              | int<br/><small>Optional</small>                                                                     |
 
-<a id="ServerPrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS"></a>ServerPrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------
+ServerPrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS{#ServerPrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPrivateLinkServiceConnectionStateProperty_STATUS](#ServerPrivateLinkServiceConnectionStateProperty_STATUS).
 
@@ -707,8 +707,8 @@ Used by: [ServerPrivateLinkServiceConnectionStateProperty_STATUS](#ServerPrivate
 |--------|-------------|
 | "None" |             |
 
-<a id="ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS"></a>ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS{#ServerPrivateLinkServiceConnectionStateProperty_Status_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServerPrivateLinkServiceConnectionStateProperty_STATUS](#ServerPrivateLinkServiceConnectionStateProperty_STATUS).
 
@@ -719,8 +719,8 @@ Used by: [ServerPrivateLinkServiceConnectionStateProperty_STATUS](#ServerPrivate
 | "Pending"      |             |
 | "Rejected"     |             |
 
-<a id="StorageProfile_GeoRedundantBackup"></a>StorageProfile_GeoRedundantBackup
--------------------------------------------------------------------------------
+StorageProfile_GeoRedundantBackup{#StorageProfile_GeoRedundantBackup}
+---------------------------------------------------------------------
 
 Used by: [StorageProfile](#StorageProfile).
 
@@ -729,8 +729,8 @@ Used by: [StorageProfile](#StorageProfile).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageProfile_StorageAutogrow"></a>StorageProfile_StorageAutogrow
--------------------------------------------------------------------------
+StorageProfile_StorageAutogrow{#StorageProfile_StorageAutogrow}
+---------------------------------------------------------------
 
 Used by: [StorageProfile](#StorageProfile).
 

--- a/docs/hugo/content/reference/dbformysql/v1.md
+++ b/docs/hugo/content/reference/dbformysql/v1.md
@@ -5,8 +5,8 @@ title: dbformysql.azure.com/
 linktitle:
 ----------
 
-<a id="User"></a>User
----------------------
+User{#User}
+-----------
 
 <br/>User is a MySQL user
 
@@ -19,7 +19,7 @@ Used by: [UserList](#UserList).
 | spec                                                                                    |             | [UserSpec](#UserSpec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [UserStatus](#UserStatus)<br/><small>Optional</small> |
 
-### <a id="UserSpec"></a>UserSpec
+### UserSpec {#UserSpec}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                     |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -31,14 +31,14 @@ Used by: [UserList](#UserList).
 | owner              | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource                                                                                                                                                                                                                             | [genruntime.KubernetesOwnerReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KubernetesOwnerReference)<br/><small>Required</small> |
 | privileges         | The server-level roles assigned to the user. Privileges include the following: RELOAD, PROCESS, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, CREATE USER                                                                                                                                                                                                                                                                                                                                                         | string[]<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="UserStatus"></a>UserStatus
+### UserStatus{#UserStatus}
 
 | Property   | Description                        | Type                                                                                                                                                    |
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="UserList"></a>UserList
------------------------------
+UserList{#UserList}
+-------------------
 
 | Property                                                                            | Description | Type                                        |
 |-------------------------------------------------------------------------------------|-------------|---------------------------------------------|
@@ -46,8 +46,8 @@ Used by: [UserList](#UserList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [User[]](#User)<br/><small>Optional</small> |
 
-<a id="UserSpec"></a>UserSpec
------------------------------
+UserSpec{#UserSpec}
+-------------------
 
 Used by: [User](#User).
 
@@ -61,8 +61,8 @@ Used by: [User](#User).
 | owner              | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource                                                                                                                                                                                                                             | [genruntime.KubernetesOwnerReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KubernetesOwnerReference)<br/><small>Required</small> |
 | privileges         | The server-level roles assigned to the user. Privileges include the following: RELOAD, PROCESS, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, CREATE USER                                                                                                                                                                                                                                                                                                                                                         | string[]<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="UserStatus"></a>UserStatus
----------------------------------
+UserStatus{#UserStatus}
+-----------------------
 
 Used by: [User](#User).
 
@@ -70,8 +70,8 @@ Used by: [User](#User).
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="AADUserSpec"></a>AADUserSpec
------------------------------------
+AADUserSpec{#AADUserSpec}
+-------------------------
 
 Used by: [UserSpec](#UserSpec).
 
@@ -80,8 +80,8 @@ Used by: [UserSpec](#UserSpec).
 | alias               | Alias is the short name associated with the user. This is required if the AzureName is longer than 32 characters. Note that Alias denotes the name used to manage the SQL user in MySQL, NOT the name used to log in to the SQL server. When logging in to the SQL server and prompted to provider the username, supply the AzureName.                                                                                                                                                                            | string<br/><small>Optional</small> |
 | serverAdminUsername | ServerAdminUsername is the username of the Server administrator. If your server admin was configured with Azure Service Operator, this should match the value of the Administrator's $.spec.login field. If the administrator is a group, the ServerAdminUsername should be the group name, not the actual username of the identity to log in with. For example if the administrator group is "admin-group" and identity "my-identity" is a member of that group, the ServerAdminUsername should be "admin-group" | string<br/><small>Required</small> |
 
-<a id="LocalUserSpec"></a>LocalUserSpec
----------------------------------------
+LocalUserSpec{#LocalUserSpec}
+-----------------------------
 
 var _ genruntime.ConvertibleSpec = &UserSpec{} <br/>ConvertSpecFrom populates our ConfigurationStore_Spec from the provided source func (userSpec *UserSpec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error { if source == userSpec { return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec") } <br/> return source.ConvertSpecTo(userSpec) } <br/>ConvertSpecTo populates the provided destination from our ConfigurationStore_Spec func (userSpec *UserSpec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error { if destination == userSpec { return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec") } <br/> return destination.ConvertSpecFrom(userSpec) } <br/>
 

--- a/docs/hugo/content/reference/dbformysql/v1api20210501.md
+++ b/docs/hugo/content/reference/dbformysql/v1api20210501.md
@@ -5,15 +5,15 @@ title: dbformysql.azure.com/v1api20210501
 linktitle: v1api20210501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-05-01" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                    | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -82,8 +82,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | Server version.                                                                                                                                                                                                                                                                                                           | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -93,8 +93,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -107,7 +107,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -117,7 +117,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -129,8 +129,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -140,8 +140,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -154,7 +154,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -164,7 +164,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,8 +176,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -187,8 +187,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -216,8 +216,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                    | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -249,8 +249,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | Server version.                                                                                                                                                                                                                                                                                                           | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -262,8 +262,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -277,8 +277,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -290,8 +290,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -305,8 +305,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Storage Profile properties of a server
 
@@ -317,8 +317,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.           | int<br/><small>Optional</small>                                   |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled. | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Storage Profile properties of a server
 
@@ -330,8 +330,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | Earliest restore point creation time (ISO8601 format) | string<br/><small>Optional</small>                                              |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled.       | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="DataEncryption"></a>DataEncryption
------------------------------------------
+DataEncryption{#DataEncryption}
+-------------------------------
 
 The date encryption for cmk.
 
@@ -345,8 +345,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | primaryUserAssignedIdentityReference   | Primary user identity resource id                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | type                                   | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type](#DataEncryption_Type)<br/><small>Optional</small>                                                                                    |
 
-<a id="DataEncryption_STATUS"></a>DataEncryption_STATUS
--------------------------------------------------------
+DataEncryption_STATUS{#DataEncryption_STATUS}
+---------------------------------------------
 
 The date encryption for cmk.
 
@@ -360,8 +360,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | primaryUserAssignedIdentityId   | Primary user identity resource id                                                                               | string<br/><small>Optional</small>                                                    |
 | type                            | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type_STATUS](#DataEncryption_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -374,8 +374,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -386,8 +386,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -398,8 +398,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 Network related properties of a server
 
@@ -410,8 +410,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | High availability mode for a server.     | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 Network related properties of a server
 
@@ -423,8 +423,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                                          |
 | state                   | The state of server high availability.   | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -435,8 +435,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | type                   | Type of managed service identity.   | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Metadata of user assigned identity. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -449,8 +449,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | type                   | Type of managed service identity.   | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | Metadata of user assigned identity. | map[string]v1.JSON<br/><small>Optional</small>                            |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window of a server.
 
@@ -463,8 +463,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window of a server.
 
@@ -477,8 +477,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network related properties of a server
 
@@ -489,8 +489,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | delegatedSubnetResourceReference | Delegated subnet resource id used to setup vnet for a server. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | privateDnsZoneResourceReference  | Private DNS zone resource id.                                 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network related properties of a server
 
@@ -502,8 +502,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneResourceId  | Private DNS zone resource id.                                                                                          | string<br/><small>Optional</small>                                              |
 | publicNetworkAccess       | Whether or not public network access is allowed for this server. Value is 'Disabled' when server has VNet integration. | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="ReplicationRole"></a>ReplicationRole
--------------------------------------------
+ReplicationRole{#ReplicationRole}
+---------------------------------
 
 The replication role.
 
@@ -515,22 +515,22 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "Replica" |             |
 | "Source"  |             |
 
-<a id="ReplicationRole_STATUS"></a>ReplicationRole_STATUS
+ReplicationRole_STATUS{#ReplicationRole_STATUS}
+-----------------------------------------------
+
+The replication role.
+
+Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "None"    |             |
+| "Replica" |             |
+| "Source"  |             |
+
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
 ---------------------------------------------------------
 
-The replication role.
-
-Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "None"    |             |
-| "Replica" |             |
-| "Source"  |             |
-
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
-
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
 | Value                | Description |
@@ -540,8 +540,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -552,8 +552,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -567,8 +567,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -579,8 +579,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -591,8 +591,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Billing information related properties of a server.
 
@@ -603,8 +603,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Required</small>                |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [Sku_Tier](#Sku_Tier)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Billing information related properties of a server.
 
@@ -615,8 +615,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage Profile properties of a server
 
@@ -628,8 +628,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | iops          | Storage IOPS for a server.             | int<br/><small>Optional</small>                                   |
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                   |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage Profile properties of a server
 
@@ -642,8 +642,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                                 |
 | storageSku    | The sku name of the server storage.    | string<br/><small>Optional</small>                                              |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -658,8 +658,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersDataba
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="DataEncryption_Type"></a>DataEncryption_Type
----------------------------------------------------
+DataEncryption_Type{#DataEncryption_Type}
+-----------------------------------------
 
 Used by: [DataEncryption](#DataEncryption).
 
@@ -668,8 +668,8 @@ Used by: [DataEncryption](#DataEncryption).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="DataEncryption_Type_STATUS"></a>DataEncryption_Type_STATUS
------------------------------------------------------------------
+DataEncryption_Type_STATUS{#DataEncryption_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
@@ -678,8 +678,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="EnableStatusEnum"></a>EnableStatusEnum
----------------------------------------------
+EnableStatusEnum{#EnableStatusEnum}
+-----------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -690,8 +690,8 @@ Used by: [Backup](#Backup), and [Storage](#Storage).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EnableStatusEnum_STATUS"></a>EnableStatusEnum_STATUS
------------------------------------------------------------
+EnableStatusEnum_STATUS{#EnableStatusEnum_STATUS}
+-------------------------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -702,8 +702,8 @@ Used by: [Backup_STATUS](#Backup_STATUS), [Network_STATUS](#Network_STATUS), and
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -712,8 +712,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 | administratorLogin       | indicates where the AdministratorLogin config map should be placed. If omitted, no config map will be created.       | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -721,8 +721,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -732,8 +732,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -743,8 +743,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -756,8 +756,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "NotEnabled"      |             |
 | "RemovingStandby" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -765,8 +765,8 @@ Used by: [Identity](#Identity).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -774,8 +774,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -785,8 +785,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -796,7 +796,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -808,20 +820,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/dbformysql/v1api20220101.md
+++ b/docs/hugo/content/reference/dbformysql/v1api20220101.md
@@ -5,15 +5,15 @@ title: dbformysql.azure.com/v1api20220101
 linktitle: v1api20220101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-01-01" |             |
 
-<a id="FlexibleServersAdministrator"></a>FlexibleServersAdministrator
----------------------------------------------------------------------
+FlexibleServersAdministrator{#FlexibleServersAdministrator}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2022-01-01/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | spec                                                                                    |             | [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
+### FlexibleServersAdministrator_Spec {#FlexibleServersAdministrator_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
+### FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -55,8 +55,8 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersAdministratorList"></a>FlexibleServersAdministratorList
------------------------------------------------------------------------------
+FlexibleServersAdministratorList{#FlexibleServersAdministratorList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2022-01-01/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -66,8 +66,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersAdministrator[]](#FlexibleServersAdministrator)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2022-01-01/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -80,7 +80,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -91,7 +91,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -112,8 +112,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2022-01-01/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -123,8 +123,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
--------------------------------------------------------------------------------
+FlexibleServersAdministrator_Spec{#FlexibleServersAdministrator_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -140,8 +140,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
------------------------------------------------------------------------------------
+FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -158,8 +158,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -172,8 +172,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -196,8 +196,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdministratorProperties_AdministratorType"></a>AdministratorProperties_AdministratorType
------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType{#AdministratorProperties_AdministratorType}
+-------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec).
 
@@ -205,8 +205,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="AdministratorProperties_AdministratorType_STATUS"></a>AdministratorProperties_AdministratorType_STATUS
--------------------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType_STATUS{#AdministratorProperties_AdministratorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS).
 
@@ -214,8 +214,8 @@ Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STA
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="ConfigurationProperties_IsConfigPendingRestart_STATUS"></a>ConfigurationProperties_IsConfigPendingRestart_STATUS
------------------------------------------------------------------------------------------------------------------------
+ConfigurationProperties_IsConfigPendingRestart_STATUS{#ConfigurationProperties_IsConfigPendingRestart_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -224,17 +224,7 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_IsDynamicConfig_STATUS"></a>ConfigurationProperties_IsDynamicConfig_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "False" |             |
-| "True"  |             |
-
-<a id="ConfigurationProperties_IsReadOnly_STATUS"></a>ConfigurationProperties_IsReadOnly_STATUS
+ConfigurationProperties_IsDynamicConfig_STATUS{#ConfigurationProperties_IsDynamicConfig_STATUS}
 -----------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
@@ -244,8 +234,18 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_Source"></a>ConfigurationProperties_Source
--------------------------------------------------------------------------
+ConfigurationProperties_IsReadOnly_STATUS{#ConfigurationProperties_IsReadOnly_STATUS}
+-------------------------------------------------------------------------------------
+
+Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "False" |             |
+| "True"  |             |
+
+ConfigurationProperties_Source{#ConfigurationProperties_Source}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec).
 
@@ -254,8 +254,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="ConfigurationProperties_Source_STATUS"></a>ConfigurationProperties_Source_STATUS
----------------------------------------------------------------------------------------
+ConfigurationProperties_Source_STATUS{#ConfigurationProperties_Source_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -264,8 +264,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="FlexibleServersAdministratorOperatorSpec"></a>FlexibleServersAdministratorOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersAdministratorOperatorSpec{#FlexibleServersAdministratorOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -276,8 +276,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -288,8 +288,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -304,8 +304,8 @@ Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -316,8 +316,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/dbformysql/v1api20230630.md
+++ b/docs/hugo/content/reference/dbformysql/v1api20230630.md
@@ -5,15 +5,15 @@ title: dbformysql.azure.com/v1api20230630
 linktitle: v1api20230630
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-06-30" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/stable/2023-06-30/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,7 +53,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -85,8 +85,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                             | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/stable/2023-06-30/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -96,8 +96,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersAdministrator"></a>FlexibleServersAdministrator
----------------------------------------------------------------------
+FlexibleServersAdministrator{#FlexibleServersAdministrator}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2023-06-30/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -110,7 +110,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | spec                                                                                    |             | [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
+### FlexibleServersAdministrator_Spec {#FlexibleServersAdministrator_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -124,7 +124,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
+### FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -139,8 +139,8 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersAdministratorList"></a>FlexibleServersAdministratorList
------------------------------------------------------------------------------
+FlexibleServersAdministratorList{#FlexibleServersAdministratorList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2023-06-30/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -150,8 +150,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersAdministrator[]](#FlexibleServersAdministrator)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2023-06-30/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -164,7 +164,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -175,7 +175,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -196,8 +196,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2023-06-30/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -207,8 +207,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Databases/stable/2023-06-30/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -221,7 +221,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -231,7 +231,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,8 +243,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Databases/stable/2023-06-30/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -254,8 +254,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Firewall/stable/2023-06-30/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -268,7 +268,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -278,7 +278,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -290,8 +290,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Firewall/stable/2023-06-30/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -301,8 +301,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -331,8 +331,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -366,8 +366,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                             | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
--------------------------------------------------------------------------------
+FlexibleServersAdministrator_Spec{#FlexibleServersAdministrator_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -383,8 +383,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
------------------------------------------------------------------------------------
+FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -401,8 +401,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -415,8 +415,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -439,8 +439,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -452,8 +452,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -467,8 +467,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -480,8 +480,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -495,8 +495,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdministratorProperties_AdministratorType"></a>AdministratorProperties_AdministratorType
------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType{#AdministratorProperties_AdministratorType}
+-------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec).
 
@@ -504,8 +504,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="AdministratorProperties_AdministratorType_STATUS"></a>AdministratorProperties_AdministratorType_STATUS
--------------------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType_STATUS{#AdministratorProperties_AdministratorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS).
 
@@ -513,8 +513,8 @@ Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STA
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Storage Profile properties of a server
 
@@ -525,8 +525,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.           | int<br/><small>Optional</small>                                   |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled. | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Storage Profile properties of a server
 
@@ -538,8 +538,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | Earliest restore point creation time (ISO8601 format) | string<br/><small>Optional</small>                                              |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled.       | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_IsConfigPendingRestart_STATUS"></a>ConfigurationProperties_IsConfigPendingRestart_STATUS
------------------------------------------------------------------------------------------------------------------------
+ConfigurationProperties_IsConfigPendingRestart_STATUS{#ConfigurationProperties_IsConfigPendingRestart_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -548,17 +548,7 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_IsDynamicConfig_STATUS"></a>ConfigurationProperties_IsDynamicConfig_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "False" |             |
-| "True"  |             |
-
-<a id="ConfigurationProperties_IsReadOnly_STATUS"></a>ConfigurationProperties_IsReadOnly_STATUS
+ConfigurationProperties_IsDynamicConfig_STATUS{#ConfigurationProperties_IsDynamicConfig_STATUS}
 -----------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
@@ -568,8 +558,18 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_Source"></a>ConfigurationProperties_Source
--------------------------------------------------------------------------
+ConfigurationProperties_IsReadOnly_STATUS{#ConfigurationProperties_IsReadOnly_STATUS}
+-------------------------------------------------------------------------------------
+
+Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "False" |             |
+| "True"  |             |
+
+ConfigurationProperties_Source{#ConfigurationProperties_Source}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec).
 
@@ -578,8 +578,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="ConfigurationProperties_Source_STATUS"></a>ConfigurationProperties_Source_STATUS
----------------------------------------------------------------------------------------
+ConfigurationProperties_Source_STATUS{#ConfigurationProperties_Source_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -588,8 +588,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="DataEncryption"></a>DataEncryption
------------------------------------------
+DataEncryption{#DataEncryption}
+-------------------------------
 
 The date encryption for cmk.
 
@@ -603,8 +603,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | primaryUserAssignedIdentityReference   | Primary user identity resource id                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | type                                   | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type](#DataEncryption_Type)<br/><small>Optional</small>                                                                                    |
 
-<a id="DataEncryption_STATUS"></a>DataEncryption_STATUS
--------------------------------------------------------
+DataEncryption_STATUS{#DataEncryption_STATUS}
+---------------------------------------------
 
 The date encryption for cmk.
 
@@ -618,8 +618,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | primaryUserAssignedIdentityId   | Primary user identity resource id                                                                               | string<br/><small>Optional</small>                                                    |
 | type                            | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type_STATUS](#DataEncryption_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -632,8 +632,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersAdministratorOperatorSpec"></a>FlexibleServersAdministratorOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersAdministratorOperatorSpec{#FlexibleServersAdministratorOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -644,8 +644,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -656,8 +656,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -668,8 +668,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -680,8 +680,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 Network related properties of a server
 
@@ -692,8 +692,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | High availability mode for a server.     | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 Network related properties of a server
 
@@ -705,8 +705,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                                          |
 | state                   | The state of server high availability.   | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ImportSourceProperties"></a>ImportSourceProperties
----------------------------------------------------------
+ImportSourceProperties{#ImportSourceProperties}
+-----------------------------------------------
 
 Import source related properties.
 
@@ -719,8 +719,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | storageType | Storage type of import source.                                                                | [ImportSourceProperties_StorageType](#ImportSourceProperties_StorageType)<br/><small>Optional</small>                                                  |
 | storageUrl  | Uri of the import source storage.                                                             | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ImportSourceProperties_STATUS"></a>ImportSourceProperties_STATUS
------------------------------------------------------------------------
+ImportSourceProperties_STATUS{#ImportSourceProperties_STATUS}
+-------------------------------------------------------------
 
 Import source related properties.
 
@@ -732,8 +732,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | storageType | Storage type of import source.              | [ImportSourceProperties_StorageType_STATUS](#ImportSourceProperties_StorageType_STATUS)<br/><small>Optional</small> |
 | storageUrl  | Uri of the import source storage.           | string<br/><small>Optional</small>                                                                                  |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window of a server.
 
@@ -746,8 +746,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window of a server.
 
@@ -760,8 +760,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MySQLServerIdentity"></a>MySQLServerIdentity
----------------------------------------------------
+MySQLServerIdentity{#MySQLServerIdentity}
+-----------------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -772,8 +772,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | type                   | Type of managed service identity.   | [MySQLServerIdentity_Type](#MySQLServerIdentity_Type)<br/><small>Optional</small>         |
 | userAssignedIdentities | Metadata of user assigned identity. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="MySQLServerIdentity_STATUS"></a>MySQLServerIdentity_STATUS
------------------------------------------------------------------
+MySQLServerIdentity_STATUS{#MySQLServerIdentity_STATUS}
+-------------------------------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -786,8 +786,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | type                   | Type of managed service identity.   | [MySQLServerIdentity_Type_STATUS](#MySQLServerIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | Metadata of user assigned identity. | map[string]v1.JSON<br/><small>Optional</small>                                                  |
 
-<a id="MySQLServerSku"></a>MySQLServerSku
------------------------------------------
+MySQLServerSku{#MySQLServerSku}
+-------------------------------
 
 Billing information related properties of a server.
 
@@ -798,8 +798,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Required</small>                                      |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [MySQLServerSku_Tier](#MySQLServerSku_Tier)<br/><small>Required</small> |
 
-<a id="MySQLServerSku_STATUS"></a>MySQLServerSku_STATUS
--------------------------------------------------------
+MySQLServerSku_STATUS{#MySQLServerSku_STATUS}
+---------------------------------------------
 
 Billing information related properties of a server.
 
@@ -810,8 +810,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Optional</small>                                                    |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [MySQLServerSku_Tier_STATUS](#MySQLServerSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network related properties of a server
 
@@ -823,8 +823,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | privateDnsZoneResourceReference  | Private DNS zone resource id.                                                                                          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | publicNetworkAccess              | Whether or not public network access is allowed for this server. Value is 'Disabled' when server has VNet integration. | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small>                                                                                          |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network related properties of a server
 
@@ -836,8 +836,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneResourceId  | Private DNS zone resource id.                                                                                          | string<br/><small>Optional</small>                                              |
 | publicNetworkAccess       | Whether or not public network access is allowed for this server. Value is 'Disabled' when server has VNet integration. | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The private endpoint connection resource.
 
@@ -847,8 +847,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="ReplicationRole"></a>ReplicationRole
--------------------------------------------
+ReplicationRole{#ReplicationRole}
+---------------------------------
 
 The replication role.
 
@@ -860,22 +860,22 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "Replica" |             |
 | "Source"  |             |
 
-<a id="ReplicationRole_STATUS"></a>ReplicationRole_STATUS
+ReplicationRole_STATUS{#ReplicationRole_STATUS}
+-----------------------------------------------
+
+The replication role.
+
+Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "None"    |             |
+| "Replica" |             |
+| "Source"  |             |
+
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
 ---------------------------------------------------------
 
-The replication role.
-
-Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "None"    |             |
-| "Replica" |             |
-| "Source"  |             |
-
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
-
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
 | Value                | Description |
@@ -885,8 +885,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -897,8 +897,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -912,8 +912,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -924,8 +924,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -936,8 +936,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage Profile properties of a server
 
@@ -951,8 +951,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | logOnDisk     | Enable Log On Disk or not.             | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small> |
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                   |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage Profile properties of a server
 
@@ -967,8 +967,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                                 |
 | storageSku    | The sku name of the server storage.    | string<br/><small>Optional</small>                                              |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -983,8 +983,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersAdmini
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="DataEncryption_Type"></a>DataEncryption_Type
----------------------------------------------------
+DataEncryption_Type{#DataEncryption_Type}
+-----------------------------------------
 
 Used by: [DataEncryption](#DataEncryption).
 
@@ -993,8 +993,8 @@ Used by: [DataEncryption](#DataEncryption).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="DataEncryption_Type_STATUS"></a>DataEncryption_Type_STATUS
------------------------------------------------------------------
+DataEncryption_Type_STATUS{#DataEncryption_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
@@ -1003,8 +1003,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="EnableStatusEnum"></a>EnableStatusEnum
----------------------------------------------
+EnableStatusEnum{#EnableStatusEnum}
+-----------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -1015,8 +1015,8 @@ Used by: [Backup](#Backup), [Network](#Network), [Storage](#Storage), [Storage](
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EnableStatusEnum_STATUS"></a>EnableStatusEnum_STATUS
------------------------------------------------------------
+EnableStatusEnum_STATUS{#EnableStatusEnum_STATUS}
+-------------------------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -1027,8 +1027,8 @@ Used by: [Backup_STATUS](#Backup_STATUS), [Network_STATUS](#Network_STATUS), [St
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1037,8 +1037,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 | administratorLogin       | indicates where the AdministratorLogin config map should be placed. If omitted, no config map will be created.       | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1046,8 +1046,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -1057,8 +1057,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1068,8 +1068,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1081,8 +1081,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "NotEnabled"      |             |
 | "RemovingStandby" |             |
 
-<a id="ImportSourceProperties_StorageType"></a>ImportSourceProperties_StorageType
----------------------------------------------------------------------------------
+ImportSourceProperties_StorageType{#ImportSourceProperties_StorageType}
+-----------------------------------------------------------------------
 
 Used by: [ImportSourceProperties](#ImportSourceProperties).
 
@@ -1090,8 +1090,8 @@ Used by: [ImportSourceProperties](#ImportSourceProperties).
 |-------------|-------------|
 | "AzureBlob" |             |
 
-<a id="ImportSourceProperties_StorageType_STATUS"></a>ImportSourceProperties_StorageType_STATUS
------------------------------------------------------------------------------------------------
+ImportSourceProperties_StorageType_STATUS{#ImportSourceProperties_StorageType_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ImportSourceProperties_STATUS](#ImportSourceProperties_STATUS).
 
@@ -1099,8 +1099,8 @@ Used by: [ImportSourceProperties_STATUS](#ImportSourceProperties_STATUS).
 |-------------|-------------|
 | "AzureBlob" |             |
 
-<a id="MySQLServerIdentity_Type"></a>MySQLServerIdentity_Type
--------------------------------------------------------------
+MySQLServerIdentity_Type{#MySQLServerIdentity_Type}
+---------------------------------------------------
 
 Used by: [MySQLServerIdentity](#MySQLServerIdentity).
 
@@ -1108,8 +1108,8 @@ Used by: [MySQLServerIdentity](#MySQLServerIdentity).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="MySQLServerIdentity_Type_STATUS"></a>MySQLServerIdentity_Type_STATUS
----------------------------------------------------------------------------
+MySQLServerIdentity_Type_STATUS{#MySQLServerIdentity_Type_STATUS}
+-----------------------------------------------------------------
 
 Used by: [MySQLServerIdentity_STATUS](#MySQLServerIdentity_STATUS).
 
@@ -1117,8 +1117,8 @@ Used by: [MySQLServerIdentity_STATUS](#MySQLServerIdentity_STATUS).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="MySQLServerSku_Tier"></a>MySQLServerSku_Tier
----------------------------------------------------
+MySQLServerSku_Tier{#MySQLServerSku_Tier}
+-----------------------------------------
 
 Used by: [MySQLServerSku](#MySQLServerSku).
 
@@ -1128,8 +1128,8 @@ Used by: [MySQLServerSku](#MySQLServerSku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="MySQLServerSku_Tier_STATUS"></a>MySQLServerSku_Tier_STATUS
------------------------------------------------------------------
+MySQLServerSku_Tier_STATUS{#MySQLServerSku_Tier_STATUS}
+-------------------------------------------------------
 
 Used by: [MySQLServerSku_STATUS](#MySQLServerSku_STATUS).
 
@@ -1139,7 +1139,19 @@ Used by: [MySQLServerSku_STATUS](#MySQLServerSku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1151,20 +1163,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/dbformysql/v1api20231230.md
+++ b/docs/hugo/content/reference/dbformysql/v1api20231230.md
@@ -5,15 +5,15 @@ title: dbformysql.azure.com/v1api20231230
 linktitle: v1api20231230
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-12-30" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/stable/2023-12-30/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,7 +53,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -85,8 +85,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                             | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/stable/2023-12-30/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}
 
@@ -96,8 +96,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersAdministrator"></a>FlexibleServersAdministrator
----------------------------------------------------------------------
+FlexibleServersAdministrator{#FlexibleServersAdministrator}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2023-12-30/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -110,7 +110,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | spec                                                                                    |             | [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
+### FlexibleServersAdministrator_Spec {#FlexibleServersAdministrator_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -124,7 +124,7 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
+### FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -139,8 +139,8 @@ Used by: [FlexibleServersAdministratorList](#FlexibleServersAdministratorList).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersAdministratorList"></a>FlexibleServersAdministratorList
------------------------------------------------------------------------------
+FlexibleServersAdministratorList{#FlexibleServersAdministratorList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2023-12-30/AzureADAdministrator.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}
 
@@ -150,8 +150,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersAdministrator[]](#FlexibleServersAdministrator)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2023-12-30/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -164,7 +164,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -175,7 +175,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -196,8 +196,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Configurations/stable/2023-12-30/Configurations.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -207,8 +207,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Databases/stable/2023-12-30/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -221,7 +221,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -231,7 +231,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,8 +243,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Databases/stable/2023-12-30/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -254,8 +254,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Firewall/stable/2023-12-30/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -268,7 +268,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                                 |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -278,7 +278,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -290,8 +290,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBforMySQL/Firewall/stable/2023-12-30/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -301,8 +301,8 @@ Generator information: - Generated from: /mysql/resource-manager/Microsoft.DBfor
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -331,8 +331,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | Server version.                                                                                                                                                                                                                                                                              | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -366,8 +366,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | Server version.                                                                                                                                                                                                                                                                                                             | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersAdministrator_Spec"></a>FlexibleServersAdministrator_Spec
--------------------------------------------------------------------------------
+FlexibleServersAdministrator_Spec{#FlexibleServersAdministrator_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -383,8 +383,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId                  | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig        | Tenant ID of the administrator.                                                                                                                                                                                                                                                                | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="FlexibleServersAdministrator_STATUS"></a>FlexibleServersAdministrator_STATUS
------------------------------------------------------------------------------------
+FlexibleServersAdministrator_STATUS{#FlexibleServersAdministrator_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 
@@ -401,8 +401,8 @@ Used by: [FlexibleServersAdministrator](#FlexibleServersAdministrator).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | type               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -415,8 +415,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                   | [ConfigurationProperties_Source](#ConfigurationProperties_Source)<br/><small>Optional</small>                                                                        |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -439,8 +439,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -452,8 +452,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -467,8 +467,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -480,8 +480,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbformysql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                         | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -495,8 +495,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdministratorProperties_AdministratorType"></a>AdministratorProperties_AdministratorType
------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType{#AdministratorProperties_AdministratorType}
+-------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec).
 
@@ -504,8 +504,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="AdministratorProperties_AdministratorType_STATUS"></a>AdministratorProperties_AdministratorType_STATUS
--------------------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType_STATUS{#AdministratorProperties_AdministratorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STATUS).
 
@@ -513,8 +513,8 @@ Used by: [FlexibleServersAdministrator_STATUS](#FlexibleServersAdministrator_STA
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Storage Profile properties of a server
 
@@ -526,8 +526,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.           | int<br/><small>Optional</small>                                   |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled. | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Storage Profile properties of a server
 
@@ -540,8 +540,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | Earliest restore point creation time (ISO8601 format) | string<br/><small>Optional</small>                                              |
 | geoRedundantBackup  | Whether or not geo redundant backup is enabled.       | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_IsConfigPendingRestart_STATUS"></a>ConfigurationProperties_IsConfigPendingRestart_STATUS
------------------------------------------------------------------------------------------------------------------------
+ConfigurationProperties_IsConfigPendingRestart_STATUS{#ConfigurationProperties_IsConfigPendingRestart_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -550,17 +550,7 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_IsDynamicConfig_STATUS"></a>ConfigurationProperties_IsDynamicConfig_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
-
-| Value   | Description |
-|---------|-------------|
-| "False" |             |
-| "True"  |             |
-
-<a id="ConfigurationProperties_IsReadOnly_STATUS"></a>ConfigurationProperties_IsReadOnly_STATUS
+ConfigurationProperties_IsDynamicConfig_STATUS{#ConfigurationProperties_IsDynamicConfig_STATUS}
 -----------------------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
@@ -570,8 +560,18 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "False" |             |
 | "True"  |             |
 
-<a id="ConfigurationProperties_Source"></a>ConfigurationProperties_Source
--------------------------------------------------------------------------
+ConfigurationProperties_IsReadOnly_STATUS{#ConfigurationProperties_IsReadOnly_STATUS}
+-------------------------------------------------------------------------------------
+
+Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
+
+| Value   | Description |
+|---------|-------------|
+| "False" |             |
+| "True"  |             |
+
+ConfigurationProperties_Source{#ConfigurationProperties_Source}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec).
 
@@ -580,8 +580,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="ConfigurationProperties_Source_STATUS"></a>ConfigurationProperties_Source_STATUS
----------------------------------------------------------------------------------------
+ConfigurationProperties_Source_STATUS{#ConfigurationProperties_Source_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -590,8 +590,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "system-default" |             |
 | "user-override"  |             |
 
-<a id="DataEncryption"></a>DataEncryption
------------------------------------------
+DataEncryption{#DataEncryption}
+-------------------------------
 
 The date encryption for cmk.
 
@@ -605,8 +605,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | primaryUserAssignedIdentityReference   | Primary user identity resource id                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | type                                   | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type](#DataEncryption_Type)<br/><small>Optional</small>                                                                                    |
 
-<a id="DataEncryption_STATUS"></a>DataEncryption_STATUS
--------------------------------------------------------
+DataEncryption_STATUS{#DataEncryption_STATUS}
+---------------------------------------------
 
 The date encryption for cmk.
 
@@ -620,8 +620,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | primaryUserAssignedIdentityId   | Primary user identity resource id                                                                               | string<br/><small>Optional</small>                                                    |
 | type                            | The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.                                      | [DataEncryption_Type_STATUS](#DataEncryption_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -634,8 +634,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersAdministratorOperatorSpec"></a>FlexibleServersAdministratorOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersAdministratorOperatorSpec{#FlexibleServersAdministratorOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -646,8 +646,8 @@ Used by: [FlexibleServersAdministrator_Spec](#FlexibleServersAdministrator_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -658,8 +658,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -670,8 +670,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -682,8 +682,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 High availability properties of a server
 
@@ -694,8 +694,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | High availability mode for a server.     | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 High availability properties of a server
 
@@ -707,8 +707,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | Availability zone of the standby server. | string<br/><small>Optional</small>                                                          |
 | state                   | The state of server high availability.   | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ImportSourceProperties"></a>ImportSourceProperties
----------------------------------------------------------
+ImportSourceProperties{#ImportSourceProperties}
+-----------------------------------------------
 
 Import source related properties.
 
@@ -721,8 +721,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | storageType | Storage type of import source.                                                                | [ImportSourceProperties_StorageType](#ImportSourceProperties_StorageType)<br/><small>Optional</small>                                                  |
 | storageUrl  | Uri of the import source storage.                                                             | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ImportSourceProperties_STATUS"></a>ImportSourceProperties_STATUS
------------------------------------------------------------------------
+ImportSourceProperties_STATUS{#ImportSourceProperties_STATUS}
+-------------------------------------------------------------
 
 Import source related properties.
 
@@ -734,8 +734,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | storageType | Storage type of import source.              | [ImportSourceProperties_StorageType_STATUS](#ImportSourceProperties_StorageType_STATUS)<br/><small>Optional</small> |
 | storageUrl  | Uri of the import source storage.           | string<br/><small>Optional</small>                                                                                  |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window of a server.
 
@@ -748,8 +748,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window of a server.
 
@@ -762,8 +762,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MySQLServerIdentity"></a>MySQLServerIdentity
----------------------------------------------------
+MySQLServerIdentity{#MySQLServerIdentity}
+-----------------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -774,8 +774,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | type                   | Type of managed service identity.   | [MySQLServerIdentity_Type](#MySQLServerIdentity_Type)<br/><small>Optional</small>         |
 | userAssignedIdentities | Metadata of user assigned identity. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="MySQLServerIdentity_STATUS"></a>MySQLServerIdentity_STATUS
------------------------------------------------------------------
+MySQLServerIdentity_STATUS{#MySQLServerIdentity_STATUS}
+-------------------------------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -788,8 +788,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | type                   | Type of managed service identity.   | [MySQLServerIdentity_Type_STATUS](#MySQLServerIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | Metadata of user assigned identity. | map[string]v1.JSON<br/><small>Optional</small>                                                  |
 
-<a id="MySQLServerSku"></a>MySQLServerSku
------------------------------------------
+MySQLServerSku{#MySQLServerSku}
+-------------------------------
 
 Billing information related properties of a server.
 
@@ -800,8 +800,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Required</small>                                      |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [MySQLServerSku_Tier](#MySQLServerSku_Tier)<br/><small>Required</small> |
 
-<a id="MySQLServerSku_STATUS"></a>MySQLServerSku_STATUS
--------------------------------------------------------
+MySQLServerSku_STATUS{#MySQLServerSku_STATUS}
+---------------------------------------------
 
 Billing information related properties of a server.
 
@@ -812,8 +812,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, e.g. Standard_D32s_v3.          | string<br/><small>Optional</small>                                                    |
 | tier     | The tier of the particular SKU, e.g. GeneralPurpose. | [MySQLServerSku_Tier_STATUS](#MySQLServerSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network related properties of a server
 
@@ -825,8 +825,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | privateDnsZoneResourceReference  | Private DNS zone resource id.                                                                                          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | publicNetworkAccess              | Whether or not public network access is allowed for this server. Value is 'Disabled' when server has VNet integration. | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small>                                                                                          |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network related properties of a server
 
@@ -838,8 +838,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneResourceId  | Private DNS zone resource id.                                                                                          | string<br/><small>Optional</small>                                              |
 | publicNetworkAccess       | Whether or not public network access is allowed for this server. Value is 'Disabled' when server has VNet integration. | [EnableStatusEnum_STATUS](#EnableStatusEnum_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The private endpoint connection resource.
 
@@ -849,8 +849,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="ReplicationRole"></a>ReplicationRole
--------------------------------------------
+ReplicationRole{#ReplicationRole}
+---------------------------------
 
 The replication role.
 
@@ -862,22 +862,22 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "Replica" |             |
 | "Source"  |             |
 
-<a id="ReplicationRole_STATUS"></a>ReplicationRole_STATUS
+ReplicationRole_STATUS{#ReplicationRole_STATUS}
+-----------------------------------------------
+
+The replication role.
+
+Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "None"    |             |
+| "Replica" |             |
+| "Source"  |             |
+
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
 ---------------------------------------------------------
 
-The replication role.
-
-Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "None"    |             |
-| "Replica" |             |
-| "Source"  |             |
-
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
-
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
 | Value                | Description |
@@ -887,8 +887,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -899,8 +899,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "PointInTimeRestore" |             |
 | "Replica"            |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -914,8 +914,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -926,8 +926,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -938,8 +938,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "5.7"    |             |
 | "8.0.21" |             |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage Profile properties of a server
 
@@ -953,8 +953,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | logOnDisk     | Enable Log On Disk or not.             | [EnableStatusEnum](#EnableStatusEnum)<br/><small>Optional</small> |
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                   |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage Profile properties of a server
 
@@ -969,8 +969,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | storageSizeGB | Max storage size allowed for a server. | int<br/><small>Optional</small>                                                 |
 | storageSku    | The sku name of the server storage.    | string<br/><small>Optional</small>                                              |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -985,8 +985,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersAdmini
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="DataEncryption_Type"></a>DataEncryption_Type
----------------------------------------------------
+DataEncryption_Type{#DataEncryption_Type}
+-----------------------------------------
 
 Used by: [DataEncryption](#DataEncryption).
 
@@ -995,8 +995,8 @@ Used by: [DataEncryption](#DataEncryption).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="DataEncryption_Type_STATUS"></a>DataEncryption_Type_STATUS
------------------------------------------------------------------
+DataEncryption_Type_STATUS{#DataEncryption_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
@@ -1005,8 +1005,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="EnableStatusEnum"></a>EnableStatusEnum
----------------------------------------------
+EnableStatusEnum{#EnableStatusEnum}
+-----------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -1017,8 +1017,8 @@ Used by: [Backup](#Backup), [Network](#Network), [Storage](#Storage), [Storage](
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EnableStatusEnum_STATUS"></a>EnableStatusEnum_STATUS
------------------------------------------------------------
+EnableStatusEnum_STATUS{#EnableStatusEnum_STATUS}
+-------------------------------------------------
 
 Enum to indicate whether value is 'Enabled' or 'Disabled'
 
@@ -1029,8 +1029,8 @@ Used by: [Backup_STATUS](#Backup_STATUS), [Network_STATUS](#Network_STATUS), [St
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1039,8 +1039,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 | administratorLogin       | indicates where the AdministratorLogin config map should be placed. If omitted, no config map will be created.       | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1048,8 +1048,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -1059,8 +1059,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1070,8 +1070,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1083,8 +1083,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "NotEnabled"      |             |
 | "RemovingStandby" |             |
 
-<a id="ImportSourceProperties_StorageType"></a>ImportSourceProperties_StorageType
----------------------------------------------------------------------------------
+ImportSourceProperties_StorageType{#ImportSourceProperties_StorageType}
+-----------------------------------------------------------------------
 
 Used by: [ImportSourceProperties](#ImportSourceProperties).
 
@@ -1092,8 +1092,8 @@ Used by: [ImportSourceProperties](#ImportSourceProperties).
 |-------------|-------------|
 | "AzureBlob" |             |
 
-<a id="ImportSourceProperties_StorageType_STATUS"></a>ImportSourceProperties_StorageType_STATUS
------------------------------------------------------------------------------------------------
+ImportSourceProperties_StorageType_STATUS{#ImportSourceProperties_StorageType_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ImportSourceProperties_STATUS](#ImportSourceProperties_STATUS).
 
@@ -1101,8 +1101,8 @@ Used by: [ImportSourceProperties_STATUS](#ImportSourceProperties_STATUS).
 |-------------|-------------|
 | "AzureBlob" |             |
 
-<a id="MySQLServerIdentity_Type"></a>MySQLServerIdentity_Type
--------------------------------------------------------------
+MySQLServerIdentity_Type{#MySQLServerIdentity_Type}
+---------------------------------------------------
 
 Used by: [MySQLServerIdentity](#MySQLServerIdentity).
 
@@ -1110,8 +1110,8 @@ Used by: [MySQLServerIdentity](#MySQLServerIdentity).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="MySQLServerIdentity_Type_STATUS"></a>MySQLServerIdentity_Type_STATUS
----------------------------------------------------------------------------
+MySQLServerIdentity_Type_STATUS{#MySQLServerIdentity_Type_STATUS}
+-----------------------------------------------------------------
 
 Used by: [MySQLServerIdentity_STATUS](#MySQLServerIdentity_STATUS).
 
@@ -1119,8 +1119,8 @@ Used by: [MySQLServerIdentity_STATUS](#MySQLServerIdentity_STATUS).
 |----------------|-------------|
 | "UserAssigned" |             |
 
-<a id="MySQLServerSku_Tier"></a>MySQLServerSku_Tier
----------------------------------------------------
+MySQLServerSku_Tier{#MySQLServerSku_Tier}
+-----------------------------------------
 
 Used by: [MySQLServerSku](#MySQLServerSku).
 
@@ -1130,8 +1130,8 @@ Used by: [MySQLServerSku](#MySQLServerSku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="MySQLServerSku_Tier_STATUS"></a>MySQLServerSku_Tier_STATUS
------------------------------------------------------------------
+MySQLServerSku_Tier_STATUS{#MySQLServerSku_Tier_STATUS}
+-------------------------------------------------------
 
 Used by: [MySQLServerSku_STATUS](#MySQLServerSku_STATUS).
 
@@ -1141,7 +1141,19 @@ Used by: [MySQLServerSku_STATUS](#MySQLServerSku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1153,20 +1165,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 

--- a/docs/hugo/content/reference/dbforpostgresql/v1.md
+++ b/docs/hugo/content/reference/dbforpostgresql/v1.md
@@ -5,8 +5,8 @@ title: dbforpostgresql.azure.com/
 linktitle:
 ----------
 
-<a id="User"></a>User
----------------------
+User{#User}
+-----------
 
 <br/>User is a postgresql user.
 
@@ -19,7 +19,7 @@ Used by: [UserList](#UserList).
 | spec                                                                                    |             | [UserSpec](#UserSpec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [UserStatus](#UserStatus)<br/><small>Optional</small> |
 
-### <a id="UserSpec"></a>UserSpec
+### UserSpec {#UserSpec}
 
 | Property    | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                     |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -29,14 +29,14 @@ Used by: [UserList](#UserList).
 | roleOptions | RoleOptions defines additional attributes of the user role. You can read more about these attributes at https://www.postgresql.org/docs/current/role-attributes.html.                                                                                                                               | [RoleOptionsSpec](#RoleOptionsSpec)<br/><small>Optional</small>                                                                                                          |
 | roles       | Roles is the set of roles granted to the user upon creation. The Azure Database for PostgreSQL server is created with 3 default roles defined: azure_pg_admin, azure_superuser, and your server admin user (this last is a role w/ login permission, commonly called a User).                       | string[]<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="UserStatus"></a>UserStatus
+### UserStatus{#UserStatus}
 
 | Property   | Description                        | Type                                                                                                                                                    |
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="UserList"></a>UserList
------------------------------
+UserList{#UserList}
+-------------------
 
 | Property                                                                            | Description | Type                                        |
 |-------------------------------------------------------------------------------------|-------------|---------------------------------------------|
@@ -44,8 +44,8 @@ Used by: [UserList](#UserList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [User[]](#User)<br/><small>Optional</small> |
 
-<a id="UserSpec"></a>UserSpec
------------------------------
+UserSpec{#UserSpec}
+-------------------
 
 Used by: [User](#User).
 
@@ -57,8 +57,8 @@ Used by: [User](#User).
 | roleOptions | RoleOptions defines additional attributes of the user role. You can read more about these attributes at https://www.postgresql.org/docs/current/role-attributes.html.                                                                                                                               | [RoleOptionsSpec](#RoleOptionsSpec)<br/><small>Optional</small>                                                                                                          |
 | roles       | Roles is the set of roles granted to the user upon creation. The Azure Database for PostgreSQL server is created with 3 default roles defined: azure_pg_admin, azure_superuser, and your server admin user (this last is a role w/ login permission, commonly called a User).                       | string[]<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="UserStatus"></a>UserStatus
----------------------------------
+UserStatus{#UserStatus}
+-----------------------
 
 Used by: [User](#User).
 
@@ -66,8 +66,8 @@ Used by: [User](#User).
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="LocalUserSpec"></a>LocalUserSpec
----------------------------------------
+LocalUserSpec{#LocalUserSpec}
+-----------------------------
 
 Used by: [UserSpec](#UserSpec).
 
@@ -77,8 +77,8 @@ Used by: [UserSpec](#UserSpec).
 | serverAdminPassword | ServerAdminPassword is a reference to a secret containing the servers administrator password | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 | serverAdminUsername | ServerAdminUsername is the user name of the Server administrator                             | string<br/><small>Required</small>                                                                                                                     |
 
-<a id="RoleOptionsSpec"></a>RoleOptionsSpec
--------------------------------------------
+RoleOptionsSpec{#RoleOptionsSpec}
+---------------------------------
 
 Used by: [UserSpec](#UserSpec).
 

--- a/docs/hugo/content/reference/dbforpostgresql/v1api20210601.md
+++ b/docs/hugo/content/reference/dbforpostgresql/v1api20210601.md
@@ -5,15 +5,15 @@ title: dbforpostgresql.azure.com/v1api20210601
 linktitle: v1api20210601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-06-01" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,7 +49,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -76,8 +76,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -87,8 +87,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -101,7 +101,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -132,8 +132,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -143,8 +143,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -157,7 +157,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,8 +179,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -190,8 +190,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -204,7 +204,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -214,7 +214,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -226,8 +226,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -237,8 +237,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -263,8 +263,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -293,8 +293,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -306,8 +306,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -330,8 +330,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -343,8 +343,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -358,8 +358,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -371,8 +371,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -386,8 +386,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Backup properties of a server
 
@@ -398,8 +398,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.                                     | int<br/><small>Optional</small>                                                     |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup](#Backup_GeoRedundantBackup)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Backup properties of a server
 
@@ -411,8 +411,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | The earliest restore point time (ISO8601 format) for server.              | string<br/><small>Optional</small>                                                                |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup_STATUS](#Backup_GeoRedundantBackup_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_DataType_STATUS"></a>ConfigurationProperties_DataType_STATUS
--------------------------------------------------------------------------------------------
+ConfigurationProperties_DataType_STATUS{#ConfigurationProperties_DataType_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -423,8 +423,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "Integer"     |             |
 | "Numeric"     |             |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -436,8 +436,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -448,8 +448,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -460,8 +460,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -472,8 +472,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 High availability properties of a server
 
@@ -484,8 +484,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | The HA mode for the server.                   | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | availability zone information of the standby. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 High availability properties of a server
 
@@ -497,8 +497,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | availability zone information of the standby.   | string<br/><small>Optional</small>                                                          |
 | state                   | A state of a HA server that is visible to user. | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window properties of a server.
 
@@ -511,8 +511,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window properties of a server.
 
@@ -525,8 +525,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network properties of a server
 
@@ -537,8 +537,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | delegatedSubnetResourceReference   | delegated subnet arm resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | privateDnsZoneArmResourceReference | private dns zone arm resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network properties of a server
 
@@ -550,8 +550,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneArmResourceId | private dns zone arm resource id.       | string<br/><small>Optional</small>                                                                    |
 | publicNetworkAccess         | public network access is enabled or not | [Network_PublicNetworkAccess_STATUS](#Network_PublicNetworkAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
+---------------------------------------------------------
 
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
@@ -562,8 +562,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "PointInTimeRestore" |             |
 | "Update"             |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -574,8 +574,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "PointInTimeRestore" |             |
 | "Update"             |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -589,8 +589,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -603,8 +603,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "13"  |             |
 | "14"  |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -617,8 +617,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "13"  |             |
 | "14"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Sku information related properties of a server.
 
@@ -629,8 +629,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Required</small>                |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier](#Sku_Tier)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Sku information related properties of a server.
 
@@ -641,8 +641,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage properties of a server
 
@@ -652,8 +652,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage properties of a server
 
@@ -663,8 +663,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -679,8 +679,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersConfig
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Backup_GeoRedundantBackup"></a>Backup_GeoRedundantBackup
----------------------------------------------------------------
+Backup_GeoRedundantBackup{#Backup_GeoRedundantBackup}
+-----------------------------------------------------
 
 Used by: [Backup](#Backup).
 
@@ -689,8 +689,8 @@ Used by: [Backup](#Backup).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Backup_GeoRedundantBackup_STATUS"></a>Backup_GeoRedundantBackup_STATUS
------------------------------------------------------------------------------
+Backup_GeoRedundantBackup_STATUS{#Backup_GeoRedundantBackup_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Backup_STATUS](#Backup_STATUS).
 
@@ -699,8 +699,8 @@ Used by: [Backup_STATUS](#Backup_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -708,8 +708,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -718,8 +718,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "Disabled"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -728,8 +728,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "Disabled"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -742,8 +742,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "RemovingStandby" |             |
 | "ReplicatingData" |             |
 
-<a id="Network_PublicNetworkAccess_STATUS"></a>Network_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------
+Network_PublicNetworkAccess_STATUS{#Network_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [Network_STATUS](#Network_STATUS).
 
@@ -752,8 +752,8 @@ Used by: [Network_STATUS](#Network_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -763,8 +763,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -774,8 +774,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -786,8 +786,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/dbforpostgresql/v1api20220120preview.md
+++ b/docs/hugo/content/reference/dbforpostgresql/v1api20220120preview.md
@@ -5,15 +5,15 @@ title: dbforpostgresql.azure.com/v1api20220120preview
 linktitle: v1api20220120preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2022-01-20-preview" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,7 +49,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -76,8 +76,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -87,8 +87,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -101,7 +101,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -132,8 +132,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -143,8 +143,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -157,7 +157,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,8 +179,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -190,8 +190,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -204,7 +204,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -214,7 +214,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -226,8 +226,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2022-01-20-preview/postgresql.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -237,8 +237,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -263,8 +263,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -293,8 +293,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -306,8 +306,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -330,8 +330,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -343,8 +343,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -358,8 +358,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -371,8 +371,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -386,8 +386,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | The system metadata relating to this resource.                                                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Backup properties of a server
 
@@ -398,8 +398,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.                                     | int<br/><small>Optional</small>                                                     |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup](#Backup_GeoRedundantBackup)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Backup properties of a server
 
@@ -411,8 +411,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | The earliest restore point time (ISO8601 format) for server.              | string<br/><small>Optional</small>                                                                |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup_STATUS](#Backup_GeoRedundantBackup_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_DataType_STATUS"></a>ConfigurationProperties_DataType_STATUS
--------------------------------------------------------------------------------------------
+ConfigurationProperties_DataType_STATUS{#ConfigurationProperties_DataType_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -423,8 +423,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "Integer"     |             |
 | "Numeric"     |             |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -437,8 +437,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -449,8 +449,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -461,8 +461,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -473,8 +473,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 High availability properties of a server
 
@@ -485,8 +485,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | The HA mode for the server.                   | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | availability zone information of the standby. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 High availability properties of a server
 
@@ -498,8 +498,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | availability zone information of the standby.   | string<br/><small>Optional</small>                                                          |
 | state                   | A state of a HA server that is visible to user. | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window properties of a server.
 
@@ -512,8 +512,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window properties of a server.
 
@@ -526,8 +526,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network properties of a server
 
@@ -538,8 +538,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | delegatedSubnetResourceReference   | delegated subnet arm resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | privateDnsZoneArmResourceReference | private dns zone arm resource id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network properties of a server
 
@@ -551,8 +551,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneArmResourceId | private dns zone arm resource id.       | string<br/><small>Optional</small>                                                                    |
 | publicNetworkAccess         | public network access is enabled or not | [Network_PublicNetworkAccess_STATUS](#Network_PublicNetworkAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
+---------------------------------------------------------
 
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
@@ -563,8 +563,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "PointInTimeRestore" |             |
 | "Update"             |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -575,8 +575,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "PointInTimeRestore" |             |
 | "Update"             |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -590,8 +590,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -604,8 +604,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "13"  |             |
 | "14"  |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -618,8 +618,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "13"  |             |
 | "14"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Sku information related properties of a server.
 
@@ -630,8 +630,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Required</small>                |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier](#Sku_Tier)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Sku information related properties of a server.
 
@@ -642,8 +642,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage properties of a server
 
@@ -653,8 +653,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage properties of a server
 
@@ -664,8 +664,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -680,8 +680,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersConfig
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Backup_GeoRedundantBackup"></a>Backup_GeoRedundantBackup
----------------------------------------------------------------
+Backup_GeoRedundantBackup{#Backup_GeoRedundantBackup}
+-----------------------------------------------------
 
 Used by: [Backup](#Backup).
 
@@ -690,8 +690,8 @@ Used by: [Backup](#Backup).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Backup_GeoRedundantBackup_STATUS"></a>Backup_GeoRedundantBackup_STATUS
------------------------------------------------------------------------------
+Backup_GeoRedundantBackup_STATUS{#Backup_GeoRedundantBackup_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Backup_STATUS](#Backup_STATUS).
 
@@ -700,8 +700,8 @@ Used by: [Backup_STATUS](#Backup_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -709,8 +709,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -718,8 +718,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -729,8 +729,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -740,8 +740,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -754,8 +754,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "RemovingStandby" |             |
 | "ReplicatingData" |             |
 
-<a id="Network_PublicNetworkAccess_STATUS"></a>Network_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------
+Network_PublicNetworkAccess_STATUS{#Network_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [Network_STATUS](#Network_STATUS).
 
@@ -764,8 +764,8 @@ Used by: [Network_STATUS](#Network_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -775,8 +775,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -786,8 +786,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -798,8 +798,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/dbforpostgresql/v1api20221201.md
+++ b/docs/hugo/content/reference/dbforpostgresql/v1api20221201.md
@@ -5,15 +5,15 @@ title: dbforpostgresql.azure.com/v1api20221201
 linktitle: v1api20221201
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-12-01" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,7 +53,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -85,8 +85,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -96,8 +96,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/Configuration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -110,7 +110,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -120,7 +120,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration. Required to update the configuration.                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration. Required to update the configuration.                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -141,8 +141,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration. Required to update the configuration.                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/Configuration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -152,8 +152,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -166,7 +166,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,7 +176,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -188,8 +188,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -199,8 +199,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -213,7 +213,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -223,7 +223,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -235,8 +235,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -246,8 +246,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -276,8 +276,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -311,8 +311,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                     | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                  | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -324,8 +324,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration. Required to update the configuration.                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration. Required to update the configuration.                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -348,8 +348,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration. Required to update the configuration.                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -361,8 +361,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -376,8 +376,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -389,8 +389,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -404,8 +404,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthConfig"></a>AuthConfig
----------------------------------
+AuthConfig{#AuthConfig}
+-----------------------
 
 Authentication configuration properties of a server
 
@@ -417,8 +417,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | passwordAuth        | If Enabled, Password authentication is enabled.               | [AuthConfig_PasswordAuth](#AuthConfig_PasswordAuth)<br/><small>Optional</small>               |
 | tenantId            | Tenant id of the server.                                      | string<br/><small>Optional</small>                                                            |
 
-<a id="AuthConfig_STATUS"></a>AuthConfig_STATUS
------------------------------------------------
+AuthConfig_STATUS{#AuthConfig_STATUS}
+-------------------------------------
 
 Authentication configuration properties of a server
 
@@ -430,8 +430,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | passwordAuth        | If Enabled, Password authentication is enabled.               | [AuthConfig_PasswordAuth_STATUS](#AuthConfig_PasswordAuth_STATUS)<br/><small>Optional</small>               |
 | tenantId            | Tenant id of the server.                                      | string<br/><small>Optional</small>                                                                          |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Backup properties of a server
 
@@ -442,8 +442,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.                                     | int<br/><small>Optional</small>                                                     |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup](#Backup_GeoRedundantBackup)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Backup properties of a server
 
@@ -455,8 +455,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | The earliest restore point time (ISO8601 format) for server.              | string<br/><small>Optional</small>                                                                |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup_STATUS](#Backup_GeoRedundantBackup_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_DataType_STATUS"></a>ConfigurationProperties_DataType_STATUS
--------------------------------------------------------------------------------------------
+ConfigurationProperties_DataType_STATUS{#ConfigurationProperties_DataType_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -467,8 +467,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "Integer"     |             |
 | "Numeric"     |             |
 
-<a id="DataEncryption"></a>DataEncryption
------------------------------------------
+DataEncryption{#DataEncryption}
+-------------------------------
 
 Data encryption properties of a server
 
@@ -481,8 +481,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | primaryUserAssignedIdentityReference | Resource Id for the User assigned identity to be used for data encryption for primary server. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>   |
 | type                                 | Data encryption type to depict if it is System Managed vs Azure Key vault.                    | [DataEncryption_Type](#DataEncryption_Type)<br/><small>Optional</small>                                                                                      |
 
-<a id="DataEncryption_STATUS"></a>DataEncryption_STATUS
--------------------------------------------------------
+DataEncryption_STATUS{#DataEncryption_STATUS}
+---------------------------------------------
 
 Data encryption properties of a server
 
@@ -494,8 +494,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | primaryUserAssignedIdentityId | Resource Id for the User assigned identity to be used for data encryption for primary server. | string<br/><small>Optional</small>                                                    |
 | type                          | Data encryption type to depict if it is System Managed vs Azure Key vault.                    | [DataEncryption_Type_STATUS](#DataEncryption_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -508,8 +508,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -520,8 +520,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -532,8 +532,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -544,8 +544,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 High availability properties of a server
 
@@ -556,8 +556,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | The HA mode for the server.                   | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | availability zone information of the standby. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 High availability properties of a server
 
@@ -569,8 +569,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | availability zone information of the standby.   | string<br/><small>Optional</small>                                                          |
 | state                   | A state of a HA server that is visible to user. | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window properties of a server.
 
@@ -583,8 +583,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window properties of a server.
 
@@ -597,8 +597,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network properties of a server.
 
@@ -609,8 +609,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | delegatedSubnetResourceReference   | Delegated subnet arm resource id. This is required to be passed during create, in case we want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the value for Private DNS zone. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | privateDnsZoneArmResourceReference | Private dns zone arm resource id. This is required to be passed during create, in case we want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the value for Private DNS zone. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network properties of a server.
 
@@ -622,8 +622,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneArmResourceId | Private dns zone arm resource id. This is required to be passed during create, in case we want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the value for Private DNS zone. | string<br/><small>Optional</small>                                                                    |
 | publicNetworkAccess         | public network access is enabled or not                                                                                                                                                                                                       | [Network_PublicNetworkAccess_STATUS](#Network_PublicNetworkAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="ReplicationRole"></a>ReplicationRole
--------------------------------------------
+ReplicationRole{#ReplicationRole}
+---------------------------------
 
 Used to indicate role of the server in replication set.
 
@@ -636,23 +636,23 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "None"            |             |
 | "Primary"         |             |
 
-<a id="ReplicationRole_STATUS"></a>ReplicationRole_STATUS
+ReplicationRole_STATUS{#ReplicationRole_STATUS}
+-----------------------------------------------
+
+Used to indicate role of the server in replication set.
+
+Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "AsyncReplica"    |             |
+| "GeoAsyncReplica" |             |
+| "None"            |             |
+| "Primary"         |             |
+
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
 ---------------------------------------------------------
 
-Used to indicate role of the server in replication set.
-
-Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "AsyncReplica"    |             |
-| "GeoAsyncReplica" |             |
-| "None"            |             |
-| "Primary"         |             |
-
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
-
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
 | Value                | Description |
@@ -664,8 +664,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "Replica"            |             |
 | "Update"             |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -678,8 +678,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Replica"            |             |
 | "Update"             |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -693,8 +693,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -707,8 +707,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "13"  |             |
 | "14"  |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -721,8 +721,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "13"  |             |
 | "14"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Sku information related properties of a server.
 
@@ -733,8 +733,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Required</small>                |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier](#Sku_Tier)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Sku information related properties of a server.
 
@@ -745,8 +745,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage properties of a server
 
@@ -756,8 +756,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage properties of a server
 
@@ -767,8 +767,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |---------------|-----------------------------------|---------------------------------|
 | storageSizeGB | Max storage allowed for a server. | int<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -783,8 +783,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersConfig
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Information describing the identities associated with this application.
 
@@ -795,8 +795,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | type                   | the types of identities associated with this resource; currently restricted to 'None and UserAssigned' | [UserAssignedIdentity_Type](#UserAssignedIdentity_Type)<br/><small>Required</small>       |
 | userAssignedIdentities | represents user assigned identities map.                                                               | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Information describing the identities associated with this application.
 
@@ -808,48 +808,48 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | type                   | the types of identities associated with this resource; currently restricted to 'None and UserAssigned' | [UserAssignedIdentity_Type_STATUS](#UserAssignedIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | represents user assigned identities map.                                                               | [map[string]UserIdentity_STATUS](#UserIdentity_STATUS)<br/><small>Optional</small>                |
 
-<a id="AuthConfig_ActiveDirectoryAuth"></a>AuthConfig_ActiveDirectoryAuth
--------------------------------------------------------------------------
-
-Used by: [AuthConfig](#AuthConfig).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_ActiveDirectoryAuth_STATUS"></a>AuthConfig_ActiveDirectoryAuth_STATUS
----------------------------------------------------------------------------------------
-
-Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_PasswordAuth"></a>AuthConfig_PasswordAuth
------------------------------------------------------------
-
-Used by: [AuthConfig](#AuthConfig).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_PasswordAuth_STATUS"></a>AuthConfig_PasswordAuth_STATUS
--------------------------------------------------------------------------
-
-Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="Backup_GeoRedundantBackup"></a>Backup_GeoRedundantBackup
+AuthConfig_ActiveDirectoryAuth{#AuthConfig_ActiveDirectoryAuth}
 ---------------------------------------------------------------
+
+Used by: [AuthConfig](#AuthConfig).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_ActiveDirectoryAuth_STATUS{#AuthConfig_ActiveDirectoryAuth_STATUS}
+-----------------------------------------------------------------------------
+
+Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_PasswordAuth{#AuthConfig_PasswordAuth}
+-------------------------------------------------
+
+Used by: [AuthConfig](#AuthConfig).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_PasswordAuth_STATUS{#AuthConfig_PasswordAuth_STATUS}
+---------------------------------------------------------------
+
+Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+Backup_GeoRedundantBackup{#Backup_GeoRedundantBackup}
+-----------------------------------------------------
 
 Used by: [Backup](#Backup).
 
@@ -858,8 +858,8 @@ Used by: [Backup](#Backup).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Backup_GeoRedundantBackup_STATUS"></a>Backup_GeoRedundantBackup_STATUS
------------------------------------------------------------------------------
+Backup_GeoRedundantBackup_STATUS{#Backup_GeoRedundantBackup_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Backup_STATUS](#Backup_STATUS).
 
@@ -868,8 +868,8 @@ Used by: [Backup_STATUS](#Backup_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DataEncryption_Type"></a>DataEncryption_Type
----------------------------------------------------
+DataEncryption_Type{#DataEncryption_Type}
+-----------------------------------------
 
 Used by: [DataEncryption](#DataEncryption).
 
@@ -878,8 +878,8 @@ Used by: [DataEncryption](#DataEncryption).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="DataEncryption_Type_STATUS"></a>DataEncryption_Type_STATUS
------------------------------------------------------------------
+DataEncryption_Type_STATUS{#DataEncryption_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
@@ -888,8 +888,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -897,8 +897,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -906,8 +906,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -917,8 +917,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -928,8 +928,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -942,8 +942,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "RemovingStandby" |             |
 | "ReplicatingData" |             |
 
-<a id="Network_PublicNetworkAccess_STATUS"></a>Network_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------
+Network_PublicNetworkAccess_STATUS{#Network_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [Network_STATUS](#Network_STATUS).
 
@@ -952,8 +952,8 @@ Used by: [Network_STATUS](#Network_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -963,8 +963,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -974,7 +974,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -986,20 +998,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_Type"></a>UserAssignedIdentity_Type
----------------------------------------------------------------
+UserAssignedIdentity_Type{#UserAssignedIdentity_Type}
+-----------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -1008,8 +1008,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="UserAssignedIdentity_Type_STATUS"></a>UserAssignedIdentity_Type_STATUS
------------------------------------------------------------------------------
+UserAssignedIdentity_Type_STATUS{#UserAssignedIdentity_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS).
 
@@ -1018,8 +1018,8 @@ Used by: [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1029,8 +1029,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentity_STATUS"></a>UserIdentity_STATUS
----------------------------------------------------
+UserIdentity_STATUS{#UserIdentity_STATUS}
+-----------------------------------------
 
 Describes a single user-assigned identity associated with the application.
 

--- a/docs/hugo/content/reference/dbforpostgresql/v1api20230601preview.md
+++ b/docs/hugo/content/reference/dbforpostgresql/v1api20230601preview.md
@@ -5,15 +5,15 @@ title: dbforpostgresql.azure.com/v1api20230601preview
 linktitle: v1api20230601preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2023-06-01-preview" |             |
 
-<a id="FlexibleServer"></a>FlexibleServer
------------------------------------------
+FlexibleServer{#FlexibleServer}
+-------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | spec                                                                                    |             | [FlexibleServer_Spec](#FlexibleServer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServer_STATUS](#FlexibleServer_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
+### FlexibleServer_Spec {#FlexibleServer_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -54,7 +54,7 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-### <a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
+### FlexibleServer_STATUS{#FlexibleServer_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -88,8 +88,8 @@ Used by: [FlexibleServerList](#FlexibleServerList).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                  | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServerList"></a>FlexibleServerList
--------------------------------------------------
+FlexibleServerList{#FlexibleServerList}
+---------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/FlexibleServers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}
 
@@ -99,8 +99,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [FlexibleServer[]](#FlexibleServer)<br/><small>Optional</small> |
 
-<a id="FlexibleServersConfiguration"></a>FlexibleServersConfiguration
----------------------------------------------------------------------
+FlexibleServersConfiguration{#FlexibleServersConfiguration}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/Configuration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -113,7 +113,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | spec                                                                                    |             | [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
+### FlexibleServersConfiguration_Spec {#FlexibleServersConfiguration_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -123,7 +123,7 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
+### FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -144,8 +144,8 @@ Used by: [FlexibleServersConfigurationList](#FlexibleServersConfigurationList).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersConfigurationList"></a>FlexibleServersConfigurationList
------------------------------------------------------------------------------
+FlexibleServersConfigurationList{#FlexibleServersConfigurationList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/Configuration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}
 
@@ -155,8 +155,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [FlexibleServersConfiguration[]](#FlexibleServersConfiguration)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabase"></a>FlexibleServersDatabase
------------------------------------------------------------
+FlexibleServersDatabase{#FlexibleServersDatabase}
+-------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -169,7 +169,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | spec                                                                                    |             | [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersDatabase_STATUS](#FlexibleServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
+### FlexibleServersDatabase_Spec {#FlexibleServersDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,7 +179,7 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
+### FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -191,8 +191,8 @@ Used by: [FlexibleServersDatabaseList](#FlexibleServersDatabaseList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabaseList"></a>FlexibleServersDatabaseList
--------------------------------------------------------------------
+FlexibleServersDatabaseList{#FlexibleServersDatabaseList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}
 
@@ -202,8 +202,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [FlexibleServersDatabase[]](#FlexibleServersDatabase)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRule"></a>FlexibleServersFirewallRule
--------------------------------------------------------------------
+FlexibleServersFirewallRule{#FlexibleServersFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -216,7 +216,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | spec                                                                                    |             | [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FlexibleServersFirewallRule_STATUS](#FlexibleServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
+### FlexibleServersFirewallRule_Spec {#FlexibleServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                         | Type                                                                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -226,7 +226,7 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
+### FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -238,8 +238,8 @@ Used by: [FlexibleServersFirewallRuleList](#FlexibleServersFirewallRuleList).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRuleList"></a>FlexibleServersFirewallRuleList
----------------------------------------------------------------------------
+FlexibleServersFirewallRuleList{#FlexibleServersFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-06-01-preview/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -249,8 +249,8 @@ Generator information: - Generated from: /postgresql/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FlexibleServersFirewallRule[]](#FlexibleServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="FlexibleServer_Spec"></a>FlexibleServer_Spec
----------------------------------------------------
+FlexibleServer_Spec{#FlexibleServer_Spec}
+-----------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -280,8 +280,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | tags                          | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                       | PostgreSQL Server version.                                                                                                                                                                                                                                                                   | [ServerVersion](#ServerVersion)<br/><small>Optional</small>                                                                                                          |
 
-<a id="FlexibleServer_STATUS"></a>FlexibleServer_STATUS
--------------------------------------------------------
+FlexibleServer_STATUS{#FlexibleServer_STATUS}
+---------------------------------------------
 
 Used by: [FlexibleServer](#FlexibleServer).
 
@@ -317,8 +317,8 @@ Used by: [FlexibleServer](#FlexibleServer).
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | version                    | PostgreSQL Server version.                                                                                                                                                                                                                                                                                                  | [ServerVersion_STATUS](#ServerVersion_STATUS)<br/><small>Optional</small>                                                                               |
 
-<a id="FlexibleServersConfiguration_Spec"></a>FlexibleServersConfiguration_Spec
--------------------------------------------------------------------------------
+FlexibleServersConfiguration_Spec{#FlexibleServersConfiguration_Spec}
+---------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -330,8 +330,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | source       | Source of the configuration.                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 | value        | Value of the configuration.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="FlexibleServersConfiguration_STATUS"></a>FlexibleServersConfiguration_STATUS
------------------------------------------------------------------------------------
+FlexibleServersConfiguration_STATUS{#FlexibleServersConfiguration_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 
@@ -354,8 +354,8 @@ Used by: [FlexibleServersConfiguration](#FlexibleServersConfiguration).
 | unit                   | Configuration unit.                                                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | value                  | Value of the configuration.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersDatabase_Spec"></a>FlexibleServersDatabase_Spec
----------------------------------------------------------------------
+FlexibleServersDatabase_Spec{#FlexibleServersDatabase_Spec}
+-----------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -367,8 +367,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                     | [FlexibleServersDatabaseOperatorSpec](#FlexibleServersDatabaseOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="FlexibleServersDatabase_STATUS"></a>FlexibleServersDatabase_STATUS
--------------------------------------------------------------------------
+FlexibleServersDatabase_STATUS{#FlexibleServersDatabase_STATUS}
+---------------------------------------------------------------
 
 Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 
@@ -382,8 +382,8 @@ Used by: [FlexibleServersDatabase](#FlexibleServersDatabase).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FlexibleServersFirewallRule_Spec"></a>FlexibleServersFirewallRule_Spec
------------------------------------------------------------------------------
+FlexibleServersFirewallRule_Spec{#FlexibleServersFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -395,8 +395,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a dbforpostgresql.azure.com/FlexibleServer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the server firewall rule. Must be IPv4 format.                                                                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="FlexibleServersFirewallRule_STATUS"></a>FlexibleServersFirewallRule_STATUS
----------------------------------------------------------------------------------
+FlexibleServersFirewallRule_STATUS{#FlexibleServersFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 
@@ -410,8 +410,8 @@ Used by: [FlexibleServersFirewallRule](#FlexibleServersFirewallRule).
 | systemData     | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AuthConfig"></a>AuthConfig
----------------------------------
+AuthConfig{#AuthConfig}
+-----------------------
 
 Authentication configuration properties of a server
 
@@ -423,8 +423,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | passwordAuth        | If Enabled, Password authentication is enabled.               | [AuthConfig_PasswordAuth](#AuthConfig_PasswordAuth)<br/><small>Optional</small>               |
 | tenantId            | Tenant id of the server.                                      | string<br/><small>Optional</small>                                                            |
 
-<a id="AuthConfig_STATUS"></a>AuthConfig_STATUS
------------------------------------------------
+AuthConfig_STATUS{#AuthConfig_STATUS}
+-------------------------------------
 
 Authentication configuration properties of a server
 
@@ -436,8 +436,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | passwordAuth        | If Enabled, Password authentication is enabled.               | [AuthConfig_PasswordAuth_STATUS](#AuthConfig_PasswordAuth_STATUS)<br/><small>Optional</small>               |
 | tenantId            | Tenant id of the server.                                      | string<br/><small>Optional</small>                                                                          |
 
-<a id="Backup"></a>Backup
--------------------------
+Backup{#Backup}
+---------------
 
 Backup properties of a server
 
@@ -448,8 +448,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | backupRetentionDays | Backup retention days for the server.                                     | int<br/><small>Optional</small>                                                     |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup](#Backup_GeoRedundantBackup)<br/><small>Optional</small> |
 
-<a id="Backup_STATUS"></a>Backup_STATUS
----------------------------------------
+Backup_STATUS{#Backup_STATUS}
+-----------------------------
 
 Backup properties of a server
 
@@ -461,8 +461,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | earliestRestoreDate | The earliest restore point time (ISO8601 format) for server.              | string<br/><small>Optional</small>                                                                |
 | geoRedundantBackup  | A value indicating whether Geo-Redundant backup is enabled on the server. | [Backup_GeoRedundantBackup_STATUS](#Backup_GeoRedundantBackup_STATUS)<br/><small>Optional</small> |
 
-<a id="ConfigurationProperties_DataType_STATUS"></a>ConfigurationProperties_DataType_STATUS
--------------------------------------------------------------------------------------------
+ConfigurationProperties_DataType_STATUS{#ConfigurationProperties_DataType_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STATUS).
 
@@ -473,8 +473,8 @@ Used by: [FlexibleServersConfiguration_STATUS](#FlexibleServersConfiguration_STA
 | "Integer"     |             |
 | "Numeric"     |             |
 
-<a id="DataEncryption"></a>DataEncryption
------------------------------------------
+DataEncryption{#DataEncryption}
+-------------------------------
 
 Data encryption properties of a server
 
@@ -492,8 +492,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | primaryUserAssignedIdentityReference   | Resource Id for the User assigned identity to be used for data encryption of the primary server.    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>   |
 | type                                   | Data encryption type to depict if it is System Managed vs Azure Key vault.                          | [DataEncryption_Type](#DataEncryption_Type)<br/><small>Optional</small>                                                                                      |
 
-<a id="DataEncryption_STATUS"></a>DataEncryption_STATUS
--------------------------------------------------------
+DataEncryption_STATUS{#DataEncryption_STATUS}
+---------------------------------------------
 
 Data encryption properties of a server
 
@@ -509,8 +509,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | primaryUserAssignedIdentityId   | Resource Id for the User assigned identity to be used for data encryption of the primary server.    | string<br/><small>Optional</small>                                                                                                    |
 | type                            | Data encryption type to depict if it is System Managed vs Azure Key vault.                          | [DataEncryption_Type_STATUS](#DataEncryption_Type_STATUS)<br/><small>Optional</small>                                                 |
 
-<a id="FlexibleServerOperatorSpec"></a>FlexibleServerOperatorSpec
------------------------------------------------------------------
+FlexibleServerOperatorSpec{#FlexibleServerOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -523,8 +523,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [FlexibleServerOperatorSecrets](#FlexibleServerOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="FlexibleServersConfigurationOperatorSpec"></a>FlexibleServersConfigurationOperatorSpec
----------------------------------------------------------------------------------------------
+FlexibleServersConfigurationOperatorSpec{#FlexibleServersConfigurationOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -535,8 +535,8 @@ Used by: [FlexibleServersConfiguration_Spec](#FlexibleServersConfiguration_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersDatabaseOperatorSpec"></a>FlexibleServersDatabaseOperatorSpec
------------------------------------------------------------------------------------
+FlexibleServersDatabaseOperatorSpec{#FlexibleServersDatabaseOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -547,8 +547,8 @@ Used by: [FlexibleServersDatabase_Spec](#FlexibleServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="FlexibleServersFirewallRuleOperatorSpec"></a>FlexibleServersFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+FlexibleServersFirewallRuleOperatorSpec{#FlexibleServersFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -559,8 +559,8 @@ Used by: [FlexibleServersFirewallRule_Spec](#FlexibleServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="HighAvailability"></a>HighAvailability
----------------------------------------------
+HighAvailability{#HighAvailability}
+-----------------------------------
 
 High availability properties of a server
 
@@ -571,8 +571,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | mode                    | The HA mode for the server.                   | [HighAvailability_Mode](#HighAvailability_Mode)<br/><small>Optional</small> |
 | standbyAvailabilityZone | availability zone information of the standby. | string<br/><small>Optional</small>                                          |
 
-<a id="HighAvailability_STATUS"></a>HighAvailability_STATUS
------------------------------------------------------------
+HighAvailability_STATUS{#HighAvailability_STATUS}
+-------------------------------------------------
 
 High availability properties of a server
 
@@ -584,8 +584,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | standbyAvailabilityZone | availability zone information of the standby.   | string<br/><small>Optional</small>                                                          |
 | state                   | A state of a HA server that is visible to user. | [HighAvailability_State_STATUS](#HighAvailability_State_STATUS)<br/><small>Optional</small> |
 
-<a id="MaintenanceWindow"></a>MaintenanceWindow
------------------------------------------------
+MaintenanceWindow{#MaintenanceWindow}
+-------------------------------------
 
 Maintenance window properties of a server.
 
@@ -598,8 +598,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="MaintenanceWindow_STATUS"></a>MaintenanceWindow_STATUS
--------------------------------------------------------------
+MaintenanceWindow_STATUS{#MaintenanceWindow_STATUS}
+---------------------------------------------------
 
 Maintenance window properties of a server.
 
@@ -612,8 +612,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | startHour    | start hour for maintenance window                      | int<br/><small>Optional</small>    |
 | startMinute  | start minute for maintenance window                    | int<br/><small>Optional</small>    |
 
-<a id="Network"></a>Network
----------------------------
+Network{#Network}
+-----------------
 
 Network properties of a server.
 
@@ -625,8 +625,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | privateDnsZoneArmResourceReference | Private dns zone arm resource id. This is required to be passed during create, in case we want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the value for Private DNS zone. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | publicNetworkAccess                | public network access is enabled or not                                                                                                                                                                                                       | [Network_PublicNetworkAccess](#Network_PublicNetworkAccess)<br/><small>Optional</small>                                                                    |
 
-<a id="Network_STATUS"></a>Network_STATUS
------------------------------------------
+Network_STATUS{#Network_STATUS}
+-------------------------------
 
 Network properties of a server.
 
@@ -638,8 +638,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | privateDnsZoneArmResourceId | Private dns zone arm resource id. This is required to be passed during create, in case we want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the value for Private DNS zone. | string<br/><small>Optional</small>                                                                    |
 | publicNetworkAccess         | public network access is enabled or not                                                                                                                                                                                                       | [Network_PublicNetworkAccess_STATUS](#Network_PublicNetworkAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The private endpoint connection resource.
 
@@ -649,8 +649,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="Replica"></a>Replica
----------------------------
+Replica{#Replica}
+-----------------
 
 Replica properties of a server
 
@@ -662,8 +662,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | promoteOption | Sets the promote options for a replica server. This is a write only property. | [Replica_PromoteOption](#Replica_PromoteOption)<br/><small>Optional</small> |
 | role          | Used to indicate role of the server in replication set.                       | [ReplicationRole](#ReplicationRole)<br/><small>Optional</small>             |
 
-<a id="Replica_STATUS"></a>Replica_STATUS
------------------------------------------
+Replica_STATUS{#Replica_STATUS}
+-------------------------------
 
 Replica properties of a server
 
@@ -677,8 +677,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | replicationState | Gets the replication state of a replica server. This property is returned only for replicas api call. Supported values are Active, Catchup, Provisioning, Updating, Broken, Reconfiguring | [Replica_ReplicationState_STATUS](#Replica_ReplicationState_STATUS)<br/><small>Optional</small> |
 | role             | Used to indicate role of the server in replication set.                                                                                                                                   | [ReplicationRole_STATUS](#ReplicationRole_STATUS)<br/><small>Optional</small>                   |
 
-<a id="ReplicationRole"></a>ReplicationRole
--------------------------------------------
+ReplicationRole{#ReplicationRole}
+---------------------------------
 
 Used to indicate role of the server in replication set.
 
@@ -691,8 +691,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec), and [Replica](#Replica).
 | "None"            |             |
 | "Primary"         |             |
 
-<a id="ReplicationRole_STATUS"></a>ReplicationRole_STATUS
----------------------------------------------------------
+ReplicationRole_STATUS{#ReplicationRole_STATUS}
+-----------------------------------------------
 
 Used to indicate role of the server in replication set.
 
@@ -705,8 +705,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), and [Replica_STATUS](#
 | "None"            |             |
 | "Primary"         |             |
 
-<a id="ServerProperties_CreateMode"></a>ServerProperties_CreateMode
--------------------------------------------------------------------
+ServerProperties_CreateMode{#ServerProperties_CreateMode}
+---------------------------------------------------------
 
 Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 
@@ -720,8 +720,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "ReviveDropped"      |             |
 | "Update"             |             |
 
-<a id="ServerProperties_CreateMode_STATUS"></a>ServerProperties_CreateMode_STATUS
----------------------------------------------------------------------------------
+ServerProperties_CreateMode_STATUS{#ServerProperties_CreateMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -735,8 +735,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "ReviveDropped"      |             |
 | "Update"             |             |
 
-<a id="ServerProperties_State_STATUS"></a>ServerProperties_State_STATUS
------------------------------------------------------------------------
+ServerProperties_State_STATUS{#ServerProperties_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 
@@ -750,8 +750,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "Stopping" |             |
 | "Updating" |             |
 
-<a id="ServerVersion"></a>ServerVersion
----------------------------------------
+ServerVersion{#ServerVersion}
+-----------------------------
 
 The version of a server.
 
@@ -766,8 +766,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | "15"  |             |
 | "16"  |             |
 
-<a id="ServerVersion_STATUS"></a>ServerVersion_STATUS
------------------------------------------------------
+ServerVersion_STATUS{#ServerVersion_STATUS}
+-------------------------------------------
 
 The version of a server.
 
@@ -782,8 +782,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | "15"  |             |
 | "16"  |             |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Sku information related properties of a server.
 
@@ -794,8 +794,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Required</small>                |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier](#Sku_Tier)<br/><small>Required</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Sku information related properties of a server.
 
@@ -806,8 +806,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | name     | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. | string<br/><small>Optional</small>                              |
 | tier     | The tier of the particular SKU, e.g. Burstable.                              | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="Storage"></a>Storage
----------------------------
+Storage{#Storage}
+-----------------
 
 Storage properties of a server
 
@@ -822,8 +822,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | tier          | Name of storage tier for IOPS.                                                                                             | [Storage_Tier](#Storage_Tier)<br/><small>Optional</small>         |
 | type          | Storage type for the server. Allowed values are Premium_LRS and PremiumV2_LRS, and default is Premium_LRS if not specified | [Storage_Type](#Storage_Type)<br/><small>Optional</small>         |
 
-<a id="Storage_STATUS"></a>Storage_STATUS
------------------------------------------
+Storage_STATUS{#Storage_STATUS}
+-------------------------------
 
 Storage properties of a server
 
@@ -838,8 +838,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | tier          | Name of storage tier for IOPS.                                                                                             | [Storage_Tier_STATUS](#Storage_Tier_STATUS)<br/><small>Optional</small>         |
 | type          | Storage type for the server. Allowed values are Premium_LRS and PremiumV2_LRS, and default is Premium_LRS if not specified | [Storage_Type_STATUS](#Storage_Type_STATUS)<br/><small>Optional</small>         |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -854,8 +854,8 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS), [FlexibleServersConfig
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Information describing the identities associated with this application.
 
@@ -866,8 +866,8 @@ Used by: [FlexibleServer_Spec](#FlexibleServer_Spec).
 | type                   | the types of identities associated with this resource; currently restricted to 'None and UserAssigned' | [UserAssignedIdentity_Type](#UserAssignedIdentity_Type)<br/><small>Required</small>       |
 | userAssignedIdentities | represents user assigned identities map.                                                               | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Information describing the identities associated with this application.
 
@@ -879,48 +879,48 @@ Used by: [FlexibleServer_STATUS](#FlexibleServer_STATUS).
 | type                   | the types of identities associated with this resource; currently restricted to 'None and UserAssigned' | [UserAssignedIdentity_Type_STATUS](#UserAssignedIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | represents user assigned identities map.                                                               | [map[string]UserIdentity_STATUS](#UserIdentity_STATUS)<br/><small>Optional</small>                |
 
-<a id="AuthConfig_ActiveDirectoryAuth"></a>AuthConfig_ActiveDirectoryAuth
--------------------------------------------------------------------------
-
-Used by: [AuthConfig](#AuthConfig).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_ActiveDirectoryAuth_STATUS"></a>AuthConfig_ActiveDirectoryAuth_STATUS
----------------------------------------------------------------------------------------
-
-Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_PasswordAuth"></a>AuthConfig_PasswordAuth
------------------------------------------------------------
-
-Used by: [AuthConfig](#AuthConfig).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="AuthConfig_PasswordAuth_STATUS"></a>AuthConfig_PasswordAuth_STATUS
--------------------------------------------------------------------------
-
-Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="Backup_GeoRedundantBackup"></a>Backup_GeoRedundantBackup
+AuthConfig_ActiveDirectoryAuth{#AuthConfig_ActiveDirectoryAuth}
 ---------------------------------------------------------------
+
+Used by: [AuthConfig](#AuthConfig).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_ActiveDirectoryAuth_STATUS{#AuthConfig_ActiveDirectoryAuth_STATUS}
+-----------------------------------------------------------------------------
+
+Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_PasswordAuth{#AuthConfig_PasswordAuth}
+-------------------------------------------------
+
+Used by: [AuthConfig](#AuthConfig).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+AuthConfig_PasswordAuth_STATUS{#AuthConfig_PasswordAuth_STATUS}
+---------------------------------------------------------------
+
+Used by: [AuthConfig_STATUS](#AuthConfig_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+Backup_GeoRedundantBackup{#Backup_GeoRedundantBackup}
+-----------------------------------------------------
 
 Used by: [Backup](#Backup).
 
@@ -929,8 +929,8 @@ Used by: [Backup](#Backup).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Backup_GeoRedundantBackup_STATUS"></a>Backup_GeoRedundantBackup_STATUS
------------------------------------------------------------------------------
+Backup_GeoRedundantBackup_STATUS{#Backup_GeoRedundantBackup_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Backup_STATUS](#Backup_STATUS).
 
@@ -939,19 +939,39 @@ Used by: [Backup_STATUS](#Backup_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DataEncryption_GeoBackupEncryptionKeyStatus"></a>DataEncryption_GeoBackupEncryptionKeyStatus
+DataEncryption_GeoBackupEncryptionKeyStatus{#DataEncryption_GeoBackupEncryptionKeyStatus}
+-----------------------------------------------------------------------------------------
+
+Used by: [DataEncryption](#DataEncryption).
+
+| Value     | Description |
+|-----------|-------------|
+| "Invalid" |             |
+| "Valid"   |             |
+
+DataEncryption_GeoBackupEncryptionKeyStatus_STATUS{#DataEncryption_GeoBackupEncryptionKeyStatus_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Invalid" |             |
+| "Valid"   |             |
+
+DataEncryption_PrimaryEncryptionKeyStatus{#DataEncryption_PrimaryEncryptionKeyStatus}
+-------------------------------------------------------------------------------------
+
+Used by: [DataEncryption](#DataEncryption).
+
+| Value     | Description |
+|-----------|-------------|
+| "Invalid" |             |
+| "Valid"   |             |
+
+DataEncryption_PrimaryEncryptionKeyStatus_STATUS{#DataEncryption_PrimaryEncryptionKeyStatus_STATUS}
 ---------------------------------------------------------------------------------------------------
 
-Used by: [DataEncryption](#DataEncryption).
-
-| Value     | Description |
-|-----------|-------------|
-| "Invalid" |             |
-| "Valid"   |             |
-
-<a id="DataEncryption_GeoBackupEncryptionKeyStatus_STATUS"></a>DataEncryption_GeoBackupEncryptionKeyStatus_STATUS
------------------------------------------------------------------------------------------------------------------
-
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
 | Value     | Description |
@@ -959,28 +979,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "Invalid" |             |
 | "Valid"   |             |
 
-<a id="DataEncryption_PrimaryEncryptionKeyStatus"></a>DataEncryption_PrimaryEncryptionKeyStatus
------------------------------------------------------------------------------------------------
-
-Used by: [DataEncryption](#DataEncryption).
-
-| Value     | Description |
-|-----------|-------------|
-| "Invalid" |             |
-| "Valid"   |             |
-
-<a id="DataEncryption_PrimaryEncryptionKeyStatus_STATUS"></a>DataEncryption_PrimaryEncryptionKeyStatus_STATUS
--------------------------------------------------------------------------------------------------------------
-
-Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Invalid" |             |
-| "Valid"   |             |
-
-<a id="DataEncryption_Type"></a>DataEncryption_Type
----------------------------------------------------
+DataEncryption_Type{#DataEncryption_Type}
+-----------------------------------------
 
 Used by: [DataEncryption](#DataEncryption).
 
@@ -989,8 +989,8 @@ Used by: [DataEncryption](#DataEncryption).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="DataEncryption_Type_STATUS"></a>DataEncryption_Type_STATUS
------------------------------------------------------------------
+DataEncryption_Type_STATUS{#DataEncryption_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 
@@ -999,8 +999,8 @@ Used by: [DataEncryption_STATUS](#DataEncryption_STATUS).
 | "AzureKeyVault" |             |
 | "SystemManaged" |             |
 
-<a id="FlexibleServerOperatorConfigMaps"></a>FlexibleServerOperatorConfigMaps
------------------------------------------------------------------------------
+FlexibleServerOperatorConfigMaps{#FlexibleServerOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1008,8 +1008,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="FlexibleServerOperatorSecrets"></a>FlexibleServerOperatorSecrets
------------------------------------------------------------------------
+FlexibleServerOperatorSecrets{#FlexibleServerOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 
@@ -1017,8 +1017,8 @@ Used by: [FlexibleServerOperatorSpec](#FlexibleServerOperatorSpec).
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="HighAvailability_Mode"></a>HighAvailability_Mode
--------------------------------------------------------
+HighAvailability_Mode{#HighAvailability_Mode}
+---------------------------------------------
 
 Used by: [HighAvailability](#HighAvailability).
 
@@ -1028,8 +1028,8 @@ Used by: [HighAvailability](#HighAvailability).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_Mode_STATUS"></a>HighAvailability_Mode_STATUS
----------------------------------------------------------------------
+HighAvailability_Mode_STATUS{#HighAvailability_Mode_STATUS}
+-----------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1039,8 +1039,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "SameZone"      |             |
 | "ZoneRedundant" |             |
 
-<a id="HighAvailability_State_STATUS"></a>HighAvailability_State_STATUS
------------------------------------------------------------------------
+HighAvailability_State_STATUS{#HighAvailability_State_STATUS}
+-------------------------------------------------------------
 
 Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 
@@ -1053,8 +1053,8 @@ Used by: [HighAvailability_STATUS](#HighAvailability_STATUS).
 | "RemovingStandby" |             |
 | "ReplicatingData" |             |
 
-<a id="Network_PublicNetworkAccess"></a>Network_PublicNetworkAccess
--------------------------------------------------------------------
+Network_PublicNetworkAccess{#Network_PublicNetworkAccess}
+---------------------------------------------------------
 
 Used by: [Network](#Network).
 
@@ -1063,8 +1063,8 @@ Used by: [Network](#Network).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Network_PublicNetworkAccess_STATUS"></a>Network_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------
+Network_PublicNetworkAccess_STATUS{#Network_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [Network_STATUS](#Network_STATUS).
 
@@ -1073,8 +1073,8 @@ Used by: [Network_STATUS](#Network_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Replica_PromoteMode"></a>Replica_PromoteMode
----------------------------------------------------
+Replica_PromoteMode{#Replica_PromoteMode}
+-----------------------------------------
 
 Used by: [Replica](#Replica).
 
@@ -1083,19 +1083,19 @@ Used by: [Replica](#Replica).
 | "standalone" |             |
 | "switchover" |             |
 
-<a id="Replica_PromoteMode_STATUS"></a>Replica_PromoteMode_STATUS
------------------------------------------------------------------
-
-Used by: [Replica_STATUS](#Replica_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "standalone" |             |
-| "switchover" |             |
-
-<a id="Replica_PromoteOption"></a>Replica_PromoteOption
+Replica_PromoteMode_STATUS{#Replica_PromoteMode_STATUS}
 -------------------------------------------------------
 
+Used by: [Replica_STATUS](#Replica_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "standalone" |             |
+| "switchover" |             |
+
+Replica_PromoteOption{#Replica_PromoteOption}
+---------------------------------------------
+
 Used by: [Replica](#Replica).
 
 | Value     | Description |
@@ -1103,8 +1103,8 @@ Used by: [Replica](#Replica).
 | "forced"  |             |
 | "planned" |             |
 
-<a id="Replica_PromoteOption_STATUS"></a>Replica_PromoteOption_STATUS
----------------------------------------------------------------------
+Replica_PromoteOption_STATUS{#Replica_PromoteOption_STATUS}
+-----------------------------------------------------------
 
 Used by: [Replica_STATUS](#Replica_STATUS).
 
@@ -1113,8 +1113,8 @@ Used by: [Replica_STATUS](#Replica_STATUS).
 | "forced"  |             |
 | "planned" |             |
 
-<a id="Replica_ReplicationState_STATUS"></a>Replica_ReplicationState_STATUS
----------------------------------------------------------------------------
+Replica_ReplicationState_STATUS{#Replica_ReplicationState_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Replica_STATUS](#Replica_STATUS).
 
@@ -1127,8 +1127,8 @@ Used by: [Replica_STATUS](#Replica_STATUS).
 | "Reconfiguring" |             |
 | "Updating"      |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -1138,8 +1138,8 @@ Used by: [Sku](#Sku).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -1149,8 +1149,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "GeneralPurpose"  |             |
 | "MemoryOptimized" |             |
 
-<a id="Storage_AutoGrow"></a>Storage_AutoGrow
----------------------------------------------
+Storage_AutoGrow{#Storage_AutoGrow}
+-----------------------------------
 
 Used by: [Storage](#Storage).
 
@@ -1159,8 +1159,8 @@ Used by: [Storage](#Storage).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Storage_AutoGrow_STATUS"></a>Storage_AutoGrow_STATUS
------------------------------------------------------------
+Storage_AutoGrow_STATUS{#Storage_AutoGrow_STATUS}
+-------------------------------------------------
 
 Used by: [Storage_STATUS](#Storage_STATUS).
 
@@ -1169,8 +1169,8 @@ Used by: [Storage_STATUS](#Storage_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Storage_Tier"></a>Storage_Tier
--------------------------------------
+Storage_Tier{#Storage_Tier}
+---------------------------
 
 Used by: [Storage](#Storage).
 
@@ -1191,8 +1191,8 @@ Used by: [Storage](#Storage).
 | "P70" |             |
 | "P80" |             |
 
-<a id="Storage_Tier_STATUS"></a>Storage_Tier_STATUS
----------------------------------------------------
+Storage_Tier_STATUS{#Storage_Tier_STATUS}
+-----------------------------------------
 
 Used by: [Storage_STATUS](#Storage_STATUS).
 
@@ -1213,8 +1213,8 @@ Used by: [Storage_STATUS](#Storage_STATUS).
 | "P70" |             |
 | "P80" |             |
 
-<a id="Storage_Type"></a>Storage_Type
--------------------------------------
+Storage_Type{#Storage_Type}
+---------------------------
 
 Used by: [Storage](#Storage).
 
@@ -1223,8 +1223,8 @@ Used by: [Storage](#Storage).
 | "PremiumV2_LRS" |             |
 | "Premium_LRS"   |             |
 
-<a id="Storage_Type_STATUS"></a>Storage_Type_STATUS
----------------------------------------------------
+Storage_Type_STATUS{#Storage_Type_STATUS}
+-----------------------------------------
 
 Used by: [Storage_STATUS](#Storage_STATUS).
 
@@ -1233,7 +1233,19 @@ Used by: [Storage_STATUS](#Storage_STATUS).
 | "PremiumV2_LRS" |             |
 | "Premium_LRS"   |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1245,20 +1257,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_Type"></a>UserAssignedIdentity_Type
----------------------------------------------------------------
+UserAssignedIdentity_Type{#UserAssignedIdentity_Type}
+-----------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -1267,8 +1267,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="UserAssignedIdentity_Type_STATUS"></a>UserAssignedIdentity_Type_STATUS
------------------------------------------------------------------------------
+UserAssignedIdentity_Type_STATUS{#UserAssignedIdentity_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS).
 
@@ -1277,8 +1277,8 @@ Used by: [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1288,8 +1288,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentity_STATUS"></a>UserIdentity_STATUS
----------------------------------------------------
+UserIdentity_STATUS{#UserIdentity_STATUS}
+-----------------------------------------
 
 Describes a single user-assigned identity associated with the application.
 

--- a/docs/hugo/content/reference/devices/v1api20210702.md
+++ b/docs/hugo/content/reference/devices/v1api20210702.md
@@ -5,15 +5,15 @@ title: devices.azure.com/v1api20210702
 linktitle: v1api20210702
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-07-02" |             |
 
-<a id="IotHub"></a>IotHub
--------------------------
+IotHub{#IotHub}
+---------------
 
 Generator information: - Generated from: /iothub/resource-manager/Microsoft.Devices/stable/2021-07-02/iothub.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Devices/IotHubs/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [IotHubList](#IotHubList).
 | spec                                                                                    |             | [IotHub_Spec](#IotHub_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [IotHub_STATUS](#IotHub_STATUS)<br/><small>Optional</small> |
 
-### <a id="IotHub_Spec"></a>IotHub_Spec
+### IotHub_Spec {#IotHub_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [IotHubList](#IotHubList).
 | sku          | IotHub SKU info                                                                                                                                                                                                                                                                              | [IotHubSkuInfo](#IotHubSkuInfo)<br/><small>Required</small>                                                                                                          |
 | tags         | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="IotHub_STATUS"></a>IotHub_STATUS
+### IotHub_STATUS{#IotHub_STATUS}
 
 | Property   | Description                                                                                                                                    | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -55,8 +55,8 @@ Used by: [IotHubList](#IotHubList).
 | tags       | The resource tags.                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The resource type.                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="IotHubList"></a>IotHubList
----------------------------------
+IotHubList{#IotHubList}
+-----------------------
 
 Generator information: - Generated from: /iothub/resource-manager/Microsoft.Devices/stable/2021-07-02/iothub.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Devices/IotHubs/{resourceName}
 
@@ -66,8 +66,8 @@ Generator information: - Generated from: /iothub/resource-manager/Microsoft.Devi
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [IotHub[]](#IotHub)<br/><small>Optional</small> |
 
-<a id="IotHub_Spec"></a>IotHub_Spec
------------------------------------
+IotHub_Spec{#IotHub_Spec}
+-------------------------
 
 Used by: [IotHub](#IotHub).
 
@@ -82,8 +82,8 @@ Used by: [IotHub](#IotHub).
 | sku          | IotHub SKU info                                                                                                                                                                                                                                                                              | [IotHubSkuInfo](#IotHubSkuInfo)<br/><small>Required</small>                                                                                                          |
 | tags         | The resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="IotHub_STATUS"></a>IotHub_STATUS
----------------------------------------
+IotHub_STATUS{#IotHub_STATUS}
+-----------------------------
 
 Used by: [IotHub](#IotHub).
 
@@ -101,8 +101,8 @@ Used by: [IotHub](#IotHub).
 | tags       | The resource tags.                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The resource type.                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ArmIdentity"></a>ArmIdentity
------------------------------------
+ArmIdentity{#ArmIdentity}
+-------------------------
 
 Used by: [IotHub_Spec](#IotHub_Spec).
 
@@ -111,8 +111,8 @@ Used by: [IotHub_Spec](#IotHub_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service. | [ArmIdentity_Type](#ArmIdentity_Type)<br/><small>Optional</small>                         |
 | userAssignedIdentities |                                                                                                                                                                                                                                      | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ArmIdentity_STATUS"></a>ArmIdentity_STATUS
--------------------------------------------------
+ArmIdentity_STATUS{#ArmIdentity_STATUS}
+---------------------------------------
 
 Used by: [IotHub_STATUS](#IotHub_STATUS).
 
@@ -123,8 +123,8 @@ Used by: [IotHub_STATUS](#IotHub_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service. | [ArmIdentity_Type_STATUS](#ArmIdentity_Type_STATUS)<br/><small>Optional</small>          |
 | userAssignedIdentities |                                                                                                                                                                                                                                      | [map[string]ArmUserIdentity_STATUS](#ArmUserIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="IotHubOperatorSpec"></a>IotHubOperatorSpec
--------------------------------------------------
+IotHubOperatorSpec{#IotHubOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -136,8 +136,8 @@ Used by: [IotHub_Spec](#IotHub_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [IotHubOperatorSecrets](#IotHubOperatorSecrets)<br/><small>Optional</small>                                                                                         |
 
-<a id="IotHubProperties"></a>IotHubProperties
----------------------------------------------
+IotHubProperties{#IotHubProperties}
+-----------------------------------
 
 The properties of an IoT hub.
 
@@ -165,8 +165,8 @@ Used by: [IotHub_Spec](#IotHub_Spec).
 | routing                       | The routing related properties of the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging                                                                                                                                                                                                                                                          | [RoutingProperties](#RoutingProperties)<br/><small>Optional</small>                                             |
 | storageEndpoints              | The list of Azure Storage endpoints where you can upload files. Currently you can configure only one Azure Storage account and that MUST have its key as $default. Specifying more than one storage account causes an error to be thrown. Not specifying a value for this property when the enableFileUploadNotifications property is set to True, causes an error to be thrown. | [map[string]StorageEndpointProperties](#StorageEndpointProperties)<br/><small>Optional</small>                  |
 
-<a id="IotHubProperties_STATUS"></a>IotHubProperties_STATUS
------------------------------------------------------------
+IotHubProperties_STATUS{#IotHubProperties_STATUS}
+-------------------------------------------------
 
 The properties of an IoT hub.
 
@@ -199,8 +199,8 @@ Used by: [IotHub_STATUS](#IotHub_STATUS).
 | state                         | The hub state.                                                                                                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                            |
 | storageEndpoints              | The list of Azure Storage endpoints where you can upload files. Currently you can configure only one Azure Storage account and that MUST have its key as $default. Specifying more than one storage account causes an error to be thrown. Not specifying a value for this property when the enableFileUploadNotifications property is set to True, causes an error to be thrown. | [map[string]StorageEndpointProperties_STATUS](#StorageEndpointProperties_STATUS)<br/><small>Optional</small>                  |
 
-<a id="IotHubSkuInfo"></a>IotHubSkuInfo
----------------------------------------
+IotHubSkuInfo{#IotHubSkuInfo}
+-----------------------------
 
 Information about the SKU of the IoT hub.
 
@@ -211,8 +211,8 @@ Used by: [IotHub_Spec](#IotHub_Spec).
 | capacity | The number of provisioned IoT Hub units. See: https://docs.microsoft.com/azure/azure-subscription-service-limits#iot-hub-limits. | int<br/><small>Optional</small>                                       |
 | name     | The name of the SKU.                                                                                                             | [IotHubSkuInfo_Name](#IotHubSkuInfo_Name)<br/><small>Required</small> |
 
-<a id="IotHubSkuInfo_STATUS"></a>IotHubSkuInfo_STATUS
------------------------------------------------------
+IotHubSkuInfo_STATUS{#IotHubSkuInfo_STATUS}
+-------------------------------------------
 
 Information about the SKU of the IoT hub.
 
@@ -224,8 +224,8 @@ Used by: [IotHub_STATUS](#IotHub_STATUS).
 | name     | The name of the SKU.                                                                                                             | [IotHubSkuInfo_Name_STATUS](#IotHubSkuInfo_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier for the IoT hub.                                                                                                | [IotHubSkuInfo_Tier_STATUS](#IotHubSkuInfo_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -240,8 +240,8 @@ Used by: [IotHub_STATUS](#IotHub_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ArmIdentity_Type"></a>ArmIdentity_Type
----------------------------------------------
+ArmIdentity_Type{#ArmIdentity_Type}
+-----------------------------------
 
 Used by: [ArmIdentity](#ArmIdentity).
 
@@ -252,8 +252,8 @@ Used by: [ArmIdentity](#ArmIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ArmIdentity_Type_STATUS"></a>ArmIdentity_Type_STATUS
------------------------------------------------------------
+ArmIdentity_Type_STATUS{#ArmIdentity_Type_STATUS}
+-------------------------------------------------
 
 Used by: [ArmIdentity_STATUS](#ArmIdentity_STATUS).
 
@@ -264,8 +264,8 @@ Used by: [ArmIdentity_STATUS](#ArmIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ArmUserIdentity_STATUS"></a>ArmUserIdentity_STATUS
----------------------------------------------------------
+ArmUserIdentity_STATUS{#ArmUserIdentity_STATUS}
+-----------------------------------------------
 
 Used by: [ArmIdentity_STATUS](#ArmIdentity_STATUS).
 
@@ -274,8 +274,8 @@ Used by: [ArmIdentity_STATUS](#ArmIdentity_STATUS).
 | clientId    |             | string<br/><small>Optional</small> |
 | principalId |             | string<br/><small>Optional</small> |
 
-<a id="CloudToDeviceProperties"></a>CloudToDeviceProperties
------------------------------------------------------------
+CloudToDeviceProperties{#CloudToDeviceProperties}
+-------------------------------------------------
 
 The IoT hub cloud-to-device messaging properties.
 
@@ -287,8 +287,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | feedback            | The properties of the feedback queue for cloud-to-device messages.                                                                                                            | [FeedbackProperties](#FeedbackProperties)<br/><small>Optional</small> |
 | maxDeliveryCount    | The max delivery count for cloud-to-device messages in the device queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.   | int<br/><small>Optional</small>                                       |
 
-<a id="CloudToDeviceProperties_STATUS"></a>CloudToDeviceProperties_STATUS
--------------------------------------------------------------------------
+CloudToDeviceProperties_STATUS{#CloudToDeviceProperties_STATUS}
+---------------------------------------------------------------
 
 The IoT hub cloud-to-device messaging properties.
 
@@ -300,8 +300,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | feedback            | The properties of the feedback queue for cloud-to-device messages.                                                                                                            | [FeedbackProperties_STATUS](#FeedbackProperties_STATUS)<br/><small>Optional</small> |
 | maxDeliveryCount    | The max delivery count for cloud-to-device messages in the device queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.   | int<br/><small>Optional</small>                                                     |
 
-<a id="EventHubProperties"></a>EventHubProperties
--------------------------------------------------
+EventHubProperties{#EventHubProperties}
+---------------------------------------
 
 The properties of the provisioned Event Hub-compatible endpoint used by the IoT hub.
 
@@ -312,8 +312,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | partitionCount      | The number of partitions for receiving device-to-cloud messages in the Event Hub-compatible endpoint. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#device-to-cloud-messages. | int<br/><small>Optional</small> |
 | retentionTimeInDays | The retention time for device-to-cloud messages in days. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#device-to-cloud-messages                                               | int<br/><small>Optional</small> |
 
-<a id="EventHubProperties_STATUS"></a>EventHubProperties_STATUS
----------------------------------------------------------------
+EventHubProperties_STATUS{#EventHubProperties_STATUS}
+-----------------------------------------------------
 
 The properties of the provisioned Event Hub-compatible endpoint used by the IoT hub.
 
@@ -327,8 +327,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | path                | The Event Hub-compatible name.                                                                                                                                                                           | string<br/><small>Optional</small>   |
 | retentionTimeInDays | The retention time for device-to-cloud messages in days. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#device-to-cloud-messages                                               | int<br/><small>Optional</small>      |
 
-<a id="IotHubLocationDescription_STATUS"></a>IotHubLocationDescription_STATUS
------------------------------------------------------------------------------
+IotHubLocationDescription_STATUS{#IotHubLocationDescription_STATUS}
+-------------------------------------------------------------------
 
 Public representation of one of the locations where a resource is provisioned.
 
@@ -339,8 +339,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | location | The name of the Azure region                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                          |
 | role     | The role of the region, can be either primary or secondary. The primary region is where the IoT hub is currently provisioned. The secondary region is the Azure disaster recovery (DR) paired region and also the region where the IoT hub can failover to. | [IotHubLocationDescription_Role_STATUS](#IotHubLocationDescription_Role_STATUS)<br/><small>Optional</small> |
 
-<a id="IotHubOperatorSecrets"></a>IotHubOperatorSecrets
--------------------------------------------------------
+IotHubOperatorSecrets{#IotHubOperatorSecrets}
+---------------------------------------------
 
 Used by: [IotHubOperatorSpec](#IotHubOperatorSpec).
 
@@ -357,8 +357,8 @@ Used by: [IotHubOperatorSpec](#IotHubOperatorSpec).
 | servicePrimaryKey             | indicates where the ServicePrimaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.             | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | serviceSecondaryKey           | indicates where the ServiceSecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.           | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="IotHubProperties_Features"></a>IotHubProperties_Features
----------------------------------------------------------------
+IotHubProperties_Features{#IotHubProperties_Features}
+-----------------------------------------------------
 
 Used by: [IotHubProperties](#IotHubProperties).
 
@@ -367,8 +367,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | "DeviceManagement" |             |
 | "None"             |             |
 
-<a id="IotHubProperties_Features_STATUS"></a>IotHubProperties_Features_STATUS
------------------------------------------------------------------------------
+IotHubProperties_Features_STATUS{#IotHubProperties_Features_STATUS}
+-------------------------------------------------------------------
 
 Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 
@@ -377,8 +377,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | "DeviceManagement" |             |
 | "None"             |             |
 
-<a id="IotHubProperties_PublicNetworkAccess"></a>IotHubProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------
+IotHubProperties_PublicNetworkAccess{#IotHubProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------
 
 Used by: [IotHubProperties](#IotHubProperties).
 
@@ -387,8 +387,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="IotHubProperties_PublicNetworkAccess_STATUS"></a>IotHubProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------
+IotHubProperties_PublicNetworkAccess_STATUS{#IotHubProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 
@@ -397,8 +397,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="IotHubSkuInfo_Name"></a>IotHubSkuInfo_Name
--------------------------------------------------
+IotHubSkuInfo_Name{#IotHubSkuInfo_Name}
+---------------------------------------
 
 Used by: [IotHubSkuInfo](#IotHubSkuInfo).
 
@@ -412,8 +412,8 @@ Used by: [IotHubSkuInfo](#IotHubSkuInfo).
 | "S2"  |             |
 | "S3"  |             |
 
-<a id="IotHubSkuInfo_Name_STATUS"></a>IotHubSkuInfo_Name_STATUS
----------------------------------------------------------------
+IotHubSkuInfo_Name_STATUS{#IotHubSkuInfo_Name_STATUS}
+-----------------------------------------------------
 
 Used by: [IotHubSkuInfo_STATUS](#IotHubSkuInfo_STATUS).
 
@@ -427,8 +427,8 @@ Used by: [IotHubSkuInfo_STATUS](#IotHubSkuInfo_STATUS).
 | "S2"  |             |
 | "S3"  |             |
 
-<a id="IotHubSkuInfo_Tier_STATUS"></a>IotHubSkuInfo_Tier_STATUS
----------------------------------------------------------------
+IotHubSkuInfo_Tier_STATUS{#IotHubSkuInfo_Tier_STATUS}
+-----------------------------------------------------
 
 Used by: [IotHubSkuInfo_STATUS](#IotHubSkuInfo_STATUS).
 
@@ -438,8 +438,8 @@ Used by: [IotHubSkuInfo_STATUS](#IotHubSkuInfo_STATUS).
 | "Free"     |             |
 | "Standard" |             |
 
-<a id="IpFilterRule"></a>IpFilterRule
--------------------------------------
+IpFilterRule{#IpFilterRule}
+---------------------------
 
 The IP filter rules for the IoT hub.
 
@@ -451,8 +451,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | filterName | The name of the IP filter rule.                                            | string<br/><small>Required</small>                                      |
 | ipMask     | A string that contains the IP address range in CIDR notation for the rule. | string<br/><small>Required</small>                                      |
 
-<a id="IpFilterRule_STATUS"></a>IpFilterRule_STATUS
----------------------------------------------------
+IpFilterRule_STATUS{#IpFilterRule_STATUS}
+-----------------------------------------
 
 The IP filter rules for the IoT hub.
 
@@ -464,8 +464,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | filterName | The name of the IP filter rule.                                            | string<br/><small>Optional</small>                                                    |
 | ipMask     | A string that contains the IP address range in CIDR notation for the rule. | string<br/><small>Optional</small>                                                    |
 
-<a id="MessagingEndpointProperties"></a>MessagingEndpointProperties
--------------------------------------------------------------------
+MessagingEndpointProperties{#MessagingEndpointProperties}
+---------------------------------------------------------
 
 The properties of the messaging endpoints used by this IoT hub.
 
@@ -477,8 +477,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | maxDeliveryCount      | The number of times the IoT hub attempts to deliver a message. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload.                                      | int<br/><small>Optional</small>    |
 | ttlAsIso8601          | The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload. | string<br/><small>Optional</small> |
 
-<a id="MessagingEndpointProperties_STATUS"></a>MessagingEndpointProperties_STATUS
----------------------------------------------------------------------------------
+MessagingEndpointProperties_STATUS{#MessagingEndpointProperties_STATUS}
+-----------------------------------------------------------------------
 
 The properties of the messaging endpoints used by this IoT hub.
 
@@ -490,8 +490,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | maxDeliveryCount      | The number of times the IoT hub attempts to deliver a message. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload.                                      | int<br/><small>Optional</small>    |
 | ttlAsIso8601          | The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload. | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSetProperties"></a>NetworkRuleSetProperties
--------------------------------------------------------------
+NetworkRuleSetProperties{#NetworkRuleSetProperties}
+---------------------------------------------------
 
 Network Rule Set Properties of IotHub
 
@@ -503,8 +503,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | defaultAction                  | Default Action for Network Rule Set                                                   | [NetworkRuleSetProperties_DefaultAction](#NetworkRuleSetProperties_DefaultAction)<br/><small>Optional</small> |
 | ipRules                        | List of IP Rules                                                                      | [NetworkRuleSetIpRule[]](#NetworkRuleSetIpRule)<br/><small>Required</small>                                   |
 
-<a id="NetworkRuleSetProperties_STATUS"></a>NetworkRuleSetProperties_STATUS
----------------------------------------------------------------------------
+NetworkRuleSetProperties_STATUS{#NetworkRuleSetProperties_STATUS}
+-----------------------------------------------------------------
 
 Network Rule Set Properties of IotHub
 
@@ -516,8 +516,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | defaultAction                  | Default Action for Network Rule Set                                                   | [NetworkRuleSetProperties_DefaultAction_STATUS](#NetworkRuleSetProperties_DefaultAction_STATUS)<br/><small>Optional</small> |
 | ipRules                        | List of IP Rules                                                                      | [NetworkRuleSetIpRule_STATUS[]](#NetworkRuleSetIpRule_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The private endpoint connection of an IotHub
 
@@ -527,8 +527,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 |----------|--------------------------|------------------------------------|
 | id       | The resource identifier. | string<br/><small>Optional</small> |
 
-<a id="RoutingProperties"></a>RoutingProperties
------------------------------------------------
+RoutingProperties{#RoutingProperties}
+-------------------------------------
 
 The routing related properties of the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging
 
@@ -541,8 +541,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | fallbackRoute | The properties of the route that is used as a fall-back route when none of the conditions specified in the 'routes' section are met. This is an optional parameter. When this property is not present in the template, the fallback route is disabled by default.                    | [FallbackRouteProperties](#FallbackRouteProperties)<br/><small>Optional</small> |
 | routes        | The list of user-provided routing rules that the IoT hub uses to route messages to built-in and custom endpoints. A maximum of 100 routing rules are allowed for paid hubs and a maximum of 5 routing rules are allowed for free hubs.                                               | [RouteProperties[]](#RouteProperties)<br/><small>Optional</small>               |
 
-<a id="RoutingProperties_STATUS"></a>RoutingProperties_STATUS
--------------------------------------------------------------
+RoutingProperties_STATUS{#RoutingProperties_STATUS}
+---------------------------------------------------
 
 The routing related properties of the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging
 
@@ -555,8 +555,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | fallbackRoute | The properties of the route that is used as a fall-back route when none of the conditions specified in the 'routes' section are met. This is an optional parameter. When this property is not present in the template, the fallback route is disabled by default.                    | [FallbackRouteProperties_STATUS](#FallbackRouteProperties_STATUS)<br/><small>Optional</small> |
 | routes        | The list of user-provided routing rules that the IoT hub uses to route messages to built-in and custom endpoints. A maximum of 100 routing rules are allowed for paid hubs and a maximum of 5 routing rules are allowed for free hubs.                                               | [RouteProperties_STATUS[]](#RouteProperties_STATUS)<br/><small>Optional</small>               |
 
-<a id="SharedAccessSignatureAuthorizationRule"></a>SharedAccessSignatureAuthorizationRule
------------------------------------------------------------------------------------------
+SharedAccessSignatureAuthorizationRule{#SharedAccessSignatureAuthorizationRule}
+-------------------------------------------------------------------------------
 
 The properties of an IoT hub shared access policy.
 
@@ -567,8 +567,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | keyName  | The name of the shared access policy.                 | string<br/><small>Required</small>                                                                                          |
 | rights   | The permissions assigned to the shared access policy. | [SharedAccessSignatureAuthorizationRule_Rights](#SharedAccessSignatureAuthorizationRule_Rights)<br/><small>Required</small> |
 
-<a id="SharedAccessSignatureAuthorizationRule_STATUS"></a>SharedAccessSignatureAuthorizationRule_STATUS
--------------------------------------------------------------------------------------------------------
+SharedAccessSignatureAuthorizationRule_STATUS{#SharedAccessSignatureAuthorizationRule_STATUS}
+---------------------------------------------------------------------------------------------
 
 The properties of an IoT hub shared access policy.
 
@@ -579,8 +579,8 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | keyName  | The name of the shared access policy.                 | string<br/><small>Optional</small>                                                                                                        |
 | rights   | The permissions assigned to the shared access policy. | [SharedAccessSignatureAuthorizationRule_Rights_STATUS](#SharedAccessSignatureAuthorizationRule_Rights_STATUS)<br/><small>Optional</small> |
 
-<a id="StorageEndpointProperties"></a>StorageEndpointProperties
----------------------------------------------------------------
+StorageEndpointProperties{#StorageEndpointProperties}
+-----------------------------------------------------
 
 The properties of the Azure Storage endpoint for file upload.
 
@@ -594,8 +594,8 @@ Used by: [IotHubProperties](#IotHubProperties).
 | identity           | Managed identity properties of storage endpoint for file upload.                                                                                                                                                   | [ManagedIdentity](#ManagedIdentity)<br/><small>Optional</small>                                                                                        |
 | sasTtlAsIso8601    | The period of time for which the SAS URI generated by IoT Hub for file upload is valid. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-notification-configuration-options. | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="StorageEndpointProperties_STATUS"></a>StorageEndpointProperties_STATUS
------------------------------------------------------------------------------
+StorageEndpointProperties_STATUS{#StorageEndpointProperties_STATUS}
+-------------------------------------------------------------------
 
 The properties of the Azure Storage endpoint for file upload.
 
@@ -608,7 +608,19 @@ Used by: [IotHubProperties_STATUS](#IotHubProperties_STATUS).
 | identity           | Managed identity properties of storage endpoint for file upload.                                                                                                                                                   | [ManagedIdentity_STATUS](#ManagedIdentity_STATUS)<br/><small>Optional</small>                                                           |
 | sasTtlAsIso8601    | The period of time for which the SAS URI generated by IoT Hub for file upload is valid. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-notification-configuration-options. | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -620,20 +632,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -643,8 +643,8 @@ Used by: [ArmIdentity](#ArmIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EnrichmentProperties"></a>EnrichmentProperties
------------------------------------------------------
+EnrichmentProperties{#EnrichmentProperties}
+-------------------------------------------
 
 The properties of an enrichment that your IoT hub applies to messages delivered to endpoints.
 
@@ -656,8 +656,8 @@ Used by: [RoutingProperties](#RoutingProperties).
 | key           | The key or name for the enrichment property.                              | string<br/><small>Required</small>   |
 | value         | The value for the enrichment property.                                    | string<br/><small>Required</small>   |
 
-<a id="EnrichmentProperties_STATUS"></a>EnrichmentProperties_STATUS
--------------------------------------------------------------------
+EnrichmentProperties_STATUS{#EnrichmentProperties_STATUS}
+---------------------------------------------------------
 
 The properties of an enrichment that your IoT hub applies to messages delivered to endpoints.
 
@@ -669,8 +669,8 @@ Used by: [RoutingProperties_STATUS](#RoutingProperties_STATUS).
 | key           | The key or name for the enrichment property.                              | string<br/><small>Optional</small>   |
 | value         | The value for the enrichment property.                                    | string<br/><small>Optional</small>   |
 
-<a id="FallbackRouteProperties"></a>FallbackRouteProperties
------------------------------------------------------------
+FallbackRouteProperties{#FallbackRouteProperties}
+-------------------------------------------------
 
 The properties of the fallback route. IoT Hub uses these properties when it routes messages to the fallback endpoint.
 
@@ -684,8 +684,8 @@ Used by: [RoutingProperties](#RoutingProperties).
 | name          | The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.                                                                     | string<br/><small>Optional</small>                                                            |
 | source        | The source to which the routing rule is to be applied to. For example, DeviceMessages                                                                                                                                                   | [FallbackRouteProperties_Source](#FallbackRouteProperties_Source)<br/><small>Required</small> |
 
-<a id="FallbackRouteProperties_STATUS"></a>FallbackRouteProperties_STATUS
--------------------------------------------------------------------------
+FallbackRouteProperties_STATUS{#FallbackRouteProperties_STATUS}
+---------------------------------------------------------------
 
 The properties of the fallback route. IoT Hub uses these properties when it routes messages to the fallback endpoint.
 
@@ -699,8 +699,8 @@ Used by: [RoutingProperties_STATUS](#RoutingProperties_STATUS).
 | name          | The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.                                                                     | string<br/><small>Optional</small>                                                                          |
 | source        | The source to which the routing rule is to be applied to. For example, DeviceMessages                                                                                                                                                   | [FallbackRouteProperties_Source_STATUS](#FallbackRouteProperties_Source_STATUS)<br/><small>Optional</small> |
 
-<a id="FeedbackProperties"></a>FeedbackProperties
--------------------------------------------------
+FeedbackProperties{#FeedbackProperties}
+---------------------------------------
 
 The properties of the feedback queue for cloud-to-device messages.
 
@@ -712,8 +712,8 @@ Used by: [CloudToDeviceProperties](#CloudToDeviceProperties).
 | maxDeliveryCount      | The number of times the IoT hub attempts to deliver a message on the feedback queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.                | int<br/><small>Optional</small>    |
 | ttlAsIso8601          | The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages. | string<br/><small>Optional</small> |
 
-<a id="FeedbackProperties_STATUS"></a>FeedbackProperties_STATUS
----------------------------------------------------------------
+FeedbackProperties_STATUS{#FeedbackProperties_STATUS}
+-----------------------------------------------------
 
 The properties of the feedback queue for cloud-to-device messages.
 
@@ -725,8 +725,8 @@ Used by: [CloudToDeviceProperties_STATUS](#CloudToDeviceProperties_STATUS).
 | maxDeliveryCount      | The number of times the IoT hub attempts to deliver a message on the feedback queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.                | int<br/><small>Optional</small>    |
 | ttlAsIso8601          | The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages. | string<br/><small>Optional</small> |
 
-<a id="IotHubLocationDescription_Role_STATUS"></a>IotHubLocationDescription_Role_STATUS
----------------------------------------------------------------------------------------
+IotHubLocationDescription_Role_STATUS{#IotHubLocationDescription_Role_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [IotHubLocationDescription_STATUS](#IotHubLocationDescription_STATUS).
 
@@ -735,8 +735,8 @@ Used by: [IotHubLocationDescription_STATUS](#IotHubLocationDescription_STATUS).
 | "primary"   |             |
 | "secondary" |             |
 
-<a id="IpFilterRule_Action"></a>IpFilterRule_Action
----------------------------------------------------
+IpFilterRule_Action{#IpFilterRule_Action}
+-----------------------------------------
 
 Used by: [IpFilterRule](#IpFilterRule).
 
@@ -745,8 +745,8 @@ Used by: [IpFilterRule](#IpFilterRule).
 | "Accept" |             |
 | "Reject" |             |
 
-<a id="IpFilterRule_Action_STATUS"></a>IpFilterRule_Action_STATUS
------------------------------------------------------------------
+IpFilterRule_Action_STATUS{#IpFilterRule_Action_STATUS}
+-------------------------------------------------------
 
 Used by: [IpFilterRule_STATUS](#IpFilterRule_STATUS).
 
@@ -755,8 +755,8 @@ Used by: [IpFilterRule_STATUS](#IpFilterRule_STATUS).
 | "Accept" |             |
 | "Reject" |             |
 
-<a id="ManagedIdentity"></a>ManagedIdentity
--------------------------------------------
+ManagedIdentity{#ManagedIdentity}
+---------------------------------
 
 The properties of the Managed identity.
 
@@ -766,8 +766,8 @@ Used by: [RoutingEventHubProperties](#RoutingEventHubProperties), [RoutingServic
 |----------------------|-----------------------------|------------------------------------|
 | userAssignedIdentity | The user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentity_STATUS"></a>ManagedIdentity_STATUS
----------------------------------------------------------
+ManagedIdentity_STATUS{#ManagedIdentity_STATUS}
+-----------------------------------------------
 
 The properties of the Managed identity.
 
@@ -777,8 +777,8 @@ Used by: [RoutingEventHubProperties_STATUS](#RoutingEventHubProperties_STATUS), 
 |----------------------|-----------------------------|------------------------------------|
 | userAssignedIdentity | The user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSetIpRule"></a>NetworkRuleSetIpRule
------------------------------------------------------
+NetworkRuleSetIpRule{#NetworkRuleSetIpRule}
+-------------------------------------------
 
 IP Rule to be applied as part of Network Rule Set
 
@@ -790,8 +790,8 @@ Used by: [NetworkRuleSetProperties](#NetworkRuleSetProperties).
 | filterName | Name of the IP filter rule.                                                | string<br/><small>Required</small>                                                      |
 | ipMask     | A string that contains the IP address range in CIDR notation for the rule. | string<br/><small>Required</small>                                                      |
 
-<a id="NetworkRuleSetIpRule_STATUS"></a>NetworkRuleSetIpRule_STATUS
--------------------------------------------------------------------
+NetworkRuleSetIpRule_STATUS{#NetworkRuleSetIpRule_STATUS}
+---------------------------------------------------------
 
 IP Rule to be applied as part of Network Rule Set
 
@@ -803,8 +803,8 @@ Used by: [NetworkRuleSetProperties_STATUS](#NetworkRuleSetProperties_STATUS).
 | filterName | Name of the IP filter rule.                                                | string<br/><small>Optional</small>                                                                    |
 | ipMask     | A string that contains the IP address range in CIDR notation for the rule. | string<br/><small>Optional</small>                                                                    |
 
-<a id="NetworkRuleSetProperties_DefaultAction"></a>NetworkRuleSetProperties_DefaultAction
------------------------------------------------------------------------------------------
+NetworkRuleSetProperties_DefaultAction{#NetworkRuleSetProperties_DefaultAction}
+-------------------------------------------------------------------------------
 
 Used by: [NetworkRuleSetProperties](#NetworkRuleSetProperties).
 
@@ -813,8 +813,8 @@ Used by: [NetworkRuleSetProperties](#NetworkRuleSetProperties).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSetProperties_DefaultAction_STATUS"></a>NetworkRuleSetProperties_DefaultAction_STATUS
--------------------------------------------------------------------------------------------------------
+NetworkRuleSetProperties_DefaultAction_STATUS{#NetworkRuleSetProperties_DefaultAction_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [NetworkRuleSetProperties_STATUS](#NetworkRuleSetProperties_STATUS).
 
@@ -823,8 +823,8 @@ Used by: [NetworkRuleSetProperties_STATUS](#NetworkRuleSetProperties_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="RouteProperties"></a>RouteProperties
--------------------------------------------
+RouteProperties{#RouteProperties}
+---------------------------------
 
 The properties of a routing rule that your IoT hub uses to route messages to endpoints.
 
@@ -838,8 +838,8 @@ Used by: [RoutingProperties](#RoutingProperties).
 | name          | The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.                                                 | string<br/><small>Required</small>                                            |
 | source        | The source that the routing rule is to be applied to, such as DeviceMessages.                                                                                                                                       | [RouteProperties_Source](#RouteProperties_Source)<br/><small>Required</small> |
 
-<a id="RouteProperties_STATUS"></a>RouteProperties_STATUS
----------------------------------------------------------
+RouteProperties_STATUS{#RouteProperties_STATUS}
+-----------------------------------------------
 
 The properties of a routing rule that your IoT hub uses to route messages to endpoints.
 
@@ -853,8 +853,8 @@ Used by: [RoutingProperties_STATUS](#RoutingProperties_STATUS).
 | name          | The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.                                                 | string<br/><small>Optional</small>                                                          |
 | source        | The source that the routing rule is to be applied to, such as DeviceMessages.                                                                                                                                       | [RouteProperties_Source_STATUS](#RouteProperties_Source_STATUS)<br/><small>Optional</small> |
 
-<a id="RoutingEndpoints"></a>RoutingEndpoints
----------------------------------------------
+RoutingEndpoints{#RoutingEndpoints}
+-----------------------------------
 
 The properties related to the custom endpoints to which your IoT hub routes messages based on the routing rules. A maximum of 10 custom endpoints are allowed across all endpoint types for paid hubs and only 1 custom endpoint is allowed across all endpoint types for free hubs.
 
@@ -867,8 +867,8 @@ Used by: [RoutingProperties](#RoutingProperties).
 | serviceBusTopics  | The list of Service Bus topic endpoints that the IoT hub routes the messages to, based on the routing rules.                                               | [RoutingServiceBusTopicEndpointProperties[]](#RoutingServiceBusTopicEndpointProperties)<br/><small>Optional</small> |
 | storageContainers | The list of storage container endpoints that IoT hub routes messages to, based on the routing rules.                                                       | [RoutingStorageContainerProperties[]](#RoutingStorageContainerProperties)<br/><small>Optional</small>               |
 
-<a id="RoutingEndpoints_STATUS"></a>RoutingEndpoints_STATUS
------------------------------------------------------------
+RoutingEndpoints_STATUS{#RoutingEndpoints_STATUS}
+-------------------------------------------------
 
 The properties related to the custom endpoints to which your IoT hub routes messages based on the routing rules. A maximum of 10 custom endpoints are allowed across all endpoint types for paid hubs and only 1 custom endpoint is allowed across all endpoint types for free hubs.
 
@@ -881,8 +881,8 @@ Used by: [RoutingProperties_STATUS](#RoutingProperties_STATUS).
 | serviceBusTopics  | The list of Service Bus topic endpoints that the IoT hub routes the messages to, based on the routing rules.                                               | [RoutingServiceBusTopicEndpointProperties_STATUS[]](#RoutingServiceBusTopicEndpointProperties_STATUS)<br/><small>Optional</small> |
 | storageContainers | The list of storage container endpoints that IoT hub routes messages to, based on the routing rules.                                                       | [RoutingStorageContainerProperties_STATUS[]](#RoutingStorageContainerProperties_STATUS)<br/><small>Optional</small>               |
 
-<a id="SharedAccessSignatureAuthorizationRule_Rights"></a>SharedAccessSignatureAuthorizationRule_Rights
--------------------------------------------------------------------------------------------------------
+SharedAccessSignatureAuthorizationRule_Rights{#SharedAccessSignatureAuthorizationRule_Rights}
+---------------------------------------------------------------------------------------------
 
 Used by: [SharedAccessSignatureAuthorizationRule](#SharedAccessSignatureAuthorizationRule).
 
@@ -904,8 +904,8 @@ Used by: [SharedAccessSignatureAuthorizationRule](#SharedAccessSignatureAuthoriz
 | "ServiceConnect"                                             |             |
 | "ServiceConnect, DeviceConnect"                              |             |
 
-<a id="SharedAccessSignatureAuthorizationRule_Rights_STATUS"></a>SharedAccessSignatureAuthorizationRule_Rights_STATUS
----------------------------------------------------------------------------------------------------------------------
+SharedAccessSignatureAuthorizationRule_Rights_STATUS{#SharedAccessSignatureAuthorizationRule_Rights_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [SharedAccessSignatureAuthorizationRule_STATUS](#SharedAccessSignatureAuthorizationRule_STATUS).
 
@@ -927,8 +927,8 @@ Used by: [SharedAccessSignatureAuthorizationRule_STATUS](#SharedAccessSignatureA
 | "ServiceConnect"                                             |             |
 | "ServiceConnect, DeviceConnect"                              |             |
 
-<a id="StorageEndpointProperties_AuthenticationType"></a>StorageEndpointProperties_AuthenticationType
------------------------------------------------------------------------------------------------------
+StorageEndpointProperties_AuthenticationType{#StorageEndpointProperties_AuthenticationType}
+-------------------------------------------------------------------------------------------
 
 Used by: [StorageEndpointProperties](#StorageEndpointProperties).
 
@@ -937,8 +937,8 @@ Used by: [StorageEndpointProperties](#StorageEndpointProperties).
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="StorageEndpointProperties_AuthenticationType_STATUS"></a>StorageEndpointProperties_AuthenticationType_STATUS
--------------------------------------------------------------------------------------------------------------------
+StorageEndpointProperties_AuthenticationType_STATUS{#StorageEndpointProperties_AuthenticationType_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageEndpointProperties_STATUS](#StorageEndpointProperties_STATUS).
 
@@ -947,8 +947,8 @@ Used by: [StorageEndpointProperties_STATUS](#StorageEndpointProperties_STATUS).
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="FallbackRouteProperties_Source"></a>FallbackRouteProperties_Source
--------------------------------------------------------------------------
+FallbackRouteProperties_Source{#FallbackRouteProperties_Source}
+---------------------------------------------------------------
 
 Used by: [FallbackRouteProperties](#FallbackRouteProperties).
 
@@ -956,8 +956,8 @@ Used by: [FallbackRouteProperties](#FallbackRouteProperties).
 |------------------|-------------|
 | "DeviceMessages" |             |
 
-<a id="FallbackRouteProperties_Source_STATUS"></a>FallbackRouteProperties_Source_STATUS
----------------------------------------------------------------------------------------
+FallbackRouteProperties_Source_STATUS{#FallbackRouteProperties_Source_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [FallbackRouteProperties_STATUS](#FallbackRouteProperties_STATUS).
 
@@ -965,8 +965,8 @@ Used by: [FallbackRouteProperties_STATUS](#FallbackRouteProperties_STATUS).
 |------------------|-------------|
 | "DeviceMessages" |             |
 
-<a id="NetworkRuleSetIpRule_Action"></a>NetworkRuleSetIpRule_Action
--------------------------------------------------------------------
+NetworkRuleSetIpRule_Action{#NetworkRuleSetIpRule_Action}
+---------------------------------------------------------
 
 Used by: [NetworkRuleSetIpRule](#NetworkRuleSetIpRule).
 
@@ -974,8 +974,8 @@ Used by: [NetworkRuleSetIpRule](#NetworkRuleSetIpRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="NetworkRuleSetIpRule_Action_STATUS"></a>NetworkRuleSetIpRule_Action_STATUS
----------------------------------------------------------------------------------
+NetworkRuleSetIpRule_Action_STATUS{#NetworkRuleSetIpRule_Action_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NetworkRuleSetIpRule_STATUS](#NetworkRuleSetIpRule_STATUS).
 
@@ -983,8 +983,8 @@ Used by: [NetworkRuleSetIpRule_STATUS](#NetworkRuleSetIpRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="RouteProperties_Source"></a>RouteProperties_Source
----------------------------------------------------------
+RouteProperties_Source{#RouteProperties_Source}
+-----------------------------------------------
 
 Used by: [RouteProperties](#RouteProperties).
 
@@ -997,8 +997,8 @@ Used by: [RouteProperties](#RouteProperties).
 | "Invalid"                     |             |
 | "TwinChangeEvents"            |             |
 
-<a id="RouteProperties_Source_STATUS"></a>RouteProperties_Source_STATUS
------------------------------------------------------------------------
+RouteProperties_Source_STATUS{#RouteProperties_Source_STATUS}
+-------------------------------------------------------------
 
 Used by: [RouteProperties_STATUS](#RouteProperties_STATUS).
 
@@ -1011,8 +1011,8 @@ Used by: [RouteProperties_STATUS](#RouteProperties_STATUS).
 | "Invalid"                     |             |
 | "TwinChangeEvents"            |             |
 
-<a id="RoutingEventHubProperties"></a>RoutingEventHubProperties
----------------------------------------------------------------
+RoutingEventHubProperties{#RoutingEventHubProperties}
+-----------------------------------------------------
 
 The properties related to an event hub endpoint.
 
@@ -1030,8 +1030,8 @@ Used by: [RoutingEndpoints](#RoutingEndpoints).
 | resourceGroup      | The name of the resource group of the event hub endpoint.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 | subscriptionId     | The subscription identifier of the event hub endpoint.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="RoutingEventHubProperties_STATUS"></a>RoutingEventHubProperties_STATUS
------------------------------------------------------------------------------
+RoutingEventHubProperties_STATUS{#RoutingEventHubProperties_STATUS}
+-------------------------------------------------------------------
 
 The properties related to an event hub endpoint.
 
@@ -1048,8 +1048,8 @@ Used by: [RoutingEndpoints_STATUS](#RoutingEndpoints_STATUS).
 | resourceGroup      | The name of the resource group of the event hub endpoint.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                      |
 | subscriptionId     | The subscription identifier of the event hub endpoint.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="RoutingServiceBusQueueEndpointProperties"></a>RoutingServiceBusQueueEndpointProperties
----------------------------------------------------------------------------------------------
+RoutingServiceBusQueueEndpointProperties{#RoutingServiceBusQueueEndpointProperties}
+-----------------------------------------------------------------------------------
 
 The properties related to service bus queue endpoint types.
 
@@ -1067,8 +1067,8 @@ Used by: [RoutingEndpoints](#RoutingEndpoints).
 | resourceGroup      | The name of the resource group of the service bus queue endpoint.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 | subscriptionId     | The subscription identifier of the service bus queue endpoint.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="RoutingServiceBusQueueEndpointProperties_STATUS"></a>RoutingServiceBusQueueEndpointProperties_STATUS
------------------------------------------------------------------------------------------------------------
+RoutingServiceBusQueueEndpointProperties_STATUS{#RoutingServiceBusQueueEndpointProperties_STATUS}
+-------------------------------------------------------------------------------------------------
 
 The properties related to service bus queue endpoint types.
 
@@ -1085,8 +1085,8 @@ Used by: [RoutingEndpoints_STATUS](#RoutingEndpoints_STATUS).
 | resourceGroup      | The name of the resource group of the service bus queue endpoint.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                    |
 | subscriptionId     | The subscription identifier of the service bus queue endpoint.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                    |
 
-<a id="RoutingServiceBusTopicEndpointProperties"></a>RoutingServiceBusTopicEndpointProperties
----------------------------------------------------------------------------------------------
+RoutingServiceBusTopicEndpointProperties{#RoutingServiceBusTopicEndpointProperties}
+-----------------------------------------------------------------------------------
 
 The properties related to service bus topic endpoint types.
 
@@ -1104,8 +1104,8 @@ Used by: [RoutingEndpoints](#RoutingEndpoints).
 | resourceGroup      | The name of the resource group of the service bus topic endpoint.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                         |
 | subscriptionId     | The subscription identifier of the service bus topic endpoint.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="RoutingServiceBusTopicEndpointProperties_STATUS"></a>RoutingServiceBusTopicEndpointProperties_STATUS
------------------------------------------------------------------------------------------------------------
+RoutingServiceBusTopicEndpointProperties_STATUS{#RoutingServiceBusTopicEndpointProperties_STATUS}
+-------------------------------------------------------------------------------------------------
 
 The properties related to service bus topic endpoint types.
 
@@ -1122,8 +1122,8 @@ Used by: [RoutingEndpoints_STATUS](#RoutingEndpoints_STATUS).
 | resourceGroup      | The name of the resource group of the service bus topic endpoint.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                    |
 | subscriptionId     | The subscription identifier of the service bus topic endpoint.                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                                    |
 
-<a id="RoutingStorageContainerProperties"></a>RoutingStorageContainerProperties
--------------------------------------------------------------------------------
+RoutingStorageContainerProperties{#RoutingStorageContainerProperties}
+---------------------------------------------------------------------
 
 The properties related to a storage container endpoint.
 
@@ -1145,8 +1145,8 @@ Used by: [RoutingEndpoints](#RoutingEndpoints).
 | resourceGroup           | The name of the resource group of the storage account.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                         |
 | subscriptionId          | The subscription identifier of the storage account.                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="RoutingStorageContainerProperties_STATUS"></a>RoutingStorageContainerProperties_STATUS
----------------------------------------------------------------------------------------------
+RoutingStorageContainerProperties_STATUS{#RoutingStorageContainerProperties_STATUS}
+-----------------------------------------------------------------------------------
 
 The properties related to a storage container endpoint.
 
@@ -1167,8 +1167,8 @@ Used by: [RoutingEndpoints_STATUS](#RoutingEndpoints_STATUS).
 | resourceGroup           | The name of the resource group of the storage account.                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | subscriptionId          | The subscription identifier of the storage account.                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RoutingEventHubProperties_AuthenticationType"></a>RoutingEventHubProperties_AuthenticationType
------------------------------------------------------------------------------------------------------
+RoutingEventHubProperties_AuthenticationType{#RoutingEventHubProperties_AuthenticationType}
+-------------------------------------------------------------------------------------------
 
 Used by: [RoutingEventHubProperties](#RoutingEventHubProperties).
 
@@ -1177,8 +1177,8 @@ Used by: [RoutingEventHubProperties](#RoutingEventHubProperties).
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingEventHubProperties_AuthenticationType_STATUS"></a>RoutingEventHubProperties_AuthenticationType_STATUS
--------------------------------------------------------------------------------------------------------------------
+RoutingEventHubProperties_AuthenticationType_STATUS{#RoutingEventHubProperties_AuthenticationType_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingEventHubProperties_STATUS](#RoutingEventHubProperties_STATUS).
 
@@ -1187,8 +1187,8 @@ Used by: [RoutingEventHubProperties_STATUS](#RoutingEventHubProperties_STATUS).
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingServiceBusQueueEndpointProperties_AuthenticationType"></a>RoutingServiceBusQueueEndpointProperties_AuthenticationType
------------------------------------------------------------------------------------------------------------------------------------
+RoutingServiceBusQueueEndpointProperties_AuthenticationType{#RoutingServiceBusQueueEndpointProperties_AuthenticationType}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingServiceBusQueueEndpointProperties](#RoutingServiceBusQueueEndpointProperties).
 
@@ -1197,8 +1197,8 @@ Used by: [RoutingServiceBusQueueEndpointProperties](#RoutingServiceBusQueueEndpo
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingServiceBusQueueEndpointProperties_AuthenticationType_STATUS"></a>RoutingServiceBusQueueEndpointProperties_AuthenticationType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------
+RoutingServiceBusQueueEndpointProperties_AuthenticationType_STATUS{#RoutingServiceBusQueueEndpointProperties_AuthenticationType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingServiceBusQueueEndpointProperties_STATUS](#RoutingServiceBusQueueEndpointProperties_STATUS).
 
@@ -1207,8 +1207,8 @@ Used by: [RoutingServiceBusQueueEndpointProperties_STATUS](#RoutingServiceBusQue
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingServiceBusTopicEndpointProperties_AuthenticationType"></a>RoutingServiceBusTopicEndpointProperties_AuthenticationType
------------------------------------------------------------------------------------------------------------------------------------
+RoutingServiceBusTopicEndpointProperties_AuthenticationType{#RoutingServiceBusTopicEndpointProperties_AuthenticationType}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingServiceBusTopicEndpointProperties](#RoutingServiceBusTopicEndpointProperties).
 
@@ -1217,8 +1217,8 @@ Used by: [RoutingServiceBusTopicEndpointProperties](#RoutingServiceBusTopicEndpo
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingServiceBusTopicEndpointProperties_AuthenticationType_STATUS"></a>RoutingServiceBusTopicEndpointProperties_AuthenticationType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------
+RoutingServiceBusTopicEndpointProperties_AuthenticationType_STATUS{#RoutingServiceBusTopicEndpointProperties_AuthenticationType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingServiceBusTopicEndpointProperties_STATUS](#RoutingServiceBusTopicEndpointProperties_STATUS).
 
@@ -1227,8 +1227,8 @@ Used by: [RoutingServiceBusTopicEndpointProperties_STATUS](#RoutingServiceBusTop
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingStorageContainerProperties_AuthenticationType"></a>RoutingStorageContainerProperties_AuthenticationType
----------------------------------------------------------------------------------------------------------------------
+RoutingStorageContainerProperties_AuthenticationType{#RoutingStorageContainerProperties_AuthenticationType}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingStorageContainerProperties](#RoutingStorageContainerProperties).
 
@@ -1237,8 +1237,8 @@ Used by: [RoutingStorageContainerProperties](#RoutingStorageContainerProperties)
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingStorageContainerProperties_AuthenticationType_STATUS"></a>RoutingStorageContainerProperties_AuthenticationType_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+RoutingStorageContainerProperties_AuthenticationType_STATUS{#RoutingStorageContainerProperties_AuthenticationType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [RoutingStorageContainerProperties_STATUS](#RoutingStorageContainerProperties_STATUS).
 
@@ -1247,8 +1247,8 @@ Used by: [RoutingStorageContainerProperties_STATUS](#RoutingStorageContainerProp
 | "identityBased" |             |
 | "keyBased"      |             |
 
-<a id="RoutingStorageContainerProperties_Encoding"></a>RoutingStorageContainerProperties_Encoding
--------------------------------------------------------------------------------------------------
+RoutingStorageContainerProperties_Encoding{#RoutingStorageContainerProperties_Encoding}
+---------------------------------------------------------------------------------------
 
 Used by: [RoutingStorageContainerProperties](#RoutingStorageContainerProperties).
 
@@ -1258,8 +1258,8 @@ Used by: [RoutingStorageContainerProperties](#RoutingStorageContainerProperties)
 | "AvroDeflate" |             |
 | "JSON"        |             |
 
-<a id="RoutingStorageContainerProperties_Encoding_STATUS"></a>RoutingStorageContainerProperties_Encoding_STATUS
----------------------------------------------------------------------------------------------------------------
+RoutingStorageContainerProperties_Encoding_STATUS{#RoutingStorageContainerProperties_Encoding_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [RoutingStorageContainerProperties_STATUS](#RoutingStorageContainerProperties_STATUS).
 

--- a/docs/hugo/content/reference/documentdb/v1api20210515.md
+++ b/docs/hugo/content/reference/documentdb/v1api20210515.md
@@ -5,15 +5,15 @@ title: documentdb.azure.com/v1api20210515
 linktitle: v1api20210515
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-05-15" |             |
 
-<a id="DatabaseAccount"></a>DatabaseAccount
--------------------------------------------
+DatabaseAccount{#DatabaseAccount}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | spec                                                                                    |             | [DatabaseAccount_Spec](#DatabaseAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DatabaseAccount_STATUS](#DatabaseAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
+### DatabaseAccount_Spec {#DatabaseAccount_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -61,7 +61,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-### <a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
+### DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -103,8 +103,8 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="DatabaseAccountList"></a>DatabaseAccountList
----------------------------------------------------
+DatabaseAccountList{#DatabaseAccountList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -114,8 +114,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [DatabaseAccount[]](#DatabaseAccount)<br/><small>Optional</small> |
 
-<a id="MongodbDatabase"></a>MongodbDatabase
--------------------------------------------
+MongodbDatabase{#MongodbDatabase}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -128,7 +128,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | spec                                                                                    |             | [MongodbDatabase_Spec](#MongodbDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabase_STATUS](#MongodbDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
+### MongodbDatabase_Spec {#MongodbDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -140,7 +140,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
+### MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -153,8 +153,8 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection"></a>MongodbDatabaseCollection
----------------------------------------------------------------
+MongodbDatabaseCollection{#MongodbDatabaseCollection}
+-----------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -167,7 +167,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | spec                                                                                    |             | [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
+### MongodbDatabaseCollection_Spec {#MongodbDatabaseCollection_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,7 +179,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
+### MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -192,8 +192,8 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionList"></a>MongodbDatabaseCollectionList
------------------------------------------------------------------------
+MongodbDatabaseCollectionList{#MongodbDatabaseCollectionList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -203,8 +203,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [MongodbDatabaseCollection[]](#MongodbDatabaseCollection)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSetting"></a>MongodbDatabaseCollectionThroughputSetting
--------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting{#MongodbDatabaseCollectionThroughputSetting}
+---------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -217,7 +217,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | spec                                                                                    |             | [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseCollectionThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
+### MongodbDatabaseCollectionThroughputSetting_Spec {#MongodbDatabaseCollectionThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -227,7 +227,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
+### MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -239,8 +239,8 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSettingList"></a>MongodbDatabaseCollectionThroughputSettingList
----------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingList{#MongodbDatabaseCollectionThroughputSettingList}
+-----------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -250,8 +250,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                         |
 | items                                                                               |             | [MongodbDatabaseCollectionThroughputSetting[]](#MongodbDatabaseCollectionThroughputSetting)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseList"></a>MongodbDatabaseList
----------------------------------------------------
+MongodbDatabaseList{#MongodbDatabaseList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -261,8 +261,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [MongodbDatabase[]](#MongodbDatabase)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseThroughputSetting"></a>MongodbDatabaseThroughputSetting
------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting{#MongodbDatabaseThroughputSetting}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -275,7 +275,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | spec                                                                                    |             | [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
+### MongodbDatabaseThroughputSetting_Spec {#MongodbDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -285,7 +285,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
+### MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -297,8 +297,8 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSettingList"></a>MongodbDatabaseThroughputSettingList
--------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingList{#MongodbDatabaseThroughputSettingList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -308,8 +308,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [MongodbDatabaseThroughputSetting[]](#MongodbDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlDatabase"></a>SqlDatabase
------------------------------------
+SqlDatabase{#SqlDatabase}
+-------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -322,7 +322,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | spec                                                                                    |             | [SqlDatabase_Spec](#SqlDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabase_STATUS](#SqlDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
+### SqlDatabase_Spec {#SqlDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -334,7 +334,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
+### SqlDatabase_STATUS{#SqlDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -347,8 +347,8 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer"></a>SqlDatabaseContainer
------------------------------------------------------
+SqlDatabaseContainer{#SqlDatabaseContainer}
+-------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -361,7 +361,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | spec                                                                                    |             | [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
+### SqlDatabaseContainer_Spec {#SqlDatabaseContainer_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -373,7 +373,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
+### SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -386,8 +386,8 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerList"></a>SqlDatabaseContainerList
--------------------------------------------------------------
+SqlDatabaseContainerList{#SqlDatabaseContainerList}
+---------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -397,8 +397,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [SqlDatabaseContainer[]](#SqlDatabaseContainer)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedure"></a>SqlDatabaseContainerStoredProcedure
------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure{#SqlDatabaseContainerStoredProcedure}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -411,7 +411,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | spec                                                                                    |             | [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredProcedure_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
+### SqlDatabaseContainerStoredProcedure_Spec {#SqlDatabaseContainerStoredProcedure_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -423,7 +423,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
+### SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -435,8 +435,8 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedureList"></a>SqlDatabaseContainerStoredProcedureList
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureList{#SqlDatabaseContainerStoredProcedureList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -446,8 +446,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerStoredProcedure[]](#SqlDatabaseContainerStoredProcedure)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSetting"></a>SqlDatabaseContainerThroughputSetting
----------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting{#SqlDatabaseContainerThroughputSetting}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -460,7 +460,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | spec                                                                                    |             | [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
+### SqlDatabaseContainerThroughputSetting_Spec {#SqlDatabaseContainerThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -470,7 +470,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
+### SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -482,8 +482,8 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSettingList"></a>SqlDatabaseContainerThroughputSettingList
------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingList{#SqlDatabaseContainerThroughputSettingList}
+-------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -493,8 +493,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                               |
 | items                                                                               |             | [SqlDatabaseContainerThroughputSetting[]](#SqlDatabaseContainerThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTrigger"></a>SqlDatabaseContainerTrigger
--------------------------------------------------------------------
+SqlDatabaseContainerTrigger{#SqlDatabaseContainerTrigger}
+---------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -507,7 +507,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | spec                                                                                    |             | [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
+### SqlDatabaseContainerTrigger_Spec {#SqlDatabaseContainerTrigger_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -519,7 +519,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
+### SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -531,8 +531,8 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTriggerList"></a>SqlDatabaseContainerTriggerList
----------------------------------------------------------------------------
+SqlDatabaseContainerTriggerList{#SqlDatabaseContainerTriggerList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -542,8 +542,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerTrigger[]](#SqlDatabaseContainerTrigger)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunction"></a>SqlDatabaseContainerUserDefinedFunction
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction{#SqlDatabaseContainerUserDefinedFunction}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -556,7 +556,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | spec                                                                                    |             | [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUserDefinedFunction_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
+### SqlDatabaseContainerUserDefinedFunction_Spec {#SqlDatabaseContainerUserDefinedFunction_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -568,7 +568,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
+### SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -580,8 +580,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionList"></a>SqlDatabaseContainerUserDefinedFunctionList
----------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionList{#SqlDatabaseContainerUserDefinedFunctionList}
+-----------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -591,8 +591,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                   |
 | items                                                                               |             | [SqlDatabaseContainerUserDefinedFunction[]](#SqlDatabaseContainerUserDefinedFunction)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseList"></a>SqlDatabaseList
--------------------------------------------
+SqlDatabaseList{#SqlDatabaseList}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -602,8 +602,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [SqlDatabase[]](#SqlDatabase)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseThroughputSetting"></a>SqlDatabaseThroughputSetting
----------------------------------------------------------------------
+SqlDatabaseThroughputSetting{#SqlDatabaseThroughputSetting}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -616,7 +616,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | spec                                                                                    |             | [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
+### SqlDatabaseThroughputSetting_Spec {#SqlDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -626,7 +626,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
+### SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -638,8 +638,8 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSettingList"></a>SqlDatabaseThroughputSettingList
------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingList{#SqlDatabaseThroughputSettingList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -649,8 +649,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [SqlDatabaseThroughputSetting[]](#SqlDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignment"></a>SqlRoleAssignment
------------------------------------------------
+SqlRoleAssignment{#SqlRoleAssignment}
+-------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -663,7 +663,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | spec                                                                                    |             | [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlRoleAssignment_STATUS](#SqlRoleAssignment_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
+### SqlRoleAssignment_Spec {#SqlRoleAssignment_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -675,7 +675,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
+### SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -687,8 +687,8 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignmentList"></a>SqlRoleAssignmentList
--------------------------------------------------------
+SqlRoleAssignmentList{#SqlRoleAssignmentList}
+---------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -698,8 +698,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [SqlRoleAssignment[]](#SqlRoleAssignment)<br/><small>Optional</small> |
 
-<a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
------------------------------------------------------
+DatabaseAccount_Spec{#DatabaseAccount_Spec}
+-------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -736,8 +736,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-<a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
----------------------------------------------------------
+DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
+-----------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -781,8 +781,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
------------------------------------------------------
+MongodbDatabase_Spec{#MongodbDatabase_Spec}
+-------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -796,8 +796,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
----------------------------------------------------------
+MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
+-----------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -812,8 +812,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
--------------------------------------------------------------------------
+MongodbDatabaseCollection_Spec{#MongodbDatabaseCollection_Spec}
+---------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -827,8 +827,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
------------------------------------------------------------------------------
+MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
+-------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -843,8 +843,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_Spec{#MongodbDatabaseCollectionThroughputSetting_Spec}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -856,8 +856,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
----------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -871,8 +871,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
----------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_Spec{#MongodbDatabaseThroughputSetting_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -884,8 +884,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
--------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -899,8 +899,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
----------------------------------------------
+SqlDatabase_Spec{#SqlDatabase_Spec}
+-----------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -914,8 +914,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
--------------------------------------------------
+SqlDatabase_STATUS{#SqlDatabase_STATUS}
+---------------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -930,8 +930,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
----------------------------------------------------------------
+SqlDatabaseContainer_Spec{#SqlDatabaseContainer_Spec}
+-----------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -945,8 +945,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
--------------------------------------------------------------------
+SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
+---------------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -961,8 +961,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
----------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_Spec{#SqlDatabaseContainerStoredProcedure_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -976,8 +976,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -991,8 +991,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_Spec{#SqlDatabaseContainerThroughputSetting_Spec}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1004,8 +1004,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1019,8 +1019,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_Spec{#SqlDatabaseContainerTrigger_Spec}
+-------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1034,8 +1034,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
----------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1049,8 +1049,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_Spec{#SqlDatabaseContainerUserDefinedFunction_Spec}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1064,8 +1064,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
----------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1079,8 +1079,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
--------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_Spec{#SqlDatabaseThroughputSetting_Spec}
+---------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1092,8 +1092,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
------------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1107,8 +1107,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
----------------------------------------------------------
+SqlRoleAssignment_Spec{#SqlRoleAssignment_Spec}
+-----------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1122,8 +1122,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
--------------------------------------------------------------
+SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
+---------------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1137,8 +1137,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AnalyticalStorageConfiguration"></a>AnalyticalStorageConfiguration
--------------------------------------------------------------------------
+AnalyticalStorageConfiguration{#AnalyticalStorageConfiguration}
+---------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1148,8 +1148,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType](#AnalyticalStorageSchemaType)<br/><small>Optional</small> |
 
-<a id="AnalyticalStorageConfiguration_STATUS"></a>AnalyticalStorageConfiguration_STATUS
----------------------------------------------------------------------------------------
+AnalyticalStorageConfiguration_STATUS{#AnalyticalStorageConfiguration_STATUS}
+-----------------------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1159,8 +1159,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType_STATUS](#AnalyticalStorageSchemaType_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiProperties"></a>ApiProperties
----------------------------------------
+ApiProperties{#ApiProperties}
+-----------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1168,8 +1168,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------------|------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | serverVersion | Describes the ServerVersion of an a MongoDB account. | [ApiProperties_ServerVersion](#ApiProperties_ServerVersion)<br/><small>Optional</small> |
 
-<a id="ApiProperties_STATUS"></a>ApiProperties_STATUS
------------------------------------------------------
+ApiProperties_STATUS{#ApiProperties_STATUS}
+-------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1177,8 +1177,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | serverVersion | Describes the ServerVersion of an a MongoDB account. | [ApiProperties_ServerVersion_STATUS](#ApiProperties_ServerVersion_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy"></a>BackupPolicy
--------------------------------------
+BackupPolicy{#BackupPolicy}
+---------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1187,8 +1187,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy)<br/><small>Optional</small>     |
 
-<a id="BackupPolicy_STATUS"></a>BackupPolicy_STATUS
----------------------------------------------------
+BackupPolicy_STATUS{#BackupPolicy_STATUS}
+-----------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1197,8 +1197,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS)<br/><small>Optional</small>     |
 
-<a id="Capability"></a>Capability
----------------------------------
+Capability{#Capability}
+-----------------------
 
 Cosmos DB capability object
 
@@ -1208,8 +1208,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
 
-<a id="Capability_STATUS"></a>Capability_STATUS
------------------------------------------------
+Capability_STATUS{#Capability_STATUS}
+-------------------------------------
 
 Cosmos DB capability object
 
@@ -1219,8 +1219,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
 
-<a id="ConnectorOffer"></a>ConnectorOffer
------------------------------------------
+ConnectorOffer{#ConnectorOffer}
+-------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1230,8 +1230,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConnectorOffer_STATUS"></a>ConnectorOffer_STATUS
--------------------------------------------------------
+ConnectorOffer_STATUS{#ConnectorOffer_STATUS}
+---------------------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1241,8 +1241,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConsistencyPolicy"></a>ConsistencyPolicy
------------------------------------------------
+ConsistencyPolicy{#ConsistencyPolicy}
+-------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1254,8 +1254,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                     |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                     |
 
-<a id="ConsistencyPolicy_STATUS"></a>ConsistencyPolicy_STATUS
--------------------------------------------------------------
+ConsistencyPolicy_STATUS{#ConsistencyPolicy_STATUS}
+---------------------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1267,8 +1267,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                                   |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                                   |
 
-<a id="CorsPolicy"></a>CorsPolicy
----------------------------------
+CorsPolicy{#CorsPolicy}
+-----------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1282,8 +1282,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CorsPolicy_STATUS"></a>CorsPolicy_STATUS
------------------------------------------------
+CorsPolicy_STATUS{#CorsPolicy_STATUS}
+-------------------------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1297,8 +1297,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CreateUpdateOptions"></a>CreateUpdateOptions
----------------------------------------------------
+CreateUpdateOptions{#CreateUpdateOptions}
+-----------------------------------------
 
 CreateUpdateOptions are a list of key-value pairs that describe the resource. Supported keys are "If-Match", "If-None-Match", "Session-Token" and "Throughput"
 
@@ -1309,8 +1309,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec), [MongodbDatabaseCollecti
 | autoscaleSettings | Specifies the Autoscale settings.                           | [AutoscaleSettings](#AutoscaleSettings)<br/><small>Optional</small> |
 | throughput        | Request Units per second. For example, "throughput": 10000. | int<br/><small>Optional</small>                                     |
 
-<a id="DatabaseAccount_Kind_Spec"></a>DatabaseAccount_Kind_Spec
----------------------------------------------------------------
+DatabaseAccount_Kind_Spec{#DatabaseAccount_Kind_Spec}
+-----------------------------------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1320,8 +1320,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccount_Kind_STATUS"></a>DatabaseAccount_Kind_STATUS
--------------------------------------------------------------------
+DatabaseAccount_Kind_STATUS{#DatabaseAccount_Kind_STATUS}
+---------------------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1331,8 +1331,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccountOfferType"></a>DatabaseAccountOfferType
--------------------------------------------------------------
+DatabaseAccountOfferType{#DatabaseAccountOfferType}
+---------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1342,8 +1342,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOfferType_STATUS"></a>DatabaseAccountOfferType_STATUS
----------------------------------------------------------------------------
+DatabaseAccountOfferType_STATUS{#DatabaseAccountOfferType_STATUS}
+-----------------------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1353,8 +1353,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOperatorSpec"></a>DatabaseAccountOperatorSpec
--------------------------------------------------------------------
+DatabaseAccountOperatorSpec{#DatabaseAccountOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1366,8 +1366,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [DatabaseAccountOperatorSecrets](#DatabaseAccountOperatorSecrets)<br/><small>Optional</small>                                                                       |
 
-<a id="FailoverPolicy_STATUS"></a>FailoverPolicy_STATUS
--------------------------------------------------------
+FailoverPolicy_STATUS{#FailoverPolicy_STATUS}
+---------------------------------------------
 
 The failover policy for a given region of a database account.
 
@@ -1379,8 +1379,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id               | The unique identifier of the region in which the database account replicates to. Example: &lt;accountName&gt;\-&lt;locationName&gt;.                                                                                                                                     | string<br/><small>Optional</small> |
 | locationName     | The name of the region in which the database account exists.                                                                                                                                                                                                             | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange"></a>IpAddressOrRange
----------------------------------------------
+IpAddressOrRange{#IpAddressOrRange}
+-----------------------------------
 
 IpAddressOrRange object
 
@@ -1390,8 +1390,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange_STATUS"></a>IpAddressOrRange_STATUS
------------------------------------------------------------
+IpAddressOrRange_STATUS{#IpAddressOrRange_STATUS}
+-------------------------------------------------
 
 IpAddressOrRange object
 
@@ -1401,8 +1401,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="Location"></a>Location
------------------------------
+Location{#Location}
+-------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1414,8 +1414,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | isZoneRedundant  | Flag to indicate whether or not this region is an AvailabilityZone region                                                                                                                                                                                                | bool<br/><small>Optional</small>   |
 | locationName     | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 
-<a id="Location_STATUS"></a>Location_STATUS
--------------------------------------------
+Location_STATUS{#Location_STATUS}
+---------------------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1430,8 +1430,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS), [DatabaseAccount_STA
 | locationName      | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 | provisioningState |                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Identity for the resource.
 
@@ -1442,8 +1442,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the resource.
 
@@ -1456,8 +1456,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS](#ManagedServiceIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="MongoDBCollectionGetProperties_Resource_STATUS"></a>MongoDBCollectionGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------------------
+MongoDBCollectionGetProperties_Resource_STATUS{#MongoDBCollectionGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 
@@ -1471,8 +1471,8 @@ Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 | indexes              | List of index keys                                                                                      | [MongoIndex_STATUS[]](#MongoIndex_STATUS)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request.                                           | map[string]string<br/><small>Optional</small>                         |
 
-<a id="MongoDBCollectionResource"></a>MongoDBCollectionResource
----------------------------------------------------------------
+MongoDBCollectionResource{#MongoDBCollectionResource}
+-----------------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -1485,8 +1485,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | indexes              | List of index keys                                            | [MongoIndex[]](#MongoIndex)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request. | map[string]string<br/><small>Optional</small>           |
 
-<a id="MongodbDatabaseCollectionOperatorSpec"></a>MongodbDatabaseCollectionOperatorSpec
----------------------------------------------------------------------------------------
+MongodbDatabaseCollectionOperatorSpec{#MongodbDatabaseCollectionOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1497,8 +1497,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSettingOperatorSpec"></a>MongodbDatabaseCollectionThroughputSettingOperatorSpec
--------------------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingOperatorSpec{#MongodbDatabaseCollectionThroughputSettingOperatorSpec}
+---------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1509,8 +1509,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseGetProperties_Resource_STATUS"></a>MongoDBDatabaseGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------
+MongoDBDatabaseGetProperties_Resource_STATUS{#MongoDBDatabaseGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 
@@ -1521,8 +1521,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 | _ts      | A system generated property that denotes the last updated timestamp of the resource.                    | float64<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB MongoDB database                                                                  | string<br/><small>Optional</small>  |
 
-<a id="MongodbDatabaseOperatorSpec"></a>MongodbDatabaseOperatorSpec
--------------------------------------------------------------------
+MongodbDatabaseOperatorSpec{#MongodbDatabaseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1533,8 +1533,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseResource"></a>MongoDBDatabaseResource
------------------------------------------------------------
+MongoDBDatabaseResource{#MongoDBDatabaseResource}
+-------------------------------------------------
 
 Cosmos DB MongoDB database resource object
 
@@ -1544,8 +1544,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 |----------|----------------------------------------|------------------------------------|
 | id       | Name of the Cosmos DB MongoDB database | string<br/><small>Required</small> |
 
-<a id="MongodbDatabaseThroughputSettingOperatorSpec"></a>MongodbDatabaseThroughputSettingOperatorSpec
------------------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingOperatorSpec{#MongodbDatabaseThroughputSettingOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1556,8 +1556,8 @@ Used by: [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetti
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkAclBypass"></a>NetworkAclBypass
----------------------------------------------
+NetworkAclBypass{#NetworkAclBypass}
+-----------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1568,8 +1568,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkAclBypass_STATUS"></a>NetworkAclBypass_STATUS
------------------------------------------------------------
+NetworkAclBypass_STATUS{#NetworkAclBypass_STATUS}
+-------------------------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1580,8 +1580,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="OptionsResource_STATUS"></a>OptionsResource_STATUS
----------------------------------------------------------
+OptionsResource_STATUS{#OptionsResource_STATUS}
+-----------------------------------------------
 
 Cosmos DB options resource object
 
@@ -1592,8 +1592,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS), [MongodbDatabaseColl
 | autoscaleSettings | Specifies the Autoscale settings.                                                                                                  | [AutoscaleSettings_STATUS](#AutoscaleSettings_STATUS)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput or autoscaleSettings. Use the ThroughputSetting resource when retrieving offer details. | int<br/><small>Optional</small>                                                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 A private endpoint connection
 
@@ -1603,8 +1603,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
----------------------------------------------------
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1615,8 +1615,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1627,8 +1627,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SqlContainerGetProperties_Resource_STATUS"></a>SqlContainerGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------
+SqlContainerGetProperties_Resource_STATUS{#SqlContainerGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 
@@ -1645,8 +1645,8 @@ Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 | partitionKey             | The configuration of the partition key to be used for partitioning data into multiple partitions                                         | [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SqlContainerResource"></a>SqlContainerResource
------------------------------------------------------
+SqlContainerResource{#SqlContainerResource}
+-------------------------------------------
 
 Cosmos DB SQL container resource object
 
@@ -1662,8 +1662,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | partitionKey             | The configuration of the partition key to be used for partitioning data into multiple partitions                                         | [ContainerPartitionKey](#ContainerPartitionKey)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy](#UniqueKeyPolicy)<br/><small>Optional</small>                   |
 
-<a id="SqlDatabaseContainerOperatorSpec"></a>SqlDatabaseContainerOperatorSpec
------------------------------------------------------------------------------
+SqlDatabaseContainerOperatorSpec{#SqlDatabaseContainerOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1674,8 +1674,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedureOperatorSpec"></a>SqlDatabaseContainerStoredProcedureOperatorSpec
------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureOperatorSpec{#SqlDatabaseContainerStoredProcedureOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1686,8 +1686,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSettingOperatorSpec"></a>SqlDatabaseContainerThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingOperatorSpec{#SqlDatabaseContainerThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1698,8 +1698,8 @@ Used by: [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThrou
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTriggerOperatorSpec"></a>SqlDatabaseContainerTriggerOperatorSpec
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerTriggerOperatorSpec{#SqlDatabaseContainerTriggerOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1710,8 +1710,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionOperatorSpec"></a>SqlDatabaseContainerUserDefinedFunctionOperatorSpec
--------------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionOperatorSpec{#SqlDatabaseContainerUserDefinedFunctionOperatorSpec}
+---------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1722,8 +1722,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseGetProperties_Resource_STATUS"></a>SqlDatabaseGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------
+SqlDatabaseGetProperties_Resource_STATUS{#SqlDatabaseGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 
@@ -1736,8 +1736,8 @@ Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 | _users   | A system generated property that specifies the addressable path of the users resource.                  | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL database                                                                      | string<br/><small>Optional</small>  |
 
-<a id="SqlDatabaseOperatorSpec"></a>SqlDatabaseOperatorSpec
------------------------------------------------------------
+SqlDatabaseOperatorSpec{#SqlDatabaseOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1748,8 +1748,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseResource"></a>SqlDatabaseResource
----------------------------------------------------
+SqlDatabaseResource{#SqlDatabaseResource}
+-----------------------------------------
 
 Cosmos DB SQL database resource object
 
@@ -1759,8 +1759,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 |----------|------------------------------------|------------------------------------|
 | id       | Name of the Cosmos DB SQL database | string<br/><small>Required</small> |
 
-<a id="SqlDatabaseThroughputSettingOperatorSpec"></a>SqlDatabaseThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingOperatorSpec{#SqlDatabaseThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1771,8 +1771,8 @@ Used by: [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignmentOperatorSpec"></a>SqlRoleAssignmentOperatorSpec
------------------------------------------------------------------------
+SqlRoleAssignmentOperatorSpec{#SqlRoleAssignmentOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1783,8 +1783,8 @@ Used by: [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlStoredProcedureGetProperties_Resource_STATUS"></a>SqlStoredProcedureGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+SqlStoredProcedureGetProperties_Resource_STATUS{#SqlStoredProcedureGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS).
 
@@ -1796,8 +1796,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStore
 | body     | Body of the Stored Procedure                                                                            | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL storedProcedure                                                               | string<br/><small>Optional</small>  |
 
-<a id="SqlStoredProcedureResource"></a>SqlStoredProcedureResource
------------------------------------------------------------------
+SqlStoredProcedureResource{#SqlStoredProcedureResource}
+-------------------------------------------------------
 
 Cosmos DB SQL storedProcedure resource object
 
@@ -1808,8 +1808,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | body     | Body of the Stored Procedure              | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL storedProcedure | string<br/><small>Required</small> |
 
-<a id="SqlTriggerGetProperties_Resource_STATUS"></a>SqlTriggerGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------
+SqlTriggerGetProperties_Resource_STATUS{#SqlTriggerGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS).
 
@@ -1823,8 +1823,8 @@ Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATU
 | triggerOperation | The operation the trigger is associated with                                                            | [SqlTriggerGetProperties_Resource_TriggerOperation_STATUS](#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                                                                                     | [SqlTriggerGetProperties_Resource_TriggerType_STATUS](#SqlTriggerGetProperties_Resource_TriggerType_STATUS)<br/><small>Optional</small>           |
 
-<a id="SqlTriggerResource"></a>SqlTriggerResource
--------------------------------------------------
+SqlTriggerResource{#SqlTriggerResource}
+---------------------------------------
 
 Cosmos DB SQL trigger resource object
 
@@ -1837,8 +1837,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | triggerOperation | The operation the trigger is associated with | [SqlTriggerResource_TriggerOperation](#SqlTriggerResource_TriggerOperation)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                          | [SqlTriggerResource_TriggerType](#SqlTriggerResource_TriggerType)<br/><small>Optional</small>           |
 
-<a id="SqlUserDefinedFunctionGetProperties_Resource_STATUS"></a>SqlUserDefinedFunctionGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------------------------------
+SqlUserDefinedFunctionGetProperties_Resource_STATUS{#SqlUserDefinedFunctionGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS).
 
@@ -1850,8 +1850,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerU
 | body     | Body of the User Defined Function                                                                       | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL userDefinedFunction                                                           | string<br/><small>Optional</small>  |
 
-<a id="SqlUserDefinedFunctionResource"></a>SqlUserDefinedFunctionResource
--------------------------------------------------------------------------
+SqlUserDefinedFunctionResource{#SqlUserDefinedFunctionResource}
+---------------------------------------------------------------
 
 Cosmos DB SQL userDefinedFunction resource object
 
@@ -1862,8 +1862,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | body     | Body of the User Defined Function             | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL userDefinedFunction | string<br/><small>Required</small> |
 
-<a id="ThroughputSettingsGetProperties_Resource_STATUS"></a>ThroughputSettingsGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+ThroughputSettingsGetProperties_Resource_STATUS{#ThroughputSettingsGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS), [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS), [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS), and [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS).
 
@@ -1877,8 +1877,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCol
 | offerReplacePending | The throughput replace is pending                                                                                         | string<br/><small>Optional</small>                                                                |
 | throughput          | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ThroughputSettingsResource"></a>ThroughputSettingsResource
------------------------------------------------------------------
+ThroughputSettingsResource{#ThroughputSettingsResource}
+-------------------------------------------------------
 
 Cosmos DB resource throughput object. Either throughput is required or autoscaleSettings is required, but not both.
 
@@ -1889,8 +1889,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | autoscaleSettings | Cosmos DB resource for autoscale settings. Either throughput is required or autoscaleSettings is required, but not both.  | [AutoscaleSettingsResource](#AutoscaleSettingsResource)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                     |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -1901,8 +1901,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                        | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -1913,8 +1913,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id                               | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | string<br/><small>Optional</small> |
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>   |
 
-<a id="AnalyticalStorageSchemaType"></a>AnalyticalStorageSchemaType
--------------------------------------------------------------------
+AnalyticalStorageSchemaType{#AnalyticalStorageSchemaType}
+---------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -1925,8 +1925,8 @@ Used by: [AnalyticalStorageConfiguration](#AnalyticalStorageConfiguration).
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="AnalyticalStorageSchemaType_STATUS"></a>AnalyticalStorageSchemaType_STATUS
----------------------------------------------------------------------------------
+AnalyticalStorageSchemaType_STATUS{#AnalyticalStorageSchemaType_STATUS}
+-----------------------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -1937,8 +1937,8 @@ Used by: [AnalyticalStorageConfiguration_STATUS](#AnalyticalStorageConfiguration
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="ApiProperties_ServerVersion"></a>ApiProperties_ServerVersion
--------------------------------------------------------------------
+ApiProperties_ServerVersion{#ApiProperties_ServerVersion}
+---------------------------------------------------------
 
 Used by: [ApiProperties](#ApiProperties).
 
@@ -1948,8 +1948,8 @@ Used by: [ApiProperties](#ApiProperties).
 | "3.6" |             |
 | "4.0" |             |
 
-<a id="ApiProperties_ServerVersion_STATUS"></a>ApiProperties_ServerVersion_STATUS
----------------------------------------------------------------------------------
+ApiProperties_ServerVersion_STATUS{#ApiProperties_ServerVersion_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 
@@ -1959,8 +1959,8 @@ Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 | "3.6" |             |
 | "4.0" |             |
 
-<a id="AutoscaleSettings"></a>AutoscaleSettings
------------------------------------------------
+AutoscaleSettings{#AutoscaleSettings}
+-------------------------------------
 
 Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 
@@ -1968,8 +1968,8 @@ Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettings_STATUS"></a>AutoscaleSettings_STATUS
--------------------------------------------------------------
+AutoscaleSettings_STATUS{#AutoscaleSettings_STATUS}
+---------------------------------------------------
 
 Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 
@@ -1977,8 +1977,8 @@ Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettingsResource"></a>AutoscaleSettingsResource
----------------------------------------------------------------
+AutoscaleSettingsResource{#AutoscaleSettingsResource}
+-----------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -1989,8 +1989,8 @@ Used by: [ThroughputSettingsResource](#ThroughputSettingsResource).
 | autoUpgradePolicy | Cosmos DB resource auto-upgrade policy                   | [AutoUpgradePolicyResource](#AutoUpgradePolicyResource)<br/><small>Optional</small> |
 | maxThroughput     | Represents maximum throughput container can scale up to. | int<br/><small>Required</small>                                                     |
 
-<a id="AutoscaleSettingsResource_STATUS"></a>AutoscaleSettingsResource_STATUS
------------------------------------------------------------------------------
+AutoscaleSettingsResource_STATUS{#AutoscaleSettingsResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -2002,8 +2002,8 @@ Used by: [ThroughputSettingsGetProperties_Resource_STATUS](#ThroughputSettingsGe
 | maxThroughput       | Represents maximum throughput container can scale up to.                                                 | int<br/><small>Optional</small>                                                                   |
 | targetMaxThroughput | Represents target maximum throughput container can scale up to once offer is no longer in pending state. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ConflictResolutionPolicy"></a>ConflictResolutionPolicy
--------------------------------------------------------------
+ConflictResolutionPolicy{#ConflictResolutionPolicy}
+---------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2015,8 +2015,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                          |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode](#ConflictResolutionPolicy_Mode)<br/><small>Optional</small> |
 
-<a id="ConflictResolutionPolicy_STATUS"></a>ConflictResolutionPolicy_STATUS
----------------------------------------------------------------------------
+ConflictResolutionPolicy_STATUS{#ConflictResolutionPolicy_STATUS}
+-----------------------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2028,8 +2028,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                                        |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode_STATUS](#ConflictResolutionPolicy_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel"></a>ConsistencyPolicy_DefaultConsistencyLevel
------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel{#ConsistencyPolicy_DefaultConsistencyLevel}
+-------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 
@@ -2041,8 +2041,8 @@ Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel_STATUS"></a>ConsistencyPolicy_DefaultConsistencyLevel_STATUS
--------------------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel_STATUS{#ConsistencyPolicy_DefaultConsistencyLevel_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 
@@ -2054,8 +2054,8 @@ Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ContainerPartitionKey"></a>ContainerPartitionKey
--------------------------------------------------------
+ContainerPartitionKey{#ContainerPartitionKey}
+---------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2067,8 +2067,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | paths    | List of paths using which data within the container can be partitioned                                                                                | string[]<br/><small>Optional</small>                                                  |
 | version  | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                       |
 
-<a id="ContainerPartitionKey_STATUS"></a>ContainerPartitionKey_STATUS
----------------------------------------------------------------------
+ContainerPartitionKey_STATUS{#ContainerPartitionKey_STATUS}
+-----------------------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2081,8 +2081,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | systemKey | Indicates if the container is using a system generated partition key                                                                                  | bool<br/><small>Optional</small>                                                                    |
 | version   | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                                     |
 
-<a id="ContinuousModeBackupPolicy"></a>ContinuousModeBackupPolicy
------------------------------------------------------------------
+ContinuousModeBackupPolicy{#ContinuousModeBackupPolicy}
+-------------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2090,8 +2090,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 |----------|-------------|-------------------------------------------------------------------------------------------------|
 | type     |             | [ContinuousModeBackupPolicy_Type](#ContinuousModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="ContinuousModeBackupPolicy_STATUS"></a>ContinuousModeBackupPolicy_STATUS
--------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_STATUS{#ContinuousModeBackupPolicy_STATUS}
+---------------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2099,8 +2099,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 |----------|-------------|---------------------------------------------------------------------------------------------------------------|
 | type     |             | [ContinuousModeBackupPolicy_Type_STATUS](#ContinuousModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseAccountOperatorSecrets"></a>DatabaseAccountOperatorSecrets
--------------------------------------------------------------------------
+DatabaseAccountOperatorSecrets{#DatabaseAccountOperatorSecrets}
+---------------------------------------------------------------
 
 Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 
@@ -2112,8 +2112,8 @@ Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 | secondaryMasterKey         | indicates where the SecondaryMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure.         | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryReadonlyMasterKey | indicates where the SecondaryReadonlyMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="IndexingPolicy"></a>IndexingPolicy
------------------------------------------
+IndexingPolicy{#IndexingPolicy}
+-------------------------------
 
 Cosmos DB indexing policy
 
@@ -2128,8 +2128,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode](#IndexingPolicy_IndexingMode)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec[]](#SpatialSpec)<br/><small>Optional</small>                               |
 
-<a id="IndexingPolicy_STATUS"></a>IndexingPolicy_STATUS
--------------------------------------------------------
+IndexingPolicy_STATUS{#IndexingPolicy_STATUS}
+---------------------------------------------
 
 Cosmos DB indexing policy
 
@@ -2144,8 +2144,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode_STATUS](#IndexingPolicy_IndexingMode_STATUS)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec_STATUS[]](#SpatialSpec_STATUS)<br/><small>Optional</small>                               |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -2156,8 +2156,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2168,8 +2168,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_UserAssignedIdentities_STATUS"></a>ManagedServiceIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedServiceIdentity_UserAssignedIdentities_STATUS{#ManagedServiceIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2178,8 +2178,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="MongoIndex"></a>MongoIndex
----------------------------------
+MongoIndex{#MongoIndex}
+-----------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2190,8 +2190,8 @@ Used by: [MongoDBCollectionResource](#MongoDBCollectionResource).
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys](#MongoIndexKeys)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions](#MongoIndexOptions)<br/><small>Optional</small> |
 
-<a id="MongoIndex_STATUS"></a>MongoIndex_STATUS
------------------------------------------------
+MongoIndex_STATUS{#MongoIndex_STATUS}
+-------------------------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2202,8 +2202,8 @@ Used by: [MongoDBCollectionGetProperties_Resource_STATUS](#MongoDBCollectionGetP
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys_STATUS](#MongoIndexKeys_STATUS)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions_STATUS](#MongoIndexOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="PeriodicModeBackupPolicy"></a>PeriodicModeBackupPolicy
--------------------------------------------------------------
+PeriodicModeBackupPolicy{#PeriodicModeBackupPolicy}
+---------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2212,8 +2212,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | periodicModeProperties | Configuration values for periodic mode backup | [PeriodicModeProperties](#PeriodicModeProperties)<br/><small>Optional</small>               |
 | type                   |                                               | [PeriodicModeBackupPolicy_Type](#PeriodicModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="PeriodicModeBackupPolicy_STATUS"></a>PeriodicModeBackupPolicy_STATUS
----------------------------------------------------------------------------
+PeriodicModeBackupPolicy_STATUS{#PeriodicModeBackupPolicy_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2222,31 +2222,31 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | periodicModeProperties | Configuration values for periodic mode backup | [PeriodicModeProperties_STATUS](#PeriodicModeProperties_STATUS)<br/><small>Optional</small>               |
 | type                   |                                               | [PeriodicModeBackupPolicy_Type_STATUS](#PeriodicModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlTriggerGetProperties_Resource_TriggerOperation_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerOperation_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "All"     |             |
-| "Create"  |             |
-| "Delete"  |             |
-| "Replace" |             |
-| "Update"  |             |
-
-<a id="SqlTriggerGetProperties_Resource_TriggerType_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerType_STATUS
+SqlTriggerGetProperties_Resource_TriggerOperation_STATUS{#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS}
 -------------------------------------------------------------------------------------------------------------------
 
 Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
 
+| Value     | Description |
+|-----------|-------------|
+| "All"     |             |
+| "Create"  |             |
+| "Delete"  |             |
+| "Replace" |             |
+| "Update"  |             |
+
+SqlTriggerGetProperties_Resource_TriggerType_STATUS{#SqlTriggerGetProperties_Resource_TriggerType_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
+
 | Value  | Description |
 |--------|-------------|
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="SqlTriggerResource_TriggerOperation"></a>SqlTriggerResource_TriggerOperation
------------------------------------------------------------------------------------
+SqlTriggerResource_TriggerOperation{#SqlTriggerResource_TriggerOperation}
+-------------------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2258,8 +2258,8 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Replace" |             |
 | "Update"  |             |
 
-<a id="SqlTriggerResource_TriggerType"></a>SqlTriggerResource_TriggerType
--------------------------------------------------------------------------
+SqlTriggerResource_TriggerType{#SqlTriggerResource_TriggerType}
+---------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2268,8 +2268,8 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="UniqueKeyPolicy"></a>UniqueKeyPolicy
--------------------------------------------
+UniqueKeyPolicy{#UniqueKeyPolicy}
+---------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2279,8 +2279,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 |------------|---------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey[]](#UniqueKey)<br/><small>Optional</small> |
 
-<a id="UniqueKeyPolicy_STATUS"></a>UniqueKeyPolicy_STATUS
----------------------------------------------------------
+UniqueKeyPolicy_STATUS{#UniqueKeyPolicy_STATUS}
+-----------------------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2290,8 +2290,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 |------------|---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey_STATUS[]](#UniqueKey_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2301,8 +2301,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource"></a>AutoUpgradePolicyResource
----------------------------------------------------------------
+AutoUpgradePolicyResource{#AutoUpgradePolicyResource}
+-----------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2312,8 +2312,8 @@ Used by: [AutoscaleSettingsResource](#AutoscaleSettingsResource).
 |------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource](#ThroughputPolicyResource)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource_STATUS"></a>AutoUpgradePolicyResource_STATUS
------------------------------------------------------------------------------
+AutoUpgradePolicyResource_STATUS{#AutoUpgradePolicyResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2323,8 +2323,8 @@ Used by: [AutoscaleSettingsResource_STATUS](#AutoscaleSettingsResource_STATUS).
 |------------------|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource_STATUS](#ThroughputPolicyResource_STATUS)<br/><small>Optional</small> |
 
-<a id="CompositePath"></a>CompositePath
----------------------------------------
+CompositePath{#CompositePath}
+-----------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2333,8 +2333,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order](#CompositePath_Order)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 
-<a id="CompositePath_STATUS"></a>CompositePath_STATUS
------------------------------------------------------
+CompositePath_STATUS{#CompositePath_STATUS}
+-------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2343,8 +2343,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order_STATUS](#CompositePath_Order_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                                    |
 
-<a id="ConflictResolutionPolicy_Mode"></a>ConflictResolutionPolicy_Mode
------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode{#ConflictResolutionPolicy_Mode}
+-------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 
@@ -2353,8 +2353,8 @@ Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ConflictResolutionPolicy_Mode_STATUS"></a>ConflictResolutionPolicy_Mode_STATUS
--------------------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode_STATUS{#ConflictResolutionPolicy_Mode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 
@@ -2363,8 +2363,8 @@ Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ContainerPartitionKey_Kind"></a>ContainerPartitionKey_Kind
------------------------------------------------------------------
+ContainerPartitionKey_Kind{#ContainerPartitionKey_Kind}
+-------------------------------------------------------
 
 Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 
@@ -2374,8 +2374,8 @@ Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContainerPartitionKey_Kind_STATUS"></a>ContainerPartitionKey_Kind_STATUS
--------------------------------------------------------------------------------
+ContainerPartitionKey_Kind_STATUS{#ContainerPartitionKey_Kind_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 
@@ -2385,8 +2385,8 @@ Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContinuousModeBackupPolicy_Type"></a>ContinuousModeBackupPolicy_Type
----------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type{#ContinuousModeBackupPolicy_Type}
+-----------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 
@@ -2394,8 +2394,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ContinuousModeBackupPolicy_Type_STATUS"></a>ContinuousModeBackupPolicy_Type_STATUS
------------------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type_STATUS{#ContinuousModeBackupPolicy_Type_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS).
 
@@ -2403,8 +2403,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ExcludedPath"></a>ExcludedPath
--------------------------------------
+ExcludedPath{#ExcludedPath}
+---------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2412,8 +2412,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="ExcludedPath_STATUS"></a>ExcludedPath_STATUS
----------------------------------------------------
+ExcludedPath_STATUS{#ExcludedPath_STATUS}
+-----------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2421,8 +2421,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="IncludedPath"></a>IncludedPath
--------------------------------------
+IncludedPath{#IncludedPath}
+---------------------------
 
 The paths that are included in indexing
 
@@ -2433,8 +2433,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | indexes  | List of indexes for this path                                                                                              | [Indexes[]](#Indexes)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                |
 
-<a id="IncludedPath_STATUS"></a>IncludedPath_STATUS
----------------------------------------------------
+IncludedPath_STATUS{#IncludedPath_STATUS}
+-----------------------------------------
 
 The paths that are included in indexing
 
@@ -2445,8 +2445,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | indexes  | List of indexes for this path                                                                                              | [Indexes_STATUS[]](#Indexes_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                              |
 
-<a id="IndexingPolicy_IndexingMode"></a>IndexingPolicy_IndexingMode
--------------------------------------------------------------------
+IndexingPolicy_IndexingMode{#IndexingPolicy_IndexingMode}
+---------------------------------------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2456,8 +2456,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="IndexingPolicy_IndexingMode_STATUS"></a>IndexingPolicy_IndexingMode_STATUS
----------------------------------------------------------------------------------
+IndexingPolicy_IndexingMode_STATUS{#IndexingPolicy_IndexingMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2467,8 +2467,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="MongoIndexKeys"></a>MongoIndexKeys
------------------------------------------
+MongoIndexKeys{#MongoIndexKeys}
+-------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -2478,8 +2478,8 @@ Used by: [MongoIndex](#MongoIndex).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexKeys_STATUS"></a>MongoIndexKeys_STATUS
--------------------------------------------------------
+MongoIndexKeys_STATUS{#MongoIndexKeys_STATUS}
+---------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -2489,8 +2489,8 @@ Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions"></a>MongoIndexOptions
------------------------------------------------
+MongoIndexOptions{#MongoIndexOptions}
+-------------------------------------
 
 Cosmos DB MongoDB collection index options
 
@@ -2501,29 +2501,29 @@ Used by: [MongoIndex](#MongoIndex).
 | expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
 | unique             | Is unique or not     | bool<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions_STATUS"></a>MongoIndexOptions_STATUS
+MongoIndexOptions_STATUS{#MongoIndexOptions_STATUS}
+---------------------------------------------------
+
+Cosmos DB MongoDB collection index options
+
+Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
+
+| Property           | Description          | Type                             |
+|--------------------|----------------------|----------------------------------|
+| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
+| unique             | Is unique or not     | bool<br/><small>Optional</small> |
+
+PeriodicModeBackupPolicy_Type{#PeriodicModeBackupPolicy_Type}
 -------------------------------------------------------------
 
-Cosmos DB MongoDB collection index options
-
-Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
-
-| Property           | Description          | Type                             |
-|--------------------|----------------------|----------------------------------|
-| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
-| unique             | Is unique or not     | bool<br/><small>Optional</small> |
-
-<a id="PeriodicModeBackupPolicy_Type"></a>PeriodicModeBackupPolicy_Type
------------------------------------------------------------------------
-
 Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 
 | Value      | Description |
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeBackupPolicy_Type_STATUS"></a>PeriodicModeBackupPolicy_Type_STATUS
--------------------------------------------------------------------------------------
+PeriodicModeBackupPolicy_Type_STATUS{#PeriodicModeBackupPolicy_Type_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 
@@ -2531,8 +2531,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeProperties"></a>PeriodicModeProperties
----------------------------------------------------------
+PeriodicModeProperties{#PeriodicModeProperties}
+-----------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2543,8 +2543,8 @@ Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 | backupIntervalInMinutes        | An integer representing the interval in minutes between two backups      | int<br/><small>Optional</small> |
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small> |
 
-<a id="PeriodicModeProperties_STATUS"></a>PeriodicModeProperties_STATUS
------------------------------------------------------------------------
+PeriodicModeProperties_STATUS{#PeriodicModeProperties_STATUS}
+-------------------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2555,8 +2555,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 | backupIntervalInMinutes        | An integer representing the interval in minutes between two backups      | int<br/><small>Optional</small> |
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small> |
 
-<a id="SpatialSpec"></a>SpatialSpec
------------------------------------
+SpatialSpec{#SpatialSpec}
+-------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2565,8 +2565,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                        |
 | types    | List of path's spatial type                                                                                                | [SpatialType[]](#SpatialType)<br/><small>Optional</small> |
 
-<a id="SpatialSpec_STATUS"></a>SpatialSpec_STATUS
--------------------------------------------------
+SpatialSpec_STATUS{#SpatialSpec_STATUS}
+---------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2575,8 +2575,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 | types    | List of path's spatial type                                                                                                | [SpatialType_STATUS[]](#SpatialType_STATUS)<br/><small>Optional</small> |
 
-<a id="UniqueKey"></a>UniqueKey
--------------------------------
+UniqueKey{#UniqueKey}
+---------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -2586,8 +2586,8 @@ Used by: [UniqueKeyPolicy](#UniqueKeyPolicy).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="UniqueKey_STATUS"></a>UniqueKey_STATUS
----------------------------------------------
+UniqueKey_STATUS{#UniqueKey_STATUS}
+-----------------------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -2597,8 +2597,8 @@ Used by: [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="CompositePath_Order"></a>CompositePath_Order
----------------------------------------------------
+CompositePath_Order{#CompositePath_Order}
+-----------------------------------------
 
 Used by: [CompositePath](#CompositePath).
 
@@ -2607,8 +2607,8 @@ Used by: [CompositePath](#CompositePath).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="CompositePath_Order_STATUS"></a>CompositePath_Order_STATUS
------------------------------------------------------------------
+CompositePath_Order_STATUS{#CompositePath_Order_STATUS}
+-------------------------------------------------------
 
 Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 
@@ -2617,8 +2617,8 @@ Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="Indexes"></a>Indexes
----------------------------
+Indexes{#Indexes}
+-----------------
 
 The indexes for the path.
 
@@ -2630,8 +2630,8 @@ Used by: [IncludedPath](#IncludedPath).
 | kind      | Indicates the type of index.                                | [Indexes_Kind](#Indexes_Kind)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                   |
 
-<a id="Indexes_STATUS"></a>Indexes_STATUS
------------------------------------------
+Indexes_STATUS{#Indexes_STATUS}
+-------------------------------
 
 The indexes for the path.
 
@@ -2643,8 +2643,8 @@ Used by: [IncludedPath_STATUS](#IncludedPath_STATUS).
 | kind      | Indicates the type of index.                                | [Indexes_Kind_STATUS](#Indexes_Kind_STATUS)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                                 |
 
-<a id="SpatialType"></a>SpatialType
------------------------------------
+SpatialType{#SpatialType}
+-------------------------
 
 Indicates the spatial type of index.
 
@@ -2657,8 +2657,8 @@ Used by: [SpatialSpec](#SpatialSpec).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="SpatialType_STATUS"></a>SpatialType_STATUS
--------------------------------------------------
+SpatialType_STATUS{#SpatialType_STATUS}
+---------------------------------------
 
 Indicates the spatial type of index.
 
@@ -2671,8 +2671,8 @@ Used by: [SpatialSpec_STATUS](#SpatialSpec_STATUS).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="ThroughputPolicyResource"></a>ThroughputPolicyResource
--------------------------------------------------------------
+ThroughputPolicyResource{#ThroughputPolicyResource}
+---------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -2683,8 +2683,8 @@ Used by: [AutoUpgradePolicyResource](#AutoUpgradePolicyResource).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="ThroughputPolicyResource_STATUS"></a>ThroughputPolicyResource_STATUS
----------------------------------------------------------------------------
+ThroughputPolicyResource_STATUS{#ThroughputPolicyResource_STATUS}
+-----------------------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -2695,8 +2695,8 @@ Used by: [AutoUpgradePolicyResource_STATUS](#AutoUpgradePolicyResource_STATUS).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="Indexes_DataType"></a>Indexes_DataType
----------------------------------------------
+Indexes_DataType{#Indexes_DataType}
+-----------------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -2709,8 +2709,8 @@ Used by: [Indexes](#Indexes).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_DataType_STATUS"></a>Indexes_DataType_STATUS
------------------------------------------------------------
+Indexes_DataType_STATUS{#Indexes_DataType_STATUS}
+-------------------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 
@@ -2723,8 +2723,8 @@ Used by: [Indexes_STATUS](#Indexes_STATUS).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_Kind"></a>Indexes_Kind
--------------------------------------
+Indexes_Kind{#Indexes_Kind}
+---------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -2734,8 +2734,8 @@ Used by: [Indexes](#Indexes).
 | "Range"   |             |
 | "Spatial" |             |
 
-<a id="Indexes_Kind_STATUS"></a>Indexes_Kind_STATUS
----------------------------------------------------
+Indexes_Kind_STATUS{#Indexes_Kind_STATUS}
+-----------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 

--- a/docs/hugo/content/reference/documentdb/v1api20231115.md
+++ b/docs/hugo/content/reference/documentdb/v1api20231115.md
@@ -5,15 +5,15 @@ title: documentdb.azure.com/v1api20231115
 linktitle: v1api20231115
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-11-15" |             |
 
-<a id="DatabaseAccount"></a>DatabaseAccount
--------------------------------------------
+DatabaseAccount{#DatabaseAccount}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | spec                                                                                    |             | [DatabaseAccount_Spec](#DatabaseAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DatabaseAccount_STATUS](#DatabaseAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
+### DatabaseAccount_Spec {#DatabaseAccount_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,7 +69,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-### <a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
+### DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -122,8 +122,8 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="DatabaseAccountList"></a>DatabaseAccountList
----------------------------------------------------
+DatabaseAccountList{#DatabaseAccountList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -133,8 +133,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [DatabaseAccount[]](#DatabaseAccount)<br/><small>Optional</small> |
 
-<a id="MongodbDatabase"></a>MongodbDatabase
--------------------------------------------
+MongodbDatabase{#MongodbDatabase}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -147,7 +147,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | spec                                                                                    |             | [MongodbDatabase_Spec](#MongodbDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabase_STATUS](#MongodbDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
+### MongodbDatabase_Spec {#MongodbDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -159,7 +159,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
+### MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -172,8 +172,8 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection"></a>MongodbDatabaseCollection
----------------------------------------------------------------
+MongodbDatabaseCollection{#MongodbDatabaseCollection}
+-----------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -186,7 +186,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | spec                                                                                    |             | [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
+### MongodbDatabaseCollection_Spec {#MongodbDatabaseCollection_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -198,7 +198,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
+### MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -211,8 +211,8 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionList"></a>MongodbDatabaseCollectionList
------------------------------------------------------------------------
+MongodbDatabaseCollectionList{#MongodbDatabaseCollectionList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -222,8 +222,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [MongodbDatabaseCollection[]](#MongodbDatabaseCollection)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSetting"></a>MongodbDatabaseCollectionThroughputSetting
--------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting{#MongodbDatabaseCollectionThroughputSetting}
+---------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -236,7 +236,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | spec                                                                                    |             | [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseCollectionThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
+### MongodbDatabaseCollectionThroughputSetting_Spec {#MongodbDatabaseCollectionThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -246,7 +246,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
+### MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -258,8 +258,8 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSettingList"></a>MongodbDatabaseCollectionThroughputSettingList
----------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingList{#MongodbDatabaseCollectionThroughputSettingList}
+-----------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -269,8 +269,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                         |
 | items                                                                               |             | [MongodbDatabaseCollectionThroughputSetting[]](#MongodbDatabaseCollectionThroughputSetting)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseList"></a>MongodbDatabaseList
----------------------------------------------------
+MongodbDatabaseList{#MongodbDatabaseList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -280,8 +280,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [MongodbDatabase[]](#MongodbDatabase)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseThroughputSetting"></a>MongodbDatabaseThroughputSetting
------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting{#MongodbDatabaseThroughputSetting}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -294,7 +294,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | spec                                                                                    |             | [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
+### MongodbDatabaseThroughputSetting_Spec {#MongodbDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -304,7 +304,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
+### MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -316,8 +316,8 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSettingList"></a>MongodbDatabaseThroughputSettingList
--------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingList{#MongodbDatabaseThroughputSettingList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -327,8 +327,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [MongodbDatabaseThroughputSetting[]](#MongodbDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlDatabase"></a>SqlDatabase
------------------------------------
+SqlDatabase{#SqlDatabase}
+-------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -341,7 +341,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | spec                                                                                    |             | [SqlDatabase_Spec](#SqlDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabase_STATUS](#SqlDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
+### SqlDatabase_Spec {#SqlDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -353,7 +353,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
+### SqlDatabase_STATUS{#SqlDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -366,8 +366,8 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer"></a>SqlDatabaseContainer
------------------------------------------------------
+SqlDatabaseContainer{#SqlDatabaseContainer}
+-------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -380,7 +380,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | spec                                                                                    |             | [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
+### SqlDatabaseContainer_Spec {#SqlDatabaseContainer_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -392,7 +392,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
+### SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -405,8 +405,8 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerList"></a>SqlDatabaseContainerList
--------------------------------------------------------------
+SqlDatabaseContainerList{#SqlDatabaseContainerList}
+---------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -416,8 +416,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [SqlDatabaseContainer[]](#SqlDatabaseContainer)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedure"></a>SqlDatabaseContainerStoredProcedure
------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure{#SqlDatabaseContainerStoredProcedure}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -430,7 +430,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | spec                                                                                    |             | [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredProcedure_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
+### SqlDatabaseContainerStoredProcedure_Spec {#SqlDatabaseContainerStoredProcedure_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -442,7 +442,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
+### SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -454,8 +454,8 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedureList"></a>SqlDatabaseContainerStoredProcedureList
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureList{#SqlDatabaseContainerStoredProcedureList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -465,8 +465,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerStoredProcedure[]](#SqlDatabaseContainerStoredProcedure)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSetting"></a>SqlDatabaseContainerThroughputSetting
----------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting{#SqlDatabaseContainerThroughputSetting}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -479,7 +479,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | spec                                                                                    |             | [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
+### SqlDatabaseContainerThroughputSetting_Spec {#SqlDatabaseContainerThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -489,7 +489,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
+### SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -501,8 +501,8 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSettingList"></a>SqlDatabaseContainerThroughputSettingList
------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingList{#SqlDatabaseContainerThroughputSettingList}
+-------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -512,8 +512,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                               |
 | items                                                                               |             | [SqlDatabaseContainerThroughputSetting[]](#SqlDatabaseContainerThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTrigger"></a>SqlDatabaseContainerTrigger
--------------------------------------------------------------------
+SqlDatabaseContainerTrigger{#SqlDatabaseContainerTrigger}
+---------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -526,7 +526,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | spec                                                                                    |             | [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
+### SqlDatabaseContainerTrigger_Spec {#SqlDatabaseContainerTrigger_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -538,7 +538,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
+### SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -550,8 +550,8 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTriggerList"></a>SqlDatabaseContainerTriggerList
----------------------------------------------------------------------------
+SqlDatabaseContainerTriggerList{#SqlDatabaseContainerTriggerList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -561,8 +561,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerTrigger[]](#SqlDatabaseContainerTrigger)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunction"></a>SqlDatabaseContainerUserDefinedFunction
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction{#SqlDatabaseContainerUserDefinedFunction}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -575,7 +575,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | spec                                                                                    |             | [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUserDefinedFunction_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
+### SqlDatabaseContainerUserDefinedFunction_Spec {#SqlDatabaseContainerUserDefinedFunction_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -587,7 +587,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
+### SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -599,8 +599,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionList"></a>SqlDatabaseContainerUserDefinedFunctionList
----------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionList{#SqlDatabaseContainerUserDefinedFunctionList}
+-----------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -610,8 +610,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                   |
 | items                                                                               |             | [SqlDatabaseContainerUserDefinedFunction[]](#SqlDatabaseContainerUserDefinedFunction)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseList"></a>SqlDatabaseList
--------------------------------------------
+SqlDatabaseList{#SqlDatabaseList}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -621,8 +621,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [SqlDatabase[]](#SqlDatabase)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseThroughputSetting"></a>SqlDatabaseThroughputSetting
----------------------------------------------------------------------
+SqlDatabaseThroughputSetting{#SqlDatabaseThroughputSetting}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -635,7 +635,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | spec                                                                                    |             | [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
+### SqlDatabaseThroughputSetting_Spec {#SqlDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -645,7 +645,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
+### SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -657,8 +657,8 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSettingList"></a>SqlDatabaseThroughputSettingList
------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingList{#SqlDatabaseThroughputSettingList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -668,8 +668,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [SqlDatabaseThroughputSetting[]](#SqlDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignment"></a>SqlRoleAssignment
------------------------------------------------
+SqlRoleAssignment{#SqlRoleAssignment}
+-------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -682,7 +682,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | spec                                                                                    |             | [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlRoleAssignment_STATUS](#SqlRoleAssignment_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
+### SqlRoleAssignment_Spec {#SqlRoleAssignment_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -694,7 +694,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
+### SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -706,8 +706,8 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignmentList"></a>SqlRoleAssignmentList
--------------------------------------------------------
+SqlRoleAssignmentList{#SqlRoleAssignmentList}
+---------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-11-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -717,8 +717,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [SqlRoleAssignment[]](#SqlRoleAssignment)<br/><small>Optional</small> |
 
-<a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
------------------------------------------------------
+DatabaseAccount_Spec{#DatabaseAccount_Spec}
+-------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -763,8 +763,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-<a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
----------------------------------------------------------
+DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
+-----------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -819,8 +819,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
------------------------------------------------------
+MongodbDatabase_Spec{#MongodbDatabase_Spec}
+-------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -834,8 +834,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
----------------------------------------------------------
+MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
+-----------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -850,8 +850,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
--------------------------------------------------------------------------
+MongodbDatabaseCollection_Spec{#MongodbDatabaseCollection_Spec}
+---------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -865,8 +865,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
------------------------------------------------------------------------------
+MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
+-------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -881,8 +881,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_Spec{#MongodbDatabaseCollectionThroughputSetting_Spec}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -894,8 +894,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
----------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -909,8 +909,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
----------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_Spec{#MongodbDatabaseThroughputSetting_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -922,8 +922,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
--------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -937,8 +937,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
----------------------------------------------
+SqlDatabase_Spec{#SqlDatabase_Spec}
+-----------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -952,8 +952,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
--------------------------------------------------
+SqlDatabase_STATUS{#SqlDatabase_STATUS}
+---------------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -968,8 +968,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
----------------------------------------------------------------
+SqlDatabaseContainer_Spec{#SqlDatabaseContainer_Spec}
+-----------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -983,8 +983,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
--------------------------------------------------------------------
+SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
+---------------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -999,8 +999,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
----------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_Spec{#SqlDatabaseContainerStoredProcedure_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -1014,8 +1014,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -1029,8 +1029,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_Spec{#SqlDatabaseContainerThroughputSetting_Spec}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1042,8 +1042,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1057,8 +1057,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_Spec{#SqlDatabaseContainerTrigger_Spec}
+-------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1072,8 +1072,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
----------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1087,8 +1087,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_Spec{#SqlDatabaseContainerUserDefinedFunction_Spec}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1102,8 +1102,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
----------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1117,8 +1117,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
--------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_Spec{#SqlDatabaseThroughputSetting_Spec}
+---------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1130,8 +1130,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
------------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1145,8 +1145,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
----------------------------------------------------------
+SqlRoleAssignment_Spec{#SqlRoleAssignment_Spec}
+-----------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1160,8 +1160,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
--------------------------------------------------------------
+SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
+---------------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1175,8 +1175,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AnalyticalStorageConfiguration"></a>AnalyticalStorageConfiguration
--------------------------------------------------------------------------
+AnalyticalStorageConfiguration{#AnalyticalStorageConfiguration}
+---------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1186,8 +1186,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType](#AnalyticalStorageSchemaType)<br/><small>Optional</small> |
 
-<a id="AnalyticalStorageConfiguration_STATUS"></a>AnalyticalStorageConfiguration_STATUS
----------------------------------------------------------------------------------------
+AnalyticalStorageConfiguration_STATUS{#AnalyticalStorageConfiguration_STATUS}
+-----------------------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1197,8 +1197,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType_STATUS](#AnalyticalStorageSchemaType_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiProperties"></a>ApiProperties
----------------------------------------
+ApiProperties{#ApiProperties}
+-----------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1206,8 +1206,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------------|------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | serverVersion | Describes the ServerVersion of an a MongoDB account. | [ApiProperties_ServerVersion](#ApiProperties_ServerVersion)<br/><small>Optional</small> |
 
-<a id="ApiProperties_STATUS"></a>ApiProperties_STATUS
------------------------------------------------------
+ApiProperties_STATUS{#ApiProperties_STATUS}
+-------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1215,8 +1215,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | serverVersion | Describes the ServerVersion of an a MongoDB account. | [ApiProperties_ServerVersion_STATUS](#ApiProperties_ServerVersion_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy"></a>BackupPolicy
--------------------------------------
+BackupPolicy{#BackupPolicy}
+---------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1225,8 +1225,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy)<br/><small>Optional</small>     |
 
-<a id="BackupPolicy_STATUS"></a>BackupPolicy_STATUS
----------------------------------------------------
+BackupPolicy_STATUS{#BackupPolicy_STATUS}
+-----------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1235,42 +1235,42 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS)<br/><small>Optional</small>     |
 
-<a id="Capability"></a>Capability
+Capability{#Capability}
+-----------------------
+
+Cosmos DB capability object
+
+Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
+
+| Property | Description                                                                                                                              | Type                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
+
+Capability_STATUS{#Capability_STATUS}
+-------------------------------------
+
+Cosmos DB capability object
+
+Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
+
+| Property | Description                                                                                                                              | Type                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
+
+Capacity{#Capacity}
+-------------------
+
+The object that represents all properties related to capacity enforcement on an account.
+
+Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
+
+| Property             | Description                                                                                                                                                                                                                                                    | Type                            |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
+
+Capacity_STATUS{#Capacity_STATUS}
 ---------------------------------
 
-Cosmos DB capability object
-
-Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
-
-| Property | Description                                                                                                                              | Type                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
-
-<a id="Capability_STATUS"></a>Capability_STATUS
------------------------------------------------
-
-Cosmos DB capability object
-
-Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
-
-| Property | Description                                                                                                                              | Type                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
-
-<a id="Capacity"></a>Capacity
------------------------------
-
-The object that represents all properties related to capacity enforcement on an account.
-
-Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
-
-| Property             | Description                                                                                                                                                                                                                                                    | Type                            |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
-
-<a id="Capacity_STATUS"></a>Capacity_STATUS
--------------------------------------------
-
 The object that represents all properties related to capacity enforcement on an account.
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
@@ -1279,8 +1279,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
 
-<a id="ConnectorOffer"></a>ConnectorOffer
------------------------------------------
+ConnectorOffer{#ConnectorOffer}
+-------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1290,8 +1290,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConnectorOffer_STATUS"></a>ConnectorOffer_STATUS
--------------------------------------------------------
+ConnectorOffer_STATUS{#ConnectorOffer_STATUS}
+---------------------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1301,8 +1301,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConsistencyPolicy"></a>ConsistencyPolicy
------------------------------------------------
+ConsistencyPolicy{#ConsistencyPolicy}
+-------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1314,8 +1314,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                     |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                     |
 
-<a id="ConsistencyPolicy_STATUS"></a>ConsistencyPolicy_STATUS
--------------------------------------------------------------
+ConsistencyPolicy_STATUS{#ConsistencyPolicy_STATUS}
+---------------------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1327,8 +1327,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                                   |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                                   |
 
-<a id="CorsPolicy"></a>CorsPolicy
----------------------------------
+CorsPolicy{#CorsPolicy}
+-----------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1342,8 +1342,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CorsPolicy_STATUS"></a>CorsPolicy_STATUS
------------------------------------------------
+CorsPolicy_STATUS{#CorsPolicy_STATUS}
+-------------------------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1357,8 +1357,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CreateMode"></a>CreateMode
----------------------------------
+CreateMode{#CreateMode}
+-----------------------
 
 Enum to indicate the mode of account creation.
 
@@ -1369,8 +1369,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec), [MongoDBCollectionResour
 | "Default" |             |
 | "Restore" |             |
 
-<a id="CreateMode_STATUS"></a>CreateMode_STATUS
------------------------------------------------
+CreateMode_STATUS{#CreateMode_STATUS}
+-------------------------------------
 
 Enum to indicate the mode of account creation.
 
@@ -1381,8 +1381,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS), [MongoDBCollectionGe
 | "Default" |             |
 | "Restore" |             |
 
-<a id="CreateUpdateOptions"></a>CreateUpdateOptions
----------------------------------------------------
+CreateUpdateOptions{#CreateUpdateOptions}
+-----------------------------------------
 
 CreateUpdateOptions are a list of key-value pairs that describe the resource. Supported keys are "If-Match", "If-None-Match", "Session-Token" and "Throughput"
 
@@ -1393,8 +1393,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec), [MongodbDatabaseCollecti
 | autoscaleSettings | Specifies the Autoscale settings. Note: Either throughput or autoscaleSettings is required, but not both. | [AutoscaleSettings](#AutoscaleSettings)<br/><small>Optional</small> |
 | throughput        | Request Units per second. For example, "throughput": 10000.                                               | int<br/><small>Optional</small>                                     |
 
-<a id="DatabaseAccount_Kind_Spec"></a>DatabaseAccount_Kind_Spec
----------------------------------------------------------------
+DatabaseAccount_Kind_Spec{#DatabaseAccount_Kind_Spec}
+-----------------------------------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1404,8 +1404,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccount_Kind_STATUS"></a>DatabaseAccount_Kind_STATUS
--------------------------------------------------------------------
+DatabaseAccount_Kind_STATUS{#DatabaseAccount_Kind_STATUS}
+---------------------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1415,8 +1415,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccountKeysMetadata_STATUS"></a>DatabaseAccountKeysMetadata_STATUS
----------------------------------------------------------------------------------
+DatabaseAccountKeysMetadata_STATUS{#DatabaseAccountKeysMetadata_STATUS}
+-----------------------------------------------------------------------
 
 The metadata related to each access key for the given Cosmos DB database account.
 
@@ -1429,8 +1429,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | secondaryMasterKey         | The metadata related to the Secondary Read-Write Key for the given Cosmos DB database account. | [AccountKeyMetadata_STATUS](#AccountKeyMetadata_STATUS)<br/><small>Optional</small> |
 | secondaryReadonlyMasterKey | The metadata related to the Secondary Read-Only Key for the given Cosmos DB database account.  | [AccountKeyMetadata_STATUS](#AccountKeyMetadata_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseAccountOfferType"></a>DatabaseAccountOfferType
--------------------------------------------------------------
+DatabaseAccountOfferType{#DatabaseAccountOfferType}
+---------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1440,8 +1440,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOfferType_STATUS"></a>DatabaseAccountOfferType_STATUS
----------------------------------------------------------------------------
+DatabaseAccountOfferType_STATUS{#DatabaseAccountOfferType_STATUS}
+-----------------------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1451,8 +1451,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOperatorSpec"></a>DatabaseAccountOperatorSpec
--------------------------------------------------------------------
+DatabaseAccountOperatorSpec{#DatabaseAccountOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1464,8 +1464,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [DatabaseAccountOperatorSecrets](#DatabaseAccountOperatorSecrets)<br/><small>Optional</small>                                                                       |
 
-<a id="FailoverPolicy_STATUS"></a>FailoverPolicy_STATUS
--------------------------------------------------------
+FailoverPolicy_STATUS{#FailoverPolicy_STATUS}
+---------------------------------------------
 
 The failover policy for a given region of a database account.
 
@@ -1477,8 +1477,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id               | The unique identifier of the region in which the database account replicates to. Example: &lt;accountName&gt;\-&lt;locationName&gt;.                                                                                                                                     | string<br/><small>Optional</small> |
 | locationName     | The name of the region in which the database account exists.                                                                                                                                                                                                             | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange"></a>IpAddressOrRange
----------------------------------------------
+IpAddressOrRange{#IpAddressOrRange}
+-----------------------------------
 
 IpAddressOrRange object
 
@@ -1488,8 +1488,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange_STATUS"></a>IpAddressOrRange_STATUS
------------------------------------------------------------
+IpAddressOrRange_STATUS{#IpAddressOrRange_STATUS}
+-------------------------------------------------
 
 IpAddressOrRange object
 
@@ -1499,8 +1499,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="Location"></a>Location
------------------------------
+Location{#Location}
+-------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1512,8 +1512,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | isZoneRedundant  | Flag to indicate whether or not this region is an AvailabilityZone region                                                                                                                                                                                                | bool<br/><small>Optional</small>   |
 | locationName     | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 
-<a id="Location_STATUS"></a>Location_STATUS
--------------------------------------------
+Location_STATUS{#Location_STATUS}
+---------------------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1528,8 +1528,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS), [DatabaseAccount_STA
 | locationName      | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 | provisioningState |                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Identity for the resource.
 
@@ -1540,8 +1540,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the resource.
 
@@ -1554,8 +1554,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS](#ManagedServiceIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="MinimalTlsVersion"></a>MinimalTlsVersion
------------------------------------------------
+MinimalTlsVersion{#MinimalTlsVersion}
+-------------------------------------
 
 Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.
 
@@ -1567,8 +1567,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "Tls11" |             |
 | "Tls12" |             |
 
-<a id="MinimalTlsVersion_STATUS"></a>MinimalTlsVersion_STATUS
--------------------------------------------------------------
+MinimalTlsVersion_STATUS{#MinimalTlsVersion_STATUS}
+---------------------------------------------------
 
 Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.
 
@@ -1580,8 +1580,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "Tls11" |             |
 | "Tls12" |             |
 
-<a id="MongoDBCollectionGetProperties_Resource_STATUS"></a>MongoDBCollectionGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------------------
+MongoDBCollectionGetProperties_Resource_STATUS{#MongoDBCollectionGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 
@@ -1597,8 +1597,8 @@ Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 | restoreParameters    | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request.                                           | map[string]string<br/><small>Optional</small>                                             |
 
-<a id="MongoDBCollectionResource"></a>MongoDBCollectionResource
----------------------------------------------------------------
+MongoDBCollectionResource{#MongoDBCollectionResource}
+-----------------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -1613,8 +1613,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | restoreParameters    | Parameters to indicate the information about the restore      | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request. | map[string]string<br/><small>Optional</small>                               |
 
-<a id="MongodbDatabaseCollectionOperatorSpec"></a>MongodbDatabaseCollectionOperatorSpec
----------------------------------------------------------------------------------------
+MongodbDatabaseCollectionOperatorSpec{#MongodbDatabaseCollectionOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1625,8 +1625,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSettingOperatorSpec"></a>MongodbDatabaseCollectionThroughputSettingOperatorSpec
--------------------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingOperatorSpec{#MongodbDatabaseCollectionThroughputSettingOperatorSpec}
+---------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1637,8 +1637,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseGetProperties_Resource_STATUS"></a>MongoDBDatabaseGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------
+MongoDBDatabaseGetProperties_Resource_STATUS{#MongoDBDatabaseGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 
@@ -1651,8 +1651,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 | id                | Name of the Cosmos DB MongoDB database                                                                  | string<br/><small>Optional</small>                                                        |
 | restoreParameters | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseOperatorSpec"></a>MongodbDatabaseOperatorSpec
--------------------------------------------------------------------
+MongodbDatabaseOperatorSpec{#MongodbDatabaseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1663,8 +1663,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseResource"></a>MongoDBDatabaseResource
------------------------------------------------------------
+MongoDBDatabaseResource{#MongoDBDatabaseResource}
+-------------------------------------------------
 
 Cosmos DB MongoDB database resource object
 
@@ -1676,8 +1676,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 | id                | Name of the Cosmos DB MongoDB database                   | string<br/><small>Required</small>                                          |
 | restoreParameters | Parameters to indicate the information about the restore | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseThroughputSettingOperatorSpec"></a>MongodbDatabaseThroughputSettingOperatorSpec
------------------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingOperatorSpec{#MongodbDatabaseThroughputSettingOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1688,8 +1688,8 @@ Used by: [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetti
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkAclBypass"></a>NetworkAclBypass
----------------------------------------------
+NetworkAclBypass{#NetworkAclBypass}
+-----------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1700,8 +1700,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkAclBypass_STATUS"></a>NetworkAclBypass_STATUS
------------------------------------------------------------
+NetworkAclBypass_STATUS{#NetworkAclBypass_STATUS}
+-------------------------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1712,8 +1712,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="OptionsResource_STATUS"></a>OptionsResource_STATUS
----------------------------------------------------------
+OptionsResource_STATUS{#OptionsResource_STATUS}
+-----------------------------------------------
 
 Cosmos DB options resource object
 
@@ -1724,8 +1724,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS), [MongodbDatabaseColl
 | autoscaleSettings | Specifies the Autoscale settings.                                                                                                  | [AutoscaleSettings_STATUS](#AutoscaleSettings_STATUS)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput or autoscaleSettings. Use the ThroughputSetting resource when retrieving offer details. | int<br/><small>Optional</small>                                                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 A private endpoint connection
 
@@ -1735,8 +1735,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
----------------------------------------------------
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1748,8 +1748,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1761,8 +1761,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="RestoreParameters"></a>RestoreParameters
------------------------------------------------
+RestoreParameters{#RestoreParameters}
+-------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -1777,8 +1777,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | restoreTimestampInUtc     | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                              |
 | tablesToRestore           | List of specific tables available for restore.                                                                                                                                                                                                                                                                    | string[]<br/><small>Optional</small>                                                            |
 
-<a id="RestoreParameters_STATUS"></a>RestoreParameters_STATUS
--------------------------------------------------------------
+RestoreParameters_STATUS{#RestoreParameters_STATUS}
+---------------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -1793,8 +1793,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | restoreTimestampInUtc     | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                            |
 | tablesToRestore           | List of specific tables available for restore.                                                                                                                                                                                                                                                                    | string[]<br/><small>Optional</small>                                                                          |
 
-<a id="SqlContainerGetProperties_Resource_STATUS"></a>SqlContainerGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------
+SqlContainerGetProperties_Resource_STATUS{#SqlContainerGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 
@@ -1815,8 +1815,8 @@ Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 | restoreParameters        | Parameters to indicate the information about the restore                                                                                 | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SqlContainerResource"></a>SqlContainerResource
------------------------------------------------------
+SqlContainerResource{#SqlContainerResource}
+-------------------------------------------
 
 Cosmos DB SQL container resource object
 
@@ -1836,8 +1836,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | restoreParameters        | Parameters to indicate the information about the restore                                                                                 | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy](#UniqueKeyPolicy)<br/><small>Optional</small>                   |
 
-<a id="SqlDatabaseContainerOperatorSpec"></a>SqlDatabaseContainerOperatorSpec
------------------------------------------------------------------------------
+SqlDatabaseContainerOperatorSpec{#SqlDatabaseContainerOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1848,8 +1848,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedureOperatorSpec"></a>SqlDatabaseContainerStoredProcedureOperatorSpec
------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureOperatorSpec{#SqlDatabaseContainerStoredProcedureOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1860,8 +1860,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSettingOperatorSpec"></a>SqlDatabaseContainerThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingOperatorSpec{#SqlDatabaseContainerThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1872,8 +1872,8 @@ Used by: [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThrou
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTriggerOperatorSpec"></a>SqlDatabaseContainerTriggerOperatorSpec
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerTriggerOperatorSpec{#SqlDatabaseContainerTriggerOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1884,8 +1884,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionOperatorSpec"></a>SqlDatabaseContainerUserDefinedFunctionOperatorSpec
--------------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionOperatorSpec{#SqlDatabaseContainerUserDefinedFunctionOperatorSpec}
+---------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1896,8 +1896,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseGetProperties_Resource_STATUS"></a>SqlDatabaseGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------
+SqlDatabaseGetProperties_Resource_STATUS{#SqlDatabaseGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 
@@ -1912,8 +1912,8 @@ Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 | id                | Name of the Cosmos DB SQL database                                                                      | string<br/><small>Optional</small>                                                        |
 | restoreParameters | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseOperatorSpec"></a>SqlDatabaseOperatorSpec
------------------------------------------------------------
+SqlDatabaseOperatorSpec{#SqlDatabaseOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1924,8 +1924,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseResource"></a>SqlDatabaseResource
----------------------------------------------------
+SqlDatabaseResource{#SqlDatabaseResource}
+-----------------------------------------
 
 Cosmos DB SQL database resource object
 
@@ -1937,8 +1937,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 | id                | Name of the Cosmos DB SQL database                       | string<br/><small>Required</small>                                          |
 | restoreParameters | Parameters to indicate the information about the restore | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseThroughputSettingOperatorSpec"></a>SqlDatabaseThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingOperatorSpec{#SqlDatabaseThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1949,8 +1949,8 @@ Used by: [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignmentOperatorSpec"></a>SqlRoleAssignmentOperatorSpec
------------------------------------------------------------------------
+SqlRoleAssignmentOperatorSpec{#SqlRoleAssignmentOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1961,8 +1961,8 @@ Used by: [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlStoredProcedureGetProperties_Resource_STATUS"></a>SqlStoredProcedureGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+SqlStoredProcedureGetProperties_Resource_STATUS{#SqlStoredProcedureGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS).
 
@@ -1974,8 +1974,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStore
 | body     | Body of the Stored Procedure                                                                            | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL storedProcedure                                                               | string<br/><small>Optional</small>  |
 
-<a id="SqlStoredProcedureResource"></a>SqlStoredProcedureResource
------------------------------------------------------------------
+SqlStoredProcedureResource{#SqlStoredProcedureResource}
+-------------------------------------------------------
 
 Cosmos DB SQL storedProcedure resource object
 
@@ -1986,8 +1986,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | body     | Body of the Stored Procedure              | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL storedProcedure | string<br/><small>Required</small> |
 
-<a id="SqlTriggerGetProperties_Resource_STATUS"></a>SqlTriggerGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------
+SqlTriggerGetProperties_Resource_STATUS{#SqlTriggerGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS).
 
@@ -2001,8 +2001,8 @@ Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATU
 | triggerOperation | The operation the trigger is associated with                                                            | [SqlTriggerGetProperties_Resource_TriggerOperation_STATUS](#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                                                                                     | [SqlTriggerGetProperties_Resource_TriggerType_STATUS](#SqlTriggerGetProperties_Resource_TriggerType_STATUS)<br/><small>Optional</small>           |
 
-<a id="SqlTriggerResource"></a>SqlTriggerResource
--------------------------------------------------
+SqlTriggerResource{#SqlTriggerResource}
+---------------------------------------
 
 Cosmos DB SQL trigger resource object
 
@@ -2015,8 +2015,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | triggerOperation | The operation the trigger is associated with | [SqlTriggerResource_TriggerOperation](#SqlTriggerResource_TriggerOperation)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                          | [SqlTriggerResource_TriggerType](#SqlTriggerResource_TriggerType)<br/><small>Optional</small>           |
 
-<a id="SqlUserDefinedFunctionGetProperties_Resource_STATUS"></a>SqlUserDefinedFunctionGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------------------------------
+SqlUserDefinedFunctionGetProperties_Resource_STATUS{#SqlUserDefinedFunctionGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS).
 
@@ -2028,8 +2028,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerU
 | body     | Body of the User Defined Function                                                                       | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL userDefinedFunction                                                           | string<br/><small>Optional</small>  |
 
-<a id="SqlUserDefinedFunctionResource"></a>SqlUserDefinedFunctionResource
--------------------------------------------------------------------------
+SqlUserDefinedFunctionResource{#SqlUserDefinedFunctionResource}
+---------------------------------------------------------------
 
 Cosmos DB SQL userDefinedFunction resource object
 
@@ -2040,8 +2040,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | body     | Body of the User Defined Function             | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL userDefinedFunction | string<br/><small>Required</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2056,8 +2056,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ThroughputSettingsGetProperties_Resource_STATUS"></a>ThroughputSettingsGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+ThroughputSettingsGetProperties_Resource_STATUS{#ThroughputSettingsGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS), [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS), [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS), and [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS).
 
@@ -2073,8 +2073,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCol
 | softAllowedMaximumThroughput | The maximum throughput value or the maximum maxThroughput value (for autoscale) that can be specified                     | string<br/><small>Optional</small>                                                                |
 | throughput                   | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ThroughputSettingsResource"></a>ThroughputSettingsResource
------------------------------------------------------------------
+ThroughputSettingsResource{#ThroughputSettingsResource}
+-------------------------------------------------------
 
 Cosmos DB resource throughput object. Either throughput is required or autoscaleSettings is required, but not both.
 
@@ -2085,8 +2085,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | autoscaleSettings | Cosmos DB resource for autoscale settings. Either throughput is required or autoscaleSettings is required, but not both.  | [AutoscaleSettingsResource](#AutoscaleSettingsResource)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                     |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -2097,8 +2097,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                        | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -2109,8 +2109,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id                               | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | string<br/><small>Optional</small> |
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>   |
 
-<a id="AccountKeyMetadata_STATUS"></a>AccountKeyMetadata_STATUS
----------------------------------------------------------------
+AccountKeyMetadata_STATUS{#AccountKeyMetadata_STATUS}
+-----------------------------------------------------
 
 The metadata related to an access key for a given database account.
 
@@ -2120,8 +2120,8 @@ Used by: [DatabaseAccountKeysMetadata_STATUS](#DatabaseAccountKeysMetadata_STATU
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | generationTime | Generation time in UTC of the key in ISO-8601 format. If the value is missing from the object, it means that the last key regeneration was triggered before 2022-06-18. | string<br/><small>Optional</small> |
 
-<a id="AnalyticalStorageSchemaType"></a>AnalyticalStorageSchemaType
--------------------------------------------------------------------
+AnalyticalStorageSchemaType{#AnalyticalStorageSchemaType}
+---------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -2132,8 +2132,8 @@ Used by: [AnalyticalStorageConfiguration](#AnalyticalStorageConfiguration).
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="AnalyticalStorageSchemaType_STATUS"></a>AnalyticalStorageSchemaType_STATUS
----------------------------------------------------------------------------------
+AnalyticalStorageSchemaType_STATUS{#AnalyticalStorageSchemaType_STATUS}
+-----------------------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -2144,8 +2144,8 @@ Used by: [AnalyticalStorageConfiguration_STATUS](#AnalyticalStorageConfiguration
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="ApiProperties_ServerVersion"></a>ApiProperties_ServerVersion
--------------------------------------------------------------------
+ApiProperties_ServerVersion{#ApiProperties_ServerVersion}
+---------------------------------------------------------
 
 Used by: [ApiProperties](#ApiProperties).
 
@@ -2156,8 +2156,8 @@ Used by: [ApiProperties](#ApiProperties).
 | "4.0" |             |
 | "4.2" |             |
 
-<a id="ApiProperties_ServerVersion_STATUS"></a>ApiProperties_ServerVersion_STATUS
----------------------------------------------------------------------------------
+ApiProperties_ServerVersion_STATUS{#ApiProperties_ServerVersion_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 
@@ -2168,8 +2168,8 @@ Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 | "4.0" |             |
 | "4.2" |             |
 
-<a id="AutoscaleSettings"></a>AutoscaleSettings
------------------------------------------------
+AutoscaleSettings{#AutoscaleSettings}
+-------------------------------------
 
 Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 
@@ -2177,8 +2177,8 @@ Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettings_STATUS"></a>AutoscaleSettings_STATUS
--------------------------------------------------------------
+AutoscaleSettings_STATUS{#AutoscaleSettings_STATUS}
+---------------------------------------------------
 
 Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 
@@ -2186,8 +2186,8 @@ Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettingsResource"></a>AutoscaleSettingsResource
----------------------------------------------------------------
+AutoscaleSettingsResource{#AutoscaleSettingsResource}
+-----------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -2198,8 +2198,8 @@ Used by: [ThroughputSettingsResource](#ThroughputSettingsResource).
 | autoUpgradePolicy | Cosmos DB resource auto-upgrade policy                   | [AutoUpgradePolicyResource](#AutoUpgradePolicyResource)<br/><small>Optional</small> |
 | maxThroughput     | Represents maximum throughput container can scale up to. | int<br/><small>Required</small>                                                     |
 
-<a id="AutoscaleSettingsResource_STATUS"></a>AutoscaleSettingsResource_STATUS
------------------------------------------------------------------------------
+AutoscaleSettingsResource_STATUS{#AutoscaleSettingsResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -2211,8 +2211,8 @@ Used by: [ThroughputSettingsGetProperties_Resource_STATUS](#ThroughputSettingsGe
 | maxThroughput       | Represents maximum throughput container can scale up to.                                                 | int<br/><small>Optional</small>                                                                   |
 | targetMaxThroughput | Represents target maximum throughput container can scale up to once offer is no longer in pending state. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ClientEncryptionPolicy"></a>ClientEncryptionPolicy
----------------------------------------------------------
+ClientEncryptionPolicy{#ClientEncryptionPolicy}
+-----------------------------------------------
 
 Cosmos DB client encryption policy.
 
@@ -2223,8 +2223,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | includedPaths       | Paths of the item that need encryption along with path-specific settings.                                                                    | [ClientEncryptionIncludedPath[]](#ClientEncryptionIncludedPath)<br/><small>Required</small> |
 | policyFormatVersion | Version of the client encryption policy definition. Supported versions are 1 and 2. Version 2 supports id and partition key path encryption. | int<br/><small>Required</small>                                                             |
 
-<a id="ClientEncryptionPolicy_STATUS"></a>ClientEncryptionPolicy_STATUS
------------------------------------------------------------------------
+ClientEncryptionPolicy_STATUS{#ClientEncryptionPolicy_STATUS}
+-------------------------------------------------------------
 
 Cosmos DB client encryption policy.
 
@@ -2235,8 +2235,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | includedPaths       | Paths of the item that need encryption along with path-specific settings.                                                                    | [ClientEncryptionIncludedPath_STATUS[]](#ClientEncryptionIncludedPath_STATUS)<br/><small>Optional</small> |
 | policyFormatVersion | Version of the client encryption policy definition. Supported versions are 1 and 2. Version 2 supports id and partition key path encryption. | int<br/><small>Optional</small>                                                                           |
 
-<a id="ComputedProperty"></a>ComputedProperty
----------------------------------------------
+ComputedProperty{#ComputedProperty}
+-----------------------------------
 
 The definition of a computed property
 
@@ -2247,8 +2247,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | name     | The name of a computed property, for example - "cp_lowerName"                                               | string<br/><small>Optional</small> |
 | query    | The query that evaluates the value for computed property, for example - "SELECT VALUE LOWER(c.name) FROM c" | string<br/><small>Optional</small> |
 
-<a id="ComputedProperty_STATUS"></a>ComputedProperty_STATUS
------------------------------------------------------------
+ComputedProperty_STATUS{#ComputedProperty_STATUS}
+-------------------------------------------------
 
 The definition of a computed property
 
@@ -2259,8 +2259,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | name     | The name of a computed property, for example - "cp_lowerName"                                               | string<br/><small>Optional</small> |
 | query    | The query that evaluates the value for computed property, for example - "SELECT VALUE LOWER(c.name) FROM c" | string<br/><small>Optional</small> |
 
-<a id="ConflictResolutionPolicy"></a>ConflictResolutionPolicy
--------------------------------------------------------------
+ConflictResolutionPolicy{#ConflictResolutionPolicy}
+---------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2272,8 +2272,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                          |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode](#ConflictResolutionPolicy_Mode)<br/><small>Optional</small> |
 
-<a id="ConflictResolutionPolicy_STATUS"></a>ConflictResolutionPolicy_STATUS
----------------------------------------------------------------------------
+ConflictResolutionPolicy_STATUS{#ConflictResolutionPolicy_STATUS}
+-----------------------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2285,8 +2285,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                                        |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode_STATUS](#ConflictResolutionPolicy_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel"></a>ConsistencyPolicy_DefaultConsistencyLevel
------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel{#ConsistencyPolicy_DefaultConsistencyLevel}
+-------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 
@@ -2298,8 +2298,8 @@ Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel_STATUS"></a>ConsistencyPolicy_DefaultConsistencyLevel_STATUS
--------------------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel_STATUS{#ConsistencyPolicy_DefaultConsistencyLevel_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 
@@ -2311,8 +2311,8 @@ Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ContainerPartitionKey"></a>ContainerPartitionKey
--------------------------------------------------------
+ContainerPartitionKey{#ContainerPartitionKey}
+---------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2324,8 +2324,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | paths    | List of paths using which data within the container can be partitioned                                                                                | string[]<br/><small>Optional</small>                                                  |
 | version  | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                       |
 
-<a id="ContainerPartitionKey_STATUS"></a>ContainerPartitionKey_STATUS
----------------------------------------------------------------------
+ContainerPartitionKey_STATUS{#ContainerPartitionKey_STATUS}
+-----------------------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2338,8 +2338,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | systemKey | Indicates if the container is using a system generated partition key                                                                                  | bool<br/><small>Optional</small>                                                                    |
 | version   | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                                     |
 
-<a id="ContinuousModeBackupPolicy"></a>ContinuousModeBackupPolicy
------------------------------------------------------------------
+ContinuousModeBackupPolicy{#ContinuousModeBackupPolicy}
+-------------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2349,8 +2349,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | migrationState           | The object representing the state of the migration between the backup policies. | [BackupPolicyMigrationState](#BackupPolicyMigrationState)<br/><small>Optional</small>           |
 | type                     | Describes the mode of backups.                                                  | [ContinuousModeBackupPolicy_Type](#ContinuousModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="ContinuousModeBackupPolicy_STATUS"></a>ContinuousModeBackupPolicy_STATUS
--------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_STATUS{#ContinuousModeBackupPolicy_STATUS}
+---------------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2360,8 +2360,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | migrationState           | The object representing the state of the migration between the backup policies. | [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)<br/><small>Optional</small>           |
 | type                     | Describes the mode of backups.                                                  | [ContinuousModeBackupPolicy_Type_STATUS](#ContinuousModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseAccountOperatorSecrets"></a>DatabaseAccountOperatorSecrets
--------------------------------------------------------------------------
+DatabaseAccountOperatorSecrets{#DatabaseAccountOperatorSecrets}
+---------------------------------------------------------------
 
 Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 
@@ -2373,8 +2373,8 @@ Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 | secondaryMasterKey         | indicates where the SecondaryMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure.         | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryReadonlyMasterKey | indicates where the SecondaryReadonlyMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="DatabaseRestoreResource"></a>DatabaseRestoreResource
------------------------------------------------------------
+DatabaseRestoreResource{#DatabaseRestoreResource}
+-------------------------------------------------
 
 Specific Databases to restore.
 
@@ -2385,8 +2385,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 | collectionNames | The names of the collections available for restore. | string[]<br/><small>Optional</small> |
 | databaseName    | The name of the database available for restore.     | string<br/><small>Optional</small>   |
 
-<a id="DatabaseRestoreResource_STATUS"></a>DatabaseRestoreResource_STATUS
--------------------------------------------------------------------------
+DatabaseRestoreResource_STATUS{#DatabaseRestoreResource_STATUS}
+---------------------------------------------------------------
 
 Specific Databases to restore.
 
@@ -2397,8 +2397,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 | collectionNames | The names of the collections available for restore. | string[]<br/><small>Optional</small> |
 | databaseName    | The name of the database available for restore.     | string<br/><small>Optional</small>   |
 
-<a id="GremlinDatabaseRestoreResource"></a>GremlinDatabaseRestoreResource
--------------------------------------------------------------------------
+GremlinDatabaseRestoreResource{#GremlinDatabaseRestoreResource}
+---------------------------------------------------------------
 
 Specific Gremlin Databases to restore.
 
@@ -2409,8 +2409,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 | databaseName | The name of the gremlin database available for restore. | string<br/><small>Optional</small>   |
 | graphNames   | The names of the graphs available for restore.          | string[]<br/><small>Optional</small> |
 
-<a id="GremlinDatabaseRestoreResource_STATUS"></a>GremlinDatabaseRestoreResource_STATUS
----------------------------------------------------------------------------------------
+GremlinDatabaseRestoreResource_STATUS{#GremlinDatabaseRestoreResource_STATUS}
+-----------------------------------------------------------------------------
 
 Specific Gremlin Databases to restore.
 
@@ -2421,8 +2421,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 | databaseName | The name of the gremlin database available for restore. | string<br/><small>Optional</small>   |
 | graphNames   | The names of the graphs available for restore.          | string[]<br/><small>Optional</small> |
 
-<a id="IndexingPolicy"></a>IndexingPolicy
------------------------------------------
+IndexingPolicy{#IndexingPolicy}
+-------------------------------
 
 Cosmos DB indexing policy
 
@@ -2437,8 +2437,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode](#IndexingPolicy_IndexingMode)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec[]](#SpatialSpec)<br/><small>Optional</small>                               |
 
-<a id="IndexingPolicy_STATUS"></a>IndexingPolicy_STATUS
--------------------------------------------------------
+IndexingPolicy_STATUS{#IndexingPolicy_STATUS}
+---------------------------------------------
 
 Cosmos DB indexing policy
 
@@ -2453,8 +2453,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode_STATUS](#IndexingPolicy_IndexingMode_STATUS)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec_STATUS[]](#SpatialSpec_STATUS)<br/><small>Optional</small>                               |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -2465,8 +2465,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2477,8 +2477,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_UserAssignedIdentities_STATUS"></a>ManagedServiceIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedServiceIdentity_UserAssignedIdentities_STATUS{#ManagedServiceIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2487,8 +2487,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="MongoIndex"></a>MongoIndex
----------------------------------
+MongoIndex{#MongoIndex}
+-----------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2499,8 +2499,8 @@ Used by: [MongoDBCollectionResource](#MongoDBCollectionResource).
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys](#MongoIndexKeys)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions](#MongoIndexOptions)<br/><small>Optional</small> |
 
-<a id="MongoIndex_STATUS"></a>MongoIndex_STATUS
------------------------------------------------
+MongoIndex_STATUS{#MongoIndex_STATUS}
+-------------------------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2511,8 +2511,8 @@ Used by: [MongoDBCollectionGetProperties_Resource_STATUS](#MongoDBCollectionGetP
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys_STATUS](#MongoIndexKeys_STATUS)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions_STATUS](#MongoIndexOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="PeriodicModeBackupPolicy"></a>PeriodicModeBackupPolicy
--------------------------------------------------------------
+PeriodicModeBackupPolicy{#PeriodicModeBackupPolicy}
+---------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2522,8 +2522,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | periodicModeProperties | Configuration values for periodic mode backup                                   | [PeriodicModeProperties](#PeriodicModeProperties)<br/><small>Optional</small>               |
 | type                   | Describes the mode of backups.                                                  | [PeriodicModeBackupPolicy_Type](#PeriodicModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="PeriodicModeBackupPolicy_STATUS"></a>PeriodicModeBackupPolicy_STATUS
----------------------------------------------------------------------------
+PeriodicModeBackupPolicy_STATUS{#PeriodicModeBackupPolicy_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2533,8 +2533,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | periodicModeProperties | Configuration values for periodic mode backup                                   | [PeriodicModeProperties_STATUS](#PeriodicModeProperties_STATUS)<br/><small>Optional</small>               |
 | type                   | Describes the mode of backups.                                                  | [PeriodicModeBackupPolicy_Type_STATUS](#PeriodicModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="RestoreParameters_RestoreMode"></a>RestoreParameters_RestoreMode
------------------------------------------------------------------------
+RestoreParameters_RestoreMode{#RestoreParameters_RestoreMode}
+-------------------------------------------------------------
 
 Used by: [RestoreParameters](#RestoreParameters).
 
@@ -2542,8 +2542,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 |---------------|-------------|
 | "PointInTime" |             |
 
-<a id="RestoreParameters_RestoreMode_STATUS"></a>RestoreParameters_RestoreMode_STATUS
--------------------------------------------------------------------------------------
+RestoreParameters_RestoreMode_STATUS{#RestoreParameters_RestoreMode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 
@@ -2551,8 +2551,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 |---------------|-------------|
 | "PointInTime" |             |
 
-<a id="RestoreParametersBase"></a>RestoreParametersBase
--------------------------------------------------------
+RestoreParametersBase{#RestoreParametersBase}
+---------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -2563,8 +2563,8 @@ Used by: [MongoDBCollectionResource](#MongoDBCollectionResource), [MongoDBDataba
 | restoreSource         | The id of the restorable database account from which the restore has to be initiated. For example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/locations/{location}/restorableDatabaseAccounts/{restorableDatabaseAccountName} | string<br/><small>Optional</small> |
 | restoreTimestampInUtc | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small> |
 
-<a id="RestoreParametersBase_STATUS"></a>RestoreParametersBase_STATUS
----------------------------------------------------------------------
+RestoreParametersBase_STATUS{#RestoreParametersBase_STATUS}
+-----------------------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -2575,31 +2575,31 @@ Used by: [MongoDBCollectionGetProperties_Resource_STATUS](#MongoDBCollectionGetP
 | restoreSource         | The id of the restorable database account from which the restore has to be initiated. For example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/locations/{location}/restorableDatabaseAccounts/{restorableDatabaseAccountName} | string<br/><small>Optional</small> |
 | restoreTimestampInUtc | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small> |
 
-<a id="SqlTriggerGetProperties_Resource_TriggerOperation_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerOperation_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "All"     |             |
-| "Create"  |             |
-| "Delete"  |             |
-| "Replace" |             |
-| "Update"  |             |
-
-<a id="SqlTriggerGetProperties_Resource_TriggerType_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerType_STATUS
+SqlTriggerGetProperties_Resource_TriggerOperation_STATUS{#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS}
 -------------------------------------------------------------------------------------------------------------------
 
 Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
 
+| Value     | Description |
+|-----------|-------------|
+| "All"     |             |
+| "Create"  |             |
+| "Delete"  |             |
+| "Replace" |             |
+| "Update"  |             |
+
+SqlTriggerGetProperties_Resource_TriggerType_STATUS{#SqlTriggerGetProperties_Resource_TriggerType_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
+
 | Value  | Description |
 |--------|-------------|
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="SqlTriggerResource_TriggerOperation"></a>SqlTriggerResource_TriggerOperation
------------------------------------------------------------------------------------
+SqlTriggerResource_TriggerOperation{#SqlTriggerResource_TriggerOperation}
+-------------------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2611,8 +2611,8 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Replace" |             |
 | "Update"  |             |
 
-<a id="SqlTriggerResource_TriggerType"></a>SqlTriggerResource_TriggerType
--------------------------------------------------------------------------
+SqlTriggerResource_TriggerType{#SqlTriggerResource_TriggerType}
+---------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2621,7 +2621,19 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2633,20 +2645,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UniqueKeyPolicy"></a>UniqueKeyPolicy
--------------------------------------------
+UniqueKeyPolicy{#UniqueKeyPolicy}
+---------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2656,8 +2656,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 |------------|---------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey[]](#UniqueKey)<br/><small>Optional</small> |
 
-<a id="UniqueKeyPolicy_STATUS"></a>UniqueKeyPolicy_STATUS
----------------------------------------------------------
+UniqueKeyPolicy_STATUS{#UniqueKeyPolicy_STATUS}
+-----------------------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2667,8 +2667,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 |------------|---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey_STATUS[]](#UniqueKey_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2678,8 +2678,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource"></a>AutoUpgradePolicyResource
----------------------------------------------------------------
+AutoUpgradePolicyResource{#AutoUpgradePolicyResource}
+-----------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2689,8 +2689,8 @@ Used by: [AutoscaleSettingsResource](#AutoscaleSettingsResource).
 |------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource](#ThroughputPolicyResource)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource_STATUS"></a>AutoUpgradePolicyResource_STATUS
------------------------------------------------------------------------------
+AutoUpgradePolicyResource_STATUS{#AutoUpgradePolicyResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2700,8 +2700,8 @@ Used by: [AutoscaleSettingsResource_STATUS](#AutoscaleSettingsResource_STATUS).
 |------------------|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource_STATUS](#ThroughputPolicyResource_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicyMigrationState"></a>BackupPolicyMigrationState
------------------------------------------------------------------
+BackupPolicyMigrationState{#BackupPolicyMigrationState}
+-------------------------------------------------------
 
 The object representing the state of the migration between the backup policies.
 
@@ -2713,8 +2713,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy), and [Periodi
 | status     | Describes the status of migration between backup policy types.          | [BackupPolicyMigrationStatus](#BackupPolicyMigrationStatus)<br/><small>Optional</small> |
 | targetType | Describes the target backup policy type of the backup policy migration. | [BackupPolicyType](#BackupPolicyType)<br/><small>Optional</small>                       |
 
-<a id="BackupPolicyMigrationState_STATUS"></a>BackupPolicyMigrationState_STATUS
--------------------------------------------------------------------------------
+BackupPolicyMigrationState_STATUS{#BackupPolicyMigrationState_STATUS}
+---------------------------------------------------------------------
 
 The object representing the state of the migration between the backup policies.
 
@@ -2726,8 +2726,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 | status     | Describes the status of migration between backup policy types.          | [BackupPolicyMigrationStatus_STATUS](#BackupPolicyMigrationStatus_STATUS)<br/><small>Optional</small> |
 | targetType | Describes the target backup policy type of the backup policy migration. | [BackupPolicyType_STATUS](#BackupPolicyType_STATUS)<br/><small>Optional</small>                       |
 
-<a id="ClientEncryptionIncludedPath"></a>ClientEncryptionIncludedPath
----------------------------------------------------------------------
+ClientEncryptionIncludedPath{#ClientEncryptionIncludedPath}
+-----------------------------------------------------------
 
 .
 
@@ -2740,8 +2740,8 @@ Used by: [ClientEncryptionPolicy](#ClientEncryptionPolicy).
 | encryptionType        | The type of encryption to be performed. Eg - Deterministic, Randomized.         | string<br/><small>Required</small> |
 | path                  | Path that needs to be encrypted.                                                | string<br/><small>Required</small> |
 
-<a id="ClientEncryptionIncludedPath_STATUS"></a>ClientEncryptionIncludedPath_STATUS
------------------------------------------------------------------------------------
+ClientEncryptionIncludedPath_STATUS{#ClientEncryptionIncludedPath_STATUS}
+-------------------------------------------------------------------------
 
 .
 
@@ -2754,8 +2754,8 @@ Used by: [ClientEncryptionPolicy_STATUS](#ClientEncryptionPolicy_STATUS).
 | encryptionType        | The type of encryption to be performed. Eg - Deterministic, Randomized.         | string<br/><small>Optional</small> |
 | path                  | Path that needs to be encrypted.                                                | string<br/><small>Optional</small> |
 
-<a id="CompositePath"></a>CompositePath
----------------------------------------
+CompositePath{#CompositePath}
+-----------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2764,8 +2764,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order](#CompositePath_Order)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 
-<a id="CompositePath_STATUS"></a>CompositePath_STATUS
------------------------------------------------------
+CompositePath_STATUS{#CompositePath_STATUS}
+-------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2774,8 +2774,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order_STATUS](#CompositePath_Order_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                                    |
 
-<a id="ConflictResolutionPolicy_Mode"></a>ConflictResolutionPolicy_Mode
------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode{#ConflictResolutionPolicy_Mode}
+-------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 
@@ -2784,8 +2784,8 @@ Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ConflictResolutionPolicy_Mode_STATUS"></a>ConflictResolutionPolicy_Mode_STATUS
--------------------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode_STATUS{#ConflictResolutionPolicy_Mode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 
@@ -2794,8 +2794,8 @@ Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ContainerPartitionKey_Kind"></a>ContainerPartitionKey_Kind
------------------------------------------------------------------
+ContainerPartitionKey_Kind{#ContainerPartitionKey_Kind}
+-------------------------------------------------------
 
 Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 
@@ -2805,8 +2805,8 @@ Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContainerPartitionKey_Kind_STATUS"></a>ContainerPartitionKey_Kind_STATUS
--------------------------------------------------------------------------------
+ContainerPartitionKey_Kind_STATUS{#ContainerPartitionKey_Kind_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 
@@ -2816,8 +2816,8 @@ Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContinuousModeBackupPolicy_Type"></a>ContinuousModeBackupPolicy_Type
----------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type{#ContinuousModeBackupPolicy_Type}
+-----------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 
@@ -2825,8 +2825,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ContinuousModeBackupPolicy_Type_STATUS"></a>ContinuousModeBackupPolicy_Type_STATUS
------------------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type_STATUS{#ContinuousModeBackupPolicy_Type_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS).
 
@@ -2834,8 +2834,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ContinuousModeProperties"></a>ContinuousModeProperties
--------------------------------------------------------------
+ContinuousModeProperties{#ContinuousModeProperties}
+---------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2845,8 +2845,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 |----------|-------------------------------------------------|---------------------------------------------------------------|
 | tier     | Enum to indicate type of Continuous backup mode | [ContinuousTier](#ContinuousTier)<br/><small>Optional</small> |
 
-<a id="ContinuousModeProperties_STATUS"></a>ContinuousModeProperties_STATUS
----------------------------------------------------------------------------
+ContinuousModeProperties_STATUS{#ContinuousModeProperties_STATUS}
+-----------------------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2856,8 +2856,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 |----------|-------------------------------------------------|-----------------------------------------------------------------------------|
 | tier     | Enum to indicate type of Continuous backup mode | [ContinuousTier_STATUS](#ContinuousTier_STATUS)<br/><small>Optional</small> |
 
-<a id="ExcludedPath"></a>ExcludedPath
--------------------------------------
+ExcludedPath{#ExcludedPath}
+---------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2865,8 +2865,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="ExcludedPath_STATUS"></a>ExcludedPath_STATUS
----------------------------------------------------
+ExcludedPath_STATUS{#ExcludedPath_STATUS}
+-----------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2874,8 +2874,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="IncludedPath"></a>IncludedPath
--------------------------------------
+IncludedPath{#IncludedPath}
+---------------------------
 
 The paths that are included in indexing
 
@@ -2886,8 +2886,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | indexes  | List of indexes for this path                                                                                              | [Indexes[]](#Indexes)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                |
 
-<a id="IncludedPath_STATUS"></a>IncludedPath_STATUS
----------------------------------------------------
+IncludedPath_STATUS{#IncludedPath_STATUS}
+-----------------------------------------
 
 The paths that are included in indexing
 
@@ -2898,8 +2898,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | indexes  | List of indexes for this path                                                                                              | [Indexes_STATUS[]](#Indexes_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                              |
 
-<a id="IndexingPolicy_IndexingMode"></a>IndexingPolicy_IndexingMode
--------------------------------------------------------------------
+IndexingPolicy_IndexingMode{#IndexingPolicy_IndexingMode}
+---------------------------------------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2909,8 +2909,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="IndexingPolicy_IndexingMode_STATUS"></a>IndexingPolicy_IndexingMode_STATUS
----------------------------------------------------------------------------------
+IndexingPolicy_IndexingMode_STATUS{#IndexingPolicy_IndexingMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2920,8 +2920,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="MongoIndexKeys"></a>MongoIndexKeys
------------------------------------------
+MongoIndexKeys{#MongoIndexKeys}
+-------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -2931,8 +2931,8 @@ Used by: [MongoIndex](#MongoIndex).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexKeys_STATUS"></a>MongoIndexKeys_STATUS
--------------------------------------------------------
+MongoIndexKeys_STATUS{#MongoIndexKeys_STATUS}
+---------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -2942,8 +2942,8 @@ Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions"></a>MongoIndexOptions
------------------------------------------------
+MongoIndexOptions{#MongoIndexOptions}
+-------------------------------------
 
 Cosmos DB MongoDB collection index options
 
@@ -2954,20 +2954,20 @@ Used by: [MongoIndex](#MongoIndex).
 | expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
 | unique             | Is unique or not     | bool<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions_STATUS"></a>MongoIndexOptions_STATUS
+MongoIndexOptions_STATUS{#MongoIndexOptions_STATUS}
+---------------------------------------------------
+
+Cosmos DB MongoDB collection index options
+
+Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
+
+| Property           | Description          | Type                             |
+|--------------------|----------------------|----------------------------------|
+| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
+| unique             | Is unique or not     | bool<br/><small>Optional</small> |
+
+PeriodicModeBackupPolicy_Type{#PeriodicModeBackupPolicy_Type}
 -------------------------------------------------------------
-
-Cosmos DB MongoDB collection index options
-
-Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
-
-| Property           | Description          | Type                             |
-|--------------------|----------------------|----------------------------------|
-| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
-| unique             | Is unique or not     | bool<br/><small>Optional</small> |
-
-<a id="PeriodicModeBackupPolicy_Type"></a>PeriodicModeBackupPolicy_Type
------------------------------------------------------------------------
 
 Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 
@@ -2975,8 +2975,8 @@ Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeBackupPolicy_Type_STATUS"></a>PeriodicModeBackupPolicy_Type_STATUS
--------------------------------------------------------------------------------------
+PeriodicModeBackupPolicy_Type_STATUS{#PeriodicModeBackupPolicy_Type_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 
@@ -2984,8 +2984,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeProperties"></a>PeriodicModeProperties
----------------------------------------------------------
+PeriodicModeProperties{#PeriodicModeProperties}
+-----------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2997,8 +2997,8 @@ Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small>                                                 |
 | backupStorageRedundancy        | Enum to indicate type of backup residency                                | [BackupStorageRedundancy](#BackupStorageRedundancy)<br/><small>Optional</small> |
 
-<a id="PeriodicModeProperties_STATUS"></a>PeriodicModeProperties_STATUS
------------------------------------------------------------------------
+PeriodicModeProperties_STATUS{#PeriodicModeProperties_STATUS}
+-------------------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -3010,8 +3010,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small>                                                               |
 | backupStorageRedundancy        | Enum to indicate type of backup residency                                | [BackupStorageRedundancy_STATUS](#BackupStorageRedundancy_STATUS)<br/><small>Optional</small> |
 
-<a id="SpatialSpec"></a>SpatialSpec
------------------------------------
+SpatialSpec{#SpatialSpec}
+-------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -3020,8 +3020,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                        |
 | types    | List of path's spatial type                                                                                                | [SpatialType[]](#SpatialType)<br/><small>Optional</small> |
 
-<a id="SpatialSpec_STATUS"></a>SpatialSpec_STATUS
--------------------------------------------------
+SpatialSpec_STATUS{#SpatialSpec_STATUS}
+---------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -3030,8 +3030,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 | types    | List of path's spatial type                                                                                                | [SpatialType_STATUS[]](#SpatialType_STATUS)<br/><small>Optional</small> |
 
-<a id="UniqueKey"></a>UniqueKey
--------------------------------
+UniqueKey{#UniqueKey}
+---------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -3041,8 +3041,8 @@ Used by: [UniqueKeyPolicy](#UniqueKeyPolicy).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="UniqueKey_STATUS"></a>UniqueKey_STATUS
----------------------------------------------
+UniqueKey_STATUS{#UniqueKey_STATUS}
+-----------------------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -3052,8 +3052,8 @@ Used by: [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="BackupPolicyMigrationStatus"></a>BackupPolicyMigrationStatus
--------------------------------------------------------------------
+BackupPolicyMigrationStatus{#BackupPolicyMigrationStatus}
+---------------------------------------------------------
 
 Describes the status of migration between backup policy types.
 
@@ -3066,8 +3066,8 @@ Used by: [BackupPolicyMigrationState](#BackupPolicyMigrationState).
 | "InProgress" |             |
 | "Invalid"    |             |
 
-<a id="BackupPolicyMigrationStatus_STATUS"></a>BackupPolicyMigrationStatus_STATUS
----------------------------------------------------------------------------------
+BackupPolicyMigrationStatus_STATUS{#BackupPolicyMigrationStatus_STATUS}
+-----------------------------------------------------------------------
 
 Describes the status of migration between backup policy types.
 
@@ -3080,8 +3080,8 @@ Used by: [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)
 | "InProgress" |             |
 | "Invalid"    |             |
 
-<a id="BackupPolicyType"></a>BackupPolicyType
----------------------------------------------
+BackupPolicyType{#BackupPolicyType}
+-----------------------------------
 
 Describes the mode of backups.
 
@@ -3092,8 +3092,8 @@ Used by: [BackupPolicyMigrationState](#BackupPolicyMigrationState).
 | "Continuous" |             |
 | "Periodic"   |             |
 
-<a id="BackupPolicyType_STATUS"></a>BackupPolicyType_STATUS
------------------------------------------------------------
+BackupPolicyType_STATUS{#BackupPolicyType_STATUS}
+-------------------------------------------------
 
 Describes the mode of backups.
 
@@ -3104,8 +3104,8 @@ Used by: [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)
 | "Continuous" |             |
 | "Periodic"   |             |
 
-<a id="BackupStorageRedundancy"></a>BackupStorageRedundancy
------------------------------------------------------------
+BackupStorageRedundancy{#BackupStorageRedundancy}
+-------------------------------------------------
 
 Enum to indicate type of backup storage redundancy.
 
@@ -3117,8 +3117,8 @@ Used by: [PeriodicModeProperties](#PeriodicModeProperties).
 | "Local" |             |
 | "Zone"  |             |
 
-<a id="BackupStorageRedundancy_STATUS"></a>BackupStorageRedundancy_STATUS
--------------------------------------------------------------------------
+BackupStorageRedundancy_STATUS{#BackupStorageRedundancy_STATUS}
+---------------------------------------------------------------
 
 Enum to indicate type of backup storage redundancy.
 
@@ -3130,8 +3130,8 @@ Used by: [PeriodicModeProperties_STATUS](#PeriodicModeProperties_STATUS).
 | "Local" |             |
 | "Zone"  |             |
 
-<a id="CompositePath_Order"></a>CompositePath_Order
----------------------------------------------------
+CompositePath_Order{#CompositePath_Order}
+-----------------------------------------
 
 Used by: [CompositePath](#CompositePath).
 
@@ -3140,8 +3140,8 @@ Used by: [CompositePath](#CompositePath).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="CompositePath_Order_STATUS"></a>CompositePath_Order_STATUS
------------------------------------------------------------------
+CompositePath_Order_STATUS{#CompositePath_Order_STATUS}
+-------------------------------------------------------
 
 Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 
@@ -3150,8 +3150,8 @@ Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="ContinuousTier"></a>ContinuousTier
------------------------------------------
+ContinuousTier{#ContinuousTier}
+-------------------------------
 
 Enum to indicate type of Continuous backup tier.
 
@@ -3162,8 +3162,8 @@ Used by: [ContinuousModeProperties](#ContinuousModeProperties).
 | "Continuous30Days" |             |
 | "Continuous7Days"  |             |
 
-<a id="ContinuousTier_STATUS"></a>ContinuousTier_STATUS
--------------------------------------------------------
+ContinuousTier_STATUS{#ContinuousTier_STATUS}
+---------------------------------------------
 
 Enum to indicate type of Continuous backup tier.
 
@@ -3174,8 +3174,8 @@ Used by: [ContinuousModeProperties_STATUS](#ContinuousModeProperties_STATUS).
 | "Continuous30Days" |             |
 | "Continuous7Days"  |             |
 
-<a id="Indexes"></a>Indexes
----------------------------
+Indexes{#Indexes}
+-----------------
 
 The indexes for the path.
 
@@ -3187,8 +3187,8 @@ Used by: [IncludedPath](#IncludedPath).
 | kind      | Indicates the type of index.                                | [Indexes_Kind](#Indexes_Kind)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                   |
 
-<a id="Indexes_STATUS"></a>Indexes_STATUS
------------------------------------------
+Indexes_STATUS{#Indexes_STATUS}
+-------------------------------
 
 The indexes for the path.
 
@@ -3200,8 +3200,8 @@ Used by: [IncludedPath_STATUS](#IncludedPath_STATUS).
 | kind      | Indicates the type of index.                                | [Indexes_Kind_STATUS](#Indexes_Kind_STATUS)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                                 |
 
-<a id="SpatialType"></a>SpatialType
------------------------------------
+SpatialType{#SpatialType}
+-------------------------
 
 Indicates the spatial type of index.
 
@@ -3214,8 +3214,8 @@ Used by: [SpatialSpec](#SpatialSpec).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="SpatialType_STATUS"></a>SpatialType_STATUS
--------------------------------------------------
+SpatialType_STATUS{#SpatialType_STATUS}
+---------------------------------------
 
 Indicates the spatial type of index.
 
@@ -3228,8 +3228,8 @@ Used by: [SpatialSpec_STATUS](#SpatialSpec_STATUS).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="ThroughputPolicyResource"></a>ThroughputPolicyResource
--------------------------------------------------------------
+ThroughputPolicyResource{#ThroughputPolicyResource}
+---------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -3240,8 +3240,8 @@ Used by: [AutoUpgradePolicyResource](#AutoUpgradePolicyResource).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="ThroughputPolicyResource_STATUS"></a>ThroughputPolicyResource_STATUS
----------------------------------------------------------------------------
+ThroughputPolicyResource_STATUS{#ThroughputPolicyResource_STATUS}
+-----------------------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -3252,8 +3252,8 @@ Used by: [AutoUpgradePolicyResource_STATUS](#AutoUpgradePolicyResource_STATUS).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="Indexes_DataType"></a>Indexes_DataType
----------------------------------------------
+Indexes_DataType{#Indexes_DataType}
+-----------------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -3266,8 +3266,8 @@ Used by: [Indexes](#Indexes).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_DataType_STATUS"></a>Indexes_DataType_STATUS
------------------------------------------------------------
+Indexes_DataType_STATUS{#Indexes_DataType_STATUS}
+-------------------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 
@@ -3280,8 +3280,8 @@ Used by: [Indexes_STATUS](#Indexes_STATUS).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_Kind"></a>Indexes_Kind
--------------------------------------
+Indexes_Kind{#Indexes_Kind}
+---------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -3291,8 +3291,8 @@ Used by: [Indexes](#Indexes).
 | "Range"   |             |
 | "Spatial" |             |
 
-<a id="Indexes_Kind_STATUS"></a>Indexes_Kind_STATUS
----------------------------------------------------
+Indexes_Kind_STATUS{#Indexes_Kind_STATUS}
+-----------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 

--- a/docs/hugo/content/reference/documentdb/v1api20240815.md
+++ b/docs/hugo/content/reference/documentdb/v1api20240815.md
@@ -5,15 +5,15 @@ title: documentdb.azure.com/v1api20240815
 linktitle: v1api20240815
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-08-15" |             |
 
-<a id="DatabaseAccount"></a>DatabaseAccount
--------------------------------------------
+DatabaseAccount{#DatabaseAccount}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | spec                                                                                    |             | [DatabaseAccount_Spec](#DatabaseAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DatabaseAccount_STATUS](#DatabaseAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
+### DatabaseAccount_Spec {#DatabaseAccount_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,7 +69,7 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-### <a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
+### DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -122,8 +122,8 @@ Used by: [DatabaseAccountList](#DatabaseAccountList).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="DatabaseAccountList"></a>DatabaseAccountList
----------------------------------------------------
+DatabaseAccountList{#DatabaseAccountList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}
 
@@ -133,8 +133,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [DatabaseAccount[]](#DatabaseAccount)<br/><small>Optional</small> |
 
-<a id="MongodbDatabase"></a>MongodbDatabase
--------------------------------------------
+MongodbDatabase{#MongodbDatabase}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -147,7 +147,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | spec                                                                                    |             | [MongodbDatabase_Spec](#MongodbDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabase_STATUS](#MongodbDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
+### MongodbDatabase_Spec {#MongodbDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -159,7 +159,7 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
+### MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -172,8 +172,8 @@ Used by: [MongodbDatabaseList](#MongodbDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection"></a>MongodbDatabaseCollection
----------------------------------------------------------------
+MongodbDatabaseCollection{#MongodbDatabaseCollection}
+-----------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -186,7 +186,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | spec                                                                                    |             | [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
+### MongodbDatabaseCollection_Spec {#MongodbDatabaseCollection_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -198,7 +198,7 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
+### MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -211,8 +211,8 @@ Used by: [MongodbDatabaseCollectionList](#MongodbDatabaseCollectionList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionList"></a>MongodbDatabaseCollectionList
------------------------------------------------------------------------
+MongodbDatabaseCollectionList{#MongodbDatabaseCollectionList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}
 
@@ -222,8 +222,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [MongodbDatabaseCollection[]](#MongodbDatabaseCollection)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSetting"></a>MongodbDatabaseCollectionThroughputSetting
--------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting{#MongodbDatabaseCollectionThroughputSetting}
+---------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -236,7 +236,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | spec                                                                                    |             | [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseCollectionThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
+### MongodbDatabaseCollectionThroughputSetting_Spec {#MongodbDatabaseCollectionThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -246,7 +246,7 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
+### MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -258,8 +258,8 @@ Used by: [MongodbDatabaseCollectionThroughputSettingList](#MongodbDatabaseCollec
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSettingList"></a>MongodbDatabaseCollectionThroughputSettingList
----------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingList{#MongodbDatabaseCollectionThroughputSettingList}
+-----------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default
 
@@ -269,8 +269,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                         |
 | items                                                                               |             | [MongodbDatabaseCollectionThroughputSetting[]](#MongodbDatabaseCollectionThroughputSetting)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseList"></a>MongodbDatabaseList
----------------------------------------------------
+MongodbDatabaseList{#MongodbDatabaseList}
+-----------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}
 
@@ -280,8 +280,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [MongodbDatabase[]](#MongodbDatabase)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseThroughputSetting"></a>MongodbDatabaseThroughputSetting
------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting{#MongodbDatabaseThroughputSetting}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -294,7 +294,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | spec                                                                                    |             | [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
+### MongodbDatabaseThroughputSetting_Spec {#MongodbDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -304,7 +304,7 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
+### MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -316,8 +316,8 @@ Used by: [MongodbDatabaseThroughputSettingList](#MongodbDatabaseThroughputSettin
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSettingList"></a>MongodbDatabaseThroughputSettingList
--------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingList{#MongodbDatabaseThroughputSettingList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default
 
@@ -327,8 +327,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [MongodbDatabaseThroughputSetting[]](#MongodbDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="MongodbUserDefinition"></a>MongodbUserDefinition
--------------------------------------------------------
+MongodbUserDefinition{#MongodbUserDefinition}
+---------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/mongorbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbUserDefinitions/{mongoUserDefinitionId}
 
@@ -341,7 +341,7 @@ Used by: [MongodbUserDefinitionList](#MongodbUserDefinitionList).
 | spec                                                                                    |             | [MongodbUserDefinition_Spec](#MongodbUserDefinition_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MongodbUserDefinition_STATUS](#MongodbUserDefinition_STATUS)<br/><small>Optional</small> |
 
-### <a id="MongodbUserDefinition_Spec"></a>MongodbUserDefinition_Spec
+### MongodbUserDefinition_Spec {#MongodbUserDefinition_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -355,7 +355,7 @@ Used by: [MongodbUserDefinitionList](#MongodbUserDefinitionList).
 | roles        | The set of roles inherited by the User Definition.                                                                                                                                                                                                                                              | [Role[]](#Role)<br/><small>Optional</small>                                                                                                                          |
 | userName     | The user name for User Definition.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="MongodbUserDefinition_STATUS"></a>MongodbUserDefinition_STATUS
+### MongodbUserDefinition_STATUS{#MongodbUserDefinition_STATUS}
 
 | Property     | Description                                                                      | Type                                                                                                                                                    |
 |--------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -369,8 +369,8 @@ Used by: [MongodbUserDefinitionList](#MongodbUserDefinitionList).
 | type         | The type of Azure resource.                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | userName     | The user name for User Definition.                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbUserDefinitionList"></a>MongodbUserDefinitionList
----------------------------------------------------------------
+MongodbUserDefinitionList{#MongodbUserDefinitionList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/mongorbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbUserDefinitions/{mongoUserDefinitionId}
 
@@ -380,8 +380,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [MongodbUserDefinition[]](#MongodbUserDefinition)<br/><small>Optional</small> |
 
-<a id="SqlDatabase"></a>SqlDatabase
------------------------------------
+SqlDatabase{#SqlDatabase}
+-------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -394,7 +394,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | spec                                                                                    |             | [SqlDatabase_Spec](#SqlDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabase_STATUS](#SqlDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
+### SqlDatabase_Spec {#SqlDatabase_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -406,7 +406,7 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
+### SqlDatabase_STATUS{#SqlDatabase_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -419,8 +419,8 @@ Used by: [SqlDatabaseList](#SqlDatabaseList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer"></a>SqlDatabaseContainer
------------------------------------------------------
+SqlDatabaseContainer{#SqlDatabaseContainer}
+-------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -433,7 +433,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | spec                                                                                    |             | [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
+### SqlDatabaseContainer_Spec {#SqlDatabaseContainer_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -445,7 +445,7 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
+### SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -458,8 +458,8 @@ Used by: [SqlDatabaseContainerList](#SqlDatabaseContainerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerList"></a>SqlDatabaseContainerList
--------------------------------------------------------------
+SqlDatabaseContainerList{#SqlDatabaseContainerList}
+---------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}
 
@@ -469,8 +469,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [SqlDatabaseContainer[]](#SqlDatabaseContainer)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedure"></a>SqlDatabaseContainerStoredProcedure
------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure{#SqlDatabaseContainerStoredProcedure}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -483,7 +483,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | spec                                                                                    |             | [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredProcedure_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
+### SqlDatabaseContainerStoredProcedure_Spec {#SqlDatabaseContainerStoredProcedure_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -495,7 +495,7 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
+### SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -507,8 +507,8 @@ Used by: [SqlDatabaseContainerStoredProcedureList](#SqlDatabaseContainerStoredPr
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedureList"></a>SqlDatabaseContainerStoredProcedureList
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureList{#SqlDatabaseContainerStoredProcedureList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}
 
@@ -518,8 +518,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerStoredProcedure[]](#SqlDatabaseContainerStoredProcedure)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSetting"></a>SqlDatabaseContainerThroughputSetting
----------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting{#SqlDatabaseContainerThroughputSetting}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -532,7 +532,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | spec                                                                                    |             | [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
+### SqlDatabaseContainerThroughputSetting_Spec {#SqlDatabaseContainerThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -542,7 +542,7 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
+### SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -554,8 +554,8 @@ Used by: [SqlDatabaseContainerThroughputSettingList](#SqlDatabaseContainerThroug
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSettingList"></a>SqlDatabaseContainerThroughputSettingList
------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingList{#SqlDatabaseContainerThroughputSettingList}
+-------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default
 
@@ -565,8 +565,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                               |
 | items                                                                               |             | [SqlDatabaseContainerThroughputSetting[]](#SqlDatabaseContainerThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTrigger"></a>SqlDatabaseContainerTrigger
--------------------------------------------------------------------
+SqlDatabaseContainerTrigger{#SqlDatabaseContainerTrigger}
+---------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -579,7 +579,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | spec                                                                                    |             | [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
+### SqlDatabaseContainerTrigger_Spec {#SqlDatabaseContainerTrigger_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -591,7 +591,7 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
+### SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -603,8 +603,8 @@ Used by: [SqlDatabaseContainerTriggerList](#SqlDatabaseContainerTriggerList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTriggerList"></a>SqlDatabaseContainerTriggerList
----------------------------------------------------------------------------
+SqlDatabaseContainerTriggerList{#SqlDatabaseContainerTriggerList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}
 
@@ -614,8 +614,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [SqlDatabaseContainerTrigger[]](#SqlDatabaseContainerTrigger)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunction"></a>SqlDatabaseContainerUserDefinedFunction
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction{#SqlDatabaseContainerUserDefinedFunction}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -628,7 +628,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | spec                                                                                    |             | [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUserDefinedFunction_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
+### SqlDatabaseContainerUserDefinedFunction_Spec {#SqlDatabaseContainerUserDefinedFunction_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -640,7 +640,7 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
+### SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -652,8 +652,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunctionList](#SqlDatabaseContainerUser
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionList"></a>SqlDatabaseContainerUserDefinedFunctionList
----------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionList{#SqlDatabaseContainerUserDefinedFunctionList}
+-----------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}
 
@@ -663,8 +663,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                   |
 | items                                                                               |             | [SqlDatabaseContainerUserDefinedFunction[]](#SqlDatabaseContainerUserDefinedFunction)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseList"></a>SqlDatabaseList
--------------------------------------------
+SqlDatabaseList{#SqlDatabaseList}
+---------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}
 
@@ -674,8 +674,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [SqlDatabase[]](#SqlDatabase)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseThroughputSetting"></a>SqlDatabaseThroughputSetting
----------------------------------------------------------------------
+SqlDatabaseThroughputSetting{#SqlDatabaseThroughputSetting}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -688,7 +688,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | spec                                                                                    |             | [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
+### SqlDatabaseThroughputSetting_Spec {#SqlDatabaseThroughputSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -698,7 +698,7 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
+### SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
 
 | Property   | Description                                                       | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -710,8 +710,8 @@ Used by: [SqlDatabaseThroughputSettingList](#SqlDatabaseThroughputSettingList).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSettingList"></a>SqlDatabaseThroughputSettingList
------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingList{#SqlDatabaseThroughputSettingList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/cosmos-db.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default
 
@@ -721,8 +721,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [SqlDatabaseThroughputSetting[]](#SqlDatabaseThroughputSetting)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignment"></a>SqlRoleAssignment
------------------------------------------------
+SqlRoleAssignment{#SqlRoleAssignment}
+-------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -735,7 +735,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | spec                                                                                    |             | [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SqlRoleAssignment_STATUS](#SqlRoleAssignment_STATUS)<br/><small>Optional</small> |
 
-### <a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
+### SqlRoleAssignment_Spec {#SqlRoleAssignment_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -747,7 +747,7 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
+### SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                       | Type                                                                                                                                                    |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -759,8 +759,8 @@ Used by: [SqlRoleAssignmentList](#SqlRoleAssignmentList).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignmentList"></a>SqlRoleAssignmentList
--------------------------------------------------------
+SqlRoleAssignmentList{#SqlRoleAssignmentList}
+---------------------------------------------
 
 Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2024-08-15/rbac.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}
 
@@ -770,8 +770,8 @@ Generator information: - Generated from: /cosmos-db/resource-manager/Microsoft.D
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [SqlRoleAssignment[]](#SqlRoleAssignment)<br/><small>Optional</small> |
 
-<a id="DatabaseAccount_Spec"></a>DatabaseAccount_Spec
------------------------------------------------------
+DatabaseAccount_Spec{#DatabaseAccount_Spec}
+-------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -816,8 +816,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | tags                               |                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                                                      | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                                                                                              |
 
-<a id="DatabaseAccount_STATUS"></a>DatabaseAccount_STATUS
----------------------------------------------------------
+DatabaseAccount_STATUS{#DatabaseAccount_STATUS}
+-----------------------------------------------
 
 Used by: [DatabaseAccount](#DatabaseAccount).
 
@@ -872,8 +872,8 @@ Used by: [DatabaseAccount](#DatabaseAccount).
 | virtualNetworkRules                | List of Virtual Network ACL rules configured for the Cosmos DB account.                                                                                                                                                                                           | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                                                                   |
 | writeLocations                     | An array that contains the write location for the Cosmos DB account.                                                                                                                                                                                              | [Location_STATUS[]](#Location_STATUS)<br/><small>Optional</small>                                                                                       |
 
-<a id="MongodbDatabase_Spec"></a>MongodbDatabase_Spec
------------------------------------------------------
+MongodbDatabase_Spec{#MongodbDatabase_Spec}
+-------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -887,8 +887,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | resource     | The standard JSON format of a MongoDB database                                                                                                                                                                                                                                                  | [MongoDBDatabaseResource](#MongoDBDatabaseResource)<br/><small>Required</small>                                                                                      |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabase_STATUS"></a>MongodbDatabase_STATUS
----------------------------------------------------------
+MongodbDatabase_STATUS{#MongodbDatabase_STATUS}
+-----------------------------------------------
 
 Used by: [MongodbDatabase](#MongodbDatabase).
 
@@ -903,8 +903,8 @@ Used by: [MongodbDatabase](#MongodbDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollection_Spec"></a>MongodbDatabaseCollection_Spec
--------------------------------------------------------------------------
+MongodbDatabaseCollection_Spec{#MongodbDatabaseCollection_Spec}
+---------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -918,8 +918,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | resource     | The standard JSON format of a MongoDB collection                                                                                                                                                                                                                                                | [MongoDBCollectionResource](#MongoDBCollectionResource)<br/><small>Required</small>                                                                                  |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollection_STATUS"></a>MongodbDatabaseCollection_STATUS
------------------------------------------------------------------------------
+MongodbDatabaseCollection_STATUS{#MongodbDatabaseCollection_STATUS}
+-------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 
@@ -934,8 +934,8 @@ Used by: [MongodbDatabaseCollection](#MongodbDatabaseCollection).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_Spec"></a>MongodbDatabaseCollectionThroughputSetting_Spec
------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_Spec{#MongodbDatabaseCollectionThroughputSetting_Spec}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -947,8 +947,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                         | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseCollectionThroughputSetting_STATUS"></a>MongodbDatabaseCollectionThroughputSetting_STATUS
----------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSetting_STATUS{#MongodbDatabaseCollectionThroughputSetting_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollectionThroughputSetting).
 
@@ -962,8 +962,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting](#MongodbDatabaseCollection
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbDatabaseThroughputSetting_Spec"></a>MongodbDatabaseThroughputSetting_Spec
----------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_Spec{#MongodbDatabaseThroughputSetting_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -975,8 +975,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                               | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="MongodbDatabaseThroughputSetting_STATUS"></a>MongodbDatabaseThroughputSetting_STATUS
--------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSetting_STATUS{#MongodbDatabaseThroughputSetting_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 
@@ -990,8 +990,8 @@ Used by: [MongodbDatabaseThroughputSetting](#MongodbDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MongodbUserDefinition_Spec"></a>MongodbUserDefinition_Spec
------------------------------------------------------------------
+MongodbUserDefinition_Spec{#MongodbUserDefinition_Spec}
+-------------------------------------------------------
 
 Used by: [MongodbUserDefinition](#MongodbUserDefinition).
 
@@ -1007,8 +1007,8 @@ Used by: [MongodbUserDefinition](#MongodbUserDefinition).
 | roles        | The set of roles inherited by the User Definition.                                                                                                                                                                                                                                              | [Role[]](#Role)<br/><small>Optional</small>                                                                                                                          |
 | userName     | The user name for User Definition.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="MongodbUserDefinition_STATUS"></a>MongodbUserDefinition_STATUS
----------------------------------------------------------------------
+MongodbUserDefinition_STATUS{#MongodbUserDefinition_STATUS}
+-----------------------------------------------------------
 
 Used by: [MongodbUserDefinition](#MongodbUserDefinition).
 
@@ -1024,8 +1024,8 @@ Used by: [MongodbUserDefinition](#MongodbUserDefinition).
 | type         | The type of Azure resource.                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | userName     | The user name for User Definition.                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabase_Spec"></a>SqlDatabase_Spec
----------------------------------------------
+SqlDatabase_Spec{#SqlDatabase_Spec}
+-----------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -1039,8 +1039,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | resource     | The standard JSON format of a SQL database                                                                                                                                                                                                                                                      | [SqlDatabaseResource](#SqlDatabaseResource)<br/><small>Required</small>                                                                                              |
 | tags         |                                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabase_STATUS"></a>SqlDatabase_STATUS
--------------------------------------------------
+SqlDatabase_STATUS{#SqlDatabase_STATUS}
+---------------------------------------
 
 Used by: [SqlDatabase](#SqlDatabase).
 
@@ -1055,8 +1055,8 @@ Used by: [SqlDatabase](#SqlDatabase).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainer_Spec"></a>SqlDatabaseContainer_Spec
----------------------------------------------------------------
+SqlDatabaseContainer_Spec{#SqlDatabaseContainer_Spec}
+-----------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -1070,8 +1070,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | resource     | The standard JSON format of a container                                                                                                                                                                                                                                                     | [SqlContainerResource](#SqlContainerResource)<br/><small>Required</small>                                                                                            |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainer_STATUS"></a>SqlDatabaseContainer_STATUS
--------------------------------------------------------------------
+SqlDatabaseContainer_STATUS{#SqlDatabaseContainer_STATUS}
+---------------------------------------------------------
 
 Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 
@@ -1086,8 +1086,8 @@ Used by: [SqlDatabaseContainer](#SqlDatabaseContainer).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerStoredProcedure_Spec"></a>SqlDatabaseContainerStoredProcedure_Spec
----------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_Spec{#SqlDatabaseContainerStoredProcedure_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -1101,8 +1101,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | resource     | The standard JSON format of a storedProcedure                                                                                                                                                                                                                                                        | [SqlStoredProcedureResource](#SqlStoredProcedureResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerStoredProcedure_STATUS"></a>SqlDatabaseContainerStoredProcedure_STATUS
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedure_STATUS{#SqlDatabaseContainerStoredProcedure_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProcedure).
 
@@ -1116,8 +1116,8 @@ Used by: [SqlDatabaseContainerStoredProcedure](#SqlDatabaseContainerStoredProced
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerThroughputSetting_Spec"></a>SqlDatabaseContainerThroughputSetting_Spec
--------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_Spec{#SqlDatabaseContainerThroughputSetting_Spec}
+---------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1129,8 +1129,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                                    | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerThroughputSetting_STATUS"></a>SqlDatabaseContainerThroughputSetting_STATUS
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSetting_STATUS{#SqlDatabaseContainerThroughputSetting_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughputSetting).
 
@@ -1144,8 +1144,8 @@ Used by: [SqlDatabaseContainerThroughputSetting](#SqlDatabaseContainerThroughput
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerTrigger_Spec"></a>SqlDatabaseContainerTrigger_Spec
------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_Spec{#SqlDatabaseContainerTrigger_Spec}
+-------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1159,8 +1159,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | resource     | The standard JSON format of a trigger                                                                                                                                                                                                                                                                | [SqlTriggerResource](#SqlTriggerResource)<br/><small>Required</small>                                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerTrigger_STATUS"></a>SqlDatabaseContainerTrigger_STATUS
----------------------------------------------------------------------------------
+SqlDatabaseContainerTrigger_STATUS{#SqlDatabaseContainerTrigger_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 
@@ -1174,8 +1174,8 @@ Used by: [SqlDatabaseContainerTrigger](#SqlDatabaseContainerTrigger).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_Spec"></a>SqlDatabaseContainerUserDefinedFunction_Spec
------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_Spec{#SqlDatabaseContainerUserDefinedFunction_Spec}
+-------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1189,8 +1189,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | resource     | The standard JSON format of a userDefinedFunction                                                                                                                                                                                                                                                    | [SqlUserDefinedFunctionResource](#SqlUserDefinedFunctionResource)<br/><small>Required</small>                                                                        |
 | tags         |                                                                                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseContainerUserDefinedFunction_STATUS"></a>SqlDatabaseContainerUserDefinedFunction_STATUS
----------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunction_STATUS{#SqlDatabaseContainerUserDefinedFunction_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefinedFunction).
 
@@ -1204,8 +1204,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction](#SqlDatabaseContainerUserDefi
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlDatabaseThroughputSetting_Spec"></a>SqlDatabaseThroughputSetting_Spec
--------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_Spec{#SqlDatabaseThroughputSetting_Spec}
+---------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1217,8 +1217,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | resource     | The standard JSON format of a resource throughput                                                                                                                                                                                                                                           | [ThroughputSettingsResource](#ThroughputSettingsResource)<br/><small>Required</small>                                                                                |
 | tags         |                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SqlDatabaseThroughputSetting_STATUS"></a>SqlDatabaseThroughputSetting_STATUS
------------------------------------------------------------------------------------
+SqlDatabaseThroughputSetting_STATUS{#SqlDatabaseThroughputSetting_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 
@@ -1232,8 +1232,8 @@ Used by: [SqlDatabaseThroughputSetting](#SqlDatabaseThroughputSetting).
 | tags       |                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of Azure resource.                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SqlRoleAssignment_Spec"></a>SqlRoleAssignment_Spec
----------------------------------------------------------
+SqlRoleAssignment_Spec{#SqlRoleAssignment_Spec}
+-----------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1247,8 +1247,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | roleDefinitionId      | The unique identifier for the associated Role Definition.                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                   |
 | scope                 | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="SqlRoleAssignment_STATUS"></a>SqlRoleAssignment_STATUS
--------------------------------------------------------------
+SqlRoleAssignment_STATUS{#SqlRoleAssignment_STATUS}
+---------------------------------------------------
 
 Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 
@@ -1262,8 +1262,8 @@ Used by: [SqlRoleAssignment](#SqlRoleAssignment).
 | scope            | The data plane resource path for which access is being granted through this Role Assignment.                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type             | The type of Azure resource.                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AnalyticalStorageConfiguration"></a>AnalyticalStorageConfiguration
--------------------------------------------------------------------------
+AnalyticalStorageConfiguration{#AnalyticalStorageConfiguration}
+---------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1273,8 +1273,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType](#AnalyticalStorageSchemaType)<br/><small>Optional</small> |
 
-<a id="AnalyticalStorageConfiguration_STATUS"></a>AnalyticalStorageConfiguration_STATUS
----------------------------------------------------------------------------------------
+AnalyticalStorageConfiguration_STATUS{#AnalyticalStorageConfiguration_STATUS}
+-----------------------------------------------------------------------------
 
 Analytical storage specific properties.
 
@@ -1284,8 +1284,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | schemaType | Describes the types of schema for analytical storage. | [AnalyticalStorageSchemaType_STATUS](#AnalyticalStorageSchemaType_STATUS)<br/><small>Optional</small> |
 
-<a id="ApiProperties"></a>ApiProperties
----------------------------------------
+ApiProperties{#ApiProperties}
+-----------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1293,8 +1293,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------------|-----------------------------------------------|-----------------------------------------------------------------------------------------|
 | serverVersion | Describes the version of the MongoDB account. | [ApiProperties_ServerVersion](#ApiProperties_ServerVersion)<br/><small>Optional</small> |
 
-<a id="ApiProperties_STATUS"></a>ApiProperties_STATUS
------------------------------------------------------
+ApiProperties_STATUS{#ApiProperties_STATUS}
+-------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1302,8 +1302,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------------|-----------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | serverVersion | Describes the version of the MongoDB account. | [ApiProperties_ServerVersion_STATUS](#ApiProperties_ServerVersion_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicy"></a>BackupPolicy
--------------------------------------
+BackupPolicy{#BackupPolicy}
+---------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1312,8 +1312,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy)<br/><small>Optional</small>     |
 
-<a id="BackupPolicy_STATUS"></a>BackupPolicy_STATUS
----------------------------------------------------
+BackupPolicy_STATUS{#BackupPolicy_STATUS}
+-----------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1322,42 +1322,42 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | continuous | Mutually exclusive with all other properties | [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)<br/><small>Optional</small> |
 | periodic   | Mutually exclusive with all other properties | [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS)<br/><small>Optional</small>     |
 
-<a id="Capability"></a>Capability
+Capability{#Capability}
+-----------------------
+
+Cosmos DB capability object
+
+Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
+
+| Property | Description                                                                                                                              | Type                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
+
+Capability_STATUS{#Capability_STATUS}
+-------------------------------------
+
+Cosmos DB capability object
+
+Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
+
+| Property | Description                                                                                                                              | Type                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
+
+Capacity{#Capacity}
+-------------------
+
+The object that represents all properties related to capacity enforcement on an account.
+
+Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
+
+| Property             | Description                                                                                                                                                                                                                                                    | Type                            |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
+
+Capacity_STATUS{#Capacity_STATUS}
 ---------------------------------
 
-Cosmos DB capability object
-
-Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
-
-| Property | Description                                                                                                                              | Type                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
-
-<a id="Capability_STATUS"></a>Capability_STATUS
------------------------------------------------
-
-Cosmos DB capability object
-
-Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
-
-| Property | Description                                                                                                                              | Type                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| name     | Name of the Cosmos DB capability. For example, "name": "EnableCassandra". Current values also include "EnableTable" and "EnableGremlin". | string<br/><small>Optional</small> |
-
-<a id="Capacity"></a>Capacity
------------------------------
-
-The object that represents all properties related to capacity enforcement on an account.
-
-Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
-
-| Property             | Description                                                                                                                                                                                                                                                    | Type                            |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
-
-<a id="Capacity_STATUS"></a>Capacity_STATUS
--------------------------------------------
-
 The object that represents all properties related to capacity enforcement on an account.
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
@@ -1366,8 +1366,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | totalThroughputLimit | The total throughput limit imposed on the account. A totalThroughputLimit of 2000 imposes a strict limit of max throughput that can be provisioned on that account to be 2000. A totalThroughputLimit of -1 indicates no limits on provisioning of throughput. | int<br/><small>Optional</small> |
 
-<a id="ConnectorOffer"></a>ConnectorOffer
------------------------------------------
+ConnectorOffer{#ConnectorOffer}
+-------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1377,8 +1377,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConnectorOffer_STATUS"></a>ConnectorOffer_STATUS
--------------------------------------------------------
+ConnectorOffer_STATUS{#ConnectorOffer_STATUS}
+---------------------------------------------
 
 The cassandra connector offer type for the Cosmos DB C* database account.
 
@@ -1388,8 +1388,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |---------|-------------|
 | "Small" |             |
 
-<a id="ConsistencyPolicy"></a>ConsistencyPolicy
------------------------------------------------
+ConsistencyPolicy{#ConsistencyPolicy}
+-------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1401,8 +1401,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                     |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                     |
 
-<a id="ConsistencyPolicy_STATUS"></a>ConsistencyPolicy_STATUS
--------------------------------------------------------------
+ConsistencyPolicy_STATUS{#ConsistencyPolicy_STATUS}
+---------------------------------------------------
 
 The consistency policy for the Cosmos DB database account.
 
@@ -1414,8 +1414,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | maxIntervalInSeconds    | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | int<br/><small>Optional</small>                                                                                                   |
 | maxStalenessPrefix      | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.      | int<br/><small>Optional</small>                                                                                                   |
 
-<a id="CorsPolicy"></a>CorsPolicy
----------------------------------
+CorsPolicy{#CorsPolicy}
+-----------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1429,8 +1429,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CorsPolicy_STATUS"></a>CorsPolicy_STATUS
------------------------------------------------
+CorsPolicy_STATUS{#CorsPolicy_STATUS}
+-------------------------------------
 
 The CORS policy for the Cosmos DB database account.
 
@@ -1444,8 +1444,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | exposedHeaders  | The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. | string<br/><small>Optional</small> |
 | maxAgeInSeconds | The maximum amount time that a browser should cache the preflight OPTIONS request.                                          | int<br/><small>Optional</small>    |
 
-<a id="CreateMode"></a>CreateMode
----------------------------------
+CreateMode{#CreateMode}
+-----------------------
 
 Enum to indicate the mode of account creation.
 
@@ -1456,8 +1456,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec), [MongoDBCollectionResour
 | "Default" |             |
 | "Restore" |             |
 
-<a id="CreateMode_STATUS"></a>CreateMode_STATUS
------------------------------------------------
+CreateMode_STATUS{#CreateMode_STATUS}
+-------------------------------------
 
 Enum to indicate the mode of account creation.
 
@@ -1468,8 +1468,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS), [MongoDBCollectionGe
 | "Default" |             |
 | "Restore" |             |
 
-<a id="CreateUpdateOptions"></a>CreateUpdateOptions
----------------------------------------------------
+CreateUpdateOptions{#CreateUpdateOptions}
+-----------------------------------------
 
 CreateUpdateOptions are a list of key-value pairs that describe the resource. Supported keys are "If-Match", "If-None-Match", "Session-Token" and "Throughput"
 
@@ -1480,8 +1480,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec), [MongodbDatabaseCollecti
 | autoscaleSettings | Specifies the Autoscale settings. Note: Either throughput or autoscaleSettings is required, but not both. | [AutoscaleSettings](#AutoscaleSettings)<br/><small>Optional</small> |
 | throughput        | Request Units per second. For example, "throughput": 10000.                                               | int<br/><small>Optional</small>                                     |
 
-<a id="DatabaseAccount_Kind_Spec"></a>DatabaseAccount_Kind_Spec
----------------------------------------------------------------
+DatabaseAccount_Kind_Spec{#DatabaseAccount_Kind_Spec}
+-----------------------------------------------------
 
 Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 
@@ -1491,8 +1491,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccount_Kind_STATUS"></a>DatabaseAccount_Kind_STATUS
--------------------------------------------------------------------
+DatabaseAccount_Kind_STATUS{#DatabaseAccount_Kind_STATUS}
+---------------------------------------------------------
 
 Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 
@@ -1502,8 +1502,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "MongoDB"          |             |
 | "Parse"            |             |
 
-<a id="DatabaseAccountKeysMetadata_STATUS"></a>DatabaseAccountKeysMetadata_STATUS
----------------------------------------------------------------------------------
+DatabaseAccountKeysMetadata_STATUS{#DatabaseAccountKeysMetadata_STATUS}
+-----------------------------------------------------------------------
 
 The metadata related to each access key for the given Cosmos DB database account.
 
@@ -1516,8 +1516,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | secondaryMasterKey         | The metadata related to the Secondary Read-Write Key for the given Cosmos DB database account. | [AccountKeyMetadata_STATUS](#AccountKeyMetadata_STATUS)<br/><small>Optional</small> |
 | secondaryReadonlyMasterKey | The metadata related to the Secondary Read-Only Key for the given Cosmos DB database account.  | [AccountKeyMetadata_STATUS](#AccountKeyMetadata_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseAccountOfferType"></a>DatabaseAccountOfferType
--------------------------------------------------------------
+DatabaseAccountOfferType{#DatabaseAccountOfferType}
+---------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1527,8 +1527,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOfferType_STATUS"></a>DatabaseAccountOfferType_STATUS
----------------------------------------------------------------------------
+DatabaseAccountOfferType_STATUS{#DatabaseAccountOfferType_STATUS}
+-----------------------------------------------------------------
 
 The offer type for the Cosmos DB database account.
 
@@ -1538,8 +1538,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="DatabaseAccountOperatorSpec"></a>DatabaseAccountOperatorSpec
--------------------------------------------------------------------
+DatabaseAccountOperatorSpec{#DatabaseAccountOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1551,8 +1551,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [DatabaseAccountOperatorSecrets](#DatabaseAccountOperatorSecrets)<br/><small>Optional</small>                                                                       |
 
-<a id="FailoverPolicy_STATUS"></a>FailoverPolicy_STATUS
--------------------------------------------------------
+FailoverPolicy_STATUS{#FailoverPolicy_STATUS}
+---------------------------------------------
 
 The failover policy for a given region of a database account.
 
@@ -1564,8 +1564,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id               | The unique identifier of the region in which the database account replicates to. Example: &lt;accountName&gt;\-&lt;locationName&gt;.                                                                                                                                     | string<br/><small>Optional</small> |
 | locationName     | The name of the region in which the database account exists.                                                                                                                                                                                                             | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange"></a>IpAddressOrRange
----------------------------------------------
+IpAddressOrRange{#IpAddressOrRange}
+-----------------------------------
 
 IpAddressOrRange object
 
@@ -1575,8 +1575,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="IpAddressOrRange_STATUS"></a>IpAddressOrRange_STATUS
------------------------------------------------------------
+IpAddressOrRange_STATUS{#IpAddressOrRange_STATUS}
+-------------------------------------------------
 
 IpAddressOrRange object
 
@@ -1586,8 +1586,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | ipAddressOrRange | A single IPv4 address or a single IPv4 address range in CIDR format. Provided IPs must be well-formatted and cannot be contained in one of the following ranges: 10.0.0.0/8, 100.64.0.0/10, 172.16.0.0/12, 192.168.0.0/16, since these are not enforceable by the IP address filter. Example of valid inputs: “23.40.210.245” or “23.40.210.0/8”. | string<br/><small>Optional</small> |
 
-<a id="Location"></a>Location
------------------------------
+Location{#Location}
+-------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1599,8 +1599,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | isZoneRedundant  | Flag to indicate whether or not this region is an AvailabilityZone region                                                                                                                                                                                                | bool<br/><small>Optional</small>   |
 | locationName     | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 
-<a id="Location_STATUS"></a>Location_STATUS
--------------------------------------------
+Location_STATUS{#Location_STATUS}
+---------------------------------
 
 A region in which the Azure Cosmos DB database account is deployed.
 
@@ -1615,8 +1615,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS), [DatabaseAccount_STA
 | locationName      | The name of the region.                                                                                                                                                                                                                                                  | string<br/><small>Optional</small> |
 | provisioningState |                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Identity for the resource.
 
@@ -1627,8 +1627,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the resource.
 
@@ -1641,8 +1641,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned,UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.                                                                                                                                                     | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS](#ManagedServiceIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="MinimalTlsVersion"></a>MinimalTlsVersion
------------------------------------------------
+MinimalTlsVersion{#MinimalTlsVersion}
+-------------------------------------
 
 Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.
 
@@ -1654,8 +1654,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "Tls11" |             |
 | "Tls12" |             |
 
-<a id="MinimalTlsVersion_STATUS"></a>MinimalTlsVersion_STATUS
--------------------------------------------------------------
+MinimalTlsVersion_STATUS{#MinimalTlsVersion_STATUS}
+---------------------------------------------------
 
 Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.
 
@@ -1667,8 +1667,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "Tls11" |             |
 | "Tls12" |             |
 
-<a id="MongoDBCollectionGetProperties_Resource_STATUS"></a>MongoDBCollectionGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------------------
+MongoDBCollectionGetProperties_Resource_STATUS{#MongoDBCollectionGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 
@@ -1684,8 +1684,8 @@ Used by: [MongodbDatabaseCollection_STATUS](#MongodbDatabaseCollection_STATUS).
 | restoreParameters    | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request.                                           | map[string]string<br/><small>Optional</small>                                             |
 
-<a id="MongoDBCollectionResource"></a>MongoDBCollectionResource
----------------------------------------------------------------
+MongoDBCollectionResource{#MongoDBCollectionResource}
+-----------------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -1700,8 +1700,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | restoreParameters    | Parameters to indicate the information about the restore      | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 | shardKey             | A key-value pair of shard keys to be applied for the request. | map[string]string<br/><small>Optional</small>                               |
 
-<a id="MongodbDatabaseCollectionOperatorSpec"></a>MongodbDatabaseCollectionOperatorSpec
----------------------------------------------------------------------------------------
+MongodbDatabaseCollectionOperatorSpec{#MongodbDatabaseCollectionOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1712,8 +1712,8 @@ Used by: [MongodbDatabaseCollection_Spec](#MongodbDatabaseCollection_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseCollectionThroughputSettingOperatorSpec"></a>MongodbDatabaseCollectionThroughputSettingOperatorSpec
--------------------------------------------------------------------------------------------------------------------------
+MongodbDatabaseCollectionThroughputSettingOperatorSpec{#MongodbDatabaseCollectionThroughputSettingOperatorSpec}
+---------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1724,8 +1724,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseGetProperties_Resource_STATUS"></a>MongoDBDatabaseGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------
+MongoDBDatabaseGetProperties_Resource_STATUS{#MongoDBDatabaseGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 
@@ -1738,8 +1738,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS).
 | id                | Name of the Cosmos DB MongoDB database                                                                  | string<br/><small>Optional</small>                                                        |
 | restoreParameters | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseOperatorSpec"></a>MongodbDatabaseOperatorSpec
--------------------------------------------------------------------
+MongodbDatabaseOperatorSpec{#MongodbDatabaseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1750,8 +1750,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongoDBDatabaseResource"></a>MongoDBDatabaseResource
------------------------------------------------------------
+MongoDBDatabaseResource{#MongoDBDatabaseResource}
+-------------------------------------------------
 
 Cosmos DB MongoDB database resource object
 
@@ -1763,8 +1763,8 @@ Used by: [MongodbDatabase_Spec](#MongodbDatabase_Spec).
 | id                | Name of the Cosmos DB MongoDB database                   | string<br/><small>Required</small>                                          |
 | restoreParameters | Parameters to indicate the information about the restore | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 
-<a id="MongodbDatabaseThroughputSettingOperatorSpec"></a>MongodbDatabaseThroughputSettingOperatorSpec
------------------------------------------------------------------------------------------------------
+MongodbDatabaseThroughputSettingOperatorSpec{#MongodbDatabaseThroughputSettingOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1775,8 +1775,8 @@ Used by: [MongodbDatabaseThroughputSetting_Spec](#MongodbDatabaseThroughputSetti
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MongodbUserDefinitionOperatorSpec"></a>MongodbUserDefinitionOperatorSpec
--------------------------------------------------------------------------------
+MongodbUserDefinitionOperatorSpec{#MongodbUserDefinitionOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1787,8 +1787,8 @@ Used by: [MongodbUserDefinition_Spec](#MongodbUserDefinition_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkAclBypass"></a>NetworkAclBypass
----------------------------------------------
+NetworkAclBypass{#NetworkAclBypass}
+-----------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1799,8 +1799,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkAclBypass_STATUS"></a>NetworkAclBypass_STATUS
------------------------------------------------------------
+NetworkAclBypass_STATUS{#NetworkAclBypass_STATUS}
+-------------------------------------------------
 
 Indicates what services are allowed to bypass firewall checks.
 
@@ -1811,8 +1811,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="OptionsResource_STATUS"></a>OptionsResource_STATUS
----------------------------------------------------------
+OptionsResource_STATUS{#OptionsResource_STATUS}
+-----------------------------------------------
 
 Cosmos DB options resource object
 
@@ -1823,8 +1823,8 @@ Used by: [MongodbDatabase_STATUS](#MongodbDatabase_STATUS), [MongodbDatabaseColl
 | autoscaleSettings | Specifies the Autoscale settings.                                                                                                  | [AutoscaleSettings_STATUS](#AutoscaleSettings_STATUS)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput or autoscaleSettings. Use the ThroughputSetting resource when retrieving offer details. | int<br/><small>Optional</small>                                                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 A private endpoint connection
 
@@ -1834,8 +1834,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
----------------------------------------------------
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1847,8 +1847,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
 
 Whether requests from Public Network are allowed
 
@@ -1860,8 +1860,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="RestoreParameters"></a>RestoreParameters
------------------------------------------------
+RestoreParameters{#RestoreParameters}
+-------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -1877,8 +1877,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | restoreWithTtlDisabled    | Specifies whether the restored account will have Time-To-Live disabled upon the successful restore.                                                                                                                                                                                                               | bool<br/><small>Optional</small>                                                                |
 | tablesToRestore           | List of specific tables available for restore.                                                                                                                                                                                                                                                                    | string[]<br/><small>Optional</small>                                                            |
 
-<a id="RestoreParameters_STATUS"></a>RestoreParameters_STATUS
--------------------------------------------------------------
+RestoreParameters_STATUS{#RestoreParameters_STATUS}
+---------------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -1894,8 +1894,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | restoreWithTtlDisabled    | Specifies whether the restored account will have Time-To-Live disabled upon the successful restore.                                                                                                                                                                                                               | bool<br/><small>Optional</small>                                                                              |
 | tablesToRestore           | List of specific tables available for restore.                                                                                                                                                                                                                                                                    | string[]<br/><small>Optional</small>                                                                          |
 
-<a id="Role"></a>Role
----------------------
+Role{#Role}
+-----------
 
 The set of roles permitted through this Role Definition.
 
@@ -1906,8 +1906,8 @@ Used by: [MongodbUserDefinition_Spec](#MongodbUserDefinition_Spec).
 | db       | The database name the role is applied. | string<br/><small>Optional</small> |
 | role     | The role name.                         | string<br/><small>Optional</small> |
 
-<a id="Role_STATUS"></a>Role_STATUS
------------------------------------
+Role_STATUS{#Role_STATUS}
+-------------------------
 
 The set of roles permitted through this Role Definition.
 
@@ -1918,8 +1918,8 @@ Used by: [MongodbUserDefinition_STATUS](#MongodbUserDefinition_STATUS).
 | db       | The database name the role is applied. | string<br/><small>Optional</small> |
 | role     | The role name.                         | string<br/><small>Optional</small> |
 
-<a id="SqlContainerGetProperties_Resource_STATUS"></a>SqlContainerGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------
+SqlContainerGetProperties_Resource_STATUS{#SqlContainerGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 
@@ -1940,8 +1940,8 @@ Used by: [SqlDatabaseContainer_STATUS](#SqlDatabaseContainer_STATUS).
 | restoreParameters        | Parameters to indicate the information about the restore                                                                                 | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SqlContainerResource"></a>SqlContainerResource
------------------------------------------------------
+SqlContainerResource{#SqlContainerResource}
+-------------------------------------------
 
 Cosmos DB SQL container resource object
 
@@ -1961,8 +1961,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | restoreParameters        | Parameters to indicate the information about the restore                                                                                 | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small>       |
 | uniqueKeyPolicy          | The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service. | [UniqueKeyPolicy](#UniqueKeyPolicy)<br/><small>Optional</small>                   |
 
-<a id="SqlDatabaseContainerOperatorSpec"></a>SqlDatabaseContainerOperatorSpec
------------------------------------------------------------------------------
+SqlDatabaseContainerOperatorSpec{#SqlDatabaseContainerOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1973,8 +1973,8 @@ Used by: [SqlDatabaseContainer_Spec](#SqlDatabaseContainer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerStoredProcedureOperatorSpec"></a>SqlDatabaseContainerStoredProcedureOperatorSpec
------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerStoredProcedureOperatorSpec{#SqlDatabaseContainerStoredProcedureOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1985,8 +1985,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerThroughputSettingOperatorSpec"></a>SqlDatabaseContainerThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerThroughputSettingOperatorSpec{#SqlDatabaseContainerThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1997,8 +1997,8 @@ Used by: [SqlDatabaseContainerThroughputSetting_Spec](#SqlDatabaseContainerThrou
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerTriggerOperatorSpec"></a>SqlDatabaseContainerTriggerOperatorSpec
--------------------------------------------------------------------------------------------
+SqlDatabaseContainerTriggerOperatorSpec{#SqlDatabaseContainerTriggerOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2009,8 +2009,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseContainerUserDefinedFunctionOperatorSpec"></a>SqlDatabaseContainerUserDefinedFunctionOperatorSpec
--------------------------------------------------------------------------------------------------------------------
+SqlDatabaseContainerUserDefinedFunctionOperatorSpec{#SqlDatabaseContainerUserDefinedFunctionOperatorSpec}
+---------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2021,8 +2021,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseGetProperties_Resource_STATUS"></a>SqlDatabaseGetProperties_Resource_STATUS
----------------------------------------------------------------------------------------------
+SqlDatabaseGetProperties_Resource_STATUS{#SqlDatabaseGetProperties_Resource_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 
@@ -2037,8 +2037,8 @@ Used by: [SqlDatabase_STATUS](#SqlDatabase_STATUS).
 | id                | Name of the Cosmos DB SQL database                                                                      | string<br/><small>Optional</small>                                                        |
 | restoreParameters | Parameters to indicate the information about the restore                                                | [RestoreParametersBase_STATUS](#RestoreParametersBase_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseOperatorSpec"></a>SqlDatabaseOperatorSpec
------------------------------------------------------------
+SqlDatabaseOperatorSpec{#SqlDatabaseOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2049,8 +2049,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseResource"></a>SqlDatabaseResource
----------------------------------------------------
+SqlDatabaseResource{#SqlDatabaseResource}
+-----------------------------------------
 
 Cosmos DB SQL database resource object
 
@@ -2062,8 +2062,8 @@ Used by: [SqlDatabase_Spec](#SqlDatabase_Spec).
 | id                | Name of the Cosmos DB SQL database                       | string<br/><small>Required</small>                                          |
 | restoreParameters | Parameters to indicate the information about the restore | [RestoreParametersBase](#RestoreParametersBase)<br/><small>Optional</small> |
 
-<a id="SqlDatabaseThroughputSettingOperatorSpec"></a>SqlDatabaseThroughputSettingOperatorSpec
----------------------------------------------------------------------------------------------
+SqlDatabaseThroughputSettingOperatorSpec{#SqlDatabaseThroughputSettingOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2074,8 +2074,8 @@ Used by: [SqlDatabaseThroughputSetting_Spec](#SqlDatabaseThroughputSetting_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlRoleAssignmentOperatorSpec"></a>SqlRoleAssignmentOperatorSpec
------------------------------------------------------------------------
+SqlRoleAssignmentOperatorSpec{#SqlRoleAssignmentOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2086,8 +2086,8 @@ Used by: [SqlRoleAssignment_Spec](#SqlRoleAssignment_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SqlStoredProcedureGetProperties_Resource_STATUS"></a>SqlStoredProcedureGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+SqlStoredProcedureGetProperties_Resource_STATUS{#SqlStoredProcedureGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStoredProcedure_STATUS).
 
@@ -2099,8 +2099,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_STATUS](#SqlDatabaseContainerStore
 | body     | Body of the Stored Procedure                                                                            | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL storedProcedure                                                               | string<br/><small>Optional</small>  |
 
-<a id="SqlStoredProcedureResource"></a>SqlStoredProcedureResource
------------------------------------------------------------------
+SqlStoredProcedureResource{#SqlStoredProcedureResource}
+-------------------------------------------------------
 
 Cosmos DB SQL storedProcedure resource object
 
@@ -2111,8 +2111,8 @@ Used by: [SqlDatabaseContainerStoredProcedure_Spec](#SqlDatabaseContainerStoredP
 | body     | Body of the Stored Procedure              | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL storedProcedure | string<br/><small>Required</small> |
 
-<a id="SqlTriggerGetProperties_Resource_STATUS"></a>SqlTriggerGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------
+SqlTriggerGetProperties_Resource_STATUS{#SqlTriggerGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATUS).
 
@@ -2126,8 +2126,8 @@ Used by: [SqlDatabaseContainerTrigger_STATUS](#SqlDatabaseContainerTrigger_STATU
 | triggerOperation | The operation the trigger is associated with                                                            | [SqlTriggerGetProperties_Resource_TriggerOperation_STATUS](#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                                                                                     | [SqlTriggerGetProperties_Resource_TriggerType_STATUS](#SqlTriggerGetProperties_Resource_TriggerType_STATUS)<br/><small>Optional</small>           |
 
-<a id="SqlTriggerResource"></a>SqlTriggerResource
--------------------------------------------------
+SqlTriggerResource{#SqlTriggerResource}
+---------------------------------------
 
 Cosmos DB SQL trigger resource object
 
@@ -2140,8 +2140,8 @@ Used by: [SqlDatabaseContainerTrigger_Spec](#SqlDatabaseContainerTrigger_Spec).
 | triggerOperation | The operation the trigger is associated with | [SqlTriggerResource_TriggerOperation](#SqlTriggerResource_TriggerOperation)<br/><small>Optional</small> |
 | triggerType      | Type of the Trigger                          | [SqlTriggerResource_TriggerType](#SqlTriggerResource_TriggerType)<br/><small>Optional</small>           |
 
-<a id="SqlUserDefinedFunctionGetProperties_Resource_STATUS"></a>SqlUserDefinedFunctionGetProperties_Resource_STATUS
--------------------------------------------------------------------------------------------------------------------
+SqlUserDefinedFunctionGetProperties_Resource_STATUS{#SqlUserDefinedFunctionGetProperties_Resource_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerUserDefinedFunction_STATUS).
 
@@ -2153,8 +2153,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_STATUS](#SqlDatabaseContainerU
 | body     | Body of the User Defined Function                                                                       | string<br/><small>Optional</small>  |
 | id       | Name of the Cosmos DB SQL userDefinedFunction                                                           | string<br/><small>Optional</small>  |
 
-<a id="SqlUserDefinedFunctionResource"></a>SqlUserDefinedFunctionResource
--------------------------------------------------------------------------
+SqlUserDefinedFunctionResource{#SqlUserDefinedFunctionResource}
+---------------------------------------------------------------
 
 Cosmos DB SQL userDefinedFunction resource object
 
@@ -2165,8 +2165,8 @@ Used by: [SqlDatabaseContainerUserDefinedFunction_Spec](#SqlDatabaseContainerUse
 | body     | Body of the User Defined Function             | string<br/><small>Optional</small> |
 | id       | Name of the Cosmos DB SQL userDefinedFunction | string<br/><small>Required</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2181,8 +2181,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ThroughputSettingsGetProperties_Resource_STATUS"></a>ThroughputSettingsGetProperties_Resource_STATUS
------------------------------------------------------------------------------------------------------------
+ThroughputSettingsGetProperties_Resource_STATUS{#ThroughputSettingsGetProperties_Resource_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCollectionThroughputSetting_STATUS), [MongodbDatabaseThroughputSetting_STATUS](#MongodbDatabaseThroughputSetting_STATUS), [SqlDatabaseContainerThroughputSetting_STATUS](#SqlDatabaseContainerThroughputSetting_STATUS), and [SqlDatabaseThroughputSetting_STATUS](#SqlDatabaseThroughputSetting_STATUS).
 
@@ -2198,8 +2198,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_STATUS](#MongodbDatabaseCol
 | softAllowedMaximumThroughput | The maximum throughput value or the maximum maxThroughput value (for autoscale) that can be specified                     | string<br/><small>Optional</small>                                                                |
 | throughput                   | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ThroughputSettingsResource"></a>ThroughputSettingsResource
------------------------------------------------------------------
+ThroughputSettingsResource{#ThroughputSettingsResource}
+-------------------------------------------------------
 
 Cosmos DB resource throughput object. Either throughput is required or autoscaleSettings is required, but not both.
 
@@ -2210,8 +2210,8 @@ Used by: [MongodbDatabaseCollectionThroughputSetting_Spec](#MongodbDatabaseColle
 | autoscaleSettings | Cosmos DB resource for autoscale settings. Either throughput is required or autoscaleSettings is required, but not both.  | [AutoscaleSettingsResource](#AutoscaleSettingsResource)<br/><small>Optional</small> |
 | throughput        | Value of the Cosmos DB resource throughput. Either throughput is required or autoscaleSettings is required, but not both. | int<br/><small>Optional</small>                                                     |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -2222,8 +2222,8 @@ Used by: [DatabaseAccount_Spec](#DatabaseAccount_Spec).
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                        | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network ACL Rule object
 
@@ -2234,8 +2234,8 @@ Used by: [DatabaseAccount_STATUS](#DatabaseAccount_STATUS).
 | id                               | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. | string<br/><small>Optional</small> |
 | ignoreMissingVNetServiceEndpoint | Create firewall rule before the virtual network has vnet service endpoint enabled.                                                                                                                                                                                                      | bool<br/><small>Optional</small>   |
 
-<a id="AccountKeyMetadata_STATUS"></a>AccountKeyMetadata_STATUS
----------------------------------------------------------------
+AccountKeyMetadata_STATUS{#AccountKeyMetadata_STATUS}
+-----------------------------------------------------
 
 The metadata related to an access key for a given database account.
 
@@ -2245,8 +2245,8 @@ Used by: [DatabaseAccountKeysMetadata_STATUS](#DatabaseAccountKeysMetadata_STATU
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | generationTime | Generation time in UTC of the key in ISO-8601 format. If the value is missing from the object, it means that the last key regeneration was triggered before 2022-06-18. | string<br/><small>Optional</small> |
 
-<a id="AnalyticalStorageSchemaType"></a>AnalyticalStorageSchemaType
--------------------------------------------------------------------
+AnalyticalStorageSchemaType{#AnalyticalStorageSchemaType}
+---------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -2257,8 +2257,8 @@ Used by: [AnalyticalStorageConfiguration](#AnalyticalStorageConfiguration).
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="AnalyticalStorageSchemaType_STATUS"></a>AnalyticalStorageSchemaType_STATUS
----------------------------------------------------------------------------------
+AnalyticalStorageSchemaType_STATUS{#AnalyticalStorageSchemaType_STATUS}
+-----------------------------------------------------------------------
 
 Describes the types of schema for analytical storage.
 
@@ -2269,8 +2269,8 @@ Used by: [AnalyticalStorageConfiguration_STATUS](#AnalyticalStorageConfiguration
 | "FullFidelity" |             |
 | "WellDefined"  |             |
 
-<a id="ApiProperties_ServerVersion"></a>ApiProperties_ServerVersion
--------------------------------------------------------------------
+ApiProperties_ServerVersion{#ApiProperties_ServerVersion}
+---------------------------------------------------------
 
 Used by: [ApiProperties](#ApiProperties).
 
@@ -2284,8 +2284,8 @@ Used by: [ApiProperties](#ApiProperties).
 | "6.0" |             |
 | "7.0" |             |
 
-<a id="ApiProperties_ServerVersion_STATUS"></a>ApiProperties_ServerVersion_STATUS
----------------------------------------------------------------------------------
+ApiProperties_ServerVersion_STATUS{#ApiProperties_ServerVersion_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 
@@ -2299,8 +2299,8 @@ Used by: [ApiProperties_STATUS](#ApiProperties_STATUS).
 | "6.0" |             |
 | "7.0" |             |
 
-<a id="AutoscaleSettings"></a>AutoscaleSettings
------------------------------------------------
+AutoscaleSettings{#AutoscaleSettings}
+-------------------------------------
 
 Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 
@@ -2308,8 +2308,8 @@ Used by: [CreateUpdateOptions](#CreateUpdateOptions).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettings_STATUS"></a>AutoscaleSettings_STATUS
--------------------------------------------------------------
+AutoscaleSettings_STATUS{#AutoscaleSettings_STATUS}
+---------------------------------------------------
 
 Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 
@@ -2317,8 +2317,8 @@ Used by: [OptionsResource_STATUS](#OptionsResource_STATUS).
 |---------------|--------------------------------------------------------------|---------------------------------|
 | maxThroughput | Represents maximum throughput, the resource can scale up to. | int<br/><small>Optional</small> |
 
-<a id="AutoscaleSettingsResource"></a>AutoscaleSettingsResource
----------------------------------------------------------------
+AutoscaleSettingsResource{#AutoscaleSettingsResource}
+-----------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -2329,8 +2329,8 @@ Used by: [ThroughputSettingsResource](#ThroughputSettingsResource).
 | autoUpgradePolicy | Cosmos DB resource auto-upgrade policy                   | [AutoUpgradePolicyResource](#AutoUpgradePolicyResource)<br/><small>Optional</small> |
 | maxThroughput     | Represents maximum throughput container can scale up to. | int<br/><small>Required</small>                                                     |
 
-<a id="AutoscaleSettingsResource_STATUS"></a>AutoscaleSettingsResource_STATUS
------------------------------------------------------------------------------
+AutoscaleSettingsResource_STATUS{#AutoscaleSettingsResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB provisioned throughput settings object
 
@@ -2342,8 +2342,8 @@ Used by: [ThroughputSettingsGetProperties_Resource_STATUS](#ThroughputSettingsGe
 | maxThroughput       | Represents maximum throughput container can scale up to.                                                 | int<br/><small>Optional</small>                                                                   |
 | targetMaxThroughput | Represents target maximum throughput container can scale up to once offer is no longer in pending state. | int<br/><small>Optional</small>                                                                   |
 
-<a id="ClientEncryptionPolicy"></a>ClientEncryptionPolicy
----------------------------------------------------------
+ClientEncryptionPolicy{#ClientEncryptionPolicy}
+-----------------------------------------------
 
 Cosmos DB client encryption policy.
 
@@ -2354,8 +2354,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | includedPaths       | Paths of the item that need encryption along with path-specific settings.                                                                    | [ClientEncryptionIncludedPath[]](#ClientEncryptionIncludedPath)<br/><small>Required</small> |
 | policyFormatVersion | Version of the client encryption policy definition. Supported versions are 1 and 2. Version 2 supports id and partition key path encryption. | int<br/><small>Required</small>                                                             |
 
-<a id="ClientEncryptionPolicy_STATUS"></a>ClientEncryptionPolicy_STATUS
------------------------------------------------------------------------
+ClientEncryptionPolicy_STATUS{#ClientEncryptionPolicy_STATUS}
+-------------------------------------------------------------
 
 Cosmos DB client encryption policy.
 
@@ -2366,8 +2366,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | includedPaths       | Paths of the item that need encryption along with path-specific settings.                                                                    | [ClientEncryptionIncludedPath_STATUS[]](#ClientEncryptionIncludedPath_STATUS)<br/><small>Optional</small> |
 | policyFormatVersion | Version of the client encryption policy definition. Supported versions are 1 and 2. Version 2 supports id and partition key path encryption. | int<br/><small>Optional</small>                                                                           |
 
-<a id="ComputedProperty"></a>ComputedProperty
----------------------------------------------
+ComputedProperty{#ComputedProperty}
+-----------------------------------
 
 The definition of a computed property
 
@@ -2378,8 +2378,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | name     | The name of a computed property, for example - "cp_lowerName"                                               | string<br/><small>Optional</small> |
 | query    | The query that evaluates the value for computed property, for example - "SELECT VALUE LOWER(c.name) FROM c" | string<br/><small>Optional</small> |
 
-<a id="ComputedProperty_STATUS"></a>ComputedProperty_STATUS
------------------------------------------------------------
+ComputedProperty_STATUS{#ComputedProperty_STATUS}
+-------------------------------------------------
 
 The definition of a computed property
 
@@ -2390,8 +2390,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | name     | The name of a computed property, for example - "cp_lowerName"                                               | string<br/><small>Optional</small> |
 | query    | The query that evaluates the value for computed property, for example - "SELECT VALUE LOWER(c.name) FROM c" | string<br/><small>Optional</small> |
 
-<a id="ConflictResolutionPolicy"></a>ConflictResolutionPolicy
--------------------------------------------------------------
+ConflictResolutionPolicy{#ConflictResolutionPolicy}
+---------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2403,8 +2403,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                          |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode](#ConflictResolutionPolicy_Mode)<br/><small>Optional</small> |
 
-<a id="ConflictResolutionPolicy_STATUS"></a>ConflictResolutionPolicy_STATUS
----------------------------------------------------------------------------
+ConflictResolutionPolicy_STATUS{#ConflictResolutionPolicy_STATUS}
+-----------------------------------------------------------------
 
 The conflict resolution policy for the container.
 
@@ -2416,8 +2416,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | conflictResolutionProcedure | The procedure to resolve conflicts in the case of custom mode.   | string<br/><small>Optional</small>                                                                        |
 | mode                        | Indicates the conflict resolution mode.                          | [ConflictResolutionPolicy_Mode_STATUS](#ConflictResolutionPolicy_Mode_STATUS)<br/><small>Optional</small> |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel"></a>ConsistencyPolicy_DefaultConsistencyLevel
------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel{#ConsistencyPolicy_DefaultConsistencyLevel}
+-------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 
@@ -2429,8 +2429,8 @@ Used by: [ConsistencyPolicy](#ConsistencyPolicy).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ConsistencyPolicy_DefaultConsistencyLevel_STATUS"></a>ConsistencyPolicy_DefaultConsistencyLevel_STATUS
--------------------------------------------------------------------------------------------------------------
+ConsistencyPolicy_DefaultConsistencyLevel_STATUS{#ConsistencyPolicy_DefaultConsistencyLevel_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 
@@ -2442,8 +2442,8 @@ Used by: [ConsistencyPolicy_STATUS](#ConsistencyPolicy_STATUS).
 | "Session"          |             |
 | "Strong"           |             |
 
-<a id="ContainerPartitionKey"></a>ContainerPartitionKey
--------------------------------------------------------
+ContainerPartitionKey{#ContainerPartitionKey}
+---------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2455,8 +2455,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | paths    | List of paths using which data within the container can be partitioned                                                                                | string[]<br/><small>Optional</small>                                                  |
 | version  | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                       |
 
-<a id="ContainerPartitionKey_STATUS"></a>ContainerPartitionKey_STATUS
----------------------------------------------------------------------
+ContainerPartitionKey_STATUS{#ContainerPartitionKey_STATUS}
+-----------------------------------------------------------
 
 The configuration of the partition key to be used for partitioning data into multiple partitions
 
@@ -2469,8 +2469,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | systemKey | Indicates if the container is using a system generated partition key                                                                                  | bool<br/><small>Optional</small>                                                                    |
 | version   | Indicates the version of the partition key definition                                                                                                 | int<br/><small>Optional</small>                                                                     |
 
-<a id="ContinuousModeBackupPolicy"></a>ContinuousModeBackupPolicy
------------------------------------------------------------------
+ContinuousModeBackupPolicy{#ContinuousModeBackupPolicy}
+-------------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2480,8 +2480,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | migrationState           | The object representing the state of the migration between the backup policies. | [BackupPolicyMigrationState](#BackupPolicyMigrationState)<br/><small>Optional</small>           |
 | type                     | Describes the mode of backups.                                                  | [ContinuousModeBackupPolicy_Type](#ContinuousModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="ContinuousModeBackupPolicy_STATUS"></a>ContinuousModeBackupPolicy_STATUS
--------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_STATUS{#ContinuousModeBackupPolicy_STATUS}
+---------------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2491,8 +2491,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | migrationState           | The object representing the state of the migration between the backup policies. | [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)<br/><small>Optional</small>           |
 | type                     | Describes the mode of backups.                                                  | [ContinuousModeBackupPolicy_Type_STATUS](#ContinuousModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseAccountOperatorSecrets"></a>DatabaseAccountOperatorSecrets
--------------------------------------------------------------------------
+DatabaseAccountOperatorSecrets{#DatabaseAccountOperatorSecrets}
+---------------------------------------------------------------
 
 Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 
@@ -2504,8 +2504,8 @@ Used by: [DatabaseAccountOperatorSpec](#DatabaseAccountOperatorSpec).
 | secondaryMasterKey         | indicates where the SecondaryMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure.         | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryReadonlyMasterKey | indicates where the SecondaryReadonlyMasterKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="DatabaseRestoreResource"></a>DatabaseRestoreResource
------------------------------------------------------------
+DatabaseRestoreResource{#DatabaseRestoreResource}
+-------------------------------------------------
 
 Specific Databases to restore.
 
@@ -2516,8 +2516,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 | collectionNames | The names of the collections available for restore. | string[]<br/><small>Optional</small> |
 | databaseName    | The name of the database available for restore.     | string<br/><small>Optional</small>   |
 
-<a id="DatabaseRestoreResource_STATUS"></a>DatabaseRestoreResource_STATUS
--------------------------------------------------------------------------
+DatabaseRestoreResource_STATUS{#DatabaseRestoreResource_STATUS}
+---------------------------------------------------------------
 
 Specific Databases to restore.
 
@@ -2528,8 +2528,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 | collectionNames | The names of the collections available for restore. | string[]<br/><small>Optional</small> |
 | databaseName    | The name of the database available for restore.     | string<br/><small>Optional</small>   |
 
-<a id="GremlinDatabaseRestoreResource"></a>GremlinDatabaseRestoreResource
--------------------------------------------------------------------------
+GremlinDatabaseRestoreResource{#GremlinDatabaseRestoreResource}
+---------------------------------------------------------------
 
 Specific Gremlin Databases to restore.
 
@@ -2540,8 +2540,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 | databaseName | The name of the gremlin database available for restore. | string<br/><small>Optional</small>   |
 | graphNames   | The names of the graphs available for restore.          | string[]<br/><small>Optional</small> |
 
-<a id="GremlinDatabaseRestoreResource_STATUS"></a>GremlinDatabaseRestoreResource_STATUS
----------------------------------------------------------------------------------------
+GremlinDatabaseRestoreResource_STATUS{#GremlinDatabaseRestoreResource_STATUS}
+-----------------------------------------------------------------------------
 
 Specific Gremlin Databases to restore.
 
@@ -2552,8 +2552,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 | databaseName | The name of the gremlin database available for restore. | string<br/><small>Optional</small>   |
 | graphNames   | The names of the graphs available for restore.          | string[]<br/><small>Optional</small> |
 
-<a id="IndexingPolicy"></a>IndexingPolicy
------------------------------------------
+IndexingPolicy{#IndexingPolicy}
+-------------------------------
 
 Cosmos DB indexing policy
 
@@ -2568,8 +2568,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode](#IndexingPolicy_IndexingMode)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec[]](#SpatialSpec)<br/><small>Optional</small>                               |
 
-<a id="IndexingPolicy_STATUS"></a>IndexingPolicy_STATUS
--------------------------------------------------------
+IndexingPolicy_STATUS{#IndexingPolicy_STATUS}
+---------------------------------------------
 
 Cosmos DB indexing policy
 
@@ -2584,8 +2584,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 | indexingMode     | Indicates the indexing mode.                  | [IndexingPolicy_IndexingMode_STATUS](#IndexingPolicy_IndexingMode_STATUS)<br/><small>Optional</small> |
 | spatialIndexes   | List of spatial specifics                     | [SpatialSpec_STATUS[]](#SpatialSpec_STATUS)<br/><small>Optional</small>                               |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -2596,8 +2596,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2608,8 +2608,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentity_UserAssignedIdentities_STATUS"></a>ManagedServiceIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedServiceIdentity_UserAssignedIdentities_STATUS{#ManagedServiceIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -2618,8 +2618,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="MongoIndex"></a>MongoIndex
----------------------------------
+MongoIndex{#MongoIndex}
+-----------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2630,8 +2630,8 @@ Used by: [MongoDBCollectionResource](#MongoDBCollectionResource).
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys](#MongoIndexKeys)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions](#MongoIndexOptions)<br/><small>Optional</small> |
 
-<a id="MongoIndex_STATUS"></a>MongoIndex_STATUS
------------------------------------------------
+MongoIndex_STATUS{#MongoIndex_STATUS}
+-------------------------------------
 
 Cosmos DB MongoDB collection index key
 
@@ -2642,8 +2642,8 @@ Used by: [MongoDBCollectionGetProperties_Resource_STATUS](#MongoDBCollectionGetP
 | key      | Cosmos DB MongoDB collection index keys        | [MongoIndexKeys_STATUS](#MongoIndexKeys_STATUS)<br/><small>Optional</small>       |
 | options  | Cosmos DB MongoDB collection index key options | [MongoIndexOptions_STATUS](#MongoIndexOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="PeriodicModeBackupPolicy"></a>PeriodicModeBackupPolicy
--------------------------------------------------------------
+PeriodicModeBackupPolicy{#PeriodicModeBackupPolicy}
+---------------------------------------------------
 
 Used by: [BackupPolicy](#BackupPolicy).
 
@@ -2653,8 +2653,8 @@ Used by: [BackupPolicy](#BackupPolicy).
 | periodicModeProperties | Configuration values for periodic mode backup                                   | [PeriodicModeProperties](#PeriodicModeProperties)<br/><small>Optional</small>               |
 | type                   | Describes the mode of backups.                                                  | [PeriodicModeBackupPolicy_Type](#PeriodicModeBackupPolicy_Type)<br/><small>Required</small> |
 
-<a id="PeriodicModeBackupPolicy_STATUS"></a>PeriodicModeBackupPolicy_STATUS
----------------------------------------------------------------------------
+PeriodicModeBackupPolicy_STATUS{#PeriodicModeBackupPolicy_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 
@@ -2664,8 +2664,8 @@ Used by: [BackupPolicy_STATUS](#BackupPolicy_STATUS).
 | periodicModeProperties | Configuration values for periodic mode backup                                   | [PeriodicModeProperties_STATUS](#PeriodicModeProperties_STATUS)<br/><small>Optional</small>               |
 | type                   | Describes the mode of backups.                                                  | [PeriodicModeBackupPolicy_Type_STATUS](#PeriodicModeBackupPolicy_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="RestoreParameters_RestoreMode"></a>RestoreParameters_RestoreMode
------------------------------------------------------------------------
+RestoreParameters_RestoreMode{#RestoreParameters_RestoreMode}
+-------------------------------------------------------------
 
 Used by: [RestoreParameters](#RestoreParameters).
 
@@ -2673,8 +2673,8 @@ Used by: [RestoreParameters](#RestoreParameters).
 |---------------|-------------|
 | "PointInTime" |             |
 
-<a id="RestoreParameters_RestoreMode_STATUS"></a>RestoreParameters_RestoreMode_STATUS
--------------------------------------------------------------------------------------
+RestoreParameters_RestoreMode_STATUS{#RestoreParameters_RestoreMode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 
@@ -2682,8 +2682,8 @@ Used by: [RestoreParameters_STATUS](#RestoreParameters_STATUS).
 |---------------|-------------|
 | "PointInTime" |             |
 
-<a id="RestoreParametersBase"></a>RestoreParametersBase
--------------------------------------------------------
+RestoreParametersBase{#RestoreParametersBase}
+---------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -2695,8 +2695,8 @@ Used by: [MongoDBCollectionResource](#MongoDBCollectionResource), [MongoDBDataba
 | restoreTimestampInUtc  | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small> |
 | restoreWithTtlDisabled | Specifies whether the restored account will have Time-To-Live disabled upon the successful restore.                                                                                                                                                                                                               | bool<br/><small>Optional</small>   |
 
-<a id="RestoreParametersBase_STATUS"></a>RestoreParametersBase_STATUS
----------------------------------------------------------------------
+RestoreParametersBase_STATUS{#RestoreParametersBase_STATUS}
+-----------------------------------------------------------
 
 Parameters to indicate the information about the restore.
 
@@ -2708,31 +2708,31 @@ Used by: [MongoDBCollectionGetProperties_Resource_STATUS](#MongoDBCollectionGetP
 | restoreTimestampInUtc  | Time to which the account has to be restored (ISO-8601 format).                                                                                                                                                                                                                                                   | string<br/><small>Optional</small> |
 | restoreWithTtlDisabled | Specifies whether the restored account will have Time-To-Live disabled upon the successful restore.                                                                                                                                                                                                               | bool<br/><small>Optional</small>   |
 
-<a id="SqlTriggerGetProperties_Resource_TriggerOperation_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerOperation_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "All"     |             |
-| "Create"  |             |
-| "Delete"  |             |
-| "Replace" |             |
-| "Update"  |             |
-
-<a id="SqlTriggerGetProperties_Resource_TriggerType_STATUS"></a>SqlTriggerGetProperties_Resource_TriggerType_STATUS
+SqlTriggerGetProperties_Resource_TriggerOperation_STATUS{#SqlTriggerGetProperties_Resource_TriggerOperation_STATUS}
 -------------------------------------------------------------------------------------------------------------------
 
 Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
 
+| Value     | Description |
+|-----------|-------------|
+| "All"     |             |
+| "Create"  |             |
+| "Delete"  |             |
+| "Replace" |             |
+| "Update"  |             |
+
+SqlTriggerGetProperties_Resource_TriggerType_STATUS{#SqlTriggerGetProperties_Resource_TriggerType_STATUS}
+---------------------------------------------------------------------------------------------------------
+
+Used by: [SqlTriggerGetProperties_Resource_STATUS](#SqlTriggerGetProperties_Resource_STATUS).
+
 | Value  | Description |
 |--------|-------------|
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="SqlTriggerResource_TriggerOperation"></a>SqlTriggerResource_TriggerOperation
------------------------------------------------------------------------------------
+SqlTriggerResource_TriggerOperation{#SqlTriggerResource_TriggerOperation}
+-------------------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2744,8 +2744,8 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Replace" |             |
 | "Update"  |             |
 
-<a id="SqlTriggerResource_TriggerType"></a>SqlTriggerResource_TriggerType
--------------------------------------------------------------------------
+SqlTriggerResource_TriggerType{#SqlTriggerResource_TriggerType}
+---------------------------------------------------------------
 
 Used by: [SqlTriggerResource](#SqlTriggerResource).
 
@@ -2754,7 +2754,19 @@ Used by: [SqlTriggerResource](#SqlTriggerResource).
 | "Post" |             |
 | "Pre"  |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2766,20 +2778,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UniqueKeyPolicy"></a>UniqueKeyPolicy
--------------------------------------------
+UniqueKeyPolicy{#UniqueKeyPolicy}
+---------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2789,8 +2789,8 @@ Used by: [SqlContainerResource](#SqlContainerResource).
 |------------|---------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey[]](#UniqueKey)<br/><small>Optional</small> |
 
-<a id="UniqueKeyPolicy_STATUS"></a>UniqueKeyPolicy_STATUS
----------------------------------------------------------
+UniqueKeyPolicy_STATUS{#UniqueKeyPolicy_STATUS}
+-----------------------------------------------
 
 The unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
 
@@ -2800,8 +2800,8 @@ Used by: [SqlContainerGetProperties_Resource_STATUS](#SqlContainerGetProperties_
 |------------|---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 | uniqueKeys | List of unique keys on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service. | [UniqueKey_STATUS[]](#UniqueKey_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2811,8 +2811,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource"></a>AutoUpgradePolicyResource
----------------------------------------------------------------
+AutoUpgradePolicyResource{#AutoUpgradePolicyResource}
+-----------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2822,8 +2822,8 @@ Used by: [AutoscaleSettingsResource](#AutoscaleSettingsResource).
 |------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource](#ThroughputPolicyResource)<br/><small>Optional</small> |
 
-<a id="AutoUpgradePolicyResource_STATUS"></a>AutoUpgradePolicyResource_STATUS
------------------------------------------------------------------------------
+AutoUpgradePolicyResource_STATUS{#AutoUpgradePolicyResource_STATUS}
+-------------------------------------------------------------------
 
 Cosmos DB resource auto-upgrade policy
 
@@ -2833,8 +2833,8 @@ Used by: [AutoscaleSettingsResource_STATUS](#AutoscaleSettingsResource_STATUS).
 |------------------|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | throughputPolicy | Represents throughput policy which service must adhere to for auto-upgrade | [ThroughputPolicyResource_STATUS](#ThroughputPolicyResource_STATUS)<br/><small>Optional</small> |
 
-<a id="BackupPolicyMigrationState"></a>BackupPolicyMigrationState
------------------------------------------------------------------
+BackupPolicyMigrationState{#BackupPolicyMigrationState}
+-------------------------------------------------------
 
 The object representing the state of the migration between the backup policies.
 
@@ -2846,8 +2846,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy), and [Periodi
 | status     | Describes the status of migration between backup policy types.          | [BackupPolicyMigrationStatus](#BackupPolicyMigrationStatus)<br/><small>Optional</small> |
 | targetType | Describes the target backup policy type of the backup policy migration. | [BackupPolicyType](#BackupPolicyType)<br/><small>Optional</small>                       |
 
-<a id="BackupPolicyMigrationState_STATUS"></a>BackupPolicyMigrationState_STATUS
--------------------------------------------------------------------------------
+BackupPolicyMigrationState_STATUS{#BackupPolicyMigrationState_STATUS}
+---------------------------------------------------------------------
 
 The object representing the state of the migration between the backup policies.
 
@@ -2859,8 +2859,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 | status     | Describes the status of migration between backup policy types.          | [BackupPolicyMigrationStatus_STATUS](#BackupPolicyMigrationStatus_STATUS)<br/><small>Optional</small> |
 | targetType | Describes the target backup policy type of the backup policy migration. | [BackupPolicyType_STATUS](#BackupPolicyType_STATUS)<br/><small>Optional</small>                       |
 
-<a id="ClientEncryptionIncludedPath"></a>ClientEncryptionIncludedPath
----------------------------------------------------------------------
+ClientEncryptionIncludedPath{#ClientEncryptionIncludedPath}
+-----------------------------------------------------------
 
 .
 
@@ -2873,8 +2873,8 @@ Used by: [ClientEncryptionPolicy](#ClientEncryptionPolicy).
 | encryptionType        | The type of encryption to be performed. Eg - Deterministic, Randomized.         | string<br/><small>Required</small> |
 | path                  | Path that needs to be encrypted.                                                | string<br/><small>Required</small> |
 
-<a id="ClientEncryptionIncludedPath_STATUS"></a>ClientEncryptionIncludedPath_STATUS
------------------------------------------------------------------------------------
+ClientEncryptionIncludedPath_STATUS{#ClientEncryptionIncludedPath_STATUS}
+-------------------------------------------------------------------------
 
 .
 
@@ -2887,8 +2887,8 @@ Used by: [ClientEncryptionPolicy_STATUS](#ClientEncryptionPolicy_STATUS).
 | encryptionType        | The type of encryption to be performed. Eg - Deterministic, Randomized.         | string<br/><small>Optional</small> |
 | path                  | Path that needs to be encrypted.                                                | string<br/><small>Optional</small> |
 
-<a id="CompositePath"></a>CompositePath
----------------------------------------
+CompositePath{#CompositePath}
+-----------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2897,8 +2897,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order](#CompositePath_Order)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 
-<a id="CompositePath_STATUS"></a>CompositePath_STATUS
------------------------------------------------------
+CompositePath_STATUS{#CompositePath_STATUS}
+-------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -2907,8 +2907,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | order    | Sort order for composite paths.                                                                                            | [CompositePath_Order_STATUS](#CompositePath_Order_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                                    |
 
-<a id="ConflictResolutionPolicy_Mode"></a>ConflictResolutionPolicy_Mode
------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode{#ConflictResolutionPolicy_Mode}
+-------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 
@@ -2917,8 +2917,8 @@ Used by: [ConflictResolutionPolicy](#ConflictResolutionPolicy).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ConflictResolutionPolicy_Mode_STATUS"></a>ConflictResolutionPolicy_Mode_STATUS
--------------------------------------------------------------------------------------
+ConflictResolutionPolicy_Mode_STATUS{#ConflictResolutionPolicy_Mode_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 
@@ -2927,8 +2927,8 @@ Used by: [ConflictResolutionPolicy_STATUS](#ConflictResolutionPolicy_STATUS).
 | "Custom"         |             |
 | "LastWriterWins" |             |
 
-<a id="ContainerPartitionKey_Kind"></a>ContainerPartitionKey_Kind
------------------------------------------------------------------
+ContainerPartitionKey_Kind{#ContainerPartitionKey_Kind}
+-------------------------------------------------------
 
 Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 
@@ -2938,8 +2938,8 @@ Used by: [ContainerPartitionKey](#ContainerPartitionKey).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContainerPartitionKey_Kind_STATUS"></a>ContainerPartitionKey_Kind_STATUS
--------------------------------------------------------------------------------
+ContainerPartitionKey_Kind_STATUS{#ContainerPartitionKey_Kind_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 
@@ -2949,8 +2949,8 @@ Used by: [ContainerPartitionKey_STATUS](#ContainerPartitionKey_STATUS).
 | "MultiHash" |             |
 | "Range"     |             |
 
-<a id="ContinuousModeBackupPolicy_Type"></a>ContinuousModeBackupPolicy_Type
----------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type{#ContinuousModeBackupPolicy_Type}
+-----------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 
@@ -2958,8 +2958,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ContinuousModeBackupPolicy_Type_STATUS"></a>ContinuousModeBackupPolicy_Type_STATUS
------------------------------------------------------------------------------------------
+ContinuousModeBackupPolicy_Type_STATUS{#ContinuousModeBackupPolicy_Type_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS).
 
@@ -2967,8 +2967,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 |--------------|-------------|
 | "Continuous" |             |
 
-<a id="ContinuousModeProperties"></a>ContinuousModeProperties
--------------------------------------------------------------
+ContinuousModeProperties{#ContinuousModeProperties}
+---------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2978,8 +2978,8 @@ Used by: [ContinuousModeBackupPolicy](#ContinuousModeBackupPolicy).
 |----------|-------------------------------------------------|---------------------------------------------------------------|
 | tier     | Enum to indicate type of Continuous backup mode | [ContinuousTier](#ContinuousTier)<br/><small>Optional</small> |
 
-<a id="ContinuousModeProperties_STATUS"></a>ContinuousModeProperties_STATUS
----------------------------------------------------------------------------
+ContinuousModeProperties_STATUS{#ContinuousModeProperties_STATUS}
+-----------------------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -2989,8 +2989,8 @@ Used by: [ContinuousModeBackupPolicy_STATUS](#ContinuousModeBackupPolicy_STATUS)
 |----------|-------------------------------------------------|-----------------------------------------------------------------------------|
 | tier     | Enum to indicate type of Continuous backup mode | [ContinuousTier_STATUS](#ContinuousTier_STATUS)<br/><small>Optional</small> |
 
-<a id="ExcludedPath"></a>ExcludedPath
--------------------------------------
+ExcludedPath{#ExcludedPath}
+---------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -2998,8 +2998,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="ExcludedPath_STATUS"></a>ExcludedPath_STATUS
----------------------------------------------------
+ExcludedPath_STATUS{#ExcludedPath_STATUS}
+-----------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -3007,8 +3007,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 |----------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small> |
 
-<a id="IncludedPath"></a>IncludedPath
--------------------------------------
+IncludedPath{#IncludedPath}
+---------------------------
 
 The paths that are included in indexing
 
@@ -3019,8 +3019,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | indexes  | List of indexes for this path                                                                                              | [Indexes[]](#Indexes)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                |
 
-<a id="IncludedPath_STATUS"></a>IncludedPath_STATUS
----------------------------------------------------
+IncludedPath_STATUS{#IncludedPath_STATUS}
+-----------------------------------------
 
 The paths that are included in indexing
 
@@ -3031,8 +3031,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | indexes  | List of indexes for this path                                                                                              | [Indexes_STATUS[]](#Indexes_STATUS)<br/><small>Optional</small> |
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                              |
 
-<a id="IndexingPolicy_IndexingMode"></a>IndexingPolicy_IndexingMode
--------------------------------------------------------------------
+IndexingPolicy_IndexingMode{#IndexingPolicy_IndexingMode}
+---------------------------------------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -3042,8 +3042,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="IndexingPolicy_IndexingMode_STATUS"></a>IndexingPolicy_IndexingMode_STATUS
----------------------------------------------------------------------------------
+IndexingPolicy_IndexingMode_STATUS{#IndexingPolicy_IndexingMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -3053,8 +3053,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | "lazy"       |             |
 | "none"       |             |
 
-<a id="MongoIndexKeys"></a>MongoIndexKeys
------------------------------------------
+MongoIndexKeys{#MongoIndexKeys}
+-------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -3064,8 +3064,8 @@ Used by: [MongoIndex](#MongoIndex).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexKeys_STATUS"></a>MongoIndexKeys_STATUS
--------------------------------------------------------
+MongoIndexKeys_STATUS{#MongoIndexKeys_STATUS}
+---------------------------------------------
 
 Cosmos DB MongoDB collection resource object
 
@@ -3075,8 +3075,8 @@ Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
 |----------|-------------------------------------------------------------------------|--------------------------------------|
 | keys     | List of keys for each MongoDB collection in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions"></a>MongoIndexOptions
------------------------------------------------
+MongoIndexOptions{#MongoIndexOptions}
+-------------------------------------
 
 Cosmos DB MongoDB collection index options
 
@@ -3087,20 +3087,20 @@ Used by: [MongoIndex](#MongoIndex).
 | expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
 | unique             | Is unique or not     | bool<br/><small>Optional</small> |
 
-<a id="MongoIndexOptions_STATUS"></a>MongoIndexOptions_STATUS
+MongoIndexOptions_STATUS{#MongoIndexOptions_STATUS}
+---------------------------------------------------
+
+Cosmos DB MongoDB collection index options
+
+Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
+
+| Property           | Description          | Type                             |
+|--------------------|----------------------|----------------------------------|
+| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
+| unique             | Is unique or not     | bool<br/><small>Optional</small> |
+
+PeriodicModeBackupPolicy_Type{#PeriodicModeBackupPolicy_Type}
 -------------------------------------------------------------
-
-Cosmos DB MongoDB collection index options
-
-Used by: [MongoIndex_STATUS](#MongoIndex_STATUS).
-
-| Property           | Description          | Type                             |
-|--------------------|----------------------|----------------------------------|
-| expireAfterSeconds | Expire after seconds | int<br/><small>Optional</small>  |
-| unique             | Is unique or not     | bool<br/><small>Optional</small> |
-
-<a id="PeriodicModeBackupPolicy_Type"></a>PeriodicModeBackupPolicy_Type
------------------------------------------------------------------------
 
 Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 
@@ -3108,8 +3108,8 @@ Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeBackupPolicy_Type_STATUS"></a>PeriodicModeBackupPolicy_Type_STATUS
--------------------------------------------------------------------------------------
+PeriodicModeBackupPolicy_Type_STATUS{#PeriodicModeBackupPolicy_Type_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 
@@ -3117,8 +3117,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 |------------|-------------|
 | "Periodic" |             |
 
-<a id="PeriodicModeProperties"></a>PeriodicModeProperties
----------------------------------------------------------
+PeriodicModeProperties{#PeriodicModeProperties}
+-----------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -3130,8 +3130,8 @@ Used by: [PeriodicModeBackupPolicy](#PeriodicModeBackupPolicy).
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small>                                                 |
 | backupStorageRedundancy        | Enum to indicate type of backup residency                                | [BackupStorageRedundancy](#BackupStorageRedundancy)<br/><small>Optional</small> |
 
-<a id="PeriodicModeProperties_STATUS"></a>PeriodicModeProperties_STATUS
------------------------------------------------------------------------
+PeriodicModeProperties_STATUS{#PeriodicModeProperties_STATUS}
+-------------------------------------------------------------
 
 Configuration values for periodic mode backup
 
@@ -3143,8 +3143,8 @@ Used by: [PeriodicModeBackupPolicy_STATUS](#PeriodicModeBackupPolicy_STATUS).
 | backupRetentionIntervalInHours | An integer representing the time (in hours) that each backup is retained | int<br/><small>Optional</small>                                                               |
 | backupStorageRedundancy        | Enum to indicate type of backup residency                                | [BackupStorageRedundancy_STATUS](#BackupStorageRedundancy_STATUS)<br/><small>Optional</small> |
 
-<a id="SpatialSpec"></a>SpatialSpec
------------------------------------
+SpatialSpec{#SpatialSpec}
+-------------------------
 
 Used by: [IndexingPolicy](#IndexingPolicy).
 
@@ -3153,8 +3153,8 @@ Used by: [IndexingPolicy](#IndexingPolicy).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                        |
 | types    | List of path's spatial type                                                                                                | [SpatialType[]](#SpatialType)<br/><small>Optional</small> |
 
-<a id="SpatialSpec_STATUS"></a>SpatialSpec_STATUS
--------------------------------------------------
+SpatialSpec_STATUS{#SpatialSpec_STATUS}
+---------------------------------------
 
 Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 
@@ -3163,8 +3163,8 @@ Used by: [IndexingPolicy_STATUS](#IndexingPolicy_STATUS).
 | path     | The path for which the indexing behavior applies to. Index paths typically start with root and end with wildcard (/path/*) | string<br/><small>Optional</small>                                      |
 | types    | List of path's spatial type                                                                                                | [SpatialType_STATUS[]](#SpatialType_STATUS)<br/><small>Optional</small> |
 
-<a id="UniqueKey"></a>UniqueKey
--------------------------------
+UniqueKey{#UniqueKey}
+---------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -3174,8 +3174,8 @@ Used by: [UniqueKeyPolicy](#UniqueKeyPolicy).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="UniqueKey_STATUS"></a>UniqueKey_STATUS
----------------------------------------------
+UniqueKey_STATUS{#UniqueKey_STATUS}
+-----------------------------------
 
 The unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
 
@@ -3185,8 +3185,8 @@ Used by: [UniqueKeyPolicy_STATUS](#UniqueKeyPolicy_STATUS).
 |----------|-------------------------------------------------------------------------------|--------------------------------------|
 | paths    | List of paths must be unique for each document in the Azure Cosmos DB service | string[]<br/><small>Optional</small> |
 
-<a id="BackupPolicyMigrationStatus"></a>BackupPolicyMigrationStatus
--------------------------------------------------------------------
+BackupPolicyMigrationStatus{#BackupPolicyMigrationStatus}
+---------------------------------------------------------
 
 Describes the status of migration between backup policy types.
 
@@ -3199,8 +3199,8 @@ Used by: [BackupPolicyMigrationState](#BackupPolicyMigrationState).
 | "InProgress" |             |
 | "Invalid"    |             |
 
-<a id="BackupPolicyMigrationStatus_STATUS"></a>BackupPolicyMigrationStatus_STATUS
----------------------------------------------------------------------------------
+BackupPolicyMigrationStatus_STATUS{#BackupPolicyMigrationStatus_STATUS}
+-----------------------------------------------------------------------
 
 Describes the status of migration between backup policy types.
 
@@ -3213,8 +3213,8 @@ Used by: [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)
 | "InProgress" |             |
 | "Invalid"    |             |
 
-<a id="BackupPolicyType"></a>BackupPolicyType
----------------------------------------------
+BackupPolicyType{#BackupPolicyType}
+-----------------------------------
 
 Describes the mode of backups.
 
@@ -3225,8 +3225,8 @@ Used by: [BackupPolicyMigrationState](#BackupPolicyMigrationState).
 | "Continuous" |             |
 | "Periodic"   |             |
 
-<a id="BackupPolicyType_STATUS"></a>BackupPolicyType_STATUS
------------------------------------------------------------
+BackupPolicyType_STATUS{#BackupPolicyType_STATUS}
+-------------------------------------------------
 
 Describes the mode of backups.
 
@@ -3237,8 +3237,8 @@ Used by: [BackupPolicyMigrationState_STATUS](#BackupPolicyMigrationState_STATUS)
 | "Continuous" |             |
 | "Periodic"   |             |
 
-<a id="BackupStorageRedundancy"></a>BackupStorageRedundancy
------------------------------------------------------------
+BackupStorageRedundancy{#BackupStorageRedundancy}
+-------------------------------------------------
 
 Enum to indicate type of backup storage redundancy.
 
@@ -3250,8 +3250,8 @@ Used by: [PeriodicModeProperties](#PeriodicModeProperties).
 | "Local" |             |
 | "Zone"  |             |
 
-<a id="BackupStorageRedundancy_STATUS"></a>BackupStorageRedundancy_STATUS
--------------------------------------------------------------------------
+BackupStorageRedundancy_STATUS{#BackupStorageRedundancy_STATUS}
+---------------------------------------------------------------
 
 Enum to indicate type of backup storage redundancy.
 
@@ -3263,8 +3263,8 @@ Used by: [PeriodicModeProperties_STATUS](#PeriodicModeProperties_STATUS).
 | "Local" |             |
 | "Zone"  |             |
 
-<a id="CompositePath_Order"></a>CompositePath_Order
----------------------------------------------------
+CompositePath_Order{#CompositePath_Order}
+-----------------------------------------
 
 Used by: [CompositePath](#CompositePath).
 
@@ -3273,8 +3273,8 @@ Used by: [CompositePath](#CompositePath).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="CompositePath_Order_STATUS"></a>CompositePath_Order_STATUS
------------------------------------------------------------------
+CompositePath_Order_STATUS{#CompositePath_Order_STATUS}
+-------------------------------------------------------
 
 Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 
@@ -3283,8 +3283,8 @@ Used by: [CompositePath_STATUS](#CompositePath_STATUS).
 | "ascending"  |             |
 | "descending" |             |
 
-<a id="ContinuousTier"></a>ContinuousTier
------------------------------------------
+ContinuousTier{#ContinuousTier}
+-------------------------------
 
 Enum to indicate type of Continuous backup tier.
 
@@ -3295,8 +3295,8 @@ Used by: [ContinuousModeProperties](#ContinuousModeProperties).
 | "Continuous30Days" |             |
 | "Continuous7Days"  |             |
 
-<a id="ContinuousTier_STATUS"></a>ContinuousTier_STATUS
--------------------------------------------------------
+ContinuousTier_STATUS{#ContinuousTier_STATUS}
+---------------------------------------------
 
 Enum to indicate type of Continuous backup tier.
 
@@ -3307,8 +3307,8 @@ Used by: [ContinuousModeProperties_STATUS](#ContinuousModeProperties_STATUS).
 | "Continuous30Days" |             |
 | "Continuous7Days"  |             |
 
-<a id="Indexes"></a>Indexes
----------------------------
+Indexes{#Indexes}
+-----------------
 
 The indexes for the path.
 
@@ -3320,8 +3320,8 @@ Used by: [IncludedPath](#IncludedPath).
 | kind      | Indicates the type of index.                                | [Indexes_Kind](#Indexes_Kind)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                   |
 
-<a id="Indexes_STATUS"></a>Indexes_STATUS
------------------------------------------
+Indexes_STATUS{#Indexes_STATUS}
+-------------------------------
 
 The indexes for the path.
 
@@ -3333,8 +3333,8 @@ Used by: [IncludedPath_STATUS](#IncludedPath_STATUS).
 | kind      | Indicates the type of index.                                | [Indexes_Kind_STATUS](#Indexes_Kind_STATUS)<br/><small>Optional</small>         |
 | precision | The precision of the index. -1 is maximum precision.        | int<br/><small>Optional</small>                                                 |
 
-<a id="SpatialType"></a>SpatialType
------------------------------------
+SpatialType{#SpatialType}
+-------------------------
 
 Indicates the spatial type of index.
 
@@ -3347,8 +3347,8 @@ Used by: [SpatialSpec](#SpatialSpec).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="SpatialType_STATUS"></a>SpatialType_STATUS
--------------------------------------------------
+SpatialType_STATUS{#SpatialType_STATUS}
+---------------------------------------
 
 Indicates the spatial type of index.
 
@@ -3361,8 +3361,8 @@ Used by: [SpatialSpec_STATUS](#SpatialSpec_STATUS).
 | "Point"        |             |
 | "Polygon"      |             |
 
-<a id="ThroughputPolicyResource"></a>ThroughputPolicyResource
--------------------------------------------------------------
+ThroughputPolicyResource{#ThroughputPolicyResource}
+---------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -3373,8 +3373,8 @@ Used by: [AutoUpgradePolicyResource](#AutoUpgradePolicyResource).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="ThroughputPolicyResource_STATUS"></a>ThroughputPolicyResource_STATUS
----------------------------------------------------------------------------
+ThroughputPolicyResource_STATUS{#ThroughputPolicyResource_STATUS}
+-----------------------------------------------------------------
 
 Cosmos DB resource throughput policy
 
@@ -3385,8 +3385,8 @@ Used by: [AutoUpgradePolicyResource_STATUS](#AutoUpgradePolicyResource_STATUS).
 | incrementPercent | Represents the percentage by which throughput can increase every time throughput policy kicks in. | int<br/><small>Optional</small>  |
 | isEnabled        | Determines whether the ThroughputPolicy is active or not                                          | bool<br/><small>Optional</small> |
 
-<a id="Indexes_DataType"></a>Indexes_DataType
----------------------------------------------
+Indexes_DataType{#Indexes_DataType}
+-----------------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -3399,8 +3399,8 @@ Used by: [Indexes](#Indexes).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_DataType_STATUS"></a>Indexes_DataType_STATUS
------------------------------------------------------------
+Indexes_DataType_STATUS{#Indexes_DataType_STATUS}
+-------------------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 
@@ -3413,8 +3413,8 @@ Used by: [Indexes_STATUS](#Indexes_STATUS).
 | "Polygon"      |             |
 | "String"       |             |
 
-<a id="Indexes_Kind"></a>Indexes_Kind
--------------------------------------
+Indexes_Kind{#Indexes_Kind}
+---------------------------
 
 Used by: [Indexes](#Indexes).
 
@@ -3424,8 +3424,8 @@ Used by: [Indexes](#Indexes).
 | "Range"   |             |
 | "Spatial" |             |
 
-<a id="Indexes_Kind_STATUS"></a>Indexes_Kind_STATUS
----------------------------------------------------
+Indexes_Kind_STATUS{#Indexes_Kind_STATUS}
+-----------------------------------------
 
 Used by: [Indexes_STATUS](#Indexes_STATUS).
 

--- a/docs/hugo/content/reference/eventgrid/v1api20200601.md
+++ b/docs/hugo/content/reference/eventgrid/v1api20200601.md
@@ -5,15 +5,15 @@ title: eventgrid.azure.com/v1api20200601
 linktitle: v1api20200601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-06-01" |             |
 
-<a id="Domain"></a>Domain
--------------------------
+Domain{#Domain}
+---------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/domains/{domainName}
 
@@ -26,7 +26,7 @@ Used by: [DomainList](#DomainList).
 | spec                                                                                    |             | [Domain_Spec](#Domain_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Domain_STATUS](#Domain_STATUS)<br/><small>Optional</small> |
 
-### <a id="Domain_Spec"></a>Domain_Spec
+### Domain_Spec {#Domain_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [DomainList](#DomainList).
 | publicNetworkAccess | This determines if traffic is allowed over public network. By default it is enabled. You can further restrict to specific IPs by configuring <seealso cref="P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.DomainProperties.InboundIpRules" />                                   | [DomainProperties_PublicNetworkAccess](#DomainProperties_PublicNetworkAccess)<br/><small>Optional</small>                                                            |
 | tags                | Tags of the resource.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Domain_STATUS"></a>Domain_STATUS
+### Domain_STATUS{#Domain_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                | Type                                                                                                                                                      |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -60,8 +60,8 @@ Used by: [DomainList](#DomainList).
 | tags                       | Tags of the resource.                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                             |
 | type                       | Type of the resource.                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DomainList"></a>DomainList
----------------------------------
+DomainList{#DomainList}
+-----------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/domains/{domainName}
 
@@ -71,8 +71,8 @@ Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.E
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Domain[]](#Domain)<br/><small>Optional</small> |
 
-<a id="DomainsTopic"></a>DomainsTopic
--------------------------------------
+DomainsTopic{#DomainsTopic}
+---------------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}
 
@@ -85,7 +85,7 @@ Used by: [DomainsTopicList](#DomainsTopicList).
 | spec                                                                                    |             | [DomainsTopic_Spec](#DomainsTopic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DomainsTopic_STATUS](#DomainsTopic_STATUS)<br/><small>Optional</small> |
 
-### <a id="DomainsTopic_Spec"></a>DomainsTopic_Spec
+### DomainsTopic_Spec {#DomainsTopic_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -93,7 +93,7 @@ Used by: [DomainsTopicList](#DomainsTopicList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                       | [DomainsTopicOperatorSpec](#DomainsTopicOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventgrid.azure.com/Domain resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="DomainsTopic_STATUS"></a>DomainsTopic_STATUS
+### DomainsTopic_STATUS{#DomainsTopic_STATUS}
 
 | Property          | Description                                            | Type                                                                                                                                                    |
 |-------------------|--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -104,8 +104,8 @@ Used by: [DomainsTopicList](#DomainsTopicList).
 | systemData        | The system metadata relating to Domain Topic resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Type of the resource.                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DomainsTopicList"></a>DomainsTopicList
----------------------------------------------
+DomainsTopicList{#DomainsTopicList}
+-----------------------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}
 
@@ -115,8 +115,8 @@ Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.E
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [DomainsTopic[]](#DomainsTopic)<br/><small>Optional</small> |
 
-<a id="EventSubscription"></a>EventSubscription
------------------------------------------------
+EventSubscription{#EventSubscription}
+-------------------------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}
 
@@ -129,7 +129,7 @@ Used by: [EventSubscriptionList](#EventSubscriptionList).
 | spec                                                                                    |             | [EventSubscription_Spec](#EventSubscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [EventSubscription_STATUS](#EventSubscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="EventSubscription_Spec"></a>EventSubscription_Spec
+### EventSubscription_Spec {#EventSubscription_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -144,7 +144,7 @@ Used by: [EventSubscriptionList](#EventSubscriptionList).
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. This resource is an extension resource, which means that any other Azure resource can be its owner. | [genruntime.ArbitraryOwnerReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ArbitraryOwnerReference)<br/><small>Required</small> |
 | retryPolicy           | The retry policy for events. This can be used to configure maximum number of delivery attempts and time to live for events.                                                                                                                                                                                  | [RetryPolicy](#RetryPolicy)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="EventSubscription_STATUS"></a>EventSubscription_STATUS
+### EventSubscription_STATUS{#EventSubscription_STATUS}
 
 | Property              | Description                                                                                                                 | Type                                                                                                                                                    |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -163,8 +163,8 @@ Used by: [EventSubscriptionList](#EventSubscriptionList).
 | topic                 | Name of the topic of the event subscription.                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                  | Type of the resource.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="EventSubscriptionList"></a>EventSubscriptionList
--------------------------------------------------------
+EventSubscriptionList{#EventSubscriptionList}
+---------------------------------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}
 
@@ -174,8 +174,8 @@ Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.E
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [EventSubscription[]](#EventSubscription)<br/><small>Optional</small> |
 
-<a id="Topic"></a>Topic
------------------------
+Topic{#Topic}
+-------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/topics/{topicName}
 
@@ -188,7 +188,7 @@ Used by: [TopicList](#TopicList).
 | spec                                                                                    |             | [Topic_Spec](#Topic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Topic_STATUS](#Topic_STATUS)<br/><small>Optional</small> |
 
-### <a id="Topic_Spec"></a>Topic_Spec
+### Topic_Spec {#Topic_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -202,7 +202,7 @@ Used by: [TopicList](#TopicList).
 | publicNetworkAccess | This determines if traffic is allowed over public network. By default it is enabled. You can further restrict to specific IPs by configuring <seealso cref="P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.TopicProperties.InboundIpRules" />                                    | [TopicProperties_PublicNetworkAccess](#TopicProperties_PublicNetworkAccess)<br/><small>Optional</small>                                                              |
 | tags                | Tags of the resource.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Topic_STATUS"></a>Topic_STATUS
+### Topic_STATUS{#Topic_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -222,8 +222,8 @@ Used by: [TopicList](#TopicList).
 | tags                       | Tags of the resource.                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Type of the resource.                                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TopicList"></a>TopicList
--------------------------------
+TopicList{#TopicList}
+---------------------
 
 Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventGrid/topics/{topicName}
 
@@ -233,8 +233,8 @@ Generator information: - Generated from: /eventgrid/resource-manager/Microsoft.E
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Topic[]](#Topic)<br/><small>Optional</small> |
 
-<a id="Domain_Spec"></a>Domain_Spec
------------------------------------
+Domain_Spec{#Domain_Spec}
+-------------------------
 
 Used by: [Domain](#Domain).
 
@@ -250,8 +250,8 @@ Used by: [Domain](#Domain).
 | publicNetworkAccess | This determines if traffic is allowed over public network. By default it is enabled. You can further restrict to specific IPs by configuring <seealso cref="P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.DomainProperties.InboundIpRules" />                                   | [DomainProperties_PublicNetworkAccess](#DomainProperties_PublicNetworkAccess)<br/><small>Optional</small>                                                            |
 | tags                | Tags of the resource.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Domain_STATUS"></a>Domain_STATUS
----------------------------------------
+Domain_STATUS{#Domain_STATUS}
+-----------------------------
 
 EventGrid Domain.
 
@@ -275,8 +275,8 @@ Used by: [Domain](#Domain).
 | tags                       | Tags of the resource.                                                                                                                                                                                                                                      | map[string]string<br/><small>Optional</small>                                                                                                             |
 | type                       | Type of the resource.                                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DomainsTopic_Spec"></a>DomainsTopic_Spec
------------------------------------------------
+DomainsTopic_Spec{#DomainsTopic_Spec}
+-------------------------------------
 
 Used by: [DomainsTopic](#DomainsTopic).
 
@@ -286,8 +286,8 @@ Used by: [DomainsTopic](#DomainsTopic).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                       | [DomainsTopicOperatorSpec](#DomainsTopicOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventgrid.azure.com/Domain resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="DomainsTopic_STATUS"></a>DomainsTopic_STATUS
----------------------------------------------------
+DomainsTopic_STATUS{#DomainsTopic_STATUS}
+-----------------------------------------
 
 Used by: [DomainsTopic](#DomainsTopic).
 
@@ -300,8 +300,8 @@ Used by: [DomainsTopic](#DomainsTopic).
 | systemData        | The system metadata relating to Domain Topic resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Type of the resource.                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="EventSubscription_Spec"></a>EventSubscription_Spec
----------------------------------------------------------
+EventSubscription_Spec{#EventSubscription_Spec}
+-----------------------------------------------
 
 Used by: [EventSubscription](#EventSubscription).
 
@@ -318,8 +318,8 @@ Used by: [EventSubscription](#EventSubscription).
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. This resource is an extension resource, which means that any other Azure resource can be its owner. | [genruntime.ArbitraryOwnerReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ArbitraryOwnerReference)<br/><small>Required</small> |
 | retryPolicy           | The retry policy for events. This can be used to configure maximum number of delivery attempts and time to live for events.                                                                                                                                                                                  | [RetryPolicy](#RetryPolicy)<br/><small>Optional</small>                                                                                                                |
 
-<a id="EventSubscription_STATUS"></a>EventSubscription_STATUS
--------------------------------------------------------------
+EventSubscription_STATUS{#EventSubscription_STATUS}
+---------------------------------------------------
 
 Event Subscription
 
@@ -342,8 +342,8 @@ Used by: [EventSubscription](#EventSubscription).
 | topic                 | Name of the topic of the event subscription.                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                  | Type of the resource.                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Topic_Spec"></a>Topic_Spec
----------------------------------
+Topic_Spec{#Topic_Spec}
+-----------------------
 
 Used by: [Topic](#Topic).
 
@@ -359,8 +359,8 @@ Used by: [Topic](#Topic).
 | publicNetworkAccess | This determines if traffic is allowed over public network. By default it is enabled. You can further restrict to specific IPs by configuring <seealso cref="P:Microsoft.Azure.Events.ResourceProvider.Common.Contracts.TopicProperties.InboundIpRules" />                                    | [TopicProperties_PublicNetworkAccess](#TopicProperties_PublicNetworkAccess)<br/><small>Optional</small>                                                              |
 | tags                | Tags of the resource.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Topic_STATUS"></a>Topic_STATUS
--------------------------------------
+Topic_STATUS{#Topic_STATUS}
+---------------------------
 
 EventGrid Topic
 
@@ -384,8 +384,8 @@ Used by: [Topic](#Topic).
 | tags                       | Tags of the resource.                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Type of the resource.                                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DeadLetterDestination"></a>DeadLetterDestination
--------------------------------------------------------
+DeadLetterDestination{#DeadLetterDestination}
+---------------------------------------------
 
 Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 
@@ -393,8 +393,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 |-------------|----------------------------------------------|---------------------------------------------------------------------------------------------------|
 | storageBlob | Mutually exclusive with all other properties | [StorageBlobDeadLetterDestination](#StorageBlobDeadLetterDestination)<br/><small>Optional</small> |
 
-<a id="DeadLetterDestination_STATUS"></a>DeadLetterDestination_STATUS
----------------------------------------------------------------------
+DeadLetterDestination_STATUS{#DeadLetterDestination_STATUS}
+-----------------------------------------------------------
 
 Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 
@@ -402,8 +402,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 |-------------|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | storageBlob | Mutually exclusive with all other properties | [StorageBlobDeadLetterDestination_STATUS](#StorageBlobDeadLetterDestination_STATUS)<br/><small>Optional</small> |
 
-<a id="DomainOperatorSpec"></a>DomainOperatorSpec
--------------------------------------------------
+DomainOperatorSpec{#DomainOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -414,8 +414,8 @@ Used by: [Domain_Spec](#Domain_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DomainProperties_InputSchema"></a>DomainProperties_InputSchema
----------------------------------------------------------------------
+DomainProperties_InputSchema{#DomainProperties_InputSchema}
+-----------------------------------------------------------
 
 Used by: [Domain_Spec](#Domain_Spec).
 
@@ -425,8 +425,8 @@ Used by: [Domain_Spec](#Domain_Spec).
 | "CustomEventSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="DomainProperties_InputSchema_STATUS"></a>DomainProperties_InputSchema_STATUS
------------------------------------------------------------------------------------
+DomainProperties_InputSchema_STATUS{#DomainProperties_InputSchema_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS).
 
@@ -436,8 +436,8 @@ Used by: [Domain_STATUS](#Domain_STATUS).
 | "CustomEventSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="DomainProperties_ProvisioningState_STATUS"></a>DomainProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------
+DomainProperties_ProvisioningState_STATUS{#DomainProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS).
 
@@ -450,8 +450,8 @@ Used by: [Domain_STATUS](#Domain_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="DomainProperties_PublicNetworkAccess"></a>DomainProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------
+DomainProperties_PublicNetworkAccess{#DomainProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------
 
 Used by: [Domain_Spec](#Domain_Spec).
 
@@ -460,8 +460,8 @@ Used by: [Domain_Spec](#Domain_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DomainProperties_PublicNetworkAccess_STATUS"></a>DomainProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------
+DomainProperties_PublicNetworkAccess_STATUS{#DomainProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS).
 
@@ -470,8 +470,8 @@ Used by: [Domain_STATUS](#Domain_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DomainsTopicOperatorSpec"></a>DomainsTopicOperatorSpec
--------------------------------------------------------------
+DomainsTopicOperatorSpec{#DomainsTopicOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -482,8 +482,8 @@ Used by: [DomainsTopic_Spec](#DomainsTopic_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DomainTopicProperties_ProvisioningState_STATUS"></a>DomainTopicProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+DomainTopicProperties_ProvisioningState_STATUS{#DomainTopicProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DomainsTopic_STATUS](#DomainsTopic_STATUS).
 
@@ -496,8 +496,8 @@ Used by: [DomainsTopic_STATUS](#DomainsTopic_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="EventSubscriptionDestination"></a>EventSubscriptionDestination
----------------------------------------------------------------------
+EventSubscriptionDestination{#EventSubscriptionDestination}
+-----------------------------------------------------------
 
 Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 
@@ -511,8 +511,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 | storageQueue     | Mutually exclusive with all other properties | [StorageQueueEventSubscriptionDestination](#StorageQueueEventSubscriptionDestination)<br/><small>Optional</small>         |
 | webHook          | Mutually exclusive with all other properties | [WebHookEventSubscriptionDestination](#WebHookEventSubscriptionDestination)<br/><small>Optional</small>                   |
 
-<a id="EventSubscriptionDestination_STATUS"></a>EventSubscriptionDestination_STATUS
------------------------------------------------------------------------------------
+EventSubscriptionDestination_STATUS{#EventSubscriptionDestination_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 
@@ -526,8 +526,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 | storageQueue     | Mutually exclusive with all other properties | [StorageQueueEventSubscriptionDestination_STATUS](#StorageQueueEventSubscriptionDestination_STATUS)<br/><small>Optional</small>         |
 | webHook          | Mutually exclusive with all other properties | [WebHookEventSubscriptionDestination_STATUS](#WebHookEventSubscriptionDestination_STATUS)<br/><small>Optional</small>                   |
 
-<a id="EventSubscriptionFilter"></a>EventSubscriptionFilter
------------------------------------------------------------
+EventSubscriptionFilter{#EventSubscriptionFilter}
+-------------------------------------------------
 
 Filter for the Event Subscription.
 
@@ -541,8 +541,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 | subjectBeginsWith      | An optional string to filter events for an event subscription based on a resource path prefix. The format of this depends on the publisher of the events. Wildcard characters are not supported in this path. | string<br/><small>Optional</small>                              |
 | subjectEndsWith        | An optional string to filter events for an event subscription based on a resource path suffix. Wildcard characters are not supported in this path.                                                            | string<br/><small>Optional</small>                              |
 
-<a id="EventSubscriptionFilter_STATUS"></a>EventSubscriptionFilter_STATUS
--------------------------------------------------------------------------
+EventSubscriptionFilter_STATUS{#EventSubscriptionFilter_STATUS}
+---------------------------------------------------------------
 
 Filter for the Event Subscription.
 
@@ -556,8 +556,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 | subjectBeginsWith      | An optional string to filter events for an event subscription based on a resource path prefix. The format of this depends on the publisher of the events. Wildcard characters are not supported in this path. | string<br/><small>Optional</small>                                            |
 | subjectEndsWith        | An optional string to filter events for an event subscription based on a resource path suffix. Wildcard characters are not supported in this path.                                                            | string<br/><small>Optional</small>                                            |
 
-<a id="EventSubscriptionOperatorSpec"></a>EventSubscriptionOperatorSpec
------------------------------------------------------------------------
+EventSubscriptionOperatorSpec{#EventSubscriptionOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -568,8 +568,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="EventSubscriptionProperties_EventDeliverySchema"></a>EventSubscriptionProperties_EventDeliverySchema
------------------------------------------------------------------------------------------------------------
+EventSubscriptionProperties_EventDeliverySchema{#EventSubscriptionProperties_EventDeliverySchema}
+-------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 
@@ -579,8 +579,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 | "CustomInputSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="EventSubscriptionProperties_EventDeliverySchema_STATUS"></a>EventSubscriptionProperties_EventDeliverySchema_STATUS
--------------------------------------------------------------------------------------------------------------------------
+EventSubscriptionProperties_EventDeliverySchema_STATUS{#EventSubscriptionProperties_EventDeliverySchema_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 
@@ -590,8 +590,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 | "CustomInputSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="EventSubscriptionProperties_ProvisioningState_STATUS"></a>EventSubscriptionProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------------
+EventSubscriptionProperties_ProvisioningState_STATUS{#EventSubscriptionProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 
@@ -605,8 +605,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 | "Succeeded"            |             |
 | "Updating"             |             |
 
-<a id="InboundIpRule"></a>InboundIpRule
----------------------------------------
+InboundIpRule{#InboundIpRule}
+-----------------------------
 
 Used by: [Domain_Spec](#Domain_Spec), and [Topic_Spec](#Topic_Spec).
 
@@ -615,8 +615,8 @@ Used by: [Domain_Spec](#Domain_Spec), and [Topic_Spec](#Topic_Spec).
 | action   | Action to perform based on the match or no match of the IpMask. | [InboundIpRule_Action](#InboundIpRule_Action)<br/><small>Optional</small> |
 | ipMask   | IP Address in CIDR notation e.g., 10.0.0.0/8.                   | string<br/><small>Optional</small>                                        |
 
-<a id="InboundIpRule_STATUS"></a>InboundIpRule_STATUS
------------------------------------------------------
+InboundIpRule_STATUS{#InboundIpRule_STATUS}
+-------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS), and [Topic_STATUS](#Topic_STATUS).
 
@@ -625,8 +625,8 @@ Used by: [Domain_STATUS](#Domain_STATUS), and [Topic_STATUS](#Topic_STATUS).
 | action   | Action to perform based on the match or no match of the IpMask. | [InboundIpRule_Action_STATUS](#InboundIpRule_Action_STATUS)<br/><small>Optional</small> |
 | ipMask   | IP Address in CIDR notation e.g., 10.0.0.0/8.                   | string<br/><small>Optional</small>                                                      |
 
-<a id="InputSchemaMapping"></a>InputSchemaMapping
--------------------------------------------------
+InputSchemaMapping{#InputSchemaMapping}
+---------------------------------------
 
 Used by: [Domain_Spec](#Domain_Spec), and [Topic_Spec](#Topic_Spec).
 
@@ -634,8 +634,8 @@ Used by: [Domain_Spec](#Domain_Spec), and [Topic_Spec](#Topic_Spec).
 |----------|----------------------------------------------|-------------------------------------------------------------------------------|
 | json     | Mutually exclusive with all other properties | [JsonInputSchemaMapping](#JsonInputSchemaMapping)<br/><small>Optional</small> |
 
-<a id="InputSchemaMapping_STATUS"></a>InputSchemaMapping_STATUS
----------------------------------------------------------------
+InputSchemaMapping_STATUS{#InputSchemaMapping_STATUS}
+-----------------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS), and [Topic_STATUS](#Topic_STATUS).
 
@@ -643,8 +643,8 @@ Used by: [Domain_STATUS](#Domain_STATUS), and [Topic_STATUS](#Topic_STATUS).
 |----------|----------------------------------------------|---------------------------------------------------------------------------------------------|
 | json     | Mutually exclusive with all other properties | [JsonInputSchemaMapping_STATUS](#JsonInputSchemaMapping_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded"></a>PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded{#PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Domain_STATUS](#Domain_STATUS).
 
@@ -652,8 +652,8 @@ Used by: [Domain_STATUS](#Domain_STATUS).
 |----------|---------------------------------------------|------------------------------------|
 | id       | Fully qualified identifier of the resource. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded"></a>PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded{#PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [Topic_STATUS](#Topic_STATUS).
 
@@ -661,8 +661,8 @@ Used by: [Topic_STATUS](#Topic_STATUS).
 |----------|---------------------------------------------|------------------------------------|
 | id       | Fully qualified identifier of the resource. | string<br/><small>Optional</small> |
 
-<a id="RetryPolicy"></a>RetryPolicy
------------------------------------
+RetryPolicy{#RetryPolicy}
+-------------------------
 
 Information about the retry policy for an event subscription.
 
@@ -673,8 +673,8 @@ Used by: [EventSubscription_Spec](#EventSubscription_Spec).
 | eventTimeToLiveInMinutes | Time To Live (in minutes) for events.                 | int<br/><small>Optional</small> |
 | maxDeliveryAttempts      | Maximum number of delivery retry attempts for events. | int<br/><small>Optional</small> |
 
-<a id="RetryPolicy_STATUS"></a>RetryPolicy_STATUS
--------------------------------------------------
+RetryPolicy_STATUS{#RetryPolicy_STATUS}
+---------------------------------------
 
 Information about the retry policy for an event subscription.
 
@@ -685,8 +685,8 @@ Used by: [EventSubscription_STATUS](#EventSubscription_STATUS).
 | eventTimeToLiveInMinutes | Time To Live (in minutes) for events.                 | int<br/><small>Optional</small> |
 | maxDeliveryAttempts      | Maximum number of delivery retry attempts for events. | int<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -701,8 +701,8 @@ Used by: [Domain_STATUS](#Domain_STATUS), [DomainsTopic_STATUS](#DomainsTopic_ST
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TopicOperatorSpec"></a>TopicOperatorSpec
------------------------------------------------
+TopicOperatorSpec{#TopicOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -715,8 +715,8 @@ Used by: [Topic_Spec](#Topic_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [TopicOperatorSecrets](#TopicOperatorSecrets)<br/><small>Optional</small>                                                                                           |
 
-<a id="TopicProperties_InputSchema"></a>TopicProperties_InputSchema
--------------------------------------------------------------------
+TopicProperties_InputSchema{#TopicProperties_InputSchema}
+---------------------------------------------------------
 
 Used by: [Topic_Spec](#Topic_Spec).
 
@@ -726,8 +726,8 @@ Used by: [Topic_Spec](#Topic_Spec).
 | "CustomEventSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="TopicProperties_InputSchema_STATUS"></a>TopicProperties_InputSchema_STATUS
----------------------------------------------------------------------------------
+TopicProperties_InputSchema_STATUS{#TopicProperties_InputSchema_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [Topic_STATUS](#Topic_STATUS).
 
@@ -737,8 +737,8 @@ Used by: [Topic_STATUS](#Topic_STATUS).
 | "CustomEventSchema"    |             |
 | "EventGridSchema"      |             |
 
-<a id="TopicProperties_ProvisioningState_STATUS"></a>TopicProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+TopicProperties_ProvisioningState_STATUS{#TopicProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Topic_STATUS](#Topic_STATUS).
 
@@ -751,8 +751,8 @@ Used by: [Topic_STATUS](#Topic_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="TopicProperties_PublicNetworkAccess"></a>TopicProperties_PublicNetworkAccess
------------------------------------------------------------------------------------
+TopicProperties_PublicNetworkAccess{#TopicProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------
 
 Used by: [Topic_Spec](#Topic_Spec).
 
@@ -761,8 +761,8 @@ Used by: [Topic_Spec](#Topic_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="TopicProperties_PublicNetworkAccess_STATUS"></a>TopicProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------
+TopicProperties_PublicNetworkAccess_STATUS{#TopicProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [Topic_STATUS](#Topic_STATUS).
 
@@ -771,8 +771,8 @@ Used by: [Topic_STATUS](#Topic_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdvancedFilter"></a>AdvancedFilter
------------------------------------------
+AdvancedFilter{#AdvancedFilter}
+-------------------------------
 
 Used by: [EventSubscriptionFilter](#EventSubscriptionFilter).
 
@@ -791,8 +791,8 @@ Used by: [EventSubscriptionFilter](#EventSubscriptionFilter).
 | stringIn                  | Mutually exclusive with all other properties | [StringInAdvancedFilter](#StringInAdvancedFilter)<br/><small>Optional</small>                                   |
 | stringNotIn               | Mutually exclusive with all other properties | [StringNotInAdvancedFilter](#StringNotInAdvancedFilter)<br/><small>Optional</small>                             |
 
-<a id="AdvancedFilter_STATUS"></a>AdvancedFilter_STATUS
--------------------------------------------------------
+AdvancedFilter_STATUS{#AdvancedFilter_STATUS}
+---------------------------------------------
 
 Used by: [EventSubscriptionFilter_STATUS](#EventSubscriptionFilter_STATUS).
 
@@ -811,8 +811,8 @@ Used by: [EventSubscriptionFilter_STATUS](#EventSubscriptionFilter_STATUS).
 | stringIn                  | Mutually exclusive with all other properties | [StringInAdvancedFilter_STATUS](#StringInAdvancedFilter_STATUS)<br/><small>Optional</small>                                   |
 | stringNotIn               | Mutually exclusive with all other properties | [StringNotInAdvancedFilter_STATUS](#StringNotInAdvancedFilter_STATUS)<br/><small>Optional</small>                             |
 
-<a id="AzureFunctionEventSubscriptionDestination"></a>AzureFunctionEventSubscriptionDestination
------------------------------------------------------------------------------------------------
+AzureFunctionEventSubscriptionDestination{#AzureFunctionEventSubscriptionDestination}
+-------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -823,8 +823,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | preferredBatchSizeInKilobytes | Preferred batch size in Kilobytes.                                                                             | int<br/><small>Optional</small>                                                                                                                            |
 | resourceReference             | The Azure Resource Id that represents the endpoint of the Azure Function destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AzureFunctionEventSubscriptionDestination_STATUS"></a>AzureFunctionEventSubscriptionDestination_STATUS
--------------------------------------------------------------------------------------------------------------
+AzureFunctionEventSubscriptionDestination_STATUS{#AzureFunctionEventSubscriptionDestination_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -835,8 +835,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | preferredBatchSizeInKilobytes | Preferred batch size in Kilobytes.                                                                             | int<br/><small>Optional</small>                                                                                                                             |
 | resourceId                    | The Azure Resource Id that represents the endpoint of the Azure Function destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                          |
 
-<a id="EventHubEventSubscriptionDestination"></a>EventHubEventSubscriptionDestination
--------------------------------------------------------------------------------------
+EventHubEventSubscriptionDestination{#EventHubEventSubscriptionDestination}
+---------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -845,8 +845,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | endpointType      | Type of the endpoint for the event subscription destination.                                             | [EventHubEventSubscriptionDestination_EndpointType](#EventHubEventSubscriptionDestination_EndpointType)<br/><small>Required</small>                        |
 | resourceReference | The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EventHubEventSubscriptionDestination_STATUS"></a>EventHubEventSubscriptionDestination_STATUS
----------------------------------------------------------------------------------------------------
+EventHubEventSubscriptionDestination_STATUS{#EventHubEventSubscriptionDestination_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -855,8 +855,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | endpointType | Type of the endpoint for the event subscription destination.                                             | [EventHubEventSubscriptionDestination_EndpointType_STATUS](#EventHubEventSubscriptionDestination_EndpointType_STATUS)<br/><small>Optional</small> |
 | resourceId   | The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                |
 
-<a id="HybridConnectionEventSubscriptionDestination"></a>HybridConnectionEventSubscriptionDestination
------------------------------------------------------------------------------------------------------
+HybridConnectionEventSubscriptionDestination{#HybridConnectionEventSubscriptionDestination}
+-------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -865,8 +865,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | endpointType      | Type of the endpoint for the event subscription destination.                                    | [HybridConnectionEventSubscriptionDestination_EndpointType](#HybridConnectionEventSubscriptionDestination_EndpointType)<br/><small>Required</small>        |
 | resourceReference | The Azure Resource ID of an hybrid connection that is the destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="HybridConnectionEventSubscriptionDestination_STATUS"></a>HybridConnectionEventSubscriptionDestination_STATUS
--------------------------------------------------------------------------------------------------------------------
+HybridConnectionEventSubscriptionDestination_STATUS{#HybridConnectionEventSubscriptionDestination_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -875,8 +875,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | endpointType | Type of the endpoint for the event subscription destination.                                    | [HybridConnectionEventSubscriptionDestination_EndpointType_STATUS](#HybridConnectionEventSubscriptionDestination_EndpointType_STATUS)<br/><small>Optional</small> |
 | resourceId   | The Azure Resource ID of an hybrid connection that is the destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="InboundIpRule_Action"></a>InboundIpRule_Action
------------------------------------------------------
+InboundIpRule_Action{#InboundIpRule_Action}
+-------------------------------------------
 
 Used by: [InboundIpRule](#InboundIpRule).
 
@@ -884,8 +884,8 @@ Used by: [InboundIpRule](#InboundIpRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="InboundIpRule_Action_STATUS"></a>InboundIpRule_Action_STATUS
--------------------------------------------------------------------
+InboundIpRule_Action_STATUS{#InboundIpRule_Action_STATUS}
+---------------------------------------------------------
 
 Used by: [InboundIpRule_STATUS](#InboundIpRule_STATUS).
 
@@ -893,8 +893,8 @@ Used by: [InboundIpRule_STATUS](#InboundIpRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="JsonInputSchemaMapping"></a>JsonInputSchemaMapping
----------------------------------------------------------
+JsonInputSchemaMapping{#JsonInputSchemaMapping}
+-----------------------------------------------
 
 Used by: [InputSchemaMapping](#InputSchemaMapping).
 
@@ -908,8 +908,8 @@ Used by: [InputSchemaMapping](#InputSchemaMapping).
 | subject                | The mapping information for the Subject property of the Event Grid Event.     | [JsonFieldWithDefault](#JsonFieldWithDefault)<br/><small>Optional</small>                                                   |
 | topic                  | The mapping information for the Topic property of the Event Grid Event.       | [JsonField](#JsonField)<br/><small>Optional</small>                                                                         |
 
-<a id="JsonInputSchemaMapping_STATUS"></a>JsonInputSchemaMapping_STATUS
------------------------------------------------------------------------
+JsonInputSchemaMapping_STATUS{#JsonInputSchemaMapping_STATUS}
+-------------------------------------------------------------
 
 Used by: [InputSchemaMapping_STATUS](#InputSchemaMapping_STATUS).
 
@@ -923,8 +923,8 @@ Used by: [InputSchemaMapping_STATUS](#InputSchemaMapping_STATUS).
 | subject                | The mapping information for the Subject property of the Event Grid Event.     | [JsonFieldWithDefault_STATUS](#JsonFieldWithDefault_STATUS)<br/><small>Optional</small>                                                   |
 | topic                  | The mapping information for the Topic property of the Event Grid Event.       | [JsonField_STATUS](#JsonField_STATUS)<br/><small>Optional</small>                                                                         |
 
-<a id="ServiceBusQueueEventSubscriptionDestination"></a>ServiceBusQueueEventSubscriptionDestination
----------------------------------------------------------------------------------------------------
+ServiceBusQueueEventSubscriptionDestination{#ServiceBusQueueEventSubscriptionDestination}
+-----------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -933,8 +933,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | endpointType      | Type of the endpoint for the event subscription destination.                                                | [ServiceBusQueueEventSubscriptionDestination_EndpointType](#ServiceBusQueueEventSubscriptionDestination_EndpointType)<br/><small>Required</small>          |
 | resourceReference | The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ServiceBusQueueEventSubscriptionDestination_STATUS"></a>ServiceBusQueueEventSubscriptionDestination_STATUS
------------------------------------------------------------------------------------------------------------------
+ServiceBusQueueEventSubscriptionDestination_STATUS{#ServiceBusQueueEventSubscriptionDestination_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -943,8 +943,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | endpointType | Type of the endpoint for the event subscription destination.                                                | [ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS](#ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS)<br/><small>Optional</small> |
 | resourceId   | The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="ServiceBusTopicEventSubscriptionDestination"></a>ServiceBusTopicEventSubscriptionDestination
----------------------------------------------------------------------------------------------------
+ServiceBusTopicEventSubscriptionDestination{#ServiceBusTopicEventSubscriptionDestination}
+-----------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -953,8 +953,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | endpointType      | Type of the endpoint for the event subscription destination.                                                      | [ServiceBusTopicEventSubscriptionDestination_EndpointType](#ServiceBusTopicEventSubscriptionDestination_EndpointType)<br/><small>Required</small>          |
 | resourceReference | The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ServiceBusTopicEventSubscriptionDestination_STATUS"></a>ServiceBusTopicEventSubscriptionDestination_STATUS
------------------------------------------------------------------------------------------------------------------
+ServiceBusTopicEventSubscriptionDestination_STATUS{#ServiceBusTopicEventSubscriptionDestination_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -963,8 +963,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | endpointType | Type of the endpoint for the event subscription destination.                                                      | [ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS](#ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS)<br/><small>Optional</small> |
 | resourceId   | The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                              |
 
-<a id="StorageBlobDeadLetterDestination"></a>StorageBlobDeadLetterDestination
------------------------------------------------------------------------------
+StorageBlobDeadLetterDestination{#StorageBlobDeadLetterDestination}
+-------------------------------------------------------------------
 
 Used by: [DeadLetterDestination](#DeadLetterDestination).
 
@@ -974,8 +974,8 @@ Used by: [DeadLetterDestination](#DeadLetterDestination).
 | endpointType      | Type of the endpoint for the dead letter destination                                          | [StorageBlobDeadLetterDestination_EndpointType](#StorageBlobDeadLetterDestination_EndpointType)<br/><small>Required</small>                                |
 | resourceReference | The Azure Resource ID of the storage account that is the destination of the deadletter events | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="StorageBlobDeadLetterDestination_STATUS"></a>StorageBlobDeadLetterDestination_STATUS
--------------------------------------------------------------------------------------------
+StorageBlobDeadLetterDestination_STATUS{#StorageBlobDeadLetterDestination_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [DeadLetterDestination_STATUS](#DeadLetterDestination_STATUS).
 
@@ -985,8 +985,8 @@ Used by: [DeadLetterDestination_STATUS](#DeadLetterDestination_STATUS).
 | endpointType      | Type of the endpoint for the dead letter destination                                          | [StorageBlobDeadLetterDestination_EndpointType_STATUS](#StorageBlobDeadLetterDestination_EndpointType_STATUS)<br/><small>Optional</small> |
 | resourceId        | The Azure Resource ID of the storage account that is the destination of the deadletter events | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="StorageQueueEventSubscriptionDestination"></a>StorageQueueEventSubscriptionDestination
----------------------------------------------------------------------------------------------
+StorageQueueEventSubscriptionDestination{#StorageQueueEventSubscriptionDestination}
+-----------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -996,8 +996,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | queueName         | The name of the Storage queue under a storage account that is the destination of an event subscription.                | string<br/><small>Optional</small>                                                                                                                         |
 | resourceReference | The Azure Resource ID of the storage account that contains the queue that is the destination of an event subscription. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="StorageQueueEventSubscriptionDestination_STATUS"></a>StorageQueueEventSubscriptionDestination_STATUS
------------------------------------------------------------------------------------------------------------
+StorageQueueEventSubscriptionDestination_STATUS{#StorageQueueEventSubscriptionDestination_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -1007,7 +1007,19 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | queueName    | The name of the Storage queue under a storage account that is the destination of an event subscription.                | string<br/><small>Optional</small>                                                                                                                        |
 | resourceId   | The Azure Resource ID of the storage account that contains the queue that is the destination of an event subscription. | string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1019,20 +1031,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="TopicOperatorConfigMaps"></a>TopicOperatorConfigMaps
------------------------------------------------------------
+TopicOperatorConfigMaps{#TopicOperatorConfigMaps}
+-------------------------------------------------
 
 Used by: [TopicOperatorSpec](#TopicOperatorSpec).
 
@@ -1040,8 +1040,8 @@ Used by: [TopicOperatorSpec](#TopicOperatorSpec).
 |----------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | endpoint | indicates where the Endpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="TopicOperatorSecrets"></a>TopicOperatorSecrets
------------------------------------------------------
+TopicOperatorSecrets{#TopicOperatorSecrets}
+-------------------------------------------
 
 Used by: [TopicOperatorSpec](#TopicOperatorSpec).
 
@@ -1050,8 +1050,8 @@ Used by: [TopicOperatorSpec](#TopicOperatorSpec).
 | key1     | indicates where the Key1 secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | key2     | indicates where the Key2 secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="WebHookEventSubscriptionDestination"></a>WebHookEventSubscriptionDestination
------------------------------------------------------------------------------------
+WebHookEventSubscriptionDestination{#WebHookEventSubscriptionDestination}
+-------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 
@@ -1064,8 +1064,8 @@ Used by: [EventSubscriptionDestination](#EventSubscriptionDestination).
 | maxEventsPerBatch                      | Maximum number of events per batch.                                                                                                      | int<br/><small>Optional</small>                                                                                                                        |
 | preferredBatchSizeInKilobytes          | Preferred batch size in Kilobytes.                                                                                                       | int<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WebHookEventSubscriptionDestination_STATUS"></a>WebHookEventSubscriptionDestination_STATUS
--------------------------------------------------------------------------------------------------
+WebHookEventSubscriptionDestination_STATUS{#WebHookEventSubscriptionDestination_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STATUS).
 
@@ -1078,8 +1078,8 @@ Used by: [EventSubscriptionDestination_STATUS](#EventSubscriptionDestination_STA
 | maxEventsPerBatch                      | Maximum number of events per batch.                                                                                                      | int<br/><small>Optional</small>                                                                                                                 |
 | preferredBatchSizeInKilobytes          | Preferred batch size in Kilobytes.                                                                                                       | int<br/><small>Optional</small>                                                                                                                 |
 
-<a id="AzureFunctionEventSubscriptionDestination_EndpointType"></a>AzureFunctionEventSubscriptionDestination_EndpointType
--------------------------------------------------------------------------------------------------------------------------
+AzureFunctionEventSubscriptionDestination_EndpointType{#AzureFunctionEventSubscriptionDestination_EndpointType}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFunctionEventSubscriptionDestination](#AzureFunctionEventSubscriptionDestination).
 
@@ -1087,8 +1087,8 @@ Used by: [AzureFunctionEventSubscriptionDestination](#AzureFunctionEventSubscrip
 |-----------------|-------------|
 | "AzureFunction" |             |
 
-<a id="AzureFunctionEventSubscriptionDestination_EndpointType_STATUS"></a>AzureFunctionEventSubscriptionDestination_EndpointType_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+AzureFunctionEventSubscriptionDestination_EndpointType_STATUS{#AzureFunctionEventSubscriptionDestination_EndpointType_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFunctionEventSubscriptionDestination_STATUS](#AzureFunctionEventSubscriptionDestination_STATUS).
 
@@ -1096,8 +1096,8 @@ Used by: [AzureFunctionEventSubscriptionDestination_STATUS](#AzureFunctionEventS
 |-----------------|-------------|
 | "AzureFunction" |             |
 
-<a id="BoolEqualsAdvancedFilter"></a>BoolEqualsAdvancedFilter
--------------------------------------------------------------
+BoolEqualsAdvancedFilter{#BoolEqualsAdvancedFilter}
+---------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1107,8 +1107,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [BoolEqualsAdvancedFilter_OperatorType](#BoolEqualsAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | value        | The boolean filter value.                                                                    | bool<br/><small>Optional</small>                                                                            |
 
-<a id="BoolEqualsAdvancedFilter_STATUS"></a>BoolEqualsAdvancedFilter_STATUS
----------------------------------------------------------------------------
+BoolEqualsAdvancedFilter_STATUS{#BoolEqualsAdvancedFilter_STATUS}
+-----------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1118,8 +1118,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [BoolEqualsAdvancedFilter_OperatorType_STATUS](#BoolEqualsAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | value        | The boolean filter value.                                                                    | bool<br/><small>Optional</small>                                                                                          |
 
-<a id="EventHubEventSubscriptionDestination_EndpointType"></a>EventHubEventSubscriptionDestination_EndpointType
----------------------------------------------------------------------------------------------------------------
+EventHubEventSubscriptionDestination_EndpointType{#EventHubEventSubscriptionDestination_EndpointType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [EventHubEventSubscriptionDestination](#EventHubEventSubscriptionDestination).
 
@@ -1127,8 +1127,8 @@ Used by: [EventHubEventSubscriptionDestination](#EventHubEventSubscriptionDestin
 |------------|-------------|
 | "EventHub" |             |
 
-<a id="EventHubEventSubscriptionDestination_EndpointType_STATUS"></a>EventHubEventSubscriptionDestination_EndpointType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+EventHubEventSubscriptionDestination_EndpointType_STATUS{#EventHubEventSubscriptionDestination_EndpointType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [EventHubEventSubscriptionDestination_STATUS](#EventHubEventSubscriptionDestination_STATUS).
 
@@ -1136,8 +1136,8 @@ Used by: [EventHubEventSubscriptionDestination_STATUS](#EventHubEventSubscriptio
 |------------|-------------|
 | "EventHub" |             |
 
-<a id="HybridConnectionEventSubscriptionDestination_EndpointType"></a>HybridConnectionEventSubscriptionDestination_EndpointType
--------------------------------------------------------------------------------------------------------------------------------
+HybridConnectionEventSubscriptionDestination_EndpointType{#HybridConnectionEventSubscriptionDestination_EndpointType}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [HybridConnectionEventSubscriptionDestination](#HybridConnectionEventSubscriptionDestination).
 
@@ -1145,8 +1145,8 @@ Used by: [HybridConnectionEventSubscriptionDestination](#HybridConnectionEventSu
 |--------------------|-------------|
 | "HybridConnection" |             |
 
-<a id="HybridConnectionEventSubscriptionDestination_EndpointType_STATUS"></a>HybridConnectionEventSubscriptionDestination_EndpointType_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------
+HybridConnectionEventSubscriptionDestination_EndpointType_STATUS{#HybridConnectionEventSubscriptionDestination_EndpointType_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [HybridConnectionEventSubscriptionDestination_STATUS](#HybridConnectionEventSubscriptionDestination_STATUS).
 
@@ -1154,8 +1154,8 @@ Used by: [HybridConnectionEventSubscriptionDestination_STATUS](#HybridConnection
 |--------------------|-------------|
 | "HybridConnection" |             |
 
-<a id="JsonField"></a>JsonField
--------------------------------
+JsonField{#JsonField}
+---------------------
 
 This is used to express the source of an input schema mapping for a single target field in the Event Grid Event schema. This is currently used in the mappings for the 'id', 'topic' and 'eventtime' properties. This represents a field in the input event schema.
 
@@ -1165,8 +1165,8 @@ Used by: [JsonInputSchemaMapping](#JsonInputSchemaMapping), [JsonInputSchemaMapp
 |-------------|-----------------------------------------------------------------------------------------|------------------------------------|
 | sourceField | Name of a field in the input event schema that's to be used as the source of a mapping. | string<br/><small>Optional</small> |
 
-<a id="JsonField_STATUS"></a>JsonField_STATUS
----------------------------------------------
+JsonField_STATUS{#JsonField_STATUS}
+-----------------------------------
 
 This is used to express the source of an input schema mapping for a single target field in the Event Grid Event schema. This is currently used in the mappings for the 'id', 'topic' and 'eventtime' properties. This represents a field in the input event schema.
 
@@ -1176,8 +1176,8 @@ Used by: [JsonInputSchemaMapping_STATUS](#JsonInputSchemaMapping_STATUS), [JsonI
 |-------------|-----------------------------------------------------------------------------------------|------------------------------------|
 | sourceField | Name of a field in the input event schema that's to be used as the source of a mapping. | string<br/><small>Optional</small> |
 
-<a id="JsonFieldWithDefault"></a>JsonFieldWithDefault
------------------------------------------------------
+JsonFieldWithDefault{#JsonFieldWithDefault}
+-------------------------------------------
 
 This is used to express the source of an input schema mapping for a single target field in the Event Grid Event schema. This is currently used in the mappings for the 'subject', 'eventtype' and 'dataversion' properties. This represents a field in the input event schema along with a default value to be used, and at least one of these two properties should be provided.
 
@@ -1188,8 +1188,8 @@ Used by: [JsonInputSchemaMapping](#JsonInputSchemaMapping), [JsonInputSchemaMapp
 | defaultValue | The default value to be used for mapping when a SourceField is not provided or if there's no property with the specified name in the published JSON event payload. | string<br/><small>Optional</small> |
 | sourceField  | Name of a field in the input event schema that's to be used as the source of a mapping.                                                                            | string<br/><small>Optional</small> |
 
-<a id="JsonFieldWithDefault_STATUS"></a>JsonFieldWithDefault_STATUS
--------------------------------------------------------------------
+JsonFieldWithDefault_STATUS{#JsonFieldWithDefault_STATUS}
+---------------------------------------------------------
 
 This is used to express the source of an input schema mapping for a single target field in the Event Grid Event schema. This is currently used in the mappings for the 'subject', 'eventtype' and 'dataversion' properties. This represents a field in the input event schema along with a default value to be used, and at least one of these two properties should be provided.
 
@@ -1200,8 +1200,8 @@ Used by: [JsonInputSchemaMapping_STATUS](#JsonInputSchemaMapping_STATUS), [JsonI
 | defaultValue | The default value to be used for mapping when a SourceField is not provided or if there's no property with the specified name in the published JSON event payload. | string<br/><small>Optional</small> |
 | sourceField  | Name of a field in the input event schema that's to be used as the source of a mapping.                                                                            | string<br/><small>Optional</small> |
 
-<a id="JsonInputSchemaMapping_InputSchemaMappingType"></a>JsonInputSchemaMapping_InputSchemaMappingType
--------------------------------------------------------------------------------------------------------
+JsonInputSchemaMapping_InputSchemaMappingType{#JsonInputSchemaMapping_InputSchemaMappingType}
+---------------------------------------------------------------------------------------------
 
 Used by: [JsonInputSchemaMapping](#JsonInputSchemaMapping).
 
@@ -1209,8 +1209,8 @@ Used by: [JsonInputSchemaMapping](#JsonInputSchemaMapping).
 |--------|-------------|
 | "Json" |             |
 
-<a id="JsonInputSchemaMapping_InputSchemaMappingType_STATUS"></a>JsonInputSchemaMapping_InputSchemaMappingType_STATUS
----------------------------------------------------------------------------------------------------------------------
+JsonInputSchemaMapping_InputSchemaMappingType_STATUS{#JsonInputSchemaMapping_InputSchemaMappingType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [JsonInputSchemaMapping_STATUS](#JsonInputSchemaMapping_STATUS).
 
@@ -1218,8 +1218,8 @@ Used by: [JsonInputSchemaMapping_STATUS](#JsonInputSchemaMapping_STATUS).
 |--------|-------------|
 | "Json" |             |
 
-<a id="NumberGreaterThanAdvancedFilter"></a>NumberGreaterThanAdvancedFilter
----------------------------------------------------------------------------
+NumberGreaterThanAdvancedFilter{#NumberGreaterThanAdvancedFilter}
+-----------------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1229,8 +1229,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberGreaterThanAdvancedFilter_OperatorType](#NumberGreaterThanAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                       |
 
-<a id="NumberGreaterThanAdvancedFilter_STATUS"></a>NumberGreaterThanAdvancedFilter_STATUS
------------------------------------------------------------------------------------------
+NumberGreaterThanAdvancedFilter_STATUS{#NumberGreaterThanAdvancedFilter_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1240,8 +1240,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberGreaterThanAdvancedFilter_OperatorType_STATUS](#NumberGreaterThanAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                                     |
 
-<a id="NumberGreaterThanOrEqualsAdvancedFilter"></a>NumberGreaterThanOrEqualsAdvancedFilter
--------------------------------------------------------------------------------------------
+NumberGreaterThanOrEqualsAdvancedFilter{#NumberGreaterThanOrEqualsAdvancedFilter}
+---------------------------------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1251,8 +1251,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberGreaterThanOrEqualsAdvancedFilter_OperatorType](#NumberGreaterThanOrEqualsAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                                       |
 
-<a id="NumberGreaterThanOrEqualsAdvancedFilter_STATUS"></a>NumberGreaterThanOrEqualsAdvancedFilter_STATUS
----------------------------------------------------------------------------------------------------------
+NumberGreaterThanOrEqualsAdvancedFilter_STATUS{#NumberGreaterThanOrEqualsAdvancedFilter_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1262,8 +1262,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS](#NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                                                     |
 
-<a id="NumberInAdvancedFilter"></a>NumberInAdvancedFilter
----------------------------------------------------------
+NumberInAdvancedFilter{#NumberInAdvancedFilter}
+-----------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1273,8 +1273,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberInAdvancedFilter_OperatorType](#NumberInAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | float64[]<br/><small>Optional</small>                                                                   |
 
-<a id="NumberInAdvancedFilter_STATUS"></a>NumberInAdvancedFilter_STATUS
------------------------------------------------------------------------
+NumberInAdvancedFilter_STATUS{#NumberInAdvancedFilter_STATUS}
+-------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1284,8 +1284,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberInAdvancedFilter_OperatorType_STATUS](#NumberInAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | float64[]<br/><small>Optional</small>                                                                                 |
 
-<a id="NumberLessThanAdvancedFilter"></a>NumberLessThanAdvancedFilter
----------------------------------------------------------------------
+NumberLessThanAdvancedFilter{#NumberLessThanAdvancedFilter}
+-----------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1295,8 +1295,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberLessThanAdvancedFilter_OperatorType](#NumberLessThanAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                 |
 
-<a id="NumberLessThanAdvancedFilter_STATUS"></a>NumberLessThanAdvancedFilter_STATUS
------------------------------------------------------------------------------------
+NumberLessThanAdvancedFilter_STATUS{#NumberLessThanAdvancedFilter_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1306,8 +1306,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberLessThanAdvancedFilter_OperatorType_STATUS](#NumberLessThanAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                               |
 
-<a id="NumberLessThanOrEqualsAdvancedFilter"></a>NumberLessThanOrEqualsAdvancedFilter
--------------------------------------------------------------------------------------
+NumberLessThanOrEqualsAdvancedFilter{#NumberLessThanOrEqualsAdvancedFilter}
+---------------------------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1317,8 +1317,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberLessThanOrEqualsAdvancedFilter_OperatorType](#NumberLessThanOrEqualsAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                                 |
 
-<a id="NumberLessThanOrEqualsAdvancedFilter_STATUS"></a>NumberLessThanOrEqualsAdvancedFilter_STATUS
----------------------------------------------------------------------------------------------------
+NumberLessThanOrEqualsAdvancedFilter_STATUS{#NumberLessThanOrEqualsAdvancedFilter_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1328,8 +1328,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS](#NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | value        | The filter value.                                                                            | float64<br/><small>Optional</small>                                                                                                               |
 
-<a id="NumberNotInAdvancedFilter"></a>NumberNotInAdvancedFilter
----------------------------------------------------------------
+NumberNotInAdvancedFilter{#NumberNotInAdvancedFilter}
+-----------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1339,8 +1339,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberNotInAdvancedFilter_OperatorType](#NumberNotInAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | float64[]<br/><small>Optional</small>                                                                         |
 
-<a id="NumberNotInAdvancedFilter_STATUS"></a>NumberNotInAdvancedFilter_STATUS
------------------------------------------------------------------------------
+NumberNotInAdvancedFilter_STATUS{#NumberNotInAdvancedFilter_STATUS}
+-------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1350,8 +1350,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [NumberNotInAdvancedFilter_OperatorType_STATUS](#NumberNotInAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | float64[]<br/><small>Optional</small>                                                                                       |
 
-<a id="ServiceBusQueueEventSubscriptionDestination_EndpointType"></a>ServiceBusQueueEventSubscriptionDestination_EndpointType
------------------------------------------------------------------------------------------------------------------------------
+ServiceBusQueueEventSubscriptionDestination_EndpointType{#ServiceBusQueueEventSubscriptionDestination_EndpointType}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServiceBusQueueEventSubscriptionDestination](#ServiceBusQueueEventSubscriptionDestination).
 
@@ -1359,8 +1359,8 @@ Used by: [ServiceBusQueueEventSubscriptionDestination](#ServiceBusQueueEventSubs
 |-------------------|-------------|
 | "ServiceBusQueue" |             |
 
-<a id="ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS"></a>ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS{#ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServiceBusQueueEventSubscriptionDestination_STATUS](#ServiceBusQueueEventSubscriptionDestination_STATUS).
 
@@ -1368,8 +1368,8 @@ Used by: [ServiceBusQueueEventSubscriptionDestination_STATUS](#ServiceBusQueueEv
 |-------------------|-------------|
 | "ServiceBusQueue" |             |
 
-<a id="ServiceBusTopicEventSubscriptionDestination_EndpointType"></a>ServiceBusTopicEventSubscriptionDestination_EndpointType
------------------------------------------------------------------------------------------------------------------------------
+ServiceBusTopicEventSubscriptionDestination_EndpointType{#ServiceBusTopicEventSubscriptionDestination_EndpointType}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServiceBusTopicEventSubscriptionDestination](#ServiceBusTopicEventSubscriptionDestination).
 
@@ -1377,8 +1377,8 @@ Used by: [ServiceBusTopicEventSubscriptionDestination](#ServiceBusTopicEventSubs
 |-------------------|-------------|
 | "ServiceBusTopic" |             |
 
-<a id="ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS"></a>ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS{#ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServiceBusTopicEventSubscriptionDestination_STATUS](#ServiceBusTopicEventSubscriptionDestination_STATUS).
 
@@ -1386,8 +1386,8 @@ Used by: [ServiceBusTopicEventSubscriptionDestination_STATUS](#ServiceBusTopicEv
 |-------------------|-------------|
 | "ServiceBusTopic" |             |
 
-<a id="StorageBlobDeadLetterDestination_EndpointType"></a>StorageBlobDeadLetterDestination_EndpointType
--------------------------------------------------------------------------------------------------------
+StorageBlobDeadLetterDestination_EndpointType{#StorageBlobDeadLetterDestination_EndpointType}
+---------------------------------------------------------------------------------------------
 
 Used by: [StorageBlobDeadLetterDestination](#StorageBlobDeadLetterDestination).
 
@@ -1395,8 +1395,8 @@ Used by: [StorageBlobDeadLetterDestination](#StorageBlobDeadLetterDestination).
 |---------------|-------------|
 | "StorageBlob" |             |
 
-<a id="StorageBlobDeadLetterDestination_EndpointType_STATUS"></a>StorageBlobDeadLetterDestination_EndpointType_STATUS
----------------------------------------------------------------------------------------------------------------------
+StorageBlobDeadLetterDestination_EndpointType_STATUS{#StorageBlobDeadLetterDestination_EndpointType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [StorageBlobDeadLetterDestination_STATUS](#StorageBlobDeadLetterDestination_STATUS).
 
@@ -1404,8 +1404,8 @@ Used by: [StorageBlobDeadLetterDestination_STATUS](#StorageBlobDeadLetterDestina
 |---------------|-------------|
 | "StorageBlob" |             |
 
-<a id="StorageQueueEventSubscriptionDestination_EndpointType"></a>StorageQueueEventSubscriptionDestination_EndpointType
------------------------------------------------------------------------------------------------------------------------
+StorageQueueEventSubscriptionDestination_EndpointType{#StorageQueueEventSubscriptionDestination_EndpointType}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageQueueEventSubscriptionDestination](#StorageQueueEventSubscriptionDestination).
 
@@ -1413,8 +1413,8 @@ Used by: [StorageQueueEventSubscriptionDestination](#StorageQueueEventSubscripti
 |----------------|-------------|
 | "StorageQueue" |             |
 
-<a id="StorageQueueEventSubscriptionDestination_EndpointType_STATUS"></a>StorageQueueEventSubscriptionDestination_EndpointType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+StorageQueueEventSubscriptionDestination_EndpointType_STATUS{#StorageQueueEventSubscriptionDestination_EndpointType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageQueueEventSubscriptionDestination_STATUS](#StorageQueueEventSubscriptionDestination_STATUS).
 
@@ -1422,8 +1422,8 @@ Used by: [StorageQueueEventSubscriptionDestination_STATUS](#StorageQueueEventSub
 |----------------|-------------|
 | "StorageQueue" |             |
 
-<a id="StringBeginsWithAdvancedFilter"></a>StringBeginsWithAdvancedFilter
--------------------------------------------------------------------------
+StringBeginsWithAdvancedFilter{#StringBeginsWithAdvancedFilter}
+---------------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1433,8 +1433,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringBeginsWithAdvancedFilter_OperatorType](#StringBeginsWithAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                    |
 
-<a id="StringBeginsWithAdvancedFilter_STATUS"></a>StringBeginsWithAdvancedFilter_STATUS
----------------------------------------------------------------------------------------
+StringBeginsWithAdvancedFilter_STATUS{#StringBeginsWithAdvancedFilter_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1444,8 +1444,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringBeginsWithAdvancedFilter_OperatorType_STATUS](#StringBeginsWithAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                                  |
 
-<a id="StringContainsAdvancedFilter"></a>StringContainsAdvancedFilter
----------------------------------------------------------------------
+StringContainsAdvancedFilter{#StringContainsAdvancedFilter}
+-----------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1455,8 +1455,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringContainsAdvancedFilter_OperatorType](#StringContainsAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                |
 
-<a id="StringContainsAdvancedFilter_STATUS"></a>StringContainsAdvancedFilter_STATUS
------------------------------------------------------------------------------------
+StringContainsAdvancedFilter_STATUS{#StringContainsAdvancedFilter_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1466,8 +1466,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringContainsAdvancedFilter_OperatorType_STATUS](#StringContainsAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                              |
 
-<a id="StringEndsWithAdvancedFilter"></a>StringEndsWithAdvancedFilter
----------------------------------------------------------------------
+StringEndsWithAdvancedFilter{#StringEndsWithAdvancedFilter}
+-----------------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1477,8 +1477,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringEndsWithAdvancedFilter_OperatorType](#StringEndsWithAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                |
 
-<a id="StringEndsWithAdvancedFilter_STATUS"></a>StringEndsWithAdvancedFilter_STATUS
------------------------------------------------------------------------------------
+StringEndsWithAdvancedFilter_STATUS{#StringEndsWithAdvancedFilter_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1488,8 +1488,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringEndsWithAdvancedFilter_OperatorType_STATUS](#StringEndsWithAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                              |
 
-<a id="StringInAdvancedFilter"></a>StringInAdvancedFilter
----------------------------------------------------------
+StringInAdvancedFilter{#StringInAdvancedFilter}
+-----------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1499,8 +1499,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringInAdvancedFilter_OperatorType](#StringInAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                    |
 
-<a id="StringInAdvancedFilter_STATUS"></a>StringInAdvancedFilter_STATUS
------------------------------------------------------------------------
+StringInAdvancedFilter_STATUS{#StringInAdvancedFilter_STATUS}
+-------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1510,8 +1510,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringInAdvancedFilter_OperatorType_STATUS](#StringInAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                  |
 
-<a id="StringNotInAdvancedFilter"></a>StringNotInAdvancedFilter
----------------------------------------------------------------
+StringNotInAdvancedFilter{#StringNotInAdvancedFilter}
+-----------------------------------------------------
 
 Used by: [AdvancedFilter](#AdvancedFilter).
 
@@ -1521,8 +1521,8 @@ Used by: [AdvancedFilter](#AdvancedFilter).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringNotInAdvancedFilter_OperatorType](#StringNotInAdvancedFilter_OperatorType)<br/><small>Required</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                          |
 
-<a id="StringNotInAdvancedFilter_STATUS"></a>StringNotInAdvancedFilter_STATUS
------------------------------------------------------------------------------
+StringNotInAdvancedFilter_STATUS{#StringNotInAdvancedFilter_STATUS}
+-------------------------------------------------------------------
 
 Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 
@@ -1532,8 +1532,8 @@ Used by: [AdvancedFilter_STATUS](#AdvancedFilter_STATUS).
 | operatorType | The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others. | [StringNotInAdvancedFilter_OperatorType_STATUS](#StringNotInAdvancedFilter_OperatorType_STATUS)<br/><small>Optional</small> |
 | values       | The set of filter values.                                                                    | string[]<br/><small>Optional</small>                                                                                        |
 
-<a id="WebHookEventSubscriptionDestination_EndpointType"></a>WebHookEventSubscriptionDestination_EndpointType
--------------------------------------------------------------------------------------------------------------
+WebHookEventSubscriptionDestination_EndpointType{#WebHookEventSubscriptionDestination_EndpointType}
+---------------------------------------------------------------------------------------------------
 
 Used by: [WebHookEventSubscriptionDestination](#WebHookEventSubscriptionDestination).
 
@@ -1541,8 +1541,8 @@ Used by: [WebHookEventSubscriptionDestination](#WebHookEventSubscriptionDestinat
 |-----------|-------------|
 | "WebHook" |             |
 
-<a id="WebHookEventSubscriptionDestination_EndpointType_STATUS"></a>WebHookEventSubscriptionDestination_EndpointType_STATUS
----------------------------------------------------------------------------------------------------------------------------
+WebHookEventSubscriptionDestination_EndpointType_STATUS{#WebHookEventSubscriptionDestination_EndpointType_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [WebHookEventSubscriptionDestination_STATUS](#WebHookEventSubscriptionDestination_STATUS).
 
@@ -1550,8 +1550,8 @@ Used by: [WebHookEventSubscriptionDestination_STATUS](#WebHookEventSubscriptionD
 |-----------|-------------|
 | "WebHook" |             |
 
-<a id="BoolEqualsAdvancedFilter_OperatorType"></a>BoolEqualsAdvancedFilter_OperatorType
----------------------------------------------------------------------------------------
+BoolEqualsAdvancedFilter_OperatorType{#BoolEqualsAdvancedFilter_OperatorType}
+-----------------------------------------------------------------------------
 
 Used by: [BoolEqualsAdvancedFilter](#BoolEqualsAdvancedFilter).
 
@@ -1559,8 +1559,8 @@ Used by: [BoolEqualsAdvancedFilter](#BoolEqualsAdvancedFilter).
 |--------------|-------------|
 | "BoolEquals" |             |
 
-<a id="BoolEqualsAdvancedFilter_OperatorType_STATUS"></a>BoolEqualsAdvancedFilter_OperatorType_STATUS
------------------------------------------------------------------------------------------------------
+BoolEqualsAdvancedFilter_OperatorType_STATUS{#BoolEqualsAdvancedFilter_OperatorType_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [BoolEqualsAdvancedFilter_STATUS](#BoolEqualsAdvancedFilter_STATUS).
 
@@ -1568,8 +1568,8 @@ Used by: [BoolEqualsAdvancedFilter_STATUS](#BoolEqualsAdvancedFilter_STATUS).
 |--------------|-------------|
 | "BoolEquals" |             |
 
-<a id="NumberGreaterThanAdvancedFilter_OperatorType"></a>NumberGreaterThanAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------------------
+NumberGreaterThanAdvancedFilter_OperatorType{#NumberGreaterThanAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------------------
 
 Used by: [NumberGreaterThanAdvancedFilter](#NumberGreaterThanAdvancedFilter).
 
@@ -1577,8 +1577,8 @@ Used by: [NumberGreaterThanAdvancedFilter](#NumberGreaterThanAdvancedFilter).
 |---------------------|-------------|
 | "NumberGreaterThan" |             |
 
-<a id="NumberGreaterThanAdvancedFilter_OperatorType_STATUS"></a>NumberGreaterThanAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------------------
+NumberGreaterThanAdvancedFilter_OperatorType_STATUS{#NumberGreaterThanAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NumberGreaterThanAdvancedFilter_STATUS](#NumberGreaterThanAdvancedFilter_STATUS).
 
@@ -1586,8 +1586,8 @@ Used by: [NumberGreaterThanAdvancedFilter_STATUS](#NumberGreaterThanAdvancedFilt
 |---------------------|-------------|
 | "NumberGreaterThan" |             |
 
-<a id="NumberGreaterThanOrEqualsAdvancedFilter_OperatorType"></a>NumberGreaterThanOrEqualsAdvancedFilter_OperatorType
----------------------------------------------------------------------------------------------------------------------
+NumberGreaterThanOrEqualsAdvancedFilter_OperatorType{#NumberGreaterThanOrEqualsAdvancedFilter_OperatorType}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [NumberGreaterThanOrEqualsAdvancedFilter](#NumberGreaterThanOrEqualsAdvancedFilter).
 
@@ -1595,8 +1595,8 @@ Used by: [NumberGreaterThanOrEqualsAdvancedFilter](#NumberGreaterThanOrEqualsAdv
 |-----------------------------|-------------|
 | "NumberGreaterThanOrEquals" |             |
 
-<a id="NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS"></a>NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS{#NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [NumberGreaterThanOrEqualsAdvancedFilter_STATUS](#NumberGreaterThanOrEqualsAdvancedFilter_STATUS).
 
@@ -1604,8 +1604,8 @@ Used by: [NumberGreaterThanOrEqualsAdvancedFilter_STATUS](#NumberGreaterThanOrEq
 |-----------------------------|-------------|
 | "NumberGreaterThanOrEquals" |             |
 
-<a id="NumberInAdvancedFilter_OperatorType"></a>NumberInAdvancedFilter_OperatorType
------------------------------------------------------------------------------------
+NumberInAdvancedFilter_OperatorType{#NumberInAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------
 
 Used by: [NumberInAdvancedFilter](#NumberInAdvancedFilter).
 
@@ -1613,8 +1613,8 @@ Used by: [NumberInAdvancedFilter](#NumberInAdvancedFilter).
 |------------|-------------|
 | "NumberIn" |             |
 
-<a id="NumberInAdvancedFilter_OperatorType_STATUS"></a>NumberInAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------
+NumberInAdvancedFilter_OperatorType_STATUS{#NumberInAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [NumberInAdvancedFilter_STATUS](#NumberInAdvancedFilter_STATUS).
 
@@ -1622,8 +1622,8 @@ Used by: [NumberInAdvancedFilter_STATUS](#NumberInAdvancedFilter_STATUS).
 |------------|-------------|
 | "NumberIn" |             |
 
-<a id="NumberLessThanAdvancedFilter_OperatorType"></a>NumberLessThanAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------------
+NumberLessThanAdvancedFilter_OperatorType{#NumberLessThanAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------------
 
 Used by: [NumberLessThanAdvancedFilter](#NumberLessThanAdvancedFilter).
 
@@ -1631,8 +1631,8 @@ Used by: [NumberLessThanAdvancedFilter](#NumberLessThanAdvancedFilter).
 |------------------|-------------|
 | "NumberLessThan" |             |
 
-<a id="NumberLessThanAdvancedFilter_OperatorType_STATUS"></a>NumberLessThanAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------------
+NumberLessThanAdvancedFilter_OperatorType_STATUS{#NumberLessThanAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [NumberLessThanAdvancedFilter_STATUS](#NumberLessThanAdvancedFilter_STATUS).
 
@@ -1640,8 +1640,8 @@ Used by: [NumberLessThanAdvancedFilter_STATUS](#NumberLessThanAdvancedFilter_STA
 |------------------|-------------|
 | "NumberLessThan" |             |
 
-<a id="NumberLessThanOrEqualsAdvancedFilter_OperatorType"></a>NumberLessThanOrEqualsAdvancedFilter_OperatorType
----------------------------------------------------------------------------------------------------------------
+NumberLessThanOrEqualsAdvancedFilter_OperatorType{#NumberLessThanOrEqualsAdvancedFilter_OperatorType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [NumberLessThanOrEqualsAdvancedFilter](#NumberLessThanOrEqualsAdvancedFilter).
 
@@ -1649,8 +1649,8 @@ Used by: [NumberLessThanOrEqualsAdvancedFilter](#NumberLessThanOrEqualsAdvancedF
 |--------------------------|-------------|
 | "NumberLessThanOrEquals" |             |
 
-<a id="NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS"></a>NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS{#NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [NumberLessThanOrEqualsAdvancedFilter_STATUS](#NumberLessThanOrEqualsAdvancedFilter_STATUS).
 
@@ -1658,8 +1658,8 @@ Used by: [NumberLessThanOrEqualsAdvancedFilter_STATUS](#NumberLessThanOrEqualsAd
 |--------------------------|-------------|
 | "NumberLessThanOrEquals" |             |
 
-<a id="NumberNotInAdvancedFilter_OperatorType"></a>NumberNotInAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------
+NumberNotInAdvancedFilter_OperatorType{#NumberNotInAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------
 
 Used by: [NumberNotInAdvancedFilter](#NumberNotInAdvancedFilter).
 
@@ -1667,8 +1667,8 @@ Used by: [NumberNotInAdvancedFilter](#NumberNotInAdvancedFilter).
 |---------------|-------------|
 | "NumberNotIn" |             |
 
-<a id="NumberNotInAdvancedFilter_OperatorType_STATUS"></a>NumberNotInAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------
+NumberNotInAdvancedFilter_OperatorType_STATUS{#NumberNotInAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [NumberNotInAdvancedFilter_STATUS](#NumberNotInAdvancedFilter_STATUS).
 
@@ -1676,8 +1676,8 @@ Used by: [NumberNotInAdvancedFilter_STATUS](#NumberNotInAdvancedFilter_STATUS).
 |---------------|-------------|
 | "NumberNotIn" |             |
 
-<a id="StringBeginsWithAdvancedFilter_OperatorType"></a>StringBeginsWithAdvancedFilter_OperatorType
----------------------------------------------------------------------------------------------------
+StringBeginsWithAdvancedFilter_OperatorType{#StringBeginsWithAdvancedFilter_OperatorType}
+-----------------------------------------------------------------------------------------
 
 Used by: [StringBeginsWithAdvancedFilter](#StringBeginsWithAdvancedFilter).
 
@@ -1685,8 +1685,8 @@ Used by: [StringBeginsWithAdvancedFilter](#StringBeginsWithAdvancedFilter).
 |--------------------|-------------|
 | "StringBeginsWith" |             |
 
-<a id="StringBeginsWithAdvancedFilter_OperatorType_STATUS"></a>StringBeginsWithAdvancedFilter_OperatorType_STATUS
------------------------------------------------------------------------------------------------------------------
+StringBeginsWithAdvancedFilter_OperatorType_STATUS{#StringBeginsWithAdvancedFilter_OperatorType_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [StringBeginsWithAdvancedFilter_STATUS](#StringBeginsWithAdvancedFilter_STATUS).
 
@@ -1694,8 +1694,8 @@ Used by: [StringBeginsWithAdvancedFilter_STATUS](#StringBeginsWithAdvancedFilter
 |--------------------|-------------|
 | "StringBeginsWith" |             |
 
-<a id="StringContainsAdvancedFilter_OperatorType"></a>StringContainsAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------------
+StringContainsAdvancedFilter_OperatorType{#StringContainsAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------------
 
 Used by: [StringContainsAdvancedFilter](#StringContainsAdvancedFilter).
 
@@ -1703,8 +1703,8 @@ Used by: [StringContainsAdvancedFilter](#StringContainsAdvancedFilter).
 |------------------|-------------|
 | "StringContains" |             |
 
-<a id="StringContainsAdvancedFilter_OperatorType_STATUS"></a>StringContainsAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------------
+StringContainsAdvancedFilter_OperatorType_STATUS{#StringContainsAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [StringContainsAdvancedFilter_STATUS](#StringContainsAdvancedFilter_STATUS).
 
@@ -1712,8 +1712,8 @@ Used by: [StringContainsAdvancedFilter_STATUS](#StringContainsAdvancedFilter_STA
 |------------------|-------------|
 | "StringContains" |             |
 
-<a id="StringEndsWithAdvancedFilter_OperatorType"></a>StringEndsWithAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------------
+StringEndsWithAdvancedFilter_OperatorType{#StringEndsWithAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------------
 
 Used by: [StringEndsWithAdvancedFilter](#StringEndsWithAdvancedFilter).
 
@@ -1721,8 +1721,8 @@ Used by: [StringEndsWithAdvancedFilter](#StringEndsWithAdvancedFilter).
 |------------------|-------------|
 | "StringEndsWith" |             |
 
-<a id="StringEndsWithAdvancedFilter_OperatorType_STATUS"></a>StringEndsWithAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------------
+StringEndsWithAdvancedFilter_OperatorType_STATUS{#StringEndsWithAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [StringEndsWithAdvancedFilter_STATUS](#StringEndsWithAdvancedFilter_STATUS).
 
@@ -1730,8 +1730,8 @@ Used by: [StringEndsWithAdvancedFilter_STATUS](#StringEndsWithAdvancedFilter_STA
 |------------------|-------------|
 | "StringEndsWith" |             |
 
-<a id="StringInAdvancedFilter_OperatorType"></a>StringInAdvancedFilter_OperatorType
------------------------------------------------------------------------------------
+StringInAdvancedFilter_OperatorType{#StringInAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------
 
 Used by: [StringInAdvancedFilter](#StringInAdvancedFilter).
 
@@ -1739,8 +1739,8 @@ Used by: [StringInAdvancedFilter](#StringInAdvancedFilter).
 |------------|-------------|
 | "StringIn" |             |
 
-<a id="StringInAdvancedFilter_OperatorType_STATUS"></a>StringInAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------
+StringInAdvancedFilter_OperatorType_STATUS{#StringInAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [StringInAdvancedFilter_STATUS](#StringInAdvancedFilter_STATUS).
 
@@ -1748,8 +1748,8 @@ Used by: [StringInAdvancedFilter_STATUS](#StringInAdvancedFilter_STATUS).
 |------------|-------------|
 | "StringIn" |             |
 
-<a id="StringNotInAdvancedFilter_OperatorType"></a>StringNotInAdvancedFilter_OperatorType
------------------------------------------------------------------------------------------
+StringNotInAdvancedFilter_OperatorType{#StringNotInAdvancedFilter_OperatorType}
+-------------------------------------------------------------------------------
 
 Used by: [StringNotInAdvancedFilter](#StringNotInAdvancedFilter).
 
@@ -1757,8 +1757,8 @@ Used by: [StringNotInAdvancedFilter](#StringNotInAdvancedFilter).
 |---------------|-------------|
 | "StringNotIn" |             |
 
-<a id="StringNotInAdvancedFilter_OperatorType_STATUS"></a>StringNotInAdvancedFilter_OperatorType_STATUS
--------------------------------------------------------------------------------------------------------
+StringNotInAdvancedFilter_OperatorType_STATUS{#StringNotInAdvancedFilter_OperatorType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [StringNotInAdvancedFilter_STATUS](#StringNotInAdvancedFilter_STATUS).
 

--- a/docs/hugo/content/reference/eventhub/v1api20211101.md
+++ b/docs/hugo/content/reference/eventhub/v1api20211101.md
@@ -5,15 +5,15 @@ title: eventhub.azure.com/v1api20211101
 linktitle: v1api20211101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-11-01" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/namespaces-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant          | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -75,8 +75,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the Namespace was updated.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/namespaces-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}
 
@@ -86,8 +86,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -100,7 +100,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -109,7 +109,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                    | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -121,8 +121,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -132,8 +132,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhub"></a>NamespacesEventhub
--------------------------------------------------
+NamespacesEventhub{#NamespacesEventhub}
+---------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/eventhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
 
@@ -146,7 +146,7 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | spec                                                                                    |             | [NamespacesEventhub_Spec](#NamespacesEventhub_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhub_Spec"></a>NamespacesEventhub_Spec
+### NamespacesEventhub_Spec {#NamespacesEventhub_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -157,7 +157,7 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | owner                  | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | partitionCount         | Number of partitions created for the Event Hub, allowed values are from 1 to 32 partitions.                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="NamespacesEventhub_STATUS"></a>NamespacesEventhub_STATUS
+### NamespacesEventhub_STATUS{#NamespacesEventhub_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -175,8 +175,8 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | type                   | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt              | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubList"></a>NamespacesEventhubList
----------------------------------------------------------
+NamespacesEventhubList{#NamespacesEventhubList}
+-----------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/eventhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
 
@@ -186,8 +186,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [NamespacesEventhub[]](#NamespacesEventhub)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRule"></a>NamespacesEventhubsAuthorizationRule
--------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule{#NamespacesEventhubsAuthorizationRule}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}
 
@@ -200,7 +200,7 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | spec                                                                                    |             | [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhubsAuthorizationRule_Spec"></a>NamespacesEventhubsAuthorizationRule_Spec
+### NamespacesEventhubsAuthorizationRule_Spec {#NamespacesEventhubsAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -209,7 +209,7 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                             | [Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>        |
 
-### <a id="NamespacesEventhubsAuthorizationRule_STATUS"></a>NamespacesEventhubsAuthorizationRule_STATUS
+### NamespacesEventhubsAuthorizationRule_STATUS{#NamespacesEventhubsAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                              |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -221,8 +221,8 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                               |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="NamespacesEventhubsAuthorizationRuleList"></a>NamespacesEventhubsAuthorizationRuleList
----------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleList{#NamespacesEventhubsAuthorizationRuleList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}
 
@@ -232,8 +232,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [NamespacesEventhubsAuthorizationRule[]](#NamespacesEventhubsAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsConsumerGroup"></a>NamespacesEventhubsConsumerGroup
------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup{#NamespacesEventhubsConsumerGroup}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/consumergroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}
 
@@ -246,7 +246,7 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | spec                                                                                    |             | [NamespacesEventhubsConsumerGroup_Spec](#NamespacesEventhubsConsumerGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhubsConsumerGroup_STATUS](#NamespacesEventhubsConsumerGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhubsConsumerGroup_Spec"></a>NamespacesEventhubsConsumerGroup_Spec
+### NamespacesEventhubsConsumerGroup_Spec {#NamespacesEventhubsConsumerGroup_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -255,7 +255,7 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                            | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="NamespacesEventhubsConsumerGroup_STATUS"></a>NamespacesEventhubsConsumerGroup_STATUS
+### NamespacesEventhubsConsumerGroup_STATUS{#NamespacesEventhubsConsumerGroup_STATUS}
 
 | Property     | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -269,8 +269,8 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | updatedAt    | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubsConsumerGroupList"></a>NamespacesEventhubsConsumerGroupList
--------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroupList{#NamespacesEventhubsConsumerGroupList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/consumergroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}
 
@@ -280,8 +280,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [NamespacesEventhubsConsumerGroup[]](#NamespacesEventhubsConsumerGroup)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -303,8 +303,8 @@ Used by: [Namespace](#Namespace).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant          | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -335,8 +335,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the Namespace was updated.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -347,8 +347,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                    | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -362,8 +362,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhub_Spec"></a>NamespacesEventhub_Spec
------------------------------------------------------------
+NamespacesEventhub_Spec{#NamespacesEventhub_Spec}
+-------------------------------------------------
 
 Used by: [NamespacesEventhub](#NamespacesEventhub).
 
@@ -376,8 +376,8 @@ Used by: [NamespacesEventhub](#NamespacesEventhub).
 | owner                  | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | partitionCount         | Number of partitions created for the Event Hub, allowed values are from 1 to 32 partitions.                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="NamespacesEventhub_STATUS"></a>NamespacesEventhub_STATUS
----------------------------------------------------------------
+NamespacesEventhub_STATUS{#NamespacesEventhub_STATUS}
+-----------------------------------------------------
 
 Used by: [NamespacesEventhub](#NamespacesEventhub).
 
@@ -397,8 +397,8 @@ Used by: [NamespacesEventhub](#NamespacesEventhub).
 | type                   | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt              | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubsAuthorizationRule_Spec"></a>NamespacesEventhubsAuthorizationRule_Spec
------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule_Spec{#NamespacesEventhubsAuthorizationRule_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizationRule).
 
@@ -409,8 +409,8 @@ Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizatio
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                             | [Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>        |
 
-<a id="NamespacesEventhubsAuthorizationRule_STATUS"></a>NamespacesEventhubsAuthorizationRule_STATUS
----------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule_STATUS{#NamespacesEventhubsAuthorizationRule_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizationRule).
 
@@ -424,8 +424,8 @@ Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizatio
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                               |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="NamespacesEventhubsConsumerGroup_Spec"></a>NamespacesEventhubsConsumerGroup_Spec
----------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup_Spec{#NamespacesEventhubsConsumerGroup_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 
@@ -436,8 +436,8 @@ Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                            | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="NamespacesEventhubsConsumerGroup_STATUS"></a>NamespacesEventhubsConsumerGroup_STATUS
--------------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup_STATUS{#NamespacesEventhubsConsumerGroup_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 
@@ -453,8 +453,8 @@ Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 | updatedAt    | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CaptureDescription"></a>CaptureDescription
--------------------------------------------------
+CaptureDescription{#CaptureDescription}
+---------------------------------------
 
 Properties to configure capture description for eventhub
 
@@ -469,8 +469,8 @@ Used by: [NamespacesEventhub_Spec](#NamespacesEventhub_Spec).
 | sizeLimitInBytes  | The size window defines the amount of data built up in your Event Hub before an capture operation, value should be between 10485760 to 524288000 bytes | int<br/><small>Optional</small>                                                         |
 | skipEmptyArchives | A value that indicates whether to Skip Empty Archives                                                                                                  | bool<br/><small>Optional</small>                                                        |
 
-<a id="CaptureDescription_STATUS"></a>CaptureDescription_STATUS
----------------------------------------------------------------
+CaptureDescription_STATUS{#CaptureDescription_STATUS}
+-----------------------------------------------------
 
 Properties to configure capture description for eventhub
 
@@ -485,8 +485,8 @@ Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 | sizeLimitInBytes  | The size window defines the amount of data built up in your Event Hub before an capture operation, value should be between 10485760 to 524288000 bytes | int<br/><small>Optional</small>                                                                       |
 | skipEmptyArchives | A value that indicates whether to Skip Empty Archives                                                                                                  | bool<br/><small>Optional</small>                                                                      |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -498,8 +498,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -511,8 +511,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -523,8 +523,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -537,8 +537,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -550,8 +550,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -561,8 +561,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -572,8 +572,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_Eventhub_Properties_Status_STATUS"></a>Namespaces_Eventhub_Properties_Status_STATUS
------------------------------------------------------------------------------------------------------
+Namespaces_Eventhub_Properties_Status_STATUS{#Namespaces_Eventhub_Properties_Status_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 
@@ -589,8 +589,8 @@ Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec
----------------------------------------------------------------------------------------------------------------------------------------
+Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec{#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthorizationRule_Spec).
 
@@ -600,8 +600,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthori
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAuthorizationRule_STATUS).
 
@@ -611,8 +611,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAutho
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -624,8 +624,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesEventhubOperatorSpec"></a>NamespacesEventhubOperatorSpec
--------------------------------------------------------------------------
+NamespacesEventhubOperatorSpec{#NamespacesEventhubOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -636,8 +636,8 @@ Used by: [NamespacesEventhub_Spec](#NamespacesEventhub_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRuleOperatorSpec"></a>NamespacesEventhubsAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleOperatorSpec{#NamespacesEventhubsAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -649,8 +649,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthori
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesEventhubsAuthorizationRuleOperatorSecrets](#NamespacesEventhubsAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                             |
 
-<a id="NamespacesEventhubsConsumerGroupOperatorSpec"></a>NamespacesEventhubsConsumerGroupOperatorSpec
------------------------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroupOperatorSpec{#NamespacesEventhubsConsumerGroupOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -661,8 +661,8 @@ Used by: [NamespacesEventhubsConsumerGroup_Spec](#NamespacesEventhubsConsumerGro
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -672,8 +672,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create namespace operation
 
@@ -685,8 +685,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                                                                                                                                        | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                 | [Sku_Tier](#Sku_Tier)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create namespace operation
 
@@ -698,8 +698,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                                                                                                                                        | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                 | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -714,8 +714,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="CaptureDescription_Encoding"></a>CaptureDescription_Encoding
--------------------------------------------------------------------
+CaptureDescription_Encoding{#CaptureDescription_Encoding}
+---------------------------------------------------------
 
 Used by: [CaptureDescription](#CaptureDescription).
 
@@ -724,8 +724,8 @@ Used by: [CaptureDescription](#CaptureDescription).
 | "Avro"        |             |
 | "AvroDeflate" |             |
 
-<a id="CaptureDescription_Encoding_STATUS"></a>CaptureDescription_Encoding_STATUS
----------------------------------------------------------------------------------
+CaptureDescription_Encoding_STATUS{#CaptureDescription_Encoding_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 
@@ -734,8 +734,8 @@ Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 | "Avro"        |             |
 | "AvroDeflate" |             |
 
-<a id="Destination"></a>Destination
------------------------------------
+Destination{#Destination}
+-------------------------
 
 Capture storage details for capture description
 
@@ -751,8 +751,8 @@ Used by: [CaptureDescription](#CaptureDescription).
 | name                            | Name for capture destination                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                         |
 | storageAccountResourceReference | Resource id of the storage account to be used to create the blobs                                                                                                                                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Destination_STATUS"></a>Destination_STATUS
--------------------------------------------------
+Destination_STATUS{#Destination_STATUS}
+---------------------------------------
 
 Capture storage details for capture description
 
@@ -768,8 +768,8 @@ Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 | name                     | Name for capture destination                                                                                                                                                                                         | string<br/><small>Optional</small> |
 | storageAccountResourceId | Resource id of the storage account to be used to create the blobs                                                                                                                                                    | string<br/><small>Optional</small> |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -777,8 +777,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -786,8 +786,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -798,8 +798,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -810,8 +810,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -824,8 +824,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Key Version                   | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -838,8 +838,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Key Version                   | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -850,8 +850,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -862,8 +862,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRuleOperatorSecrets"></a>NamespacesEventhubsAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleOperatorSecrets{#NamespacesEventhubsAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRuleOperatorSpec](#NamespacesEventhubsAuthorizationRuleOperatorSpec).
 
@@ -874,8 +874,8 @@ Used by: [NamespacesEventhubsAuthorizationRuleOperatorSpec](#NamespacesEventhubs
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -885,8 +885,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -896,8 +896,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -907,8 +907,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -918,7 +918,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -930,20 +942,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Recognized Dictionary value.
 
@@ -954,8 +954,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -965,8 +965,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -974,8 +974,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 

--- a/docs/hugo/content/reference/eventhub/v1api20240101.md
+++ b/docs/hugo/content/reference/eventhub/v1api20240101.md
@@ -5,15 +5,15 @@ title: eventhub.azure.com/v1api20240101
 linktitle: v1api20240101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-01-01" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/namespaces.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -48,7 +48,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant          | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -79,8 +79,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the Namespace was updated.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/namespaces.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}
 
@@ -90,8 +90,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -104,7 +104,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -113,7 +113,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                    | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -125,8 +125,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -136,8 +136,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhub"></a>NamespacesEventhub
--------------------------------------------------
+NamespacesEventhub{#NamespacesEventhub}
+---------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/eventhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
 
@@ -150,7 +150,7 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | spec                                                                                    |             | [NamespacesEventhub_Spec](#NamespacesEventhub_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhub_Spec"></a>NamespacesEventhub_Spec
+### NamespacesEventhub_Spec {#NamespacesEventhub_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -163,7 +163,7 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | retentionDescription   | Event Hub retention settings                                                                                                                                                                                                                                                            | [RetentionDescription](#RetentionDescription)<br/><small>Optional</small>                                                                                            |
 | userMetadata           | Gets and Sets Metadata of User.                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="NamespacesEventhub_STATUS"></a>NamespacesEventhub_STATUS
+### NamespacesEventhub_STATUS{#NamespacesEventhub_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -183,8 +183,8 @@ Used by: [NamespacesEventhubList](#NamespacesEventhubList).
 | updatedAt              | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata           | Gets and Sets Metadata of User.                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubList"></a>NamespacesEventhubList
----------------------------------------------------------
+NamespacesEventhubList{#NamespacesEventhubList}
+-----------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/eventhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
 
@@ -194,8 +194,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [NamespacesEventhub[]](#NamespacesEventhub)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRule"></a>NamespacesEventhubsAuthorizationRule
--------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule{#NamespacesEventhubsAuthorizationRule}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}
 
@@ -208,7 +208,7 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | spec                                                                                    |             | [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhubsAuthorizationRule_Spec"></a>NamespacesEventhubsAuthorizationRule_Spec
+### NamespacesEventhubsAuthorizationRule_Spec {#NamespacesEventhubsAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -217,7 +217,7 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                             | [Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>        |
 
-### <a id="NamespacesEventhubsAuthorizationRule_STATUS"></a>NamespacesEventhubsAuthorizationRule_STATUS
+### NamespacesEventhubsAuthorizationRule_STATUS{#NamespacesEventhubsAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                              |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -229,8 +229,8 @@ Used by: [NamespacesEventhubsAuthorizationRuleList](#NamespacesEventhubsAuthoriz
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                               |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="NamespacesEventhubsAuthorizationRuleList"></a>NamespacesEventhubsAuthorizationRuleList
----------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleList{#NamespacesEventhubsAuthorizationRuleList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}
 
@@ -240,8 +240,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [NamespacesEventhubsAuthorizationRule[]](#NamespacesEventhubsAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsConsumerGroup"></a>NamespacesEventhubsConsumerGroup
------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup{#NamespacesEventhubsConsumerGroup}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/consumergroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}
 
@@ -254,7 +254,7 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | spec                                                                                    |             | [NamespacesEventhubsConsumerGroup_Spec](#NamespacesEventhubsConsumerGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesEventhubsConsumerGroup_STATUS](#NamespacesEventhubsConsumerGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesEventhubsConsumerGroup_Spec"></a>NamespacesEventhubsConsumerGroup_Spec
+### NamespacesEventhubsConsumerGroup_Spec {#NamespacesEventhubsConsumerGroup_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -263,7 +263,7 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                            | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="NamespacesEventhubsConsumerGroup_STATUS"></a>NamespacesEventhubsConsumerGroup_STATUS
+### NamespacesEventhubsConsumerGroup_STATUS{#NamespacesEventhubsConsumerGroup_STATUS}
 
 | Property     | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -277,8 +277,8 @@ Used by: [NamespacesEventhubsConsumerGroupList](#NamespacesEventhubsConsumerGrou
 | updatedAt    | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubsConsumerGroupList"></a>NamespacesEventhubsConsumerGroupList
--------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroupList{#NamespacesEventhubsConsumerGroupList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /eventhub/resource-manager/Microsoft.EventHub/stable/2024-01-01/consumergroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}
 
@@ -288,8 +288,8 @@ Generator information: - Generated from: /eventhub/resource-manager/Microsoft.Ev
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [NamespacesEventhubsConsumerGroup[]](#NamespacesEventhubsConsumerGroup)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -313,8 +313,8 @@ Used by: [Namespace](#Namespace).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant          | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -347,8 +347,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the Namespace was updated.                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.                                                                                                                                                                                                                   | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -359,8 +359,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                    | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -374,8 +374,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhub_Spec"></a>NamespacesEventhub_Spec
------------------------------------------------------------
+NamespacesEventhub_Spec{#NamespacesEventhub_Spec}
+-------------------------------------------------
 
 Used by: [NamespacesEventhub](#NamespacesEventhub).
 
@@ -390,8 +390,8 @@ Used by: [NamespacesEventhub](#NamespacesEventhub).
 | retentionDescription   | Event Hub retention settings                                                                                                                                                                                                                                                            | [RetentionDescription](#RetentionDescription)<br/><small>Optional</small>                                                                                            |
 | userMetadata           | Gets and Sets Metadata of User.                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="NamespacesEventhub_STATUS"></a>NamespacesEventhub_STATUS
----------------------------------------------------------------
+NamespacesEventhub_STATUS{#NamespacesEventhub_STATUS}
+-----------------------------------------------------
 
 Used by: [NamespacesEventhub](#NamespacesEventhub).
 
@@ -413,8 +413,8 @@ Used by: [NamespacesEventhub](#NamespacesEventhub).
 | updatedAt              | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata           | Gets and Sets Metadata of User.                                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesEventhubsAuthorizationRule_Spec"></a>NamespacesEventhubsAuthorizationRule_Spec
------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule_Spec{#NamespacesEventhubsAuthorizationRule_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizationRule).
 
@@ -425,8 +425,8 @@ Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizatio
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                             | [Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>        |
 
-<a id="NamespacesEventhubsAuthorizationRule_STATUS"></a>NamespacesEventhubsAuthorizationRule_STATUS
----------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRule_STATUS{#NamespacesEventhubsAuthorizationRule_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizationRule).
 
@@ -440,8 +440,8 @@ Used by: [NamespacesEventhubsAuthorizationRule](#NamespacesEventhubsAuthorizatio
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                               |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="NamespacesEventhubsConsumerGroup_Spec"></a>NamespacesEventhubsConsumerGroup_Spec
----------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup_Spec{#NamespacesEventhubsConsumerGroup_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 
@@ -452,8 +452,8 @@ Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a eventhub.azure.com/NamespacesEventhub resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                            | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="NamespacesEventhubsConsumerGroup_STATUS"></a>NamespacesEventhubsConsumerGroup_STATUS
--------------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroup_STATUS{#NamespacesEventhubsConsumerGroup_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 
@@ -469,8 +469,8 @@ Used by: [NamespacesEventhubsConsumerGroup](#NamespacesEventhubsConsumerGroup).
 | updatedAt    | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 | userMetadata | User Metadata is a placeholder to store user-defined string data with maximum length 1024. e.g. it can be used to store descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CaptureDescription"></a>CaptureDescription
--------------------------------------------------
+CaptureDescription{#CaptureDescription}
+---------------------------------------
 
 Properties to configure capture description for eventhub
 
@@ -485,8 +485,8 @@ Used by: [NamespacesEventhub_Spec](#NamespacesEventhub_Spec).
 | sizeLimitInBytes  | The size window defines the amount of data built up in your Event Hub before an capture operation, value should be between 10485760 to 524288000 bytes | int<br/><small>Optional</small>                                                         |
 | skipEmptyArchives | A value that indicates whether to Skip Empty Archives                                                                                                  | bool<br/><small>Optional</small>                                                        |
 
-<a id="CaptureDescription_STATUS"></a>CaptureDescription_STATUS
----------------------------------------------------------------
+CaptureDescription_STATUS{#CaptureDescription_STATUS}
+-----------------------------------------------------
 
 Properties to configure capture description for eventhub
 
@@ -501,8 +501,8 @@ Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 | sizeLimitInBytes  | The size window defines the amount of data built up in your Event Hub before an capture operation, value should be between 10485760 to 524288000 bytes | int<br/><small>Optional</small>                                                                       |
 | skipEmptyArchives | A value that indicates whether to Skip Empty Archives                                                                                                  | bool<br/><small>Optional</small>                                                                      |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -514,8 +514,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -527,8 +527,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -539,8 +539,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure Identity for Bring your Own Keys
 
@@ -553,8 +553,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="Namespace_Properties_MinimumTlsVersion_Spec"></a>Namespace_Properties_MinimumTlsVersion_Spec
----------------------------------------------------------------------------------------------------
+Namespace_Properties_MinimumTlsVersion_Spec{#Namespace_Properties_MinimumTlsVersion_Spec}
+-----------------------------------------------------------------------------------------
 
 Used by: [Namespace_Spec](#Namespace_Spec).
 
@@ -564,8 +564,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="Namespace_Properties_MinimumTlsVersion_STATUS"></a>Namespace_Properties_MinimumTlsVersion_STATUS
--------------------------------------------------------------------------------------------------------
+Namespace_Properties_MinimumTlsVersion_STATUS{#Namespace_Properties_MinimumTlsVersion_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [Namespace_STATUS](#Namespace_STATUS).
 
@@ -575,8 +575,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="Namespace_Properties_PublicNetworkAccess_Spec"></a>Namespace_Properties_PublicNetworkAccess_Spec
--------------------------------------------------------------------------------------------------------
+Namespace_Properties_PublicNetworkAccess_Spec{#Namespace_Properties_PublicNetworkAccess_Spec}
+---------------------------------------------------------------------------------------------
 
 Used by: [Namespace_Spec](#Namespace_Spec).
 
@@ -586,8 +586,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="Namespace_Properties_PublicNetworkAccess_STATUS"></a>Namespace_Properties_PublicNetworkAccess_STATUS
------------------------------------------------------------------------------------------------------------
+Namespace_Properties_PublicNetworkAccess_STATUS{#Namespace_Properties_PublicNetworkAccess_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [Namespace_STATUS](#Namespace_STATUS).
 
@@ -597,8 +597,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -610,8 +610,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -621,8 +621,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -632,8 +632,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_Eventhub_Properties_Status_STATUS"></a>Namespaces_Eventhub_Properties_Status_STATUS
------------------------------------------------------------------------------------------------------
+Namespaces_Eventhub_Properties_Status_STATUS{#Namespaces_Eventhub_Properties_Status_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 
@@ -649,8 +649,8 @@ Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec
----------------------------------------------------------------------------------------------------------------------------------------
+Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec{#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_Spec}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthorizationRule_Spec).
 
@@ -660,8 +660,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthori
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_Eventhubs_AuthorizationRule_Properties_Rights_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAuthorizationRule_STATUS).
 
@@ -671,8 +671,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_STATUS](#NamespacesEventhubsAutho
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -684,8 +684,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesEventhubOperatorSpec"></a>NamespacesEventhubOperatorSpec
--------------------------------------------------------------------------
+NamespacesEventhubOperatorSpec{#NamespacesEventhubOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -696,8 +696,8 @@ Used by: [NamespacesEventhub_Spec](#NamespacesEventhub_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRuleOperatorSpec"></a>NamespacesEventhubsAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleOperatorSpec{#NamespacesEventhubsAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -709,8 +709,8 @@ Used by: [NamespacesEventhubsAuthorizationRule_Spec](#NamespacesEventhubsAuthori
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesEventhubsAuthorizationRuleOperatorSecrets](#NamespacesEventhubsAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                             |
 
-<a id="NamespacesEventhubsConsumerGroupOperatorSpec"></a>NamespacesEventhubsConsumerGroupOperatorSpec
------------------------------------------------------------------------------------------------------
+NamespacesEventhubsConsumerGroupOperatorSpec{#NamespacesEventhubsConsumerGroupOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -721,8 +721,8 @@ Used by: [NamespacesEventhubsConsumerGroup_Spec](#NamespacesEventhubsConsumerGro
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -732,8 +732,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RetentionDescription"></a>RetentionDescription
------------------------------------------------------
+RetentionDescription{#RetentionDescription}
+-------------------------------------------
 
 Properties to configure retention settings for the eventhub
 
@@ -745,8 +745,8 @@ Used by: [NamespacesEventhub_Spec](#NamespacesEventhub_Spec).
 | retentionTimeInHours          | Number of hours to retain the events for this Event Hub. This value is only used when cleanupPolicy is Delete. If cleanupPolicy is Compact the returned value of this property is Long.MaxValue                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                       |
 | tombstoneRetentionTimeInHours | Number of hours to retain the tombstone markers of a compacted Event Hub. This value is only used when cleanupPolicy is Compact. Consumer must complete reading the tombstone marker within this specified amount of time if consumer begins from starting offset to ensure they get a valid snapshot for the specific key described by the tombstone marker within the compacted Event Hub | int<br/><small>Optional</small>                                                                       |
 
-<a id="RetentionDescription_STATUS"></a>RetentionDescription_STATUS
--------------------------------------------------------------------
+RetentionDescription_STATUS{#RetentionDescription_STATUS}
+---------------------------------------------------------
 
 Properties to configure retention settings for the eventhub
 
@@ -758,8 +758,8 @@ Used by: [NamespacesEventhub_STATUS](#NamespacesEventhub_STATUS).
 | retentionTimeInHours          | Number of hours to retain the events for this Event Hub. This value is only used when cleanupPolicy is Delete. If cleanupPolicy is Compact the returned value of this property is Long.MaxValue                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                     |
 | tombstoneRetentionTimeInHours | Number of hours to retain the tombstone markers of a compacted Event Hub. This value is only used when cleanupPolicy is Compact. Consumer must complete reading the tombstone marker within this specified amount of time if consumer begins from starting offset to ensure they get a valid snapshot for the specific key described by the tombstone marker within the compacted Event Hub | int<br/><small>Optional</small>                                                                                     |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU parameters supplied to the create namespace operation
 
@@ -771,8 +771,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                                                                                                                                        | [Sku_Name](#Sku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                 | [Sku_Tier](#Sku_Tier)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU parameters supplied to the create namespace operation
 
@@ -784,8 +784,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                                                                                                                                        | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                 | [Sku_Tier_STATUS](#Sku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -800,8 +800,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="CaptureDescription_Encoding"></a>CaptureDescription_Encoding
--------------------------------------------------------------------
+CaptureDescription_Encoding{#CaptureDescription_Encoding}
+---------------------------------------------------------
 
 Used by: [CaptureDescription](#CaptureDescription).
 
@@ -810,8 +810,8 @@ Used by: [CaptureDescription](#CaptureDescription).
 | "Avro"        |             |
 | "AvroDeflate" |             |
 
-<a id="CaptureDescription_Encoding_STATUS"></a>CaptureDescription_Encoding_STATUS
----------------------------------------------------------------------------------
+CaptureDescription_Encoding_STATUS{#CaptureDescription_Encoding_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 
@@ -820,8 +820,8 @@ Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 | "Avro"        |             |
 | "AvroDeflate" |             |
 
-<a id="Destination"></a>Destination
------------------------------------
+Destination{#Destination}
+-------------------------
 
 Capture storage details for capture description
 
@@ -838,8 +838,8 @@ Used by: [CaptureDescription](#CaptureDescription).
 | name                            | Name for capture destination                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                         |
 | storageAccountResourceReference | Resource id of the storage account to be used to create the blobs                                                                                                                                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Destination_STATUS"></a>Destination_STATUS
--------------------------------------------------
+Destination_STATUS{#Destination_STATUS}
+---------------------------------------
 
 Capture storage details for capture description
 
@@ -856,8 +856,8 @@ Used by: [CaptureDescription_STATUS](#CaptureDescription_STATUS).
 | name                     | Name for capture destination                                                                                                                                                                                         | string<br/><small>Optional</small>                                            |
 | storageAccountResourceId | Resource id of the storage account to be used to create the blobs                                                                                                                                                    | string<br/><small>Optional</small>                                            |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -865,8 +865,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -874,8 +874,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -886,8 +886,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -898,8 +898,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -912,8 +912,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Key Version                   | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -926,8 +926,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Key Version                   | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -938,8 +938,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -950,8 +950,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesEventhubsAuthorizationRuleOperatorSecrets"></a>NamespacesEventhubsAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------------------------
+NamespacesEventhubsAuthorizationRuleOperatorSecrets{#NamespacesEventhubsAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesEventhubsAuthorizationRuleOperatorSpec](#NamespacesEventhubsAuthorizationRuleOperatorSpec).
 
@@ -962,8 +962,8 @@ Used by: [NamespacesEventhubsAuthorizationRuleOperatorSpec](#NamespacesEventhubs
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="RetentionDescription_CleanupPolicy"></a>RetentionDescription_CleanupPolicy
----------------------------------------------------------------------------------
+RetentionDescription_CleanupPolicy{#RetentionDescription_CleanupPolicy}
+-----------------------------------------------------------------------
 
 Used by: [RetentionDescription](#RetentionDescription).
 
@@ -972,8 +972,8 @@ Used by: [RetentionDescription](#RetentionDescription).
 | "Compact" |             |
 | "Delete"  |             |
 
-<a id="RetentionDescription_CleanupPolicy_STATUS"></a>RetentionDescription_CleanupPolicy_STATUS
------------------------------------------------------------------------------------------------
+RetentionDescription_CleanupPolicy_STATUS{#RetentionDescription_CleanupPolicy_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [RetentionDescription_STATUS](#RetentionDescription_STATUS).
 
@@ -982,8 +982,8 @@ Used by: [RetentionDescription_STATUS](#RetentionDescription_STATUS).
 | "Compact" |             |
 | "Delete"  |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -993,8 +993,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -1004,8 +1004,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier"></a>Sku_Tier
------------------------------
+Sku_Tier{#Sku_Tier}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -1015,8 +1015,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Sku_Tier_STATUS"></a>Sku_Tier_STATUS
--------------------------------------------
+Sku_Tier_STATUS{#Sku_Tier_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -1026,7 +1026,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1038,20 +1050,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Recognized Dictionary value.
 
@@ -1062,8 +1062,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1073,8 +1073,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CaptureIdentity"></a>CaptureIdentity
--------------------------------------------
+CaptureIdentity{#CaptureIdentity}
+---------------------------------
 
 A value that indicates whether capture description is enabled.
 
@@ -1085,8 +1085,8 @@ Used by: [Destination](#Destination).
 | type                          | Type of Azure Active Directory Managed Identity.                                                                                                                                                         | [CaptureIdentity_Type](#CaptureIdentity_Type)<br/><small>Optional</small>                                                                                  |
 | userAssignedIdentityReference | ARM ID of Managed User Identity. This property is required is the type is UserAssignedIdentity. If type is SystemAssigned, then the System Assigned Identity Associated with the namespace will be used. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CaptureIdentity_STATUS"></a>CaptureIdentity_STATUS
----------------------------------------------------------
+CaptureIdentity_STATUS{#CaptureIdentity_STATUS}
+-----------------------------------------------
 
 A value that indicates whether capture description is enabled.
 
@@ -1097,8 +1097,8 @@ Used by: [Destination_STATUS](#Destination_STATUS).
 | type                 | Type of Azure Active Directory Managed Identity.                                                                                                                                                         | [CaptureIdentity_Type_STATUS](#CaptureIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentity | ARM ID of Managed User Identity. This property is required is the type is UserAssignedIdentity. If type is SystemAssigned, then the System Assigned Identity Associated with the namespace will be used. | string<br/><small>Optional</small>                                                      |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -1106,8 +1106,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 
@@ -1115,8 +1115,8 @@ Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 |----------------------|-------------------------------------------------|------------------------------------|
 | userAssignedIdentity | ARM ID of user Identity selected for encryption | string<br/><small>Optional</small> |
 
-<a id="CaptureIdentity_Type"></a>CaptureIdentity_Type
------------------------------------------------------
+CaptureIdentity_Type{#CaptureIdentity_Type}
+-------------------------------------------
 
 Used by: [CaptureIdentity](#CaptureIdentity).
 
@@ -1125,8 +1125,8 @@ Used by: [CaptureIdentity](#CaptureIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="CaptureIdentity_Type_STATUS"></a>CaptureIdentity_Type_STATUS
--------------------------------------------------------------------
+CaptureIdentity_Type_STATUS{#CaptureIdentity_Type_STATUS}
+---------------------------------------------------------
 
 Used by: [CaptureIdentity_STATUS](#CaptureIdentity_STATUS).
 

--- a/docs/hugo/content/reference/insights/v1api20180301.md
+++ b/docs/hugo/content/reference/insights/v1api20180301.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20180301
 linktitle: v1api20180301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-03-01" |             |
 
-<a id="MetricAlert"></a>MetricAlert
------------------------------------
+MetricAlert{#MetricAlert}
+-------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2018-03-01/metricAlert_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/metricAlerts/{ruleName}
 
@@ -26,7 +26,7 @@ Used by: [MetricAlertList](#MetricAlertList).
 | spec                                                                                    |             | [MetricAlert_Spec](#MetricAlert_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [MetricAlert_STATUS](#MetricAlert_STATUS)<br/><small>Optional</small> |
 
-### <a id="MetricAlert_Spec"></a>MetricAlert_Spec
+### MetricAlert_Spec {#MetricAlert_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -47,7 +47,7 @@ Used by: [MetricAlertList](#MetricAlertList).
 | targetResourceType   | the resource type of the target resource(s) on which the alert is created/updated. Mandatory if the scope contains a subscription, resource group, or more than one resource.                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | windowSize           | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold.                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-### <a id="MetricAlert_STATUS"></a>MetricAlert_STATUS
+### MetricAlert_STATUS{#MetricAlert_STATUS}
 
 | Property             | Description                                                                                                                                                                   | Type                                                                                                                                                    |
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -71,8 +71,8 @@ Used by: [MetricAlertList](#MetricAlertList).
 | type                 | Azure resource type                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize           | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold.                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MetricAlertList"></a>MetricAlertList
--------------------------------------------
+MetricAlertList{#MetricAlertList}
+---------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2018-03-01/metricAlert_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/metricAlerts/{ruleName}
 
@@ -82,8 +82,8 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [MetricAlert[]](#MetricAlert)<br/><small>Optional</small> |
 
-<a id="MetricAlert_Spec"></a>MetricAlert_Spec
----------------------------------------------
+MetricAlert_Spec{#MetricAlert_Spec}
+-----------------------------------
 
 Used by: [MetricAlert](#MetricAlert).
 
@@ -106,8 +106,8 @@ Used by: [MetricAlert](#MetricAlert).
 | targetResourceType   | the resource type of the target resource(s) on which the alert is created/updated. Mandatory if the scope contains a subscription, resource group, or more than one resource.                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 | windowSize           | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold.                                                                                                                                                                              | string<br/><small>Required</small>                                                                                                                                   |
 
-<a id="MetricAlert_STATUS"></a>MetricAlert_STATUS
--------------------------------------------------
+MetricAlert_STATUS{#MetricAlert_STATUS}
+---------------------------------------
 
 Used by: [MetricAlert](#MetricAlert).
 
@@ -133,8 +133,8 @@ Used by: [MetricAlert](#MetricAlert).
 | type                 | Azure resource type                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize           | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold.                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="MetricAlertAction"></a>MetricAlertAction
------------------------------------------------
+MetricAlertAction{#MetricAlertAction}
+-------------------------------------
 
 An alert action.
 
@@ -145,8 +145,8 @@ Used by: [MetricAlert_Spec](#MetricAlert_Spec).
 | actionGroupId     | the id of the action group to use.                                                                                         | string<br/><small>Optional</small>            |
 | webHookProperties | This field allows specifying custom properties, which would be appended to the alert payload sent as input to the webhook. | map[string]string<br/><small>Optional</small> |
 
-<a id="MetricAlertAction_STATUS"></a>MetricAlertAction_STATUS
--------------------------------------------------------------
+MetricAlertAction_STATUS{#MetricAlertAction_STATUS}
+---------------------------------------------------
 
 An alert action.
 
@@ -157,8 +157,8 @@ Used by: [MetricAlert_STATUS](#MetricAlert_STATUS).
 | actionGroupId     | the id of the action group to use.                                                                                         | string<br/><small>Optional</small>            |
 | webHookProperties | This field allows specifying custom properties, which would be appended to the alert payload sent as input to the webhook. | map[string]string<br/><small>Optional</small> |
 
-<a id="MetricAlertCriteria"></a>MetricAlertCriteria
----------------------------------------------------
+MetricAlertCriteria{#MetricAlertCriteria}
+-----------------------------------------
 
 Used by: [MetricAlert_Spec](#MetricAlert_Spec).
 
@@ -168,8 +168,8 @@ Used by: [MetricAlert_Spec](#MetricAlert_Spec).
 | microsoftAzureMonitorSingleResourceMultipleMetricCriteria   | Mutually exclusive with all other properties | [MetricAlertSingleResourceMultipleMetricCriteria](#MetricAlertSingleResourceMultipleMetricCriteria)<br/><small>Optional</small>     |
 | microsoftAzureMonitorWebtestLocationAvailabilityCriteria    | Mutually exclusive with all other properties | [WebtestLocationAvailabilityCriteria](#WebtestLocationAvailabilityCriteria)<br/><small>Optional</small>                             |
 
-<a id="MetricAlertCriteria_STATUS"></a>MetricAlertCriteria_STATUS
------------------------------------------------------------------
+MetricAlertCriteria_STATUS{#MetricAlertCriteria_STATUS}
+-------------------------------------------------------
 
 Used by: [MetricAlert_STATUS](#MetricAlert_STATUS).
 
@@ -179,8 +179,8 @@ Used by: [MetricAlert_STATUS](#MetricAlert_STATUS).
 | microsoftAzureMonitorSingleResourceMultipleMetricCriteria   | Mutually exclusive with all other properties | [MetricAlertSingleResourceMultipleMetricCriteria_STATUS](#MetricAlertSingleResourceMultipleMetricCriteria_STATUS)<br/><small>Optional</small>     |
 | microsoftAzureMonitorWebtestLocationAvailabilityCriteria    | Mutually exclusive with all other properties | [WebtestLocationAvailabilityCriteria_STATUS](#WebtestLocationAvailabilityCriteria_STATUS)<br/><small>Optional</small>                             |
 
-<a id="MetricAlertOperatorSpec"></a>MetricAlertOperatorSpec
------------------------------------------------------------
+MetricAlertOperatorSpec{#MetricAlertOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -191,8 +191,8 @@ Used by: [MetricAlert_Spec](#MetricAlert_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MetricAlertMultipleResourceMultipleMetricCriteria"></a>MetricAlertMultipleResourceMultipleMetricCriteria
----------------------------------------------------------------------------------------------------------------
+MetricAlertMultipleResourceMultipleMetricCriteria{#MetricAlertMultipleResourceMultipleMetricCriteria}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 
@@ -202,8 +202,8 @@ Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 | allOf                | the list of multiple metric criteria for this 'all of' operation. | [MultiMetricCriteria[]](#MultiMetricCriteria)<br/><small>Optional</small>                                                                               |
 | odata.type           | specifies the type of the alert criteria.                         | [MetricAlertMultipleResourceMultipleMetricCriteria_OdataType](#MetricAlertMultipleResourceMultipleMetricCriteria_OdataType)<br/><small>Required</small> |
 
-<a id="MetricAlertMultipleResourceMultipleMetricCriteria_STATUS"></a>MetricAlertMultipleResourceMultipleMetricCriteria_STATUS
------------------------------------------------------------------------------------------------------------------------------
+MetricAlertMultipleResourceMultipleMetricCriteria_STATUS{#MetricAlertMultipleResourceMultipleMetricCriteria_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 
@@ -213,8 +213,8 @@ Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 | allOf                | the list of multiple metric criteria for this 'all of' operation. | [MultiMetricCriteria_STATUS[]](#MultiMetricCriteria_STATUS)<br/><small>Optional</small>                                                                               |
 | odata.type           | specifies the type of the alert criteria.                         | [MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS](#MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS)<br/><small>Optional</small> |
 
-<a id="MetricAlertSingleResourceMultipleMetricCriteria"></a>MetricAlertSingleResourceMultipleMetricCriteria
------------------------------------------------------------------------------------------------------------
+MetricAlertSingleResourceMultipleMetricCriteria{#MetricAlertSingleResourceMultipleMetricCriteria}
+-------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 
@@ -224,8 +224,8 @@ Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 | allOf                | The list of metric criteria for this 'all of' operation. | [MetricCriteria[]](#MetricCriteria)<br/><small>Optional</small>                                                                                     |
 | odata.type           | specifies the type of the alert criteria.                | [MetricAlertSingleResourceMultipleMetricCriteria_OdataType](#MetricAlertSingleResourceMultipleMetricCriteria_OdataType)<br/><small>Required</small> |
 
-<a id="MetricAlertSingleResourceMultipleMetricCriteria_STATUS"></a>MetricAlertSingleResourceMultipleMetricCriteria_STATUS
--------------------------------------------------------------------------------------------------------------------------
+MetricAlertSingleResourceMultipleMetricCriteria_STATUS{#MetricAlertSingleResourceMultipleMetricCriteria_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 
@@ -235,8 +235,8 @@ Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 | allOf                | The list of metric criteria for this 'all of' operation. | [MetricCriteria_STATUS[]](#MetricCriteria_STATUS)<br/><small>Optional</small>                                                                                     |
 | odata.type           | specifies the type of the alert criteria.                | [MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS](#MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS)<br/><small>Optional</small> |
 
-<a id="WebtestLocationAvailabilityCriteria"></a>WebtestLocationAvailabilityCriteria
------------------------------------------------------------------------------------
+WebtestLocationAvailabilityCriteria{#WebtestLocationAvailabilityCriteria}
+-------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 
@@ -248,8 +248,8 @@ Used by: [MetricAlertCriteria](#MetricAlertCriteria).
 | odata.type           | specifies the type of the alert criteria. | [WebtestLocationAvailabilityCriteria_OdataType](#WebtestLocationAvailabilityCriteria_OdataType)<br/><small>Required</small>                                |
 | webTestId            | The Application Insights web test Id.     | string<br/><small>Required</small>                                                                                                                         |
 
-<a id="WebtestLocationAvailabilityCriteria_STATUS"></a>WebtestLocationAvailabilityCriteria_STATUS
--------------------------------------------------------------------------------------------------
+WebtestLocationAvailabilityCriteria_STATUS{#WebtestLocationAvailabilityCriteria_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 
@@ -261,8 +261,8 @@ Used by: [MetricAlertCriteria_STATUS](#MetricAlertCriteria_STATUS).
 | odata.type           | specifies the type of the alert criteria. | [WebtestLocationAvailabilityCriteria_OdataType_STATUS](#WebtestLocationAvailabilityCriteria_OdataType_STATUS)<br/><small>Optional</small> |
 | webTestId            | The Application Insights web test Id.     | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="MetricAlertMultipleResourceMultipleMetricCriteria_OdataType"></a>MetricAlertMultipleResourceMultipleMetricCriteria_OdataType
------------------------------------------------------------------------------------------------------------------------------------
+MetricAlertMultipleResourceMultipleMetricCriteria_OdataType{#MetricAlertMultipleResourceMultipleMetricCriteria_OdataType}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertMultipleResourceMultipleMetricCriteria](#MetricAlertMultipleResourceMultipleMetricCriteria).
 
@@ -270,8 +270,8 @@ Used by: [MetricAlertMultipleResourceMultipleMetricCriteria](#MetricAlertMultipl
 |------------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria" |             |
 
-<a id="MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS"></a>MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------
+MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS{#MetricAlertMultipleResourceMultipleMetricCriteria_OdataType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertMultipleResourceMultipleMetricCriteria_STATUS](#MetricAlertMultipleResourceMultipleMetricCriteria_STATUS).
 
@@ -279,8 +279,8 @@ Used by: [MetricAlertMultipleResourceMultipleMetricCriteria_STATUS](#MetricAlert
 |------------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria" |             |
 
-<a id="MetricAlertSingleResourceMultipleMetricCriteria_OdataType"></a>MetricAlertSingleResourceMultipleMetricCriteria_OdataType
--------------------------------------------------------------------------------------------------------------------------------
+MetricAlertSingleResourceMultipleMetricCriteria_OdataType{#MetricAlertSingleResourceMultipleMetricCriteria_OdataType}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertSingleResourceMultipleMetricCriteria](#MetricAlertSingleResourceMultipleMetricCriteria).
 
@@ -288,8 +288,8 @@ Used by: [MetricAlertSingleResourceMultipleMetricCriteria](#MetricAlertSingleRes
 |----------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria" |             |
 
-<a id="MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS"></a>MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------
+MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS{#MetricAlertSingleResourceMultipleMetricCriteria_OdataType_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [MetricAlertSingleResourceMultipleMetricCriteria_STATUS](#MetricAlertSingleResourceMultipleMetricCriteria_STATUS).
 
@@ -297,8 +297,8 @@ Used by: [MetricAlertSingleResourceMultipleMetricCriteria_STATUS](#MetricAlertSi
 |----------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria" |             |
 
-<a id="MetricCriteria"></a>MetricCriteria
------------------------------------------
+MetricCriteria{#MetricCriteria}
+-------------------------------
 
 Used by: [MetricAlertSingleResourceMultipleMetricCriteria](#MetricAlertSingleResourceMultipleMetricCriteria), and [MultiMetricCriteria](#MultiMetricCriteria).
 
@@ -315,8 +315,8 @@ Used by: [MetricAlertSingleResourceMultipleMetricCriteria](#MetricAlertSingleRes
 | threshold            | the criteria threshold value that activates the alert.                                                                   | float64<br/><small>Required</small>                                                           |
 | timeAggregation      | the criteria time aggregation types.                                                                                     | [MetricCriteria_TimeAggregation](#MetricCriteria_TimeAggregation)<br/><small>Required</small> |
 
-<a id="MetricCriteria_STATUS"></a>MetricCriteria_STATUS
--------------------------------------------------------
+MetricCriteria_STATUS{#MetricCriteria_STATUS}
+---------------------------------------------
 
 Used by: [MetricAlertSingleResourceMultipleMetricCriteria_STATUS](#MetricAlertSingleResourceMultipleMetricCriteria_STATUS), and [MultiMetricCriteria_STATUS](#MultiMetricCriteria_STATUS).
 
@@ -333,8 +333,8 @@ Used by: [MetricAlertSingleResourceMultipleMetricCriteria_STATUS](#MetricAlertSi
 | threshold            | the criteria threshold value that activates the alert.                                                                   | float64<br/><small>Optional</small>                                                                         |
 | timeAggregation      | the criteria time aggregation types.                                                                                     | [MetricCriteria_TimeAggregation_STATUS](#MetricCriteria_TimeAggregation_STATUS)<br/><small>Optional</small> |
 
-<a id="MultiMetricCriteria"></a>MultiMetricCriteria
----------------------------------------------------
+MultiMetricCriteria{#MultiMetricCriteria}
+-----------------------------------------
 
 Used by: [MetricAlertMultipleResourceMultipleMetricCriteria](#MetricAlertMultipleResourceMultipleMetricCriteria).
 
@@ -343,8 +343,8 @@ Used by: [MetricAlertMultipleResourceMultipleMetricCriteria](#MetricAlertMultipl
 | dynamicThresholdCriterion | Mutually exclusive with all other properties | [DynamicMetricCriteria](#DynamicMetricCriteria)<br/><small>Optional</small> |
 | staticThresholdCriterion  | Mutually exclusive with all other properties | [MetricCriteria](#MetricCriteria)<br/><small>Optional</small>               |
 
-<a id="MultiMetricCriteria_STATUS"></a>MultiMetricCriteria_STATUS
------------------------------------------------------------------
+MultiMetricCriteria_STATUS{#MultiMetricCriteria_STATUS}
+-------------------------------------------------------
 
 Used by: [MetricAlertMultipleResourceMultipleMetricCriteria_STATUS](#MetricAlertMultipleResourceMultipleMetricCriteria_STATUS).
 
@@ -353,8 +353,8 @@ Used by: [MetricAlertMultipleResourceMultipleMetricCriteria_STATUS](#MetricAlert
 | dynamicThresholdCriterion | Mutually exclusive with all other properties | [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS)<br/><small>Optional</small> |
 | staticThresholdCriterion  | Mutually exclusive with all other properties | [MetricCriteria_STATUS](#MetricCriteria_STATUS)<br/><small>Optional</small>               |
 
-<a id="WebtestLocationAvailabilityCriteria_OdataType"></a>WebtestLocationAvailabilityCriteria_OdataType
--------------------------------------------------------------------------------------------------------
+WebtestLocationAvailabilityCriteria_OdataType{#WebtestLocationAvailabilityCriteria_OdataType}
+---------------------------------------------------------------------------------------------
 
 Used by: [WebtestLocationAvailabilityCriteria](#WebtestLocationAvailabilityCriteria).
 
@@ -362,8 +362,8 @@ Used by: [WebtestLocationAvailabilityCriteria](#WebtestLocationAvailabilityCrite
 |---------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria" |             |
 
-<a id="WebtestLocationAvailabilityCriteria_OdataType_STATUS"></a>WebtestLocationAvailabilityCriteria_OdataType_STATUS
----------------------------------------------------------------------------------------------------------------------
+WebtestLocationAvailabilityCriteria_OdataType_STATUS{#WebtestLocationAvailabilityCriteria_OdataType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [WebtestLocationAvailabilityCriteria_STATUS](#WebtestLocationAvailabilityCriteria_STATUS).
 
@@ -371,8 +371,8 @@ Used by: [WebtestLocationAvailabilityCriteria_STATUS](#WebtestLocationAvailabili
 |---------------------------------------------------------------|-------------|
 | "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria" |             |
 
-<a id="DynamicMetricCriteria"></a>DynamicMetricCriteria
--------------------------------------------------------
+DynamicMetricCriteria{#DynamicMetricCriteria}
+---------------------------------------------
 
 Used by: [MultiMetricCriteria](#MultiMetricCriteria).
 
@@ -391,8 +391,8 @@ Used by: [MultiMetricCriteria](#MultiMetricCriteria).
 | skipMetricValidation | Allows creating an alert rule on a custom metric that isn't yet emitted, by causing the metric validation to be skipped.                         | bool<br/><small>Optional</small>                                                                              |
 | timeAggregation      | the criteria time aggregation types.                                                                                                             | [DynamicMetricCriteria_TimeAggregation](#DynamicMetricCriteria_TimeAggregation)<br/><small>Required</small>   |
 
-<a id="DynamicMetricCriteria_STATUS"></a>DynamicMetricCriteria_STATUS
----------------------------------------------------------------------
+DynamicMetricCriteria_STATUS{#DynamicMetricCriteria_STATUS}
+-----------------------------------------------------------
 
 Used by: [MultiMetricCriteria_STATUS](#MultiMetricCriteria_STATUS).
 
@@ -411,29 +411,29 @@ Used by: [MultiMetricCriteria_STATUS](#MultiMetricCriteria_STATUS).
 | skipMetricValidation | Allows creating an alert rule on a custom metric that isn't yet emitted, by causing the metric validation to be skipped.                         | bool<br/><small>Optional</small>                                                                                            |
 | timeAggregation      | the criteria time aggregation types.                                                                                                             | [DynamicMetricCriteria_TimeAggregation_STATUS](#DynamicMetricCriteria_TimeAggregation_STATUS)<br/><small>Optional</small>   |
 
-<a id="MetricCriteria_CriterionType"></a>MetricCriteria_CriterionType
----------------------------------------------------------------------
-
-Used by: [MetricCriteria](#MetricCriteria).
-
-| Value                      | Description |
-|----------------------------|-------------|
-| "StaticThresholdCriterion" |             |
-
-<a id="MetricCriteria_CriterionType_STATUS"></a>MetricCriteria_CriterionType_STATUS
------------------------------------------------------------------------------------
-
-Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
-
-| Value                      | Description |
-|----------------------------|-------------|
-| "StaticThresholdCriterion" |             |
-
-<a id="MetricCriteria_Operator"></a>MetricCriteria_Operator
+MetricCriteria_CriterionType{#MetricCriteria_CriterionType}
 -----------------------------------------------------------
 
 Used by: [MetricCriteria](#MetricCriteria).
 
+| Value                      | Description |
+|----------------------------|-------------|
+| "StaticThresholdCriterion" |             |
+
+MetricCriteria_CriterionType_STATUS{#MetricCriteria_CriterionType_STATUS}
+-------------------------------------------------------------------------
+
+Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
+
+| Value                      | Description |
+|----------------------------|-------------|
+| "StaticThresholdCriterion" |             |
+
+MetricCriteria_Operator{#MetricCriteria_Operator}
+-------------------------------------------------
+
+Used by: [MetricCriteria](#MetricCriteria).
+
 | Value                | Description |
 |----------------------|-------------|
 | "Equals"             |             |
@@ -442,8 +442,8 @@ Used by: [MetricCriteria](#MetricCriteria).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="MetricCriteria_Operator_STATUS"></a>MetricCriteria_Operator_STATUS
--------------------------------------------------------------------------
+MetricCriteria_Operator_STATUS{#MetricCriteria_Operator_STATUS}
+---------------------------------------------------------------
 
 Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
 
@@ -455,8 +455,8 @@ Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="MetricCriteria_TimeAggregation"></a>MetricCriteria_TimeAggregation
--------------------------------------------------------------------------
+MetricCriteria_TimeAggregation{#MetricCriteria_TimeAggregation}
+---------------------------------------------------------------
 
 Used by: [MetricCriteria](#MetricCriteria).
 
@@ -468,8 +468,8 @@ Used by: [MetricCriteria](#MetricCriteria).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="MetricCriteria_TimeAggregation_STATUS"></a>MetricCriteria_TimeAggregation_STATUS
----------------------------------------------------------------------------------------
+MetricCriteria_TimeAggregation_STATUS{#MetricCriteria_TimeAggregation_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
 
@@ -481,8 +481,8 @@ Used by: [MetricCriteria_STATUS](#MetricCriteria_STATUS).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="MetricDimension"></a>MetricDimension
--------------------------------------------
+MetricDimension{#MetricDimension}
+---------------------------------
 
 Specifies a metric dimension.
 
@@ -494,8 +494,8 @@ Used by: [DynamicMetricCriteria](#DynamicMetricCriteria), and [MetricCriteria](#
 | operator | the dimension operator. Only 'Include' and 'Exclude' are supported | string<br/><small>Required</small>   |
 | values   | list of dimension values.                                          | string[]<br/><small>Required</small> |
 
-<a id="MetricDimension_STATUS"></a>MetricDimension_STATUS
----------------------------------------------------------
+MetricDimension_STATUS{#MetricDimension_STATUS}
+-----------------------------------------------
 
 Specifies a metric dimension.
 
@@ -507,8 +507,8 @@ Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS), and [Met
 | operator | the dimension operator. Only 'Include' and 'Exclude' are supported | string<br/><small>Optional</small>   |
 | values   | list of dimension values.                                          | string[]<br/><small>Optional</small> |
 
-<a id="DynamicMetricCriteria_AlertSensitivity"></a>DynamicMetricCriteria_AlertSensitivity
------------------------------------------------------------------------------------------
+DynamicMetricCriteria_AlertSensitivity{#DynamicMetricCriteria_AlertSensitivity}
+-------------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 
@@ -518,8 +518,8 @@ Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 | "Low"    |             |
 | "Medium" |             |
 
-<a id="DynamicMetricCriteria_AlertSensitivity_STATUS"></a>DynamicMetricCriteria_AlertSensitivity_STATUS
--------------------------------------------------------------------------------------------------------
+DynamicMetricCriteria_AlertSensitivity_STATUS{#DynamicMetricCriteria_AlertSensitivity_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 
@@ -529,37 +529,37 @@ Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 | "Low"    |             |
 | "Medium" |             |
 
-<a id="DynamicMetricCriteria_CriterionType"></a>DynamicMetricCriteria_CriterionType
------------------------------------------------------------------------------------
-
-Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
-
-| Value                       | Description |
-|-----------------------------|-------------|
-| "DynamicThresholdCriterion" |             |
-
-<a id="DynamicMetricCriteria_CriterionType_STATUS"></a>DynamicMetricCriteria_CriterionType_STATUS
--------------------------------------------------------------------------------------------------
-
-Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
-
-| Value                       | Description |
-|-----------------------------|-------------|
-| "DynamicThresholdCriterion" |             |
-
-<a id="DynamicMetricCriteria_Operator"></a>DynamicMetricCriteria_Operator
+DynamicMetricCriteria_CriterionType{#DynamicMetricCriteria_CriterionType}
 -------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 
+| Value                       | Description |
+|-----------------------------|-------------|
+| "DynamicThresholdCriterion" |             |
+
+DynamicMetricCriteria_CriterionType_STATUS{#DynamicMetricCriteria_CriterionType_STATUS}
+---------------------------------------------------------------------------------------
+
+Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
+
+| Value                       | Description |
+|-----------------------------|-------------|
+| "DynamicThresholdCriterion" |             |
+
+DynamicMetricCriteria_Operator{#DynamicMetricCriteria_Operator}
+---------------------------------------------------------------
+
+Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
+
 | Value               | Description |
 |---------------------|-------------|
 | "GreaterOrLessThan" |             |
 | "GreaterThan"       |             |
 | "LessThan"          |             |
 
-<a id="DynamicMetricCriteria_Operator_STATUS"></a>DynamicMetricCriteria_Operator_STATUS
----------------------------------------------------------------------------------------
+DynamicMetricCriteria_Operator_STATUS{#DynamicMetricCriteria_Operator_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 
@@ -569,8 +569,8 @@ Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 | "GreaterThan"       |             |
 | "LessThan"          |             |
 
-<a id="DynamicMetricCriteria_TimeAggregation"></a>DynamicMetricCriteria_TimeAggregation
----------------------------------------------------------------------------------------
+DynamicMetricCriteria_TimeAggregation{#DynamicMetricCriteria_TimeAggregation}
+-----------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 
@@ -582,8 +582,8 @@ Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="DynamicMetricCriteria_TimeAggregation_STATUS"></a>DynamicMetricCriteria_TimeAggregation_STATUS
------------------------------------------------------------------------------------------------------
+DynamicMetricCriteria_TimeAggregation_STATUS{#DynamicMetricCriteria_TimeAggregation_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 
@@ -595,8 +595,8 @@ Used by: [DynamicMetricCriteria_STATUS](#DynamicMetricCriteria_STATUS).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="DynamicThresholdFailingPeriods"></a>DynamicThresholdFailingPeriods
--------------------------------------------------------------------------
+DynamicThresholdFailingPeriods{#DynamicThresholdFailingPeriods}
+---------------------------------------------------------------
 
 The minimum number of violations required within the selected lookback time window required to raise an alert.
 
@@ -607,8 +607,8 @@ Used by: [DynamicMetricCriteria](#DynamicMetricCriteria).
 | minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods.                                                                           | float64<br/><small>Required</small> |
 | numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. | float64<br/><small>Required</small> |
 
-<a id="DynamicThresholdFailingPeriods_STATUS"></a>DynamicThresholdFailingPeriods_STATUS
----------------------------------------------------------------------------------------
+DynamicThresholdFailingPeriods_STATUS{#DynamicThresholdFailingPeriods_STATUS}
+-----------------------------------------------------------------------------
 
 The minimum number of violations required within the selected lookback time window required to raise an alert.
 

--- a/docs/hugo/content/reference/insights/v1api20180501preview.md
+++ b/docs/hugo/content/reference/insights/v1api20180501preview.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20180501preview
 linktitle: v1api20180501preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2018-05-01-preview" |             |
 
-<a id="Webtest"></a>Webtest
----------------------------
+Webtest{#Webtest}
+-----------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/preview/2018-05-01-preview/webTests_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/webtests/{webTestName}
 
@@ -26,7 +26,7 @@ Used by: [WebtestList](#WebtestList).
 | spec                                                                                    |             | [Webtest_Spec](#Webtest_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Webtest_STATUS](#Webtest_STATUS)<br/><small>Optional</small> |
 
-### <a id="Webtest_Spec"></a>Webtest_Spec
+### Webtest_Spec {#Webtest_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -48,7 +48,7 @@ Used by: [WebtestList](#WebtestList).
 | Timeout            | Seconds until this WebTest will timeout and fail. Default value is 30.                                                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                                                                 | [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)<br/><small>Optional</small>                                                                  |
 
-### <a id="Webtest_STATUS"></a>Webtest_STATUS
+### Webtest_STATUS{#Webtest_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                   | Type                                                                                                                                                    |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -72,8 +72,8 @@ Used by: [WebtestList](#WebtestList).
 | type               | Azure resource type                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                  | [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="WebtestList"></a>WebtestList
------------------------------------
+WebtestList{#WebtestList}
+-------------------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/preview/2018-05-01-preview/webTests_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/webtests/{webTestName}
 
@@ -83,8 +83,8 @@ Generator information: - Generated from: /applicationinsights/resource-manager/M
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Webtest[]](#Webtest)<br/><small>Optional</small> |
 
-<a id="Webtest_Spec"></a>Webtest_Spec
--------------------------------------
+Webtest_Spec{#Webtest_Spec}
+---------------------------
 
 Used by: [Webtest](#Webtest).
 
@@ -108,8 +108,8 @@ Used by: [Webtest](#Webtest).
 | Timeout            | Seconds until this WebTest will timeout and fail. Default value is 30.                                                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                                                                 | [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)<br/><small>Optional</small>                                                                  |
 
-<a id="Webtest_STATUS"></a>Webtest_STATUS
------------------------------------------
+Webtest_STATUS{#Webtest_STATUS}
+-------------------------------
 
 Used by: [Webtest](#Webtest).
 
@@ -135,8 +135,8 @@ Used by: [Webtest](#Webtest).
 | type               | Azure resource type                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                  | [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="WebTestGeolocation"></a>WebTestGeolocation
--------------------------------------------------
+WebTestGeolocation{#WebTestGeolocation}
+---------------------------------------
 
 Geo-physical location to run a WebTest from. You must specify one or more locations for the test to run from.
 
@@ -146,8 +146,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 |----------|------------------------------------------|------------------------------------|
 | Id       | Location ID for the WebTest to run from. | string<br/><small>Optional</small> |
 
-<a id="WebTestGeolocation_STATUS"></a>WebTestGeolocation_STATUS
----------------------------------------------------------------
+WebTestGeolocation_STATUS{#WebTestGeolocation_STATUS}
+-----------------------------------------------------
 
 Geo-physical location to run a WebTest from. You must specify one or more locations for the test to run from.
 
@@ -157,8 +157,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 |----------|------------------------------------------|------------------------------------|
 | Id       | Location ID for the WebTest to run from. | string<br/><small>Optional</small> |
 
-<a id="WebtestOperatorSpec"></a>WebtestOperatorSpec
----------------------------------------------------
+WebtestOperatorSpec{#WebtestOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -169,8 +169,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Configuration"></a>WebTestProperties_Configuration
----------------------------------------------------------------------------
+WebTestProperties_Configuration{#WebTestProperties_Configuration}
+-----------------------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -178,8 +178,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 |----------|-------------------------------------------------------------------|------------------------------------|
 | WebTest  | The XML specification of a WebTest to run against an application. | string<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Configuration_STATUS"></a>WebTestProperties_Configuration_STATUS
------------------------------------------------------------------------------------------
+WebTestProperties_Configuration_STATUS{#WebTestProperties_Configuration_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -187,8 +187,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 |----------|-------------------------------------------------------------------|------------------------------------|
 | WebTest  | The XML specification of a WebTest to run against an application. | string<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Kind"></a>WebTestProperties_Kind
----------------------------------------------------------
+WebTestProperties_Kind{#WebTestProperties_Kind}
+-----------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -199,8 +199,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | "ping"      |             |
 | "standard"  |             |
 
-<a id="WebTestProperties_Kind_STATUS"></a>WebTestProperties_Kind_STATUS
------------------------------------------------------------------------
+WebTestProperties_Kind_STATUS{#WebTestProperties_Kind_STATUS}
+-------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -211,8 +211,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | "ping"      |             |
 | "standard"  |             |
 
-<a id="WebTestProperties_Request"></a>WebTestProperties_Request
----------------------------------------------------------------
+WebTestProperties_Request{#WebTestProperties_Request}
+-----------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -225,8 +225,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | RequestBody            | Base64 encoded string body to send with this web test.       | string<br/><small>Optional</small>                        |
 | RequestUrl             | Url location to test.                                        | string<br/><small>Optional</small>                        |
 
-<a id="WebTestProperties_Request_STATUS"></a>WebTestProperties_Request_STATUS
------------------------------------------------------------------------------
+WebTestProperties_Request_STATUS{#WebTestProperties_Request_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -239,8 +239,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | RequestBody            | Base64 encoded string body to send with this web test.       | string<br/><small>Optional</small>                                      |
 | RequestUrl             | Url location to test.                                        | string<br/><small>Optional</small>                                      |
 
-<a id="WebTestProperties_ValidationRules"></a>WebTestProperties_ValidationRules
--------------------------------------------------------------------------------
+WebTestProperties_ValidationRules{#WebTestProperties_ValidationRules}
+---------------------------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -252,8 +252,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | SSLCertRemainingLifetimeCheck | A number of days to check still remain before the the existing SSL cert expires. Value must be positive and the SSLCheck must be set to true. | int<br/><small>Optional</small>                                                                                                         |
 | SSLCheck                      | Checks to see if the SSL cert is still valid.                                                                                                 | bool<br/><small>Optional</small>                                                                                                        |
 
-<a id="WebTestProperties_ValidationRules_STATUS"></a>WebTestProperties_ValidationRules_STATUS
----------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_STATUS{#WebTestProperties_ValidationRules_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -265,8 +265,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | SSLCertRemainingLifetimeCheck | A number of days to check still remain before the the existing SSL cert expires. Value must be positive and the SSLCheck must be set to true. | int<br/><small>Optional</small>                                                                                                                       |
 | SSLCheck                      | Checks to see if the SSL cert is still valid.                                                                                                 | bool<br/><small>Optional</small>                                                                                                                      |
 
-<a id="HeaderField"></a>HeaderField
------------------------------------
+HeaderField{#HeaderField}
+-------------------------
 
 A header to add to the WebTest.
 
@@ -277,8 +277,8 @@ Used by: [WebTestProperties_Request](#WebTestProperties_Request).
 | key      | The name of the header.  | string<br/><small>Optional</small> |
 | value    | The value of the header. | string<br/><small>Optional</small> |
 
-<a id="HeaderField_STATUS"></a>HeaderField_STATUS
--------------------------------------------------
+HeaderField_STATUS{#HeaderField_STATUS}
+---------------------------------------
 
 A header to add to the WebTest.
 
@@ -289,8 +289,8 @@ Used by: [WebTestProperties_Request_STATUS](#WebTestProperties_Request_STATUS).
 | key      | The name of the header.  | string<br/><small>Optional</small> |
 | value    | The value of the header. | string<br/><small>Optional</small> |
 
-<a id="WebTestProperties_ValidationRules_ContentValidation"></a>WebTestProperties_ValidationRules_ContentValidation
--------------------------------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_ContentValidation{#WebTestProperties_ValidationRules_ContentValidation}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules).
 
@@ -300,8 +300,8 @@ Used by: [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)
 | IgnoreCase      | When set, this value makes the ContentMatch validation case insensitive.                                                            | bool<br/><small>Optional</small>   |
 | PassIfTextFound | When true, validation will pass if there is a match for the ContentMatch string. If false, validation will fail if there is a match | bool<br/><small>Optional</small>   |
 
-<a id="WebTestProperties_ValidationRules_ContentValidation_STATUS"></a>WebTestProperties_ValidationRules_ContentValidation_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_ContentValidation_STATUS{#WebTestProperties_ValidationRules_ContentValidation_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS).
 

--- a/docs/hugo/content/reference/insights/v1api20200202.md
+++ b/docs/hugo/content/reference/insights/v1api20200202.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20200202
 linktitle: v1api20200202
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-02-02" |             |
 
-<a id="Component"></a>Component
--------------------------------
+Component{#Component}
+---------------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/stable/2020-02-02/components_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/components/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [ComponentList](#ComponentList).
 | spec                                                                                    |             | [Component_Spec](#Component_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Component_STATUS](#Component_STATUS)<br/><small>Optional</small> |
 
-### <a id="Component_Spec"></a>Component_Spec
+### Component_Spec {#Component_Spec}
 
 | Property                        | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ Used by: [ComponentList](#ComponentList).
 | tags                            | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workspaceResourceReference      | Resource Id of the log analytics workspace which the data will be ingested to. This property is required to create an application with this API version. Applications from older versions will not have this property.                                                                       | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-### <a id="Component_STATUS"></a>Component_STATUS
+### Component_STATUS{#Component_STATUS}
 
 | Property                        | Description                                                                                                                                                                                                                                                       | Type                                                                                                                                                          |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -90,8 +90,8 @@ Used by: [ComponentList](#ComponentList).
 | type                            | Azure resource type                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                            |
 | WorkspaceResourceId             | Resource Id of the log analytics workspace which the data will be ingested to. This property is required to create an application with this API version. Applications from older versions will not have this property.                                            | string<br/><small>Optional</small>                                                                                                                            |
 
-<a id="ComponentList"></a>ComponentList
----------------------------------------
+ComponentList{#ComponentList}
+-----------------------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/stable/2020-02-02/components_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/components/{resourceName}
 
@@ -101,8 +101,8 @@ Generator information: - Generated from: /applicationinsights/resource-manager/M
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Component[]](#Component)<br/><small>Optional</small> |
 
-<a id="Component_Spec"></a>Component_Spec
------------------------------------------
+Component_Spec{#Component_Spec}
+-------------------------------
 
 Used by: [Component](#Component).
 
@@ -130,8 +130,8 @@ Used by: [Component](#Component).
 | tags                            | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workspaceResourceReference      | Resource Id of the log analytics workspace which the data will be ingested to. This property is required to create an application with this API version. Applications from older versions will not have this property.                                                                       | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-<a id="Component_STATUS"></a>Component_STATUS
----------------------------------------------
+Component_STATUS{#Component_STATUS}
+-----------------------------------
 
 Used by: [Component](#Component).
 
@@ -171,8 +171,8 @@ Used by: [Component](#Component).
 | type                            | Azure resource type                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                            |
 | WorkspaceResourceId             | Resource Id of the log analytics workspace which the data will be ingested to. This property is required to create an application with this API version. Applications from older versions will not have this property.                                            | string<br/><small>Optional</small>                                                                                                                            |
 
-<a id="ApplicationInsightsComponentProperties_Application_Type"></a>ApplicationInsightsComponentProperties_Application_Type
----------------------------------------------------------------------------------------------------------------------------
+ApplicationInsightsComponentProperties_Application_Type{#ApplicationInsightsComponentProperties_Application_Type}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [Component_Spec](#Component_Spec).
 
@@ -181,8 +181,8 @@ Used by: [Component_Spec](#Component_Spec).
 | "other" |             |
 | "web"   |             |
 
-<a id="ApplicationInsightsComponentProperties_Application_Type_STATUS"></a>ApplicationInsightsComponentProperties_Application_Type_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationInsightsComponentProperties_Application_Type_STATUS{#ApplicationInsightsComponentProperties_Application_Type_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Component_STATUS](#Component_STATUS).
 
@@ -191,66 +191,66 @@ Used by: [Component_STATUS](#Component_STATUS).
 | "other" |             |
 | "web"   |             |
 
-<a id="ApplicationInsightsComponentProperties_Flow_Type"></a>ApplicationInsightsComponentProperties_Flow_Type
+ApplicationInsightsComponentProperties_Flow_Type{#ApplicationInsightsComponentProperties_Flow_Type}
+---------------------------------------------------------------------------------------------------
+
+Used by: [Component_Spec](#Component_Spec).
+
+| Value       | Description |
+|-------------|-------------|
+| "Bluefield" |             |
+
+ApplicationInsightsComponentProperties_Flow_Type_STATUS{#ApplicationInsightsComponentProperties_Flow_Type_STATUS}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [Component_STATUS](#Component_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "Bluefield" |             |
+
+ApplicationInsightsComponentProperties_IngestionMode{#ApplicationInsightsComponentProperties_IngestionMode}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [Component_Spec](#Component_Spec).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "ApplicationInsights"                       |             |
+| "ApplicationInsightsWithDiagnosticSettings" |             |
+| "LogAnalytics"                              |             |
+
+ApplicationInsightsComponentProperties_IngestionMode_STATUS{#ApplicationInsightsComponentProperties_IngestionMode_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
+
+Used by: [Component_STATUS](#Component_STATUS).
+
+| Value                                       | Description |
+|---------------------------------------------|-------------|
+| "ApplicationInsights"                       |             |
+| "ApplicationInsightsWithDiagnosticSettings" |             |
+| "LogAnalytics"                              |             |
+
+ApplicationInsightsComponentProperties_Request_Source{#ApplicationInsightsComponentProperties_Request_Source}
 -------------------------------------------------------------------------------------------------------------
 
 Used by: [Component_Spec](#Component_Spec).
 
-| Value       | Description |
-|-------------|-------------|
-| "Bluefield" |             |
+| Value  | Description |
+|--------|-------------|
+| "rest" |             |
 
-<a id="ApplicationInsightsComponentProperties_Flow_Type_STATUS"></a>ApplicationInsightsComponentProperties_Flow_Type_STATUS
+ApplicationInsightsComponentProperties_Request_Source_STATUS{#ApplicationInsightsComponentProperties_Request_Source_STATUS}
 ---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [Component_STATUS](#Component_STATUS).
 
-| Value       | Description |
-|-------------|-------------|
-| "Bluefield" |             |
-
-<a id="ApplicationInsightsComponentProperties_IngestionMode"></a>ApplicationInsightsComponentProperties_IngestionMode
----------------------------------------------------------------------------------------------------------------------
-
-Used by: [Component_Spec](#Component_Spec).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "ApplicationInsights"                       |             |
-| "ApplicationInsightsWithDiagnosticSettings" |             |
-| "LogAnalytics"                              |             |
-
-<a id="ApplicationInsightsComponentProperties_IngestionMode_STATUS"></a>ApplicationInsightsComponentProperties_IngestionMode_STATUS
------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [Component_STATUS](#Component_STATUS).
-
-| Value                                       | Description |
-|---------------------------------------------|-------------|
-| "ApplicationInsights"                       |             |
-| "ApplicationInsightsWithDiagnosticSettings" |             |
-| "LogAnalytics"                              |             |
-
-<a id="ApplicationInsightsComponentProperties_Request_Source"></a>ApplicationInsightsComponentProperties_Request_Source
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [Component_Spec](#Component_Spec).
-
 | Value  | Description |
 |--------|-------------|
 | "rest" |             |
 
-<a id="ApplicationInsightsComponentProperties_Request_Source_STATUS"></a>ApplicationInsightsComponentProperties_Request_Source_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [Component_STATUS](#Component_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "rest" |             |
-
-<a id="ComponentOperatorSpec"></a>ComponentOperatorSpec
--------------------------------------------------------
+ComponentOperatorSpec{#ComponentOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -262,8 +262,8 @@ Used by: [Component_Spec](#Component_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [ComponentOperatorConfigMaps](#ComponentOperatorConfigMaps)<br/><small>Optional</small>                                                                             |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateLinkScopedResource_STATUS"></a>PrivateLinkScopedResource_STATUS
------------------------------------------------------------------------------
+PrivateLinkScopedResource_STATUS{#PrivateLinkScopedResource_STATUS}
+-------------------------------------------------------------------
 
 The private link scope resource reference.
 
@@ -274,8 +274,8 @@ Used by: [Component_STATUS](#Component_STATUS).
 | ResourceId | The full resource Id of the private link scope resource. | string<br/><small>Optional</small> |
 | ScopeId    | The private link scope unique Identifier.                | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccessType"></a>PublicNetworkAccessType
------------------------------------------------------------
+PublicNetworkAccessType{#PublicNetworkAccessType}
+-------------------------------------------------
 
 The network access type for operating on the Application Insights Component. By default it is Enabled
 
@@ -286,8 +286,8 @@ Used by: [Component_Spec](#Component_Spec), and [Component_Spec](#Component_Spec
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PublicNetworkAccessType_STATUS"></a>PublicNetworkAccessType_STATUS
--------------------------------------------------------------------------
+PublicNetworkAccessType_STATUS{#PublicNetworkAccessType_STATUS}
+---------------------------------------------------------------
 
 The network access type for operating on the Application Insights Component. By default it is Enabled
 
@@ -298,8 +298,8 @@ Used by: [Component_STATUS](#Component_STATUS), and [Component_STATUS](#Componen
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ComponentOperatorConfigMaps"></a>ComponentOperatorConfigMaps
--------------------------------------------------------------------
+ComponentOperatorConfigMaps{#ComponentOperatorConfigMaps}
+---------------------------------------------------------
 
 Used by: [ComponentOperatorSpec](#ComponentOperatorSpec).
 

--- a/docs/hugo/content/reference/insights/v1api20210501preview.md
+++ b/docs/hugo/content/reference/insights/v1api20210501preview.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20210501preview
 linktitle: v1api20210501preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2021-05-01-preview" |             |
 
-<a id="DiagnosticSetting"></a>DiagnosticSetting
------------------------------------------------
+DiagnosticSetting{#DiagnosticSetting}
+-------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/preview/2021-05-01-preview/diagnosticsSettings_API.json - ARM URI: /{resourceUri}/providers/Microsoft.Insights/diagnosticSettings/{name}
 
@@ -26,7 +26,7 @@ Used by: [DiagnosticSettingList](#DiagnosticSettingList).
 | spec                                                                                    |             | [DiagnosticSetting_Spec](#DiagnosticSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DiagnosticSetting_STATUS](#DiagnosticSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="DiagnosticSetting_Spec"></a>DiagnosticSetting_Spec
+### DiagnosticSetting_Spec {#DiagnosticSetting_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                   |
 |------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -43,7 +43,7 @@ Used by: [DiagnosticSettingList](#DiagnosticSettingList).
 | storageAccountReference            | The resource ID of the storage account to which you would like to send Diagnostic Logs.                                                                                                                                                                                                                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>             |
 | workspaceReference                 | The full ARM resource ID of the Log Analytics workspace to which you would like to send Diagnostic Logs. Example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;insights-integration/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/viruela2 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>             |
 
-### <a id="DiagnosticSetting_STATUS"></a>DiagnosticSetting_STATUS
+### DiagnosticSetting_STATUS{#DiagnosticSetting_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                    |
 |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -62,8 +62,8 @@ Used by: [DiagnosticSettingList](#DiagnosticSettingList).
 | type                        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceId                 | The full ARM resource ID of the Log Analytics workspace to which you would like to send Diagnostic Logs. Example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;insights-integration/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/viruela2 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiagnosticSettingList"></a>DiagnosticSettingList
--------------------------------------------------------
+DiagnosticSettingList{#DiagnosticSettingList}
+---------------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/preview/2021-05-01-preview/diagnosticsSettings_API.json - ARM URI: /{resourceUri}/providers/Microsoft.Insights/diagnosticSettings/{name}
 
@@ -73,8 +73,8 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DiagnosticSetting[]](#DiagnosticSetting)<br/><small>Optional</small> |
 
-<a id="DiagnosticSetting_Spec"></a>DiagnosticSetting_Spec
----------------------------------------------------------
+DiagnosticSetting_Spec{#DiagnosticSetting_Spec}
+-----------------------------------------------
 
 Used by: [DiagnosticSetting](#DiagnosticSetting).
 
@@ -93,8 +93,8 @@ Used by: [DiagnosticSetting](#DiagnosticSetting).
 | storageAccountReference            | The resource ID of the storage account to which you would like to send Diagnostic Logs.                                                                                                                                                                                                                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>             |
 | workspaceReference                 | The full ARM resource ID of the Log Analytics workspace to which you would like to send Diagnostic Logs. Example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;insights-integration/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/viruela2 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>             |
 
-<a id="DiagnosticSetting_STATUS"></a>DiagnosticSetting_STATUS
--------------------------------------------------------------
+DiagnosticSetting_STATUS{#DiagnosticSetting_STATUS}
+---------------------------------------------------
 
 Used by: [DiagnosticSetting](#DiagnosticSetting).
 
@@ -115,8 +115,8 @@ Used by: [DiagnosticSetting](#DiagnosticSetting).
 | type                        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceId                 | The full ARM resource ID of the Log Analytics workspace to which you would like to send Diagnostic Logs. Example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;insights-integration/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/viruela2 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DiagnosticSettingOperatorSpec"></a>DiagnosticSettingOperatorSpec
------------------------------------------------------------------------
+DiagnosticSettingOperatorSpec{#DiagnosticSettingOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -127,8 +127,8 @@ Used by: [DiagnosticSetting_Spec](#DiagnosticSetting_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LogSettings"></a>LogSettings
------------------------------------
+LogSettings{#LogSettings}
+-------------------------
 
 Part of MultiTenantDiagnosticSettings. Specifies the settings for a particular log.
 
@@ -141,8 +141,8 @@ Used by: [DiagnosticSetting_Spec](#DiagnosticSetting_Spec).
 | enabled         | a value indicating whether this log is enabled.                                                                                                                                                            | bool<br/><small>Required</small>                                |
 | retentionPolicy | the retention policy for this log.                                                                                                                                                                         | [RetentionPolicy](#RetentionPolicy)<br/><small>Optional</small> |
 
-<a id="LogSettings_STATUS"></a>LogSettings_STATUS
--------------------------------------------------
+LogSettings_STATUS{#LogSettings_STATUS}
+---------------------------------------
 
 Part of MultiTenantDiagnosticSettings. Specifies the settings for a particular log.
 
@@ -155,8 +155,8 @@ Used by: [DiagnosticSetting_STATUS](#DiagnosticSetting_STATUS).
 | enabled         | a value indicating whether this log is enabled.                                                                                                                                                            | bool<br/><small>Optional</small>                                              |
 | retentionPolicy | the retention policy for this log.                                                                                                                                                                         | [RetentionPolicy_STATUS](#RetentionPolicy_STATUS)<br/><small>Optional</small> |
 
-<a id="MetricSettings"></a>MetricSettings
------------------------------------------
+MetricSettings{#MetricSettings}
+-------------------------------
 
 Part of MultiTenantDiagnosticSettings. Specifies the settings for a particular metric.
 
@@ -169,8 +169,8 @@ Used by: [DiagnosticSetting_Spec](#DiagnosticSetting_Spec).
 | retentionPolicy | the retention policy for this category.                                                                                                                                                                    | [RetentionPolicy](#RetentionPolicy)<br/><small>Optional</small> |
 | timeGrain       | the timegrain of the metric in ISO8601 format.                                                                                                                                                             | string<br/><small>Optional</small>                              |
 
-<a id="MetricSettings_STATUS"></a>MetricSettings_STATUS
--------------------------------------------------------
+MetricSettings_STATUS{#MetricSettings_STATUS}
+---------------------------------------------
 
 Part of MultiTenantDiagnosticSettings. Specifies the settings for a particular metric.
 
@@ -183,8 +183,8 @@ Used by: [DiagnosticSetting_STATUS](#DiagnosticSetting_STATUS).
 | retentionPolicy | the retention policy for this category.                                                                                                                                                                    | [RetentionPolicy_STATUS](#RetentionPolicy_STATUS)<br/><small>Optional</small> |
 | timeGrain       | the timegrain of the metric in ISO8601 format.                                                                                                                                                             | string<br/><small>Optional</small>                                            |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -199,8 +199,8 @@ Used by: [DiagnosticSetting_STATUS](#DiagnosticSetting_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="RetentionPolicy"></a>RetentionPolicy
--------------------------------------------
+RetentionPolicy{#RetentionPolicy}
+---------------------------------
 
 Specifies the retention policy for the log.
 
@@ -211,8 +211,8 @@ Used by: [LogSettings](#LogSettings), and [MetricSettings](#MetricSettings).
 | days     | the number of days for the retention in days. A value of 0 will retain the events indefinitely. | int<br/><small>Required</small>  |
 | enabled  | a value indicating whether the retention policy is enabled.                                     | bool<br/><small>Required</small> |
 
-<a id="RetentionPolicy_STATUS"></a>RetentionPolicy_STATUS
----------------------------------------------------------
+RetentionPolicy_STATUS{#RetentionPolicy_STATUS}
+-----------------------------------------------
 
 Specifies the retention policy for the log.
 
@@ -223,8 +223,8 @@ Used by: [LogSettings_STATUS](#LogSettings_STATUS), and [MetricSettings_STATUS](
 | days     | the number of days for the retention in days. A value of 0 will retain the events indefinitely. | int<br/><small>Optional</small>  |
 | enabled  | a value indicating whether the retention policy is enabled.                                     | bool<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -235,8 +235,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/insights/v1api20220615.md
+++ b/docs/hugo/content/reference/insights/v1api20220615.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20220615
 linktitle: v1api20220615
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-06-15" |             |
 
-<a id="ScheduledQueryRule"></a>ScheduledQueryRule
--------------------------------------------------
+ScheduledQueryRule{#ScheduledQueryRule}
+---------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2022-06-15/scheduledQueryRule_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/scheduledQueryRules/{ruleName}
 
@@ -26,7 +26,7 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | spec                                                                                    |             | [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ScheduledQueryRule_Spec"></a>ScheduledQueryRule_Spec
+### ScheduledQueryRule_Spec {#ScheduledQueryRule_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,7 +52,7 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | targetResourceTypes                   | List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert | string[]<br/><small>Optional</small>                                                                                                                                 |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ScheduledQueryRule_STATUS"></a>ScheduledQueryRule_STATUS
+### ScheduledQueryRule_STATUS{#ScheduledQueryRule_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                    |
 |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -84,8 +84,8 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ScheduledQueryRuleList"></a>ScheduledQueryRuleList
----------------------------------------------------------
+ScheduledQueryRuleList{#ScheduledQueryRuleList}
+-----------------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2022-06-15/scheduledQueryRule_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/scheduledQueryRules/{ruleName}
 
@@ -95,8 +95,8 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ScheduledQueryRule[]](#ScheduledQueryRule)<br/><small>Optional</small> |
 
-<a id="Webtest"></a>Webtest
----------------------------
+Webtest{#Webtest}
+-----------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/stable/2022-06-15/webTests_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/webtests/{webTestName}
 
@@ -109,7 +109,7 @@ Used by: [WebtestList](#WebtestList).
 | spec                                                                                    |             | [Webtest_Spec](#Webtest_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Webtest_STATUS](#Webtest_STATUS)<br/><small>Optional</small> |
 
-### <a id="Webtest_Spec"></a>Webtest_Spec
+### Webtest_Spec {#Webtest_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -131,7 +131,7 @@ Used by: [WebtestList](#WebtestList).
 | Timeout            | Seconds until this WebTest will timeout and fail. Default value is 30.                                                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                                                                 | [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)<br/><small>Optional</small>                                                                  |
 
-### <a id="Webtest_STATUS"></a>Webtest_STATUS
+### Webtest_STATUS{#Webtest_STATUS}
 
 | Property           | Description                                                                                                                                                                                                                                   | Type                                                                                                                                                    |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -155,8 +155,8 @@ Used by: [WebtestList](#WebtestList).
 | type               | Azure resource type                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                  | [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="WebtestList"></a>WebtestList
------------------------------------
+WebtestList{#WebtestList}
+-------------------------
 
 Generator information: - Generated from: /applicationinsights/resource-manager/Microsoft.Insights/stable/2022-06-15/webTests_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/webtests/{webTestName}
 
@@ -166,8 +166,8 @@ Generator information: - Generated from: /applicationinsights/resource-manager/M
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Webtest[]](#Webtest)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRule_Spec"></a>ScheduledQueryRule_Spec
------------------------------------------------------------
+ScheduledQueryRule_Spec{#ScheduledQueryRule_Spec}
+-------------------------------------------------
 
 Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 
@@ -195,8 +195,8 @@ Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 | targetResourceTypes                   | List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert | string[]<br/><small>Optional</small>                                                                                                                                 |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ScheduledQueryRule_STATUS"></a>ScheduledQueryRule_STATUS
----------------------------------------------------------------
+ScheduledQueryRule_STATUS{#ScheduledQueryRule_STATUS}
+-----------------------------------------------------
 
 Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 
@@ -230,8 +230,8 @@ Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Webtest_Spec"></a>Webtest_Spec
--------------------------------------
+Webtest_Spec{#Webtest_Spec}
+---------------------------
 
 Used by: [Webtest](#Webtest).
 
@@ -255,8 +255,8 @@ Used by: [Webtest](#Webtest).
 | Timeout            | Seconds until this WebTest will timeout and fail. Default value is 30.                                                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                                                                 | [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)<br/><small>Optional</small>                                                                  |
 
-<a id="Webtest_STATUS"></a>Webtest_STATUS
------------------------------------------
+Webtest_STATUS{#Webtest_STATUS}
+-------------------------------
 
 Used by: [Webtest](#Webtest).
 
@@ -282,8 +282,8 @@ Used by: [Webtest](#Webtest).
 | type               | Azure resource type                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 | ValidationRules    | The collection of validation rule properties                                                                                                                                                                                                  | [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="Actions"></a>Actions
----------------------------
+Actions{#Actions}
+-----------------
 
 Actions to invoke when the alert fires.
 
@@ -294,8 +294,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | actionGroupsReferences | Action Group resource Ids to invoke when the alert fires. | [genruntime.ResourceReference[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | customProperties       | The properties of an alert payload.                       | map[string]string<br/><small>Optional</small>                                                                                                                |
 
-<a id="Actions_STATUS"></a>Actions_STATUS
------------------------------------------
+Actions_STATUS{#Actions_STATUS}
+-------------------------------
 
 Actions to invoke when the alert fires.
 
@@ -306,8 +306,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | actionGroups     | Action Group resource Ids to invoke when the alert fires. | string[]<br/><small>Optional</small>          |
 | customProperties | The properties of an alert payload.                       | map[string]string<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRule_Kind_Spec"></a>ScheduledQueryRule_Kind_Spec
----------------------------------------------------------------------
+ScheduledQueryRule_Kind_Spec{#ScheduledQueryRule_Kind_Spec}
+-----------------------------------------------------------
 
 Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 
@@ -316,8 +316,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | "LogAlert"    |             |
 | "LogToMetric" |             |
 
-<a id="ScheduledQueryRule_Kind_STATUS"></a>ScheduledQueryRule_Kind_STATUS
--------------------------------------------------------------------------
+ScheduledQueryRule_Kind_STATUS{#ScheduledQueryRule_Kind_STATUS}
+---------------------------------------------------------------
 
 Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 
@@ -326,8 +326,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | "LogAlert"    |             |
 | "LogToMetric" |             |
 
-<a id="ScheduledQueryRuleCriteria"></a>ScheduledQueryRuleCriteria
------------------------------------------------------------------
+ScheduledQueryRuleCriteria{#ScheduledQueryRuleCriteria}
+-------------------------------------------------------
 
 The rule criteria that defines the conditions of the scheduled query rule.
 
@@ -337,8 +337,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 |----------|---------------------------------------------------------------|-------------------------------------------------------|
 | allOf    | A list of conditions to evaluate against the specified scopes | [Condition[]](#Condition)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleCriteria_STATUS"></a>ScheduledQueryRuleCriteria_STATUS
--------------------------------------------------------------------------------
+ScheduledQueryRuleCriteria_STATUS{#ScheduledQueryRuleCriteria_STATUS}
+---------------------------------------------------------------------
 
 The rule criteria that defines the conditions of the scheduled query rule.
 
@@ -348,8 +348,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 |----------|---------------------------------------------------------------|---------------------------------------------------------------------|
 | allOf    | A list of conditions to evaluate against the specified scopes | [Condition_STATUS[]](#Condition_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleOperatorSpec"></a>ScheduledQueryRuleOperatorSpec
--------------------------------------------------------------------------
+ScheduledQueryRuleOperatorSpec{#ScheduledQueryRuleOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -360,8 +360,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleProperties_Severity"></a>ScheduledQueryRuleProperties_Severity
----------------------------------------------------------------------------------------
+ScheduledQueryRuleProperties_Severity{#ScheduledQueryRuleProperties_Severity}
+-----------------------------------------------------------------------------
 
 Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 
@@ -373,8 +373,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | 3     |             |
 | 4     |             |
 
-<a id="ScheduledQueryRuleProperties_Severity_STATUS"></a>ScheduledQueryRuleProperties_Severity_STATUS
------------------------------------------------------------------------------------------------------
+ScheduledQueryRuleProperties_Severity_STATUS{#ScheduledQueryRuleProperties_Severity_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 
@@ -386,8 +386,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | 3     |             |
 | 4     |             |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -402,8 +402,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="WebTestGeolocation"></a>WebTestGeolocation
--------------------------------------------------
+WebTestGeolocation{#WebTestGeolocation}
+---------------------------------------
 
 Geo-physical location to run a WebTest from. You must specify one or more locations for the test to run from.
 
@@ -413,8 +413,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 |----------|------------------------------------------|------------------------------------|
 | Id       | Location ID for the WebTest to run from. | string<br/><small>Optional</small> |
 
-<a id="WebTestGeolocation_STATUS"></a>WebTestGeolocation_STATUS
----------------------------------------------------------------
+WebTestGeolocation_STATUS{#WebTestGeolocation_STATUS}
+-----------------------------------------------------
 
 Geo-physical location to run a WebTest from. You must specify one or more locations for the test to run from.
 
@@ -424,8 +424,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 |----------|------------------------------------------|------------------------------------|
 | Id       | Location ID for the WebTest to run from. | string<br/><small>Optional</small> |
 
-<a id="WebtestOperatorSpec"></a>WebtestOperatorSpec
----------------------------------------------------
+WebtestOperatorSpec{#WebtestOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -436,8 +436,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Configuration"></a>WebTestProperties_Configuration
----------------------------------------------------------------------------
+WebTestProperties_Configuration{#WebTestProperties_Configuration}
+-----------------------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -445,8 +445,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 |----------|-------------------------------------------------------------------|------------------------------------|
 | WebTest  | The XML specification of a WebTest to run against an application. | string<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Configuration_STATUS"></a>WebTestProperties_Configuration_STATUS
------------------------------------------------------------------------------------------
+WebTestProperties_Configuration_STATUS{#WebTestProperties_Configuration_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -454,8 +454,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 |----------|-------------------------------------------------------------------|------------------------------------|
 | WebTest  | The XML specification of a WebTest to run against an application. | string<br/><small>Optional</small> |
 
-<a id="WebTestProperties_Kind"></a>WebTestProperties_Kind
----------------------------------------------------------
+WebTestProperties_Kind{#WebTestProperties_Kind}
+-----------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -465,8 +465,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | "ping"      |             |
 | "standard"  |             |
 
-<a id="WebTestProperties_Kind_STATUS"></a>WebTestProperties_Kind_STATUS
------------------------------------------------------------------------
+WebTestProperties_Kind_STATUS{#WebTestProperties_Kind_STATUS}
+-------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -476,8 +476,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | "ping"      |             |
 | "standard"  |             |
 
-<a id="WebTestProperties_Request"></a>WebTestProperties_Request
----------------------------------------------------------------
+WebTestProperties_Request{#WebTestProperties_Request}
+-----------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -490,8 +490,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | RequestBody            | Base64 encoded string body to send with this web test.       | string<br/><small>Optional</small>                        |
 | RequestUrl             | Url location to test.                                        | string<br/><small>Optional</small>                        |
 
-<a id="WebTestProperties_Request_STATUS"></a>WebTestProperties_Request_STATUS
------------------------------------------------------------------------------
+WebTestProperties_Request_STATUS{#WebTestProperties_Request_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -504,8 +504,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | RequestBody            | Base64 encoded string body to send with this web test.       | string<br/><small>Optional</small>                                      |
 | RequestUrl             | Url location to test.                                        | string<br/><small>Optional</small>                                      |
 
-<a id="WebTestProperties_ValidationRules"></a>WebTestProperties_ValidationRules
--------------------------------------------------------------------------------
+WebTestProperties_ValidationRules{#WebTestProperties_ValidationRules}
+---------------------------------------------------------------------
 
 Used by: [Webtest_Spec](#Webtest_Spec).
 
@@ -517,8 +517,8 @@ Used by: [Webtest_Spec](#Webtest_Spec).
 | SSLCertRemainingLifetimeCheck | A number of days to check still remain before the the existing SSL cert expires. Value must be positive and the SSLCheck must be set to true. | int<br/><small>Optional</small>                                                                                                         |
 | SSLCheck                      | Checks to see if the SSL cert is still valid.                                                                                                 | bool<br/><small>Optional</small>                                                                                                        |
 
-<a id="WebTestProperties_ValidationRules_STATUS"></a>WebTestProperties_ValidationRules_STATUS
----------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_STATUS{#WebTestProperties_ValidationRules_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Webtest_STATUS](#Webtest_STATUS).
 
@@ -530,8 +530,8 @@ Used by: [Webtest_STATUS](#Webtest_STATUS).
 | SSLCertRemainingLifetimeCheck | A number of days to check still remain before the the existing SSL cert expires. Value must be positive and the SSLCheck must be set to true. | int<br/><small>Optional</small>                                                                                                                       |
 | SSLCheck                      | Checks to see if the SSL cert is still valid.                                                                                                 | bool<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Condition"></a>Condition
--------------------------------
+Condition{#Condition}
+---------------------
 
 A condition of the scheduled query rule.
 
@@ -549,8 +549,8 @@ Used by: [ScheduledQueryRuleCriteria](#ScheduledQueryRuleCriteria).
 | threshold                 | the criteria threshold value that activates the alert. Relevant and required only for rules of the kind LogAlert.                                            | float64<br/><small>Optional</small>                                                                                                                        |
 | timeAggregation           | Aggregation type. Relevant and required only for rules of the kind LogAlert.                                                                                 | [Condition_TimeAggregation](#Condition_TimeAggregation)<br/><small>Optional</small>                                                                        |
 
-<a id="Condition_STATUS"></a>Condition_STATUS
----------------------------------------------
+Condition_STATUS{#Condition_STATUS}
+-----------------------------------
 
 A condition of the scheduled query rule.
 
@@ -568,8 +568,8 @@ Used by: [ScheduledQueryRuleCriteria_STATUS](#ScheduledQueryRuleCriteria_STATUS)
 | threshold           | the criteria threshold value that activates the alert. Relevant and required only for rules of the kind LogAlert.                                            | float64<br/><small>Optional</small>                                                               |
 | timeAggregation     | Aggregation type. Relevant and required only for rules of the kind LogAlert.                                                                                 | [Condition_TimeAggregation_STATUS](#Condition_TimeAggregation_STATUS)<br/><small>Optional</small> |
 
-<a id="HeaderField"></a>HeaderField
------------------------------------
+HeaderField{#HeaderField}
+-------------------------
 
 A header to add to the WebTest.
 
@@ -580,8 +580,8 @@ Used by: [WebTestProperties_Request](#WebTestProperties_Request).
 | key      | The name of the header.  | string<br/><small>Optional</small> |
 | value    | The value of the header. | string<br/><small>Optional</small> |
 
-<a id="HeaderField_STATUS"></a>HeaderField_STATUS
--------------------------------------------------
+HeaderField_STATUS{#HeaderField_STATUS}
+---------------------------------------
 
 A header to add to the WebTest.
 
@@ -592,7 +592,19 @@ Used by: [WebTestProperties_Request_STATUS](#WebTestProperties_Request_STATUS).
 | key      | The name of the header.  | string<br/><small>Optional</small> |
 | value    | The value of the header. | string<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -604,20 +616,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="WebTestProperties_ValidationRules_ContentValidation"></a>WebTestProperties_ValidationRules_ContentValidation
--------------------------------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_ContentValidation{#WebTestProperties_ValidationRules_ContentValidation}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules).
 
@@ -627,8 +627,8 @@ Used by: [WebTestProperties_ValidationRules](#WebTestProperties_ValidationRules)
 | IgnoreCase      | When set, this value makes the ContentMatch validation case insensitive.                                                            | bool<br/><small>Optional</small>   |
 | PassIfTextFound | When true, validation will pass if there is a match for the ContentMatch string. If false, validation will fail if there is a match | bool<br/><small>Optional</small>   |
 
-<a id="WebTestProperties_ValidationRules_ContentValidation_STATUS"></a>WebTestProperties_ValidationRules_ContentValidation_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+WebTestProperties_ValidationRules_ContentValidation_STATUS{#WebTestProperties_ValidationRules_ContentValidation_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_ValidationRules_STATUS).
 
@@ -638,8 +638,8 @@ Used by: [WebTestProperties_ValidationRules_STATUS](#WebTestProperties_Validatio
 | IgnoreCase      | When set, this value makes the ContentMatch validation case insensitive.                                                            | bool<br/><small>Optional</small>   |
 | PassIfTextFound | When true, validation will pass if there is a match for the ContentMatch string. If false, validation will fail if there is a match | bool<br/><small>Optional</small>   |
 
-<a id="Condition_FailingPeriods"></a>Condition_FailingPeriods
--------------------------------------------------------------
+Condition_FailingPeriods{#Condition_FailingPeriods}
+---------------------------------------------------
 
 Used by: [Condition](#Condition).
 
@@ -648,8 +648,8 @@ Used by: [Condition](#Condition).
 | minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
 | numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
 
-<a id="Condition_FailingPeriods_STATUS"></a>Condition_FailingPeriods_STATUS
----------------------------------------------------------------------------
+Condition_FailingPeriods_STATUS{#Condition_FailingPeriods_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Condition_STATUS](#Condition_STATUS).
 
@@ -658,8 +658,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
 | numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
 
-<a id="Condition_Operator"></a>Condition_Operator
--------------------------------------------------
+Condition_Operator{#Condition_Operator}
+---------------------------------------
 
 Used by: [Condition](#Condition).
 
@@ -671,8 +671,8 @@ Used by: [Condition](#Condition).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="Condition_Operator_STATUS"></a>Condition_Operator_STATUS
----------------------------------------------------------------
+Condition_Operator_STATUS{#Condition_Operator_STATUS}
+-----------------------------------------------------
 
 Used by: [Condition_STATUS](#Condition_STATUS).
 
@@ -684,8 +684,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="Condition_TimeAggregation"></a>Condition_TimeAggregation
----------------------------------------------------------------
+Condition_TimeAggregation{#Condition_TimeAggregation}
+-----------------------------------------------------
 
 Used by: [Condition](#Condition).
 
@@ -697,8 +697,8 @@ Used by: [Condition](#Condition).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="Condition_TimeAggregation_STATUS"></a>Condition_TimeAggregation_STATUS
------------------------------------------------------------------------------
+Condition_TimeAggregation_STATUS{#Condition_TimeAggregation_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Condition_STATUS](#Condition_STATUS).
 
@@ -710,8 +710,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="Dimension"></a>Dimension
--------------------------------
+Dimension{#Dimension}
+---------------------
 
 Dimension splitting and filtering definition
 
@@ -723,8 +723,8 @@ Used by: [Condition](#Condition).
 | operator | Operator for dimension values | [Dimension_Operator](#Dimension_Operator)<br/><small>Required</small> |
 | values   | List of dimension values      | string[]<br/><small>Required</small>                                  |
 
-<a id="Dimension_STATUS"></a>Dimension_STATUS
----------------------------------------------
+Dimension_STATUS{#Dimension_STATUS}
+-----------------------------------
 
 Dimension splitting and filtering definition
 
@@ -736,8 +736,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | operator | Operator for dimension values | [Dimension_Operator_STATUS](#Dimension_Operator_STATUS)<br/><small>Optional</small> |
 | values   | List of dimension values      | string[]<br/><small>Optional</small>                                                |
 
-<a id="Dimension_Operator"></a>Dimension_Operator
--------------------------------------------------
+Dimension_Operator{#Dimension_Operator}
+---------------------------------------
 
 Used by: [Dimension](#Dimension).
 
@@ -746,8 +746,8 @@ Used by: [Dimension](#Dimension).
 | "Exclude" |             |
 | "Include" |             |
 
-<a id="Dimension_Operator_STATUS"></a>Dimension_Operator_STATUS
----------------------------------------------------------------
+Dimension_Operator_STATUS{#Dimension_Operator_STATUS}
+-----------------------------------------------------
 
 Used by: [Dimension_STATUS](#Dimension_STATUS).
 

--- a/docs/hugo/content/reference/insights/v1api20221001.md
+++ b/docs/hugo/content/reference/insights/v1api20221001.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20221001
 linktitle: v1api20221001
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-10-01" |             |
 
-<a id="AutoscaleSetting"></a>AutoscaleSetting
----------------------------------------------
+AutoscaleSetting{#AutoscaleSetting}
+-----------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/autoscalesettings/{autoscaleSettingName}
 
@@ -26,7 +26,7 @@ Used by: [AutoscaleSettingList](#AutoscaleSettingList).
 | spec                                                                                    |             | [AutoscaleSetting_Spec](#AutoscaleSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Autoscalesetting_STATUS](#Autoscalesetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="AutoscaleSetting_Spec"></a>AutoscaleSetting_Spec
+### AutoscaleSetting_Spec {#AutoscaleSetting_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -43,7 +43,7 @@ Used by: [AutoscaleSettingList](#AutoscaleSettingList).
 | targetResourceLocation     | the location of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                                   |
 | targetResourceUriReference | the resource identifier of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-### <a id="Autoscalesetting_STATUS"></a>Autoscalesetting_STATUS
+### Autoscalesetting_STATUS{#Autoscalesetting_STATUS}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -62,8 +62,8 @@ Used by: [AutoscaleSettingList](#AutoscaleSettingList).
 | targetResourceUri         | the resource identifier of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Azure resource type                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AutoscaleSettingList"></a>AutoscaleSettingList
------------------------------------------------------
+AutoscaleSettingList{#AutoscaleSettingList}
+-------------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/autoscalesettings/{autoscaleSettingName}
 
@@ -73,8 +73,8 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [AutoscaleSetting[]](#AutoscaleSetting)<br/><small>Optional</small> |
 
-<a id="AutoscaleSetting_Spec"></a>AutoscaleSetting_Spec
--------------------------------------------------------
+AutoscaleSetting_Spec{#AutoscaleSetting_Spec}
+---------------------------------------------
 
 Used by: [AutoscaleSetting](#AutoscaleSetting).
 
@@ -93,8 +93,8 @@ Used by: [AutoscaleSetting](#AutoscaleSetting).
 | targetResourceLocation     | the location of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                                   |
 | targetResourceUriReference | the resource identifier of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                 | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>           |
 
-<a id="Autoscalesetting_STATUS"></a>Autoscalesetting_STATUS
------------------------------------------------------------
+Autoscalesetting_STATUS{#Autoscalesetting_STATUS}
+-------------------------------------------------
 
 Used by: [AutoscaleSetting](#AutoscaleSetting).
 
@@ -115,8 +115,8 @@ Used by: [AutoscaleSetting](#AutoscaleSetting).
 | targetResourceUri         | the resource identifier of the resource that the autoscale setting should be added to.                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Azure resource type                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AutoscaleNotification"></a>AutoscaleNotification
--------------------------------------------------------
+AutoscaleNotification{#AutoscaleNotification}
+---------------------------------------------
 
 Autoscale notification.
 
@@ -128,8 +128,8 @@ Used by: [AutoscaleSetting_Spec](#AutoscaleSetting_Spec).
 | operation | the operation associated with the notification and its value must be "scale" | [AutoscaleNotification_Operation](#AutoscaleNotification_Operation)<br/><small>Required</small> |
 | webhooks  | the collection of webhook notifications.                                     | [WebhookNotification[]](#WebhookNotification)<br/><small>Optional</small>                       |
 
-<a id="AutoscaleNotification_STATUS"></a>AutoscaleNotification_STATUS
----------------------------------------------------------------------
+AutoscaleNotification_STATUS{#AutoscaleNotification_STATUS}
+-----------------------------------------------------------
 
 Autoscale notification.
 
@@ -141,8 +141,8 @@ Used by: [Autoscalesetting_STATUS](#Autoscalesetting_STATUS).
 | operation | the operation associated with the notification and its value must be "scale" | [AutoscaleNotification_Operation_STATUS](#AutoscaleNotification_Operation_STATUS)<br/><small>Optional</small> |
 | webhooks  | the collection of webhook notifications.                                     | [WebhookNotification_STATUS[]](#WebhookNotification_STATUS)<br/><small>Optional</small>                       |
 
-<a id="AutoscaleProfile"></a>AutoscaleProfile
----------------------------------------------
+AutoscaleProfile{#AutoscaleProfile}
+-----------------------------------
 
 Autoscale profile.
 
@@ -156,8 +156,8 @@ Used by: [AutoscaleSetting_Spec](#AutoscaleSetting_Spec).
 | recurrence | the repeating times at which this profile begins. This element is not used if the FixedDate element is used.                     | [Recurrence](#Recurrence)<br/><small>Optional</small>       |
 | rules      | the collection of rules that provide the triggers and parameters for the scaling action. A maximum of 10 rules can be specified. | [ScaleRule[]](#ScaleRule)<br/><small>Required</small>       |
 
-<a id="AutoscaleProfile_STATUS"></a>AutoscaleProfile_STATUS
------------------------------------------------------------
+AutoscaleProfile_STATUS{#AutoscaleProfile_STATUS}
+-------------------------------------------------
 
 Autoscale profile.
 
@@ -171,8 +171,8 @@ Used by: [Autoscalesetting_STATUS](#Autoscalesetting_STATUS).
 | recurrence | the repeating times at which this profile begins. This element is not used if the FixedDate element is used.                     | [Recurrence_STATUS](#Recurrence_STATUS)<br/><small>Optional</small>       |
 | rules      | the collection of rules that provide the triggers and parameters for the scaling action. A maximum of 10 rules can be specified. | [ScaleRule_STATUS[]](#ScaleRule_STATUS)<br/><small>Required</small>       |
 
-<a id="AutoscaleSettingOperatorSpec"></a>AutoscaleSettingOperatorSpec
----------------------------------------------------------------------
+AutoscaleSettingOperatorSpec{#AutoscaleSettingOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -183,8 +183,8 @@ Used by: [AutoscaleSetting_Spec](#AutoscaleSetting_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PredictiveAutoscalePolicy"></a>PredictiveAutoscalePolicy
----------------------------------------------------------------
+PredictiveAutoscalePolicy{#PredictiveAutoscalePolicy}
+-----------------------------------------------------
 
 The parameters for enabling predictive autoscale.
 
@@ -195,8 +195,8 @@ Used by: [AutoscaleSetting_Spec](#AutoscaleSetting_Spec).
 | scaleLookAheadTime | the amount of time to specify by which instances are launched in advance. It must be between 1 minute and 60 minutes in ISO 8601 format. | string<br/><small>Optional</small>                                                                      |
 | scaleMode          | the predictive autoscale mode                                                                                                            | [PredictiveAutoscalePolicy_ScaleMode](#PredictiveAutoscalePolicy_ScaleMode)<br/><small>Required</small> |
 
-<a id="PredictiveAutoscalePolicy_STATUS"></a>PredictiveAutoscalePolicy_STATUS
------------------------------------------------------------------------------
+PredictiveAutoscalePolicy_STATUS{#PredictiveAutoscalePolicy_STATUS}
+-------------------------------------------------------------------
 
 The parameters for enabling predictive autoscale.
 
@@ -207,8 +207,8 @@ Used by: [Autoscalesetting_STATUS](#Autoscalesetting_STATUS).
 | scaleLookAheadTime | the amount of time to specify by which instances are launched in advance. It must be between 1 minute and 60 minutes in ISO 8601 format. | string<br/><small>Optional</small>                                                                                    |
 | scaleMode          | the predictive autoscale mode                                                                                                            | [PredictiveAutoscalePolicy_ScaleMode_STATUS](#PredictiveAutoscalePolicy_ScaleMode_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -223,8 +223,8 @@ Used by: [Autoscalesetting_STATUS](#Autoscalesetting_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="AutoscaleNotification_Operation"></a>AutoscaleNotification_Operation
----------------------------------------------------------------------------
+AutoscaleNotification_Operation{#AutoscaleNotification_Operation}
+-----------------------------------------------------------------
 
 Used by: [AutoscaleNotification](#AutoscaleNotification).
 
@@ -232,8 +232,8 @@ Used by: [AutoscaleNotification](#AutoscaleNotification).
 |---------|-------------|
 | "Scale" |             |
 
-<a id="AutoscaleNotification_Operation_STATUS"></a>AutoscaleNotification_Operation_STATUS
------------------------------------------------------------------------------------------
+AutoscaleNotification_Operation_STATUS{#AutoscaleNotification_Operation_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AutoscaleNotification_STATUS](#AutoscaleNotification_STATUS).
 
@@ -241,8 +241,8 @@ Used by: [AutoscaleNotification_STATUS](#AutoscaleNotification_STATUS).
 |---------|-------------|
 | "Scale" |             |
 
-<a id="EmailNotification"></a>EmailNotification
------------------------------------------------
+EmailNotification{#EmailNotification}
+-------------------------------------
 
 Email notification of an autoscale event.
 
@@ -254,8 +254,8 @@ Used by: [AutoscaleNotification](#AutoscaleNotification).
 | sendToSubscriptionAdministrator    | a value indicating whether to send email to subscription administrator.                                 | bool<br/><small>Optional</small>     |
 | sendToSubscriptionCoAdministrators | a value indicating whether to send email to subscription co-administrators.                             | bool<br/><small>Optional</small>     |
 
-<a id="EmailNotification_STATUS"></a>EmailNotification_STATUS
--------------------------------------------------------------
+EmailNotification_STATUS{#EmailNotification_STATUS}
+---------------------------------------------------
 
 Email notification of an autoscale event.
 
@@ -267,8 +267,8 @@ Used by: [AutoscaleNotification_STATUS](#AutoscaleNotification_STATUS).
 | sendToSubscriptionAdministrator    | a value indicating whether to send email to subscription administrator.                                 | bool<br/><small>Optional</small>     |
 | sendToSubscriptionCoAdministrators | a value indicating whether to send email to subscription co-administrators.                             | bool<br/><small>Optional</small>     |
 
-<a id="PredictiveAutoscalePolicy_ScaleMode"></a>PredictiveAutoscalePolicy_ScaleMode
------------------------------------------------------------------------------------
+PredictiveAutoscalePolicy_ScaleMode{#PredictiveAutoscalePolicy_ScaleMode}
+-------------------------------------------------------------------------
 
 Used by: [PredictiveAutoscalePolicy](#PredictiveAutoscalePolicy).
 
@@ -278,8 +278,8 @@ Used by: [PredictiveAutoscalePolicy](#PredictiveAutoscalePolicy).
 | "Enabled"      |             |
 | "ForecastOnly" |             |
 
-<a id="PredictiveAutoscalePolicy_ScaleMode_STATUS"></a>PredictiveAutoscalePolicy_ScaleMode_STATUS
--------------------------------------------------------------------------------------------------
+PredictiveAutoscalePolicy_ScaleMode_STATUS{#PredictiveAutoscalePolicy_ScaleMode_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [PredictiveAutoscalePolicy_STATUS](#PredictiveAutoscalePolicy_STATUS).
 
@@ -289,8 +289,8 @@ Used by: [PredictiveAutoscalePolicy_STATUS](#PredictiveAutoscalePolicy_STATUS).
 | "Enabled"      |             |
 | "ForecastOnly" |             |
 
-<a id="Recurrence"></a>Recurrence
----------------------------------
+Recurrence{#Recurrence}
+-----------------------
 
 The repeating times at which this profile begins. This element is not used if the FixedDate element is used.
 
@@ -301,8 +301,8 @@ Used by: [AutoscaleProfile](#AutoscaleProfile).
 | frequency | the recurrence frequency. How often the schedule profile should take effect. This value must be Week, meaning each week will have the same set of profiles. For example, to set a daily schedule, set schedule to every day of the week. The frequency property specifies that the schedule is repeated weekly. | [Recurrence_Frequency](#Recurrence_Frequency)<br/><small>Required</small> |
 | schedule  | the scheduling constraints for when the profile begins.                                                                                                                                                                                                                                                         | [RecurrentSchedule](#RecurrentSchedule)<br/><small>Required</small>       |
 
-<a id="Recurrence_STATUS"></a>Recurrence_STATUS
------------------------------------------------
+Recurrence_STATUS{#Recurrence_STATUS}
+-------------------------------------
 
 The repeating times at which this profile begins. This element is not used if the FixedDate element is used.
 
@@ -313,8 +313,8 @@ Used by: [AutoscaleProfile_STATUS](#AutoscaleProfile_STATUS).
 | frequency | the recurrence frequency. How often the schedule profile should take effect. This value must be Week, meaning each week will have the same set of profiles. For example, to set a daily schedule, set schedule to every day of the week. The frequency property specifies that the schedule is repeated weekly. | [Recurrence_Frequency_STATUS](#Recurrence_Frequency_STATUS)<br/><small>Required</small> |
 | schedule  | the scheduling constraints for when the profile begins.                                                                                                                                                                                                                                                         | [RecurrentSchedule_STATUS](#RecurrentSchedule_STATUS)<br/><small>Required</small>       |
 
-<a id="ScaleCapacity"></a>ScaleCapacity
----------------------------------------
+ScaleCapacity{#ScaleCapacity}
+-----------------------------
 
 The number of instances that can be used during this profile.
 
@@ -326,8 +326,8 @@ Used by: [AutoscaleProfile](#AutoscaleProfile).
 | maximum  | the maximum number of instances for the resource. The actual maximum number of instances is limited by the cores that are available in the subscription.                | string<br/><small>Required</small> |
 | minimum  | the minimum number of instances for the resource.                                                                                                                       | string<br/><small>Required</small> |
 
-<a id="ScaleCapacity_STATUS"></a>ScaleCapacity_STATUS
------------------------------------------------------
+ScaleCapacity_STATUS{#ScaleCapacity_STATUS}
+-------------------------------------------
 
 The number of instances that can be used during this profile.
 
@@ -339,8 +339,8 @@ Used by: [AutoscaleProfile_STATUS](#AutoscaleProfile_STATUS).
 | maximum  | the maximum number of instances for the resource. The actual maximum number of instances is limited by the cores that are available in the subscription.                | string<br/><small>Required</small> |
 | minimum  | the minimum number of instances for the resource.                                                                                                                       | string<br/><small>Required</small> |
 
-<a id="ScaleRule"></a>ScaleRule
--------------------------------
+ScaleRule{#ScaleRule}
+---------------------
 
 A rule that provide the triggers and parameters for the scaling action.
 
@@ -351,8 +351,8 @@ Used by: [AutoscaleProfile](#AutoscaleProfile).
 | metricTrigger | the trigger that results in a scaling action. | [MetricTrigger](#MetricTrigger)<br/><small>Required</small> |
 | scaleAction   | the parameters for the scaling action.        | [ScaleAction](#ScaleAction)<br/><small>Required</small>     |
 
-<a id="ScaleRule_STATUS"></a>ScaleRule_STATUS
----------------------------------------------
+ScaleRule_STATUS{#ScaleRule_STATUS}
+-----------------------------------
 
 A rule that provide the triggers and parameters for the scaling action.
 
@@ -363,7 +363,19 @@ Used by: [AutoscaleProfile_STATUS](#AutoscaleProfile_STATUS).
 | metricTrigger | the trigger that results in a scaling action. | [MetricTrigger_STATUS](#MetricTrigger_STATUS)<br/><small>Required</small> |
 | scaleAction   | the parameters for the scaling action.        | [ScaleAction_STATUS](#ScaleAction_STATUS)<br/><small>Required</small>     |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -375,20 +387,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="TimeWindow"></a>TimeWindow
----------------------------------
+TimeWindow{#TimeWindow}
+-----------------------
 
 A specific date-time for the profile.
 
@@ -400,8 +400,8 @@ Used by: [AutoscaleProfile](#AutoscaleProfile).
 | start    | the start time for the profile in ISO 8601 format.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | string<br/><small>Required</small> |
 | timeZone | the timezone of the start and end times for the profile. Some examples of valid time zones are: Dateline Standard Time, UTC-11, Hawaiian Standard Time, Alaskan Standard Time, Pacific Standard Time (Mexico), Pacific Standard Time, US Mountain Standard Time, Mountain Standard Time (Mexico), Mountain Standard Time, Central America Standard Time, Central Standard Time, Central Standard Time (Mexico), Canada Central Standard Time, SA Pacific Standard Time, Eastern Standard Time, US Eastern Standard Time, Venezuela Standard Time, Paraguay Standard Time, Atlantic Standard Time, Central Brazilian Standard Time, SA Western Standard Time, Pacific SA Standard Time, Newfoundland Standard Time, E. South America Standard Time, Argentina Standard Time, SA Eastern Standard Time, Greenland Standard Time, Montevideo Standard Time, Bahia Standard Time, UTC-02, Mid-Atlantic Standard Time, Azores Standard Time, Cape Verde Standard Time, Morocco Standard Time, UTC, GMT Standard Time, Greenwich Standard Time, W. Europe Standard Time, Central Europe Standard Time, Romance Standard Time, Central European Standard Time, W. Central Africa Standard Time, Namibia Standard Time, Jordan Standard Time, GTB Standard Time, Middle East Standard Time, Egypt Standard Time, Syria Standard Time, E. Europe Standard Time, South Africa Standard Time, FLE Standard Time, Turkey Standard Time, Israel Standard Time, Kaliningrad Standard Time, Libya Standard Time, Arabic Standard Time, Arab Standard Time, Belarus Standard Time, Russian Standard Time, E. Africa Standard Time, Iran Standard Time, Arabian Standard Time, Azerbaijan Standard Time, Russia Time Zone 3, Mauritius Standard Time, Georgian Standard Time, Caucasus Standard Time, Afghanistan Standard Time, West Asia Standard Time, Ekaterinburg Standard Time, Pakistan Standard Time, India Standard Time, Sri Lanka Standard Time, Nepal Standard Time, Central Asia Standard Time, Bangladesh Standard Time, N. Central Asia Standard Time, Myanmar Standard Time, SE Asia Standard Time, North Asia Standard Time, China Standard Time, North Asia East Standard Time, Singapore Standard Time, W. Australia Standard Time, Taipei Standard Time, Ulaanbaatar Standard Time, Tokyo Standard Time, Korea Standard Time, Yakutsk Standard Time, Cen. Australia Standard Time, AUS Central Standard Time, E. Australia Standard Time, AUS Eastern Standard Time, West Pacific Standard Time, Tasmania Standard Time, Magadan Standard Time, Vladivostok Standard Time, Russia Time Zone 10, Central Pacific Standard Time, Russia Time Zone 11, New Zealand Standard Time, UTC+12, Fiji Standard Time, Kamchatka Standard Time, Tonga Standard Time, Samoa Standard Time, Line Islands Standard Time | string<br/><small>Optional</small> |
 
-<a id="TimeWindow_STATUS"></a>TimeWindow_STATUS
------------------------------------------------
+TimeWindow_STATUS{#TimeWindow_STATUS}
+-------------------------------------
 
 A specific date-time for the profile.
 
@@ -413,8 +413,8 @@ Used by: [AutoscaleProfile_STATUS](#AutoscaleProfile_STATUS).
 | start    | the start time for the profile in ISO 8601 format.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | string<br/><small>Required</small> |
 | timeZone | the timezone of the start and end times for the profile. Some examples of valid time zones are: Dateline Standard Time, UTC-11, Hawaiian Standard Time, Alaskan Standard Time, Pacific Standard Time (Mexico), Pacific Standard Time, US Mountain Standard Time, Mountain Standard Time (Mexico), Mountain Standard Time, Central America Standard Time, Central Standard Time, Central Standard Time (Mexico), Canada Central Standard Time, SA Pacific Standard Time, Eastern Standard Time, US Eastern Standard Time, Venezuela Standard Time, Paraguay Standard Time, Atlantic Standard Time, Central Brazilian Standard Time, SA Western Standard Time, Pacific SA Standard Time, Newfoundland Standard Time, E. South America Standard Time, Argentina Standard Time, SA Eastern Standard Time, Greenland Standard Time, Montevideo Standard Time, Bahia Standard Time, UTC-02, Mid-Atlantic Standard Time, Azores Standard Time, Cape Verde Standard Time, Morocco Standard Time, UTC, GMT Standard Time, Greenwich Standard Time, W. Europe Standard Time, Central Europe Standard Time, Romance Standard Time, Central European Standard Time, W. Central Africa Standard Time, Namibia Standard Time, Jordan Standard Time, GTB Standard Time, Middle East Standard Time, Egypt Standard Time, Syria Standard Time, E. Europe Standard Time, South Africa Standard Time, FLE Standard Time, Turkey Standard Time, Israel Standard Time, Kaliningrad Standard Time, Libya Standard Time, Arabic Standard Time, Arab Standard Time, Belarus Standard Time, Russian Standard Time, E. Africa Standard Time, Iran Standard Time, Arabian Standard Time, Azerbaijan Standard Time, Russia Time Zone 3, Mauritius Standard Time, Georgian Standard Time, Caucasus Standard Time, Afghanistan Standard Time, West Asia Standard Time, Ekaterinburg Standard Time, Pakistan Standard Time, India Standard Time, Sri Lanka Standard Time, Nepal Standard Time, Central Asia Standard Time, Bangladesh Standard Time, N. Central Asia Standard Time, Myanmar Standard Time, SE Asia Standard Time, North Asia Standard Time, China Standard Time, North Asia East Standard Time, Singapore Standard Time, W. Australia Standard Time, Taipei Standard Time, Ulaanbaatar Standard Time, Tokyo Standard Time, Korea Standard Time, Yakutsk Standard Time, Cen. Australia Standard Time, AUS Central Standard Time, E. Australia Standard Time, AUS Eastern Standard Time, West Pacific Standard Time, Tasmania Standard Time, Magadan Standard Time, Vladivostok Standard Time, Russia Time Zone 10, Central Pacific Standard Time, Russia Time Zone 11, New Zealand Standard Time, UTC+12, Fiji Standard Time, Kamchatka Standard Time, Tonga Standard Time, Samoa Standard Time, Line Islands Standard Time | string<br/><small>Optional</small> |
 
-<a id="WebhookNotification"></a>WebhookNotification
----------------------------------------------------
+WebhookNotification{#WebhookNotification}
+-----------------------------------------
 
 Webhook notification of an autoscale event.
 
@@ -425,8 +425,8 @@ Used by: [AutoscaleNotification](#AutoscaleNotification).
 | properties | a property bag of settings. This value can be empty. | map[string]string<br/><small>Optional</small> |
 | serviceUri | the service address to receive the notification.     | string<br/><small>Optional</small>            |
 
-<a id="WebhookNotification_STATUS"></a>WebhookNotification_STATUS
------------------------------------------------------------------
+WebhookNotification_STATUS{#WebhookNotification_STATUS}
+-------------------------------------------------------
 
 Webhook notification of an autoscale event.
 
@@ -437,8 +437,8 @@ Used by: [AutoscaleNotification_STATUS](#AutoscaleNotification_STATUS).
 | properties | a property bag of settings. This value can be empty. | map[string]string<br/><small>Optional</small> |
 | serviceUri | the service address to receive the notification.     | string<br/><small>Optional</small>            |
 
-<a id="MetricTrigger"></a>MetricTrigger
----------------------------------------
+MetricTrigger{#MetricTrigger}
+-----------------------------
 
 The trigger that results in a scaling action.
 
@@ -459,8 +459,8 @@ Used by: [ScaleRule](#ScaleRule).
 | timeGrain                  | the granularity of metrics the rule monitors. Must be one of the predefined values returned from metric definitions for the metric. Must be between 12 hours and 1 minute.                               | string<br/><small>Required</small>                                                                                                                         |
 | timeWindow                 | the range of time in which instance data is collected. This value must be greater than the delay in metric collection, which can vary from resource-to-resource. Must be between 12 hours and 5 minutes. | string<br/><small>Required</small>                                                                                                                         |
 
-<a id="MetricTrigger_STATUS"></a>MetricTrigger_STATUS
------------------------------------------------------
+MetricTrigger_STATUS{#MetricTrigger_STATUS}
+-------------------------------------------
 
 The trigger that results in a scaling action.
 
@@ -481,8 +481,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | timeGrain              | the granularity of metrics the rule monitors. Must be one of the predefined values returned from metric definitions for the metric. Must be between 12 hours and 1 minute.                               | string<br/><small>Required</small>                                                                        |
 | timeWindow             | the range of time in which instance data is collected. This value must be greater than the delay in metric collection, which can vary from resource-to-resource. Must be between 12 hours and 5 minutes. | string<br/><small>Required</small>                                                                        |
 
-<a id="Recurrence_Frequency"></a>Recurrence_Frequency
------------------------------------------------------
+Recurrence_Frequency{#Recurrence_Frequency}
+-------------------------------------------
 
 Used by: [Recurrence](#Recurrence).
 
@@ -497,8 +497,8 @@ Used by: [Recurrence](#Recurrence).
 | "Week"   |             |
 | "Year"   |             |
 
-<a id="Recurrence_Frequency_STATUS"></a>Recurrence_Frequency_STATUS
--------------------------------------------------------------------
+Recurrence_Frequency_STATUS{#Recurrence_Frequency_STATUS}
+---------------------------------------------------------
 
 Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 
@@ -513,8 +513,8 @@ Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 | "Week"   |             |
 | "Year"   |             |
 
-<a id="RecurrentSchedule"></a>RecurrentSchedule
------------------------------------------------
+RecurrentSchedule{#RecurrentSchedule}
+-------------------------------------
 
 The scheduling constraints for when the profile begins.
 
@@ -527,8 +527,8 @@ Used by: [Recurrence](#Recurrence).
 | minutes  | A collection of minutes at which the profile takes effect at.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | int[]<br/><small>Required</small>    |
 | timeZone | the timezone for the hours of the profile. Some examples of valid time zones are: Dateline Standard Time, UTC-11, Hawaiian Standard Time, Alaskan Standard Time, Pacific Standard Time (Mexico), Pacific Standard Time, US Mountain Standard Time, Mountain Standard Time (Mexico), Mountain Standard Time, Central America Standard Time, Central Standard Time, Central Standard Time (Mexico), Canada Central Standard Time, SA Pacific Standard Time, Eastern Standard Time, US Eastern Standard Time, Venezuela Standard Time, Paraguay Standard Time, Atlantic Standard Time, Central Brazilian Standard Time, SA Western Standard Time, Pacific SA Standard Time, Newfoundland Standard Time, E. South America Standard Time, Argentina Standard Time, SA Eastern Standard Time, Greenland Standard Time, Montevideo Standard Time, Bahia Standard Time, UTC-02, Mid-Atlantic Standard Time, Azores Standard Time, Cape Verde Standard Time, Morocco Standard Time, UTC, GMT Standard Time, Greenwich Standard Time, W. Europe Standard Time, Central Europe Standard Time, Romance Standard Time, Central European Standard Time, W. Central Africa Standard Time, Namibia Standard Time, Jordan Standard Time, GTB Standard Time, Middle East Standard Time, Egypt Standard Time, Syria Standard Time, E. Europe Standard Time, South Africa Standard Time, FLE Standard Time, Turkey Standard Time, Israel Standard Time, Kaliningrad Standard Time, Libya Standard Time, Arabic Standard Time, Arab Standard Time, Belarus Standard Time, Russian Standard Time, E. Africa Standard Time, Iran Standard Time, Arabian Standard Time, Azerbaijan Standard Time, Russia Time Zone 3, Mauritius Standard Time, Georgian Standard Time, Caucasus Standard Time, Afghanistan Standard Time, West Asia Standard Time, Ekaterinburg Standard Time, Pakistan Standard Time, India Standard Time, Sri Lanka Standard Time, Nepal Standard Time, Central Asia Standard Time, Bangladesh Standard Time, N. Central Asia Standard Time, Myanmar Standard Time, SE Asia Standard Time, North Asia Standard Time, China Standard Time, North Asia East Standard Time, Singapore Standard Time, W. Australia Standard Time, Taipei Standard Time, Ulaanbaatar Standard Time, Tokyo Standard Time, Korea Standard Time, Yakutsk Standard Time, Cen. Australia Standard Time, AUS Central Standard Time, E. Australia Standard Time, AUS Eastern Standard Time, West Pacific Standard Time, Tasmania Standard Time, Magadan Standard Time, Vladivostok Standard Time, Russia Time Zone 10, Central Pacific Standard Time, Russia Time Zone 11, New Zealand Standard Time, UTC+12, Fiji Standard Time, Kamchatka Standard Time, Tonga Standard Time, Samoa Standard Time, Line Islands Standard Time | string<br/><small>Required</small>   |
 
-<a id="RecurrentSchedule_STATUS"></a>RecurrentSchedule_STATUS
--------------------------------------------------------------
+RecurrentSchedule_STATUS{#RecurrentSchedule_STATUS}
+---------------------------------------------------
 
 The scheduling constraints for when the profile begins.
 
@@ -541,8 +541,8 @@ Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 | minutes  | A collection of minutes at which the profile takes effect at.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | int[]<br/><small>Required</small>    |
 | timeZone | the timezone for the hours of the profile. Some examples of valid time zones are: Dateline Standard Time, UTC-11, Hawaiian Standard Time, Alaskan Standard Time, Pacific Standard Time (Mexico), Pacific Standard Time, US Mountain Standard Time, Mountain Standard Time (Mexico), Mountain Standard Time, Central America Standard Time, Central Standard Time, Central Standard Time (Mexico), Canada Central Standard Time, SA Pacific Standard Time, Eastern Standard Time, US Eastern Standard Time, Venezuela Standard Time, Paraguay Standard Time, Atlantic Standard Time, Central Brazilian Standard Time, SA Western Standard Time, Pacific SA Standard Time, Newfoundland Standard Time, E. South America Standard Time, Argentina Standard Time, SA Eastern Standard Time, Greenland Standard Time, Montevideo Standard Time, Bahia Standard Time, UTC-02, Mid-Atlantic Standard Time, Azores Standard Time, Cape Verde Standard Time, Morocco Standard Time, UTC, GMT Standard Time, Greenwich Standard Time, W. Europe Standard Time, Central Europe Standard Time, Romance Standard Time, Central European Standard Time, W. Central Africa Standard Time, Namibia Standard Time, Jordan Standard Time, GTB Standard Time, Middle East Standard Time, Egypt Standard Time, Syria Standard Time, E. Europe Standard Time, South Africa Standard Time, FLE Standard Time, Turkey Standard Time, Israel Standard Time, Kaliningrad Standard Time, Libya Standard Time, Arabic Standard Time, Arab Standard Time, Belarus Standard Time, Russian Standard Time, E. Africa Standard Time, Iran Standard Time, Arabian Standard Time, Azerbaijan Standard Time, Russia Time Zone 3, Mauritius Standard Time, Georgian Standard Time, Caucasus Standard Time, Afghanistan Standard Time, West Asia Standard Time, Ekaterinburg Standard Time, Pakistan Standard Time, India Standard Time, Sri Lanka Standard Time, Nepal Standard Time, Central Asia Standard Time, Bangladesh Standard Time, N. Central Asia Standard Time, Myanmar Standard Time, SE Asia Standard Time, North Asia Standard Time, China Standard Time, North Asia East Standard Time, Singapore Standard Time, W. Australia Standard Time, Taipei Standard Time, Ulaanbaatar Standard Time, Tokyo Standard Time, Korea Standard Time, Yakutsk Standard Time, Cen. Australia Standard Time, AUS Central Standard Time, E. Australia Standard Time, AUS Eastern Standard Time, West Pacific Standard Time, Tasmania Standard Time, Magadan Standard Time, Vladivostok Standard Time, Russia Time Zone 10, Central Pacific Standard Time, Russia Time Zone 11, New Zealand Standard Time, UTC+12, Fiji Standard Time, Kamchatka Standard Time, Tonga Standard Time, Samoa Standard Time, Line Islands Standard Time | string<br/><small>Required</small>   |
 
-<a id="ScaleAction"></a>ScaleAction
------------------------------------
+ScaleAction{#ScaleAction}
+-------------------------
 
 The parameters for the scaling action.
 
@@ -555,8 +555,8 @@ Used by: [ScaleRule](#ScaleRule).
 | type      | the type of action that should occur when the scale rule fires.                                                                                | [ScaleAction_Type](#ScaleAction_Type)<br/><small>Required</small>           |
 | value     | the number of instances that are involved in the scaling action. This value must be 1 or greater. The default value is 1.                      | string<br/><small>Optional</small>                                          |
 
-<a id="ScaleAction_STATUS"></a>ScaleAction_STATUS
--------------------------------------------------
+ScaleAction_STATUS{#ScaleAction_STATUS}
+---------------------------------------
 
 The parameters for the scaling action.
 
@@ -569,8 +569,8 @@ Used by: [ScaleRule_STATUS](#ScaleRule_STATUS).
 | type      | the type of action that should occur when the scale rule fires.                                                                                | [ScaleAction_Type_STATUS](#ScaleAction_Type_STATUS)<br/><small>Required</small>           |
 | value     | the number of instances that are involved in the scaling action. This value must be 1 or greater. The default value is 1.                      | string<br/><small>Optional</small>                                                        |
 
-<a id="MetricTrigger_Operator"></a>MetricTrigger_Operator
----------------------------------------------------------
+MetricTrigger_Operator{#MetricTrigger_Operator}
+-----------------------------------------------
 
 Used by: [MetricTrigger](#MetricTrigger).
 
@@ -583,8 +583,8 @@ Used by: [MetricTrigger](#MetricTrigger).
 | "LessThanOrEqual"    |             |
 | "NotEquals"          |             |
 
-<a id="MetricTrigger_Operator_STATUS"></a>MetricTrigger_Operator_STATUS
------------------------------------------------------------------------
+MetricTrigger_Operator_STATUS{#MetricTrigger_Operator_STATUS}
+-------------------------------------------------------------
 
 Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 
@@ -597,8 +597,8 @@ Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 | "LessThanOrEqual"    |             |
 | "NotEquals"          |             |
 
-<a id="MetricTrigger_Statistic"></a>MetricTrigger_Statistic
------------------------------------------------------------
+MetricTrigger_Statistic{#MetricTrigger_Statistic}
+-------------------------------------------------
 
 Used by: [MetricTrigger](#MetricTrigger).
 
@@ -610,8 +610,8 @@ Used by: [MetricTrigger](#MetricTrigger).
 | "Min"     |             |
 | "Sum"     |             |
 
-<a id="MetricTrigger_Statistic_STATUS"></a>MetricTrigger_Statistic_STATUS
--------------------------------------------------------------------------
+MetricTrigger_Statistic_STATUS{#MetricTrigger_Statistic_STATUS}
+---------------------------------------------------------------
 
 Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 
@@ -623,8 +623,8 @@ Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 | "Min"     |             |
 | "Sum"     |             |
 
-<a id="MetricTrigger_TimeAggregation"></a>MetricTrigger_TimeAggregation
------------------------------------------------------------------------
+MetricTrigger_TimeAggregation{#MetricTrigger_TimeAggregation}
+-------------------------------------------------------------
 
 Used by: [MetricTrigger](#MetricTrigger).
 
@@ -637,8 +637,8 @@ Used by: [MetricTrigger](#MetricTrigger).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="MetricTrigger_TimeAggregation_STATUS"></a>MetricTrigger_TimeAggregation_STATUS
--------------------------------------------------------------------------------------
+MetricTrigger_TimeAggregation_STATUS{#MetricTrigger_TimeAggregation_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 
@@ -651,33 +651,33 @@ Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="ScaleAction_Direction"></a>ScaleAction_Direction
--------------------------------------------------------
-
-Used by: [ScaleAction](#ScaleAction).
-
-| Value      | Description |
-|------------|-------------|
-| "Decrease" |             |
-| "Increase" |             |
-| "None"     |             |
-
-<a id="ScaleAction_Direction_STATUS"></a>ScaleAction_Direction_STATUS
----------------------------------------------------------------------
-
-Used by: [ScaleAction_STATUS](#ScaleAction_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Decrease" |             |
-| "Increase" |             |
-| "None"     |             |
-
-<a id="ScaleAction_Type"></a>ScaleAction_Type
+ScaleAction_Direction{#ScaleAction_Direction}
 ---------------------------------------------
 
 Used by: [ScaleAction](#ScaleAction).
 
+| Value      | Description |
+|------------|-------------|
+| "Decrease" |             |
+| "Increase" |             |
+| "None"     |             |
+
+ScaleAction_Direction_STATUS{#ScaleAction_Direction_STATUS}
+-----------------------------------------------------------
+
+Used by: [ScaleAction_STATUS](#ScaleAction_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Decrease" |             |
+| "Increase" |             |
+| "None"     |             |
+
+ScaleAction_Type{#ScaleAction_Type}
+-----------------------------------
+
+Used by: [ScaleAction](#ScaleAction).
+
 | Value                     | Description |
 |---------------------------|-------------|
 | "ChangeCount"             |             |
@@ -685,8 +685,8 @@ Used by: [ScaleAction](#ScaleAction).
 | "PercentChangeCount"      |             |
 | "ServiceAllowedNextValue" |             |
 
-<a id="ScaleAction_Type_STATUS"></a>ScaleAction_Type_STATUS
------------------------------------------------------------
+ScaleAction_Type_STATUS{#ScaleAction_Type_STATUS}
+-------------------------------------------------
 
 Used by: [ScaleAction_STATUS](#ScaleAction_STATUS).
 
@@ -697,8 +697,8 @@ Used by: [ScaleAction_STATUS](#ScaleAction_STATUS).
 | "PercentChangeCount"      |             |
 | "ServiceAllowedNextValue" |             |
 
-<a id="ScaleRuleMetricDimension"></a>ScaleRuleMetricDimension
--------------------------------------------------------------
+ScaleRuleMetricDimension{#ScaleRuleMetricDimension}
+---------------------------------------------------
 
 Specifies an auto scale rule metric dimension.
 
@@ -710,8 +710,8 @@ Used by: [MetricTrigger](#MetricTrigger).
 | Operator      | the dimension operator. Only 'Equals' and 'NotEquals' are supported. 'Equals' being equal to any of the values. 'NotEquals' being not equal to all of the values | [ScaleRuleMetricDimension_Operator](#ScaleRuleMetricDimension_Operator)<br/><small>Required</small> |
 | Values        | list of dimension values. For example: ["App1","App2"].                                                                                                          | string[]<br/><small>Required</small>                                                                |
 
-<a id="ScaleRuleMetricDimension_STATUS"></a>ScaleRuleMetricDimension_STATUS
----------------------------------------------------------------------------
+ScaleRuleMetricDimension_STATUS{#ScaleRuleMetricDimension_STATUS}
+-----------------------------------------------------------------
 
 Specifies an auto scale rule metric dimension.
 
@@ -723,8 +723,8 @@ Used by: [MetricTrigger_STATUS](#MetricTrigger_STATUS).
 | Operator      | the dimension operator. Only 'Equals' and 'NotEquals' are supported. 'Equals' being equal to any of the values. 'NotEquals' being not equal to all of the values | [ScaleRuleMetricDimension_Operator_STATUS](#ScaleRuleMetricDimension_Operator_STATUS)<br/><small>Required</small> |
 | Values        | list of dimension values. For example: ["App1","App2"].                                                                                                          | string[]<br/><small>Required</small>                                                                              |
 
-<a id="ScaleRuleMetricDimension_Operator"></a>ScaleRuleMetricDimension_Operator
--------------------------------------------------------------------------------
+ScaleRuleMetricDimension_Operator{#ScaleRuleMetricDimension_Operator}
+---------------------------------------------------------------------
 
 Used by: [ScaleRuleMetricDimension](#ScaleRuleMetricDimension).
 
@@ -733,8 +733,8 @@ Used by: [ScaleRuleMetricDimension](#ScaleRuleMetricDimension).
 | "Equals"    |             |
 | "NotEquals" |             |
 
-<a id="ScaleRuleMetricDimension_Operator_STATUS"></a>ScaleRuleMetricDimension_Operator_STATUS
----------------------------------------------------------------------------------------------
+ScaleRuleMetricDimension_Operator_STATUS{#ScaleRuleMetricDimension_Operator_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ScaleRuleMetricDimension_STATUS](#ScaleRuleMetricDimension_STATUS).
 

--- a/docs/hugo/content/reference/insights/v1api20230101.md
+++ b/docs/hugo/content/reference/insights/v1api20230101.md
@@ -5,8 +5,8 @@ title: insights.azure.com/v1api20230101
 linktitle: v1api20230101
 ------------------------
 
-<a id="ActionGroup"></a>ActionGroup
------------------------------------
+ActionGroup{#ActionGroup}
+-------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2023-01-01/actionGroups_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/actionGroups/{actionGroupName}
 
@@ -19,7 +19,7 @@ Used by: [ActionGroupList](#ActionGroupList).
 | spec                                                                                    |             | [ActionGroup_Spec](#ActionGroup_Spec)<br/><small>Optional</small>                     |
 | status                                                                                  |             | [ActionGroupResource_STATUS](#ActionGroupResource_STATUS)<br/><small>Optional</small> |
 
-### <a id="ActionGroup_Spec"></a>ActionGroup_Spec
+### ActionGroup_Spec {#ActionGroup_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [ActionGroupList](#ActionGroupList).
 | voiceReceivers             | The list of voice receivers that are part of this action group.                                                                                                                                                                                                                              | [VoiceReceiver[]](#VoiceReceiver)<br/><small>Optional</small>                                                                                                        |
 | webhookReceivers           | The list of webhook receivers that are part of this action group.                                                                                                                                                                                                                            | [WebhookReceiver[]](#WebhookReceiver)<br/><small>Optional</small>                                                                                                    |
 
-### <a id="ActionGroupResource_STATUS"></a>ActionGroupResource_STATUS
+### ActionGroupResource_STATUS{#ActionGroupResource_STATUS}
 
 | Property                   | Description                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -66,8 +66,8 @@ Used by: [ActionGroupList](#ActionGroupList).
 | voiceReceivers             | The list of voice receivers that are part of this action group.                                                                            | [VoiceReceiver_STATUS[]](#VoiceReceiver_STATUS)<br/><small>Optional</small>                                                                             |
 | webhookReceivers           | The list of webhook receivers that are part of this action group.                                                                          | [WebhookReceiver_STATUS[]](#WebhookReceiver_STATUS)<br/><small>Optional</small>                                                                         |
 
-<a id="ActionGroupList"></a>ActionGroupList
--------------------------------------------
+ActionGroupList{#ActionGroupList}
+---------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/stable/2023-01-01/actionGroups_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/actionGroups/{actionGroupName}
 
@@ -77,15 +77,15 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [ActionGroup[]](#ActionGroup)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-01-01" |             |
 
-<a id="ActionGroup_Spec"></a>ActionGroup_Spec
----------------------------------------------
+ActionGroup_Spec{#ActionGroup_Spec}
+-----------------------------------
 
 Used by: [ActionGroup](#ActionGroup).
 
@@ -110,8 +110,8 @@ Used by: [ActionGroup](#ActionGroup).
 | voiceReceivers             | The list of voice receivers that are part of this action group.                                                                                                                                                                                                                              | [VoiceReceiver[]](#VoiceReceiver)<br/><small>Optional</small>                                                                                                        |
 | webhookReceivers           | The list of webhook receivers that are part of this action group.                                                                                                                                                                                                                            | [WebhookReceiver[]](#WebhookReceiver)<br/><small>Optional</small>                                                                                                    |
 
-<a id="ActionGroupResource_STATUS"></a>ActionGroupResource_STATUS
------------------------------------------------------------------
+ActionGroupResource_STATUS{#ActionGroupResource_STATUS}
+-------------------------------------------------------
 
 An action group resource.
 
@@ -139,8 +139,8 @@ Used by: [ActionGroup](#ActionGroup).
 | voiceReceivers             | The list of voice receivers that are part of this action group.                                                                            | [VoiceReceiver_STATUS[]](#VoiceReceiver_STATUS)<br/><small>Optional</small>                                                                             |
 | webhookReceivers           | The list of webhook receivers that are part of this action group.                                                                          | [WebhookReceiver_STATUS[]](#WebhookReceiver_STATUS)<br/><small>Optional</small>                                                                         |
 
-<a id="ActionGroupOperatorSpec"></a>ActionGroupOperatorSpec
------------------------------------------------------------
+ActionGroupOperatorSpec{#ActionGroupOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -151,8 +151,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ArmRoleReceiver"></a>ArmRoleReceiver
--------------------------------------------
+ArmRoleReceiver{#ArmRoleReceiver}
+---------------------------------
 
 An arm role receiver.
 
@@ -164,8 +164,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | roleId               | The arm role id.                                                                                     | string<br/><small>Required</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                        | bool<br/><small>Optional</small>   |
 
-<a id="ArmRoleReceiver_STATUS"></a>ArmRoleReceiver_STATUS
----------------------------------------------------------
+ArmRoleReceiver_STATUS{#ArmRoleReceiver_STATUS}
+-----------------------------------------------
 
 An arm role receiver.
 
@@ -177,8 +177,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | roleId               | The arm role id.                                                                                     | string<br/><small>Optional</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                        | bool<br/><small>Optional</small>   |
 
-<a id="AutomationRunbookReceiver"></a>AutomationRunbookReceiver
----------------------------------------------------------------
+AutomationRunbookReceiver{#AutomationRunbookReceiver}
+-----------------------------------------------------
 
 The Azure Automation Runbook notification receiver.
 
@@ -194,8 +194,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | useCommonAlertSchema     | Indicates whether to use common alert schema.                                                | bool<br/><small>Optional</small>                                                                                                                           |
 | webhookResourceReference | The resource id for webhook linked to this runbook.                                          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="AutomationRunbookReceiver_STATUS"></a>AutomationRunbookReceiver_STATUS
------------------------------------------------------------------------------
+AutomationRunbookReceiver_STATUS{#AutomationRunbookReceiver_STATUS}
+-------------------------------------------------------------------
 
 The Azure Automation Runbook notification receiver.
 
@@ -211,8 +211,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                | bool<br/><small>Optional</small>   |
 | webhookResourceId    | The resource id for webhook linked to this runbook.                                          | string<br/><small>Optional</small> |
 
-<a id="AzureAppPushReceiver"></a>AzureAppPushReceiver
------------------------------------------------------
+AzureAppPushReceiver{#AzureAppPushReceiver}
+-------------------------------------------
 
 The Azure mobile App push notification receiver.
 
@@ -223,8 +223,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | emailAddress | The email address registered for the Azure mobile app.                                                            | string<br/><small>Required</small> |
 | name         | The name of the Azure mobile app push receiver. Names must be unique across all receivers within an action group. | string<br/><small>Required</small> |
 
-<a id="AzureAppPushReceiver_STATUS"></a>AzureAppPushReceiver_STATUS
--------------------------------------------------------------------
+AzureAppPushReceiver_STATUS{#AzureAppPushReceiver_STATUS}
+---------------------------------------------------------
 
 The Azure mobile App push notification receiver.
 
@@ -235,8 +235,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | emailAddress | The email address registered for the Azure mobile app.                                                            | string<br/><small>Optional</small> |
 | name         | The name of the Azure mobile app push receiver. Names must be unique across all receivers within an action group. | string<br/><small>Optional</small> |
 
-<a id="AzureFunctionReceiver"></a>AzureFunctionReceiver
--------------------------------------------------------
+AzureFunctionReceiver{#AzureFunctionReceiver}
+---------------------------------------------
 
 An azure function receiver.
 
@@ -250,8 +250,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | name                         | The name of the azure function receiver. Names must be unique across all receivers within an action group. | string<br/><small>Required</small>                                                                                                                         |
 | useCommonAlertSchema         | Indicates whether to use common alert schema.                                                              | bool<br/><small>Optional</small>                                                                                                                           |
 
-<a id="AzureFunctionReceiver_STATUS"></a>AzureFunctionReceiver_STATUS
----------------------------------------------------------------------
+AzureFunctionReceiver_STATUS{#AzureFunctionReceiver_STATUS}
+-----------------------------------------------------------
 
 An azure function receiver.
 
@@ -265,8 +265,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | name                  | The name of the azure function receiver. Names must be unique across all receivers within an action group. | string<br/><small>Optional</small> |
 | useCommonAlertSchema  | Indicates whether to use common alert schema.                                                              | bool<br/><small>Optional</small>   |
 
-<a id="EmailReceiver"></a>EmailReceiver
----------------------------------------
+EmailReceiver{#EmailReceiver}
+-----------------------------
 
 An email receiver.
 
@@ -278,8 +278,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | name                 | The name of the email receiver. Names must be unique across all receivers within an action group. | string<br/><small>Required</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                     | bool<br/><small>Optional</small>   |
 
-<a id="EmailReceiver_STATUS"></a>EmailReceiver_STATUS
------------------------------------------------------
+EmailReceiver_STATUS{#EmailReceiver_STATUS}
+-------------------------------------------
 
 An email receiver.
 
@@ -292,8 +292,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | status               | The receiver status of the e-mail.                                                                | [ReceiverStatus_STATUS](#ReceiverStatus_STATUS)<br/><small>Optional</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                     | bool<br/><small>Optional</small>                                            |
 
-<a id="EventHubReceiver"></a>EventHubReceiver
----------------------------------------------
+EventHubReceiver{#EventHubReceiver}
+-----------------------------------
 
 An Event hub receiver.
 
@@ -308,8 +308,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | tenantId             | The tenant Id for the subscription containing this event hub                                          | string<br/><small>Optional</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                         | bool<br/><small>Optional</small>   |
 
-<a id="EventHubReceiver_STATUS"></a>EventHubReceiver_STATUS
------------------------------------------------------------
+EventHubReceiver_STATUS{#EventHubReceiver_STATUS}
+-------------------------------------------------
 
 An Event hub receiver.
 
@@ -324,8 +324,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | tenantId             | The tenant Id for the subscription containing this event hub                                          | string<br/><small>Optional</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                         | bool<br/><small>Optional</small>   |
 
-<a id="ItsmReceiver"></a>ItsmReceiver
--------------------------------------
+ItsmReceiver{#ItsmReceiver}
+---------------------------
 
 An Itsm receiver.
 
@@ -339,8 +339,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | ticketConfiguration | JSON blob for the configurations of the ITSM action. CreateMultipleWorkItems option will be part of this blob as well.                                                              | string<br/><small>Required</small> |
 | workspaceId         | OMS LA instance identifier.                                                                                                                                                         | string<br/><small>Required</small> |
 
-<a id="ItsmReceiver_STATUS"></a>ItsmReceiver_STATUS
----------------------------------------------------
+ItsmReceiver_STATUS{#ItsmReceiver_STATUS}
+-----------------------------------------
 
 An Itsm receiver.
 
@@ -354,8 +354,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | ticketConfiguration | JSON blob for the configurations of the ITSM action. CreateMultipleWorkItems option will be part of this blob as well.                                                              | string<br/><small>Optional</small> |
 | workspaceId         | OMS LA instance identifier.                                                                                                                                                         | string<br/><small>Optional</small> |
 
-<a id="LogicAppReceiver"></a>LogicAppReceiver
----------------------------------------------
+LogicAppReceiver{#LogicAppReceiver}
+-----------------------------------
 
 A logic app receiver.
 
@@ -368,8 +368,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | resourceReference    | The azure resource id of the logic app receiver.                                                      | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                         | bool<br/><small>Optional</small>                                                                                                                           |
 
-<a id="LogicAppReceiver_STATUS"></a>LogicAppReceiver_STATUS
------------------------------------------------------------
+LogicAppReceiver_STATUS{#LogicAppReceiver_STATUS}
+-------------------------------------------------
 
 A logic app receiver.
 
@@ -382,8 +382,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | resourceId           | The azure resource id of the logic app receiver.                                                      | string<br/><small>Optional</small> |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                         | bool<br/><small>Optional</small>   |
 
-<a id="SmsReceiver"></a>SmsReceiver
------------------------------------
+SmsReceiver{#SmsReceiver}
+-------------------------
 
 An SMS receiver.
 
@@ -395,8 +395,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | name        | The name of the SMS receiver. Names must be unique across all receivers within an action group. | string<br/><small>Required</small> |
 | phoneNumber | The phone number of the SMS receiver.                                                           | string<br/><small>Required</small> |
 
-<a id="SmsReceiver_STATUS"></a>SmsReceiver_STATUS
--------------------------------------------------
+SmsReceiver_STATUS{#SmsReceiver_STATUS}
+---------------------------------------
 
 An SMS receiver.
 
@@ -409,8 +409,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | phoneNumber | The phone number of the SMS receiver.                                                           | string<br/><small>Optional</small>                                          |
 | status      | The status of the receiver.                                                                     | [ReceiverStatus_STATUS](#ReceiverStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="VoiceReceiver"></a>VoiceReceiver
----------------------------------------
+VoiceReceiver{#VoiceReceiver}
+-----------------------------
 
 A voice receiver.
 
@@ -422,8 +422,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | name        | The name of the voice receiver. Names must be unique across all receivers within an action group. | string<br/><small>Required</small> |
 | phoneNumber | The phone number of the voice receiver.                                                           | string<br/><small>Required</small> |
 
-<a id="VoiceReceiver_STATUS"></a>VoiceReceiver_STATUS
------------------------------------------------------
+VoiceReceiver_STATUS{#VoiceReceiver_STATUS}
+-------------------------------------------
 
 A voice receiver.
 
@@ -435,8 +435,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | name        | The name of the voice receiver. Names must be unique across all receivers within an action group. | string<br/><small>Optional</small> |
 | phoneNumber | The phone number of the voice receiver.                                                           | string<br/><small>Optional</small> |
 
-<a id="WebhookReceiver"></a>WebhookReceiver
--------------------------------------------
+WebhookReceiver{#WebhookReceiver}
+---------------------------------
 
 A webhook receiver.
 
@@ -452,8 +452,8 @@ Used by: [ActionGroup_Spec](#ActionGroup_Spec).
 | useAadAuth           | Indicates whether or not use AAD authentication.                                                    | bool<br/><small>Optional</small>   |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                       | bool<br/><small>Optional</small>   |
 
-<a id="WebhookReceiver_STATUS"></a>WebhookReceiver_STATUS
----------------------------------------------------------
+WebhookReceiver_STATUS{#WebhookReceiver_STATUS}
+-----------------------------------------------
 
 A webhook receiver.
 
@@ -469,8 +469,8 @@ Used by: [ActionGroupResource_STATUS](#ActionGroupResource_STATUS).
 | useAadAuth           | Indicates whether or not use AAD authentication.                                                    | bool<br/><small>Optional</small>   |
 | useCommonAlertSchema | Indicates whether to use common alert schema.                                                       | bool<br/><small>Optional</small>   |
 
-<a id="ReceiverStatus_STATUS"></a>ReceiverStatus_STATUS
--------------------------------------------------------
+ReceiverStatus_STATUS{#ReceiverStatus_STATUS}
+---------------------------------------------
 
 Indicates the status of the receiver. Receivers that are not Enabled will not receive any communications.
 

--- a/docs/hugo/content/reference/insights/v1api20240101preview.md
+++ b/docs/hugo/content/reference/insights/v1api20240101preview.md
@@ -5,15 +5,15 @@ title: insights.azure.com/v1api20240101preview
 linktitle: v1api20240101preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2024-01-01-preview" |             |
 
-<a id="ScheduledQueryRule"></a>ScheduledQueryRule
--------------------------------------------------
+ScheduledQueryRule{#ScheduledQueryRule}
+---------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/preview/2024-01-01-preview/scheduledQueryRule_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/scheduledQueryRules/{ruleName}
 
@@ -26,7 +26,7 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | spec                                                                                    |             | [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ScheduledQueryRule_Spec"></a>ScheduledQueryRule_Spec
+### ScheduledQueryRule_Spec {#ScheduledQueryRule_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -54,7 +54,7 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | targetResourceTypes                   | List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert | string[]<br/><small>Optional</small>                                                                                                                                 |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ScheduledQueryRule_STATUS"></a>ScheduledQueryRule_STATUS
+### ScheduledQueryRule_STATUS{#ScheduledQueryRule_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                    |
 |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -88,8 +88,8 @@ Used by: [ScheduledQueryRuleList](#ScheduledQueryRuleList).
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ScheduledQueryRuleList"></a>ScheduledQueryRuleList
----------------------------------------------------------
+ScheduledQueryRuleList{#ScheduledQueryRuleList}
+-----------------------------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Insights/preview/2024-01-01-preview/scheduledQueryRule_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Insights/scheduledQueryRules/{ruleName}
 
@@ -99,8 +99,8 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Ins
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ScheduledQueryRule[]](#ScheduledQueryRule)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRule_Spec"></a>ScheduledQueryRule_Spec
------------------------------------------------------------
+ScheduledQueryRule_Spec{#ScheduledQueryRule_Spec}
+-------------------------------------------------
 
 Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 
@@ -130,8 +130,8 @@ Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 | targetResourceTypes                   | List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert | string[]<br/><small>Optional</small>                                                                                                                                 |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ScheduledQueryRule_STATUS"></a>ScheduledQueryRule_STATUS
----------------------------------------------------------------
+ScheduledQueryRule_STATUS{#ScheduledQueryRule_STATUS}
+-----------------------------------------------------
 
 Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 
@@ -167,8 +167,8 @@ Used by: [ScheduledQueryRule](#ScheduledQueryRule).
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 | windowSize                            | The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Actions"></a>Actions
----------------------------
+Actions{#Actions}
+-----------------
 
 Actions to invoke when the alert fires.
 
@@ -180,8 +180,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | actionProperties       | The properties of an action properties.                   | map[string]string<br/><small>Optional</small>                                                                                                                |
 | customProperties       | The properties of an alert payload.                       | map[string]string<br/><small>Optional</small>                                                                                                                |
 
-<a id="Actions_STATUS"></a>Actions_STATUS
------------------------------------------
+Actions_STATUS{#Actions_STATUS}
+-------------------------------
 
 Actions to invoke when the alert fires.
 
@@ -193,8 +193,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | actionProperties | The properties of an action properties.                   | map[string]string<br/><small>Optional</small> |
 | customProperties | The properties of an alert payload.                       | map[string]string<br/><small>Optional</small> |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -205,8 +205,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | type                   | Type of managed service identity.                                                                                                                                                                                                                                                                                                                                                           | [Identity_Type](#Identity_Type)<br/><small>Required</small>                               |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -219,8 +219,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | type                   | Type of managed service identity.                                                                                                                                                                                                                                                                                                                                                           | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                              |
 | userAssignedIdentities | The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]UserIdentityProperties_STATUS](#UserIdentityProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="RuleResolveConfiguration"></a>RuleResolveConfiguration
--------------------------------------------------------------
+RuleResolveConfiguration{#RuleResolveConfiguration}
+---------------------------------------------------
 
 TBD. Relevant only for rules of the kind LogAlert.
 
@@ -231,42 +231,42 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | autoResolved  | The flag that indicates whether or not to auto resolve a fired alert.                                                                  | bool<br/><small>Optional</small>   |
 | timeToResolve | The duration a rule must evaluate as healthy before the fired alert is automatically resolved represented in ISO 8601 duration format. | string<br/><small>Optional</small> |
 
-<a id="RuleResolveConfiguration_STATUS"></a>RuleResolveConfiguration_STATUS
----------------------------------------------------------------------------
-
-TBD. Relevant only for rules of the kind LogAlert.
-
-Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
-
-| Property      | Description                                                                                                                            | Type                               |
-|---------------|----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| autoResolved  | The flag that indicates whether or not to auto resolve a fired alert.                                                                  | bool<br/><small>Optional</small>   |
-| timeToResolve | The duration a rule must evaluate as healthy before the fired alert is automatically resolved represented in ISO 8601 duration format. | string<br/><small>Optional</small> |
-
-<a id="ScheduledQueryRule_Kind_Spec"></a>ScheduledQueryRule_Kind_Spec
----------------------------------------------------------------------
-
-Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
-
-| Value           | Description |
-|-----------------|-------------|
-| "EventLogAlert" |             |
-| "LogAlert"      |             |
-| "LogToMetric"   |             |
-
-<a id="ScheduledQueryRule_Kind_STATUS"></a>ScheduledQueryRule_Kind_STATUS
--------------------------------------------------------------------------
-
-Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
-
-| Value           | Description |
-|-----------------|-------------|
-| "EventLogAlert" |             |
-| "LogAlert"      |             |
-| "LogToMetric"   |             |
-
-<a id="ScheduledQueryRuleCriteria"></a>ScheduledQueryRuleCriteria
+RuleResolveConfiguration_STATUS{#RuleResolveConfiguration_STATUS}
 -----------------------------------------------------------------
+
+TBD. Relevant only for rules of the kind LogAlert.
+
+Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
+
+| Property      | Description                                                                                                                            | Type                               |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| autoResolved  | The flag that indicates whether or not to auto resolve a fired alert.                                                                  | bool<br/><small>Optional</small>   |
+| timeToResolve | The duration a rule must evaluate as healthy before the fired alert is automatically resolved represented in ISO 8601 duration format. | string<br/><small>Optional</small> |
+
+ScheduledQueryRule_Kind_Spec{#ScheduledQueryRule_Kind_Spec}
+-----------------------------------------------------------
+
+Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
+
+| Value           | Description |
+|-----------------|-------------|
+| "EventLogAlert" |             |
+| "LogAlert"      |             |
+| "LogToMetric"   |             |
+
+ScheduledQueryRule_Kind_STATUS{#ScheduledQueryRule_Kind_STATUS}
+---------------------------------------------------------------
+
+Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
+
+| Value           | Description |
+|-----------------|-------------|
+| "EventLogAlert" |             |
+| "LogAlert"      |             |
+| "LogToMetric"   |             |
+
+ScheduledQueryRuleCriteria{#ScheduledQueryRuleCriteria}
+-------------------------------------------------------
 
 The rule criteria that defines the conditions of the scheduled query rule.
 
@@ -276,8 +276,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 |----------|---------------------------------------------------------------|-------------------------------------------------------|
 | allOf    | A list of conditions to evaluate against the specified scopes | [Condition[]](#Condition)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleCriteria_STATUS"></a>ScheduledQueryRuleCriteria_STATUS
--------------------------------------------------------------------------------
+ScheduledQueryRuleCriteria_STATUS{#ScheduledQueryRuleCriteria_STATUS}
+---------------------------------------------------------------------
 
 The rule criteria that defines the conditions of the scheduled query rule.
 
@@ -287,8 +287,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 |----------|---------------------------------------------------------------|---------------------------------------------------------------------|
 | allOf    | A list of conditions to evaluate against the specified scopes | [Condition_STATUS[]](#Condition_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleOperatorSpec"></a>ScheduledQueryRuleOperatorSpec
--------------------------------------------------------------------------
+ScheduledQueryRuleOperatorSpec{#ScheduledQueryRuleOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -299,8 +299,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ScheduledQueryRuleProperties_Severity"></a>ScheduledQueryRuleProperties_Severity
----------------------------------------------------------------------------------------
+ScheduledQueryRuleProperties_Severity{#ScheduledQueryRuleProperties_Severity}
+-----------------------------------------------------------------------------
 
 Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 
@@ -312,8 +312,8 @@ Used by: [ScheduledQueryRule_Spec](#ScheduledQueryRule_Spec).
 | 3     |             |
 | 4     |             |
 
-<a id="ScheduledQueryRuleProperties_Severity_STATUS"></a>ScheduledQueryRuleProperties_Severity_STATUS
------------------------------------------------------------------------------------------------------
+ScheduledQueryRuleProperties_Severity_STATUS{#ScheduledQueryRuleProperties_Severity_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 
@@ -325,8 +325,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | 3     |             |
 | 4     |             |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -341,8 +341,8 @@ Used by: [ScheduledQueryRule_STATUS](#ScheduledQueryRule_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Condition"></a>Condition
--------------------------------
+Condition{#Condition}
+---------------------
 
 A condition of the scheduled query rule.
 
@@ -363,8 +363,8 @@ Used by: [ScheduledQueryRuleCriteria](#ScheduledQueryRuleCriteria).
 | threshold                 | the criteria threshold value that activates the alert. Relevant and required only for static threshold rules of the kind LogAlert.                                                                                                                          | float64<br/><small>Optional</small>                                                                                                                        |
 | timeAggregation           | Aggregation type. Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                | [Condition_TimeAggregation](#Condition_TimeAggregation)<br/><small>Optional</small>                                                                        |
 
-<a id="Condition_STATUS"></a>Condition_STATUS
----------------------------------------------
+Condition_STATUS{#Condition_STATUS}
+-----------------------------------
 
 A condition of the scheduled query rule.
 
@@ -385,8 +385,8 @@ Used by: [ScheduledQueryRuleCriteria_STATUS](#ScheduledQueryRuleCriteria_STATUS)
 | threshold           | the criteria threshold value that activates the alert. Relevant and required only for static threshold rules of the kind LogAlert.                                                                                                                          | float64<br/><small>Optional</small>                                                               |
 | timeAggregation     | Aggregation type. Relevant and required only for rules of the kind LogAlert.                                                                                                                                                                                | [Condition_TimeAggregation_STATUS](#Condition_TimeAggregation_STATUS)<br/><small>Optional</small> |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -396,8 +396,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -407,7 +407,19 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -419,20 +431,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -442,8 +442,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentityProperties_STATUS"></a>UserIdentityProperties_STATUS
------------------------------------------------------------------------
+UserIdentityProperties_STATUS{#UserIdentityProperties_STATUS}
+-------------------------------------------------------------
 
 User assigned identity properties.
 
@@ -454,51 +454,51 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="Condition_CriterionType"></a>Condition_CriterionType
------------------------------------------------------------
-
-Used by: [Condition](#Condition).
-
-| Value                       | Description |
-|-----------------------------|-------------|
-| "DynamicThresholdCriterion" |             |
-| "StaticThresholdCriterion"  |             |
-
-<a id="Condition_CriterionType_STATUS"></a>Condition_CriterionType_STATUS
--------------------------------------------------------------------------
-
-Used by: [Condition_STATUS](#Condition_STATUS).
-
-| Value                       | Description |
-|-----------------------------|-------------|
-| "DynamicThresholdCriterion" |             |
-| "StaticThresholdCriterion"  |             |
-
-<a id="Condition_FailingPeriods"></a>Condition_FailingPeriods
--------------------------------------------------------------
-
-Used by: [Condition](#Condition).
-
-| Property                  | Description                                                                                                                                                                                         | Type                            |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
-| numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
-
-<a id="Condition_FailingPeriods_STATUS"></a>Condition_FailingPeriods_STATUS
----------------------------------------------------------------------------
-
-Used by: [Condition_STATUS](#Condition_STATUS).
-
-| Property                  | Description                                                                                                                                                                                         | Type                            |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
-| numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
-
-<a id="Condition_Operator"></a>Condition_Operator
+Condition_CriterionType{#Condition_CriterionType}
 -------------------------------------------------
 
 Used by: [Condition](#Condition).
 
+| Value                       | Description |
+|-----------------------------|-------------|
+| "DynamicThresholdCriterion" |             |
+| "StaticThresholdCriterion"  |             |
+
+Condition_CriterionType_STATUS{#Condition_CriterionType_STATUS}
+---------------------------------------------------------------
+
+Used by: [Condition_STATUS](#Condition_STATUS).
+
+| Value                       | Description |
+|-----------------------------|-------------|
+| "DynamicThresholdCriterion" |             |
+| "StaticThresholdCriterion"  |             |
+
+Condition_FailingPeriods{#Condition_FailingPeriods}
+---------------------------------------------------
+
+Used by: [Condition](#Condition).
+
+| Property                  | Description                                                                                                                                                                                         | Type                            |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
+| numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
+
+Condition_FailingPeriods_STATUS{#Condition_FailingPeriods_STATUS}
+-----------------------------------------------------------------
+
+Used by: [Condition_STATUS](#Condition_STATUS).
+
+| Property                  | Description                                                                                                                                                                                         | Type                            |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| minFailingPeriodsToAlert  | The number of violations to trigger an alert. Should be smaller or equal to numberOfEvaluationPeriods. Default value is 1                                                                           | int<br/><small>Optional</small> |
+| numberOfEvaluationPeriods | The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (windowSize) and the selected number of aggregated points. Default value is 1 | int<br/><small>Optional</small> |
+
+Condition_Operator{#Condition_Operator}
+---------------------------------------
+
+Used by: [Condition](#Condition).
+
 | Value                | Description |
 |----------------------|-------------|
 | "Equals"             |             |
@@ -508,8 +508,8 @@ Used by: [Condition](#Condition).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="Condition_Operator_STATUS"></a>Condition_Operator_STATUS
----------------------------------------------------------------
+Condition_Operator_STATUS{#Condition_Operator_STATUS}
+-----------------------------------------------------
 
 Used by: [Condition_STATUS](#Condition_STATUS).
 
@@ -522,8 +522,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | "LessThan"           |             |
 | "LessThanOrEqual"    |             |
 
-<a id="Condition_TimeAggregation"></a>Condition_TimeAggregation
----------------------------------------------------------------
+Condition_TimeAggregation{#Condition_TimeAggregation}
+-----------------------------------------------------
 
 Used by: [Condition](#Condition).
 
@@ -535,8 +535,8 @@ Used by: [Condition](#Condition).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="Condition_TimeAggregation_STATUS"></a>Condition_TimeAggregation_STATUS
------------------------------------------------------------------------------
+Condition_TimeAggregation_STATUS{#Condition_TimeAggregation_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Condition_STATUS](#Condition_STATUS).
 
@@ -548,8 +548,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | "Minimum" |             |
 | "Total"   |             |
 
-<a id="Dimension"></a>Dimension
--------------------------------
+Dimension{#Dimension}
+---------------------
 
 Dimension splitting and filtering definition
 
@@ -561,8 +561,8 @@ Used by: [Condition](#Condition).
 | operator | Operator for dimension values | [Dimension_Operator](#Dimension_Operator)<br/><small>Required</small> |
 | values   | List of dimension values      | string[]<br/><small>Required</small>                                  |
 
-<a id="Dimension_STATUS"></a>Dimension_STATUS
----------------------------------------------
+Dimension_STATUS{#Dimension_STATUS}
+-----------------------------------
 
 Dimension splitting and filtering definition
 
@@ -574,8 +574,8 @@ Used by: [Condition_STATUS](#Condition_STATUS).
 | operator | Operator for dimension values | [Dimension_Operator_STATUS](#Dimension_Operator_STATUS)<br/><small>Optional</small> |
 | values   | List of dimension values      | string[]<br/><small>Optional</small>                                                |
 
-<a id="Dimension_Operator"></a>Dimension_Operator
--------------------------------------------------
+Dimension_Operator{#Dimension_Operator}
+---------------------------------------
 
 Used by: [Dimension](#Dimension).
 
@@ -584,8 +584,8 @@ Used by: [Dimension](#Dimension).
 | "Exclude" |             |
 | "Include" |             |
 
-<a id="Dimension_Operator_STATUS"></a>Dimension_Operator_STATUS
----------------------------------------------------------------
+Dimension_Operator_STATUS{#Dimension_Operator_STATUS}
+-----------------------------------------------------
 
 Used by: [Dimension_STATUS](#Dimension_STATUS).
 

--- a/docs/hugo/content/reference/keyvault/v1api20210401preview.md
+++ b/docs/hugo/content/reference/keyvault/v1api20210401preview.md
@@ -5,15 +5,15 @@ title: keyvault.azure.com/v1api20210401preview
 linktitle: v1api20210401preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2021-04-01-preview" |             |
 
-<a id="Vault"></a>Vault
------------------------
+Vault{#Vault}
+-------------
 
 Generator information: - Generated from: /keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keyvault.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -26,7 +26,7 @@ Used by: [VaultList](#VaultList).
 | spec                                                                                    |             | [Vault_Spec](#Vault_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Vault_STATUS](#Vault_STATUS)<br/><small>Optional</small> |
 
-### <a id="Vault_Spec"></a>Vault_Spec
+### Vault_Spec {#Vault_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [VaultList](#VaultList).
 | properties   | Properties of the vault                                                                                                                                                                                                                                                                      | [VaultProperties](#VaultProperties)<br/><small>Required</small>                                                                                                      |
 | tags         | The tags that will be assigned to the key vault.                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Vault_STATUS"></a>Vault_STATUS
+### Vault_STATUS{#Vault_STATUS}
 
 | Property   | Description                                           | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,8 +50,8 @@ Used by: [VaultList](#VaultList).
 | tags       | Tags assigned to the key vault resource.              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type of the key vault resource.              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VaultList"></a>VaultList
--------------------------------
+VaultList{#VaultList}
+---------------------
 
 Generator information: - Generated from: /keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keyvault.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -61,8 +61,8 @@ Generator information: - Generated from: /keyvault/resource-manager/Microsoft.Ke
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Vault[]](#Vault)<br/><small>Optional</small> |
 
-<a id="Vault_Spec"></a>Vault_Spec
----------------------------------
+Vault_Spec{#Vault_Spec}
+-----------------------
 
 Used by: [Vault](#Vault).
 
@@ -75,8 +75,8 @@ Used by: [Vault](#Vault).
 | properties   | Properties of the vault                                                                                                                                                                                                                                                                      | [VaultProperties](#VaultProperties)<br/><small>Required</small>                                                                                                      |
 | tags         | The tags that will be assigned to the key vault.                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Vault_STATUS"></a>Vault_STATUS
--------------------------------------
+Vault_STATUS{#Vault_STATUS}
+---------------------------
 
 Resource information with extended details.
 
@@ -93,8 +93,8 @@ Used by: [Vault](#Vault).
 | tags       | Tags assigned to the key vault resource.              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type of the key vault resource.              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the key vault resource.
 
@@ -109,8 +109,8 @@ Used by: [Vault_STATUS](#Vault_STATUS).
 | lastModifiedBy     | The identity that last modified the key vault resource.          | string<br/><small>Optional</small>                                      |
 | lastModifiedByType | The type of identity that last modified the key vault resource.  | [IdentityType_STATUS](#IdentityType_STATUS)<br/><small>Optional</small> |
 
-<a id="VaultOperatorSpec"></a>VaultOperatorSpec
------------------------------------------------
+VaultOperatorSpec{#VaultOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -121,8 +121,8 @@ Used by: [Vault_Spec](#Vault_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VaultProperties"></a>VaultProperties
--------------------------------------------
+VaultProperties{#VaultProperties}
+---------------------------------
 
 Properties of the vault
 
@@ -146,8 +146,8 @@ Used by: [Vault_Spec](#Vault_Spec).
 | tenantIdFromConfig           | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                                                                                                                                                                                                                                                                                                                                                                                    | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | vaultUri                     | The URI of the vault for performing operations on keys and secrets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="VaultProperties_STATUS"></a>VaultProperties_STATUS
----------------------------------------------------------
+VaultProperties_STATUS{#VaultProperties_STATUS}
+-----------------------------------------------
 
 Properties of the vault
 
@@ -172,8 +172,8 @@ Used by: [Vault_STATUS](#Vault_STATUS).
 | tenantId                     | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                                                                                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                |
 | vaultUri                     | The URI of the vault for performing operations on keys and secrets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                |
 
-<a id="AccessPolicyEntry"></a>AccessPolicyEntry
------------------------------------------------
+AccessPolicyEntry{#AccessPolicyEntry}
+-------------------------------------
 
 An identity that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
 
@@ -189,8 +189,8 @@ Used by: [VaultProperties](#VaultProperties).
 | tenantId                | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | string<br/><small>Optional</small>                                                                                                                           |
 | tenantIdFromConfig      | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="AccessPolicyEntry_STATUS"></a>AccessPolicyEntry_STATUS
--------------------------------------------------------------
+AccessPolicyEntry_STATUS{#AccessPolicyEntry_STATUS}
+---------------------------------------------------
 
 An identity that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
 
@@ -203,8 +203,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | permissions   | Permissions the identity has for keys, secrets and certificates.                                                                                                               | [Permissions_STATUS](#Permissions_STATUS)<br/><small>Optional</small> |
 | tenantId      | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | string<br/><small>Optional</small>                                    |
 
-<a id="IdentityType_STATUS"></a>IdentityType_STATUS
----------------------------------------------------
+IdentityType_STATUS{#IdentityType_STATUS}
+-----------------------------------------
 
 The type of identity.
 
@@ -217,8 +217,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS), and [SystemData_STATUS](#Syste
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 A set of rules governing the network accessibility of a vault.
 
@@ -231,8 +231,8 @@ Used by: [VaultProperties](#VaultProperties).
 | ipRules             | The list of IP address rules.                                                                                                                    | [IPRule[]](#IPRule)<br/><small>Optional</small>                                           |
 | virtualNetworkRules | The list of virtual network rules.                                                                                                               | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                   |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 A set of rules governing the network accessibility of a vault.
 
@@ -245,8 +245,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | ipRules             | The list of IP address rules.                                                                                                                    | [IPRule_STATUS[]](#IPRule_STATUS)<br/><small>Optional</small>                                           |
 | virtualNetworkRules | The list of virtual network rules.                                                                                                               | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateEndpointConnectionItem_STATUS"></a>PrivateEndpointConnectionItem_STATUS
--------------------------------------------------------------------------------------
+PrivateEndpointConnectionItem_STATUS{#PrivateEndpointConnectionItem_STATUS}
+---------------------------------------------------------------------------
 
 Private endpoint connection item.
 
@@ -260,8 +260,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | privateLinkServiceConnectionState | Approval state of the private link connection.                                   | [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectionState_STATUS)<br/><small>Optional</small>                   |
 | provisioningState                 | Provisioning state of the private endpoint connection.                           | [PrivateEndpointConnectionProvisioningState_STATUS](#PrivateEndpointConnectionProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU details
 
@@ -272,8 +272,8 @@ Used by: [VaultProperties](#VaultProperties).
 | family   | SKU family name                                                                   | [Sku_Family](#Sku_Family)<br/><small>Required</small> |
 | name     | SKU name to specify whether the key vault is a standard vault or a premium vault. | [Sku_Name](#Sku_Name)<br/><small>Required</small>     |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU details
 
@@ -284,8 +284,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | family   | SKU family name                                                                   | [Sku_Family_STATUS](#Sku_Family_STATUS)<br/><small>Optional</small> |
 | name     | SKU name to specify whether the key vault is a standard vault or a premium vault. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small>     |
 
-<a id="VaultProperties_CreateMode"></a>VaultProperties_CreateMode
------------------------------------------------------------------
+VaultProperties_CreateMode{#VaultProperties_CreateMode}
+-------------------------------------------------------
 
 Used by: [VaultProperties](#VaultProperties).
 
@@ -296,8 +296,8 @@ Used by: [VaultProperties](#VaultProperties).
 | "purgeThenCreate" |             |
 | "recover"         |             |
 
-<a id="VaultProperties_CreateMode_STATUS"></a>VaultProperties_CreateMode_STATUS
--------------------------------------------------------------------------------
+VaultProperties_CreateMode_STATUS{#VaultProperties_CreateMode_STATUS}
+---------------------------------------------------------------------
 
 Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 
@@ -308,8 +308,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | "purgeThenCreate" |             |
 | "recover"         |             |
 
-<a id="VaultProperties_ProvisioningState"></a>VaultProperties_ProvisioningState
--------------------------------------------------------------------------------
+VaultProperties_ProvisioningState{#VaultProperties_ProvisioningState}
+---------------------------------------------------------------------
 
 Used by: [VaultProperties](#VaultProperties).
 
@@ -318,8 +318,8 @@ Used by: [VaultProperties](#VaultProperties).
 | "RegisteringDns" |             |
 | "Succeeded"      |             |
 
-<a id="VaultProperties_ProvisioningState_STATUS"></a>VaultProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+VaultProperties_ProvisioningState_STATUS{#VaultProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 
@@ -328,8 +328,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | "RegisteringDns" |             |
 | "Succeeded"      |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 A rule governing the accessibility of a vault from a specific ip address or ip range.
 
@@ -339,8 +339,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). | string<br/><small>Required</small> |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 A rule governing the accessibility of a vault from a specific ip address or ip range.
 
@@ -350,8 +350,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet_Bypass"></a>NetworkRuleSet_Bypass
--------------------------------------------------------
+NetworkRuleSet_Bypass{#NetworkRuleSet_Bypass}
+---------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -360,8 +360,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_Bypass_STATUS"></a>NetworkRuleSet_Bypass_STATUS
----------------------------------------------------------------------
+NetworkRuleSet_Bypass_STATUS{#NetworkRuleSet_Bypass_STATUS}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -370,8 +370,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -380,8 +380,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -390,8 +390,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="Permissions"></a>Permissions
------------------------------------
+Permissions{#Permissions}
+-------------------------
 
 Permissions the identity has for keys, secrets, certificates and storage.
 
@@ -404,8 +404,8 @@ Used by: [AccessPolicyEntry](#AccessPolicyEntry).
 | secrets      | Permissions to secrets          | [Permissions_Secrets[]](#Permissions_Secrets)<br/><small>Optional</small>           |
 | storage      | Permissions to storage accounts | [Permissions_Storage[]](#Permissions_Storage)<br/><small>Optional</small>           |
 
-<a id="Permissions_STATUS"></a>Permissions_STATUS
--------------------------------------------------
+Permissions_STATUS{#Permissions_STATUS}
+---------------------------------------
 
 Permissions the identity has for keys, secrets, certificates and storage.
 
@@ -418,8 +418,8 @@ Used by: [AccessPolicyEntry_STATUS](#AccessPolicyEntry_STATUS).
 | secrets      | Permissions to secrets          | [Permissions_Secrets_STATUS[]](#Permissions_Secrets_STATUS)<br/><small>Optional</small>           |
 | storage      | Permissions to storage accounts | [Permissions_Storage_STATUS[]](#Permissions_Storage_STATUS)<br/><small>Optional</small>           |
 
-<a id="PrivateEndpoint_STATUS"></a>PrivateEndpoint_STATUS
----------------------------------------------------------
+PrivateEndpoint_STATUS{#PrivateEndpoint_STATUS}
+-----------------------------------------------
 
 Private endpoint object properties.
 
@@ -429,8 +429,8 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 |----------|---------------------------------------------------|------------------------------------|
 | id       | Full identifier of the private endpoint resource. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnectionProvisioningState_STATUS"></a>PrivateEndpointConnectionProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnectionProvisioningState_STATUS{#PrivateEndpointConnectionProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -445,8 +445,8 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 | "Succeeded"    |             |
 | "Updating"     |             |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 An object that represents the approval state of the private link connection.
 
@@ -458,37 +458,37 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 | description     | The reason for approval or rejection.                                                           | string<br/><small>Optional</small>                                                                                                                |
 | status          | Indicates whether the connection has been approved, rejected or removed by the key vault owner. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small>                       |
 
-<a id="Sku_Family"></a>Sku_Family
+Sku_Family{#Sku_Family}
+-----------------------
+
+Used by: [Sku](#Sku).
+
+| Value | Description |
+|-------|-------------|
+| "A"   |             |
+
+Sku_Family_STATUS{#Sku_Family_STATUS}
+-------------------------------------
+
+Used by: [Sku_STATUS](#Sku_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "A"   |             |
+
+Sku_Name{#Sku_Name}
+-------------------
+
+Used by: [Sku](#Sku).
+
+| Value      | Description |
+|------------|-------------|
+| "premium"  |             |
+| "standard" |             |
+
+Sku_Name_STATUS{#Sku_Name_STATUS}
 ---------------------------------
 
-Used by: [Sku](#Sku).
-
-| Value | Description |
-|-------|-------------|
-| "A"   |             |
-
-<a id="Sku_Family_STATUS"></a>Sku_Family_STATUS
------------------------------------------------
-
-Used by: [Sku_STATUS](#Sku_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "A"   |             |
-
-<a id="Sku_Name"></a>Sku_Name
------------------------------
-
-Used by: [Sku](#Sku).
-
-| Value      | Description |
-|------------|-------------|
-| "premium"  |             |
-| "standard" |             |
-
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
-
 Used by: [Sku_STATUS](#Sku_STATUS).
 
 | Value      | Description |
@@ -496,8 +496,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "premium"  |             |
 | "standard" |             |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 A rule governing the accessibility of a vault from a specific virtual network.
 
@@ -508,8 +508,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | ignoreMissingVnetServiceEndpoint | Property to specify whether NRP will ignore the check if parent subnet has serviceEndpoints configured.                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                        | Full resource id of a vnet subnet, such as '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;subid/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;rg1/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 A rule governing the accessibility of a vault from a specific virtual network.
 
@@ -520,8 +520,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | id                               | Full resource id of a vnet subnet, such as '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;subid/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;rg1/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. | string<br/><small>Optional</small> |
 | ignoreMissingVnetServiceEndpoint | Property to specify whether NRP will ignore the check if parent subnet has serviceEndpoints configured.                                                                                                                                                     | bool<br/><small>Optional</small>   |
 
-<a id="Permissions_Certificates"></a>Permissions_Certificates
--------------------------------------------------------------
+Permissions_Certificates{#Permissions_Certificates}
+---------------------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -544,8 +544,8 @@ Used by: [Permissions](#Permissions).
 | "setissuers"     |             |
 | "update"         |             |
 
-<a id="Permissions_Certificates_STATUS"></a>Permissions_Certificates_STATUS
----------------------------------------------------------------------------
+Permissions_Certificates_STATUS{#Permissions_Certificates_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -568,8 +568,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "setissuers"     |             |
 | "update"         |             |
 
-<a id="Permissions_Keys"></a>Permissions_Keys
----------------------------------------------
+Permissions_Keys{#Permissions_Keys}
+-----------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -593,8 +593,8 @@ Used by: [Permissions](#Permissions).
 | "verify"    |             |
 | "wrapKey"   |             |
 
-<a id="Permissions_Keys_STATUS"></a>Permissions_Keys_STATUS
------------------------------------------------------------
+Permissions_Keys_STATUS{#Permissions_Keys_STATUS}
+-------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -618,8 +618,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "verify"    |             |
 | "wrapKey"   |             |
 
-<a id="Permissions_Secrets"></a>Permissions_Secrets
----------------------------------------------------
+Permissions_Secrets{#Permissions_Secrets}
+-----------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -634,8 +634,8 @@ Used by: [Permissions](#Permissions).
 | "restore" |             |
 | "set"     |             |
 
-<a id="Permissions_Secrets_STATUS"></a>Permissions_Secrets_STATUS
------------------------------------------------------------------
+Permissions_Secrets_STATUS{#Permissions_Secrets_STATUS}
+-------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -650,8 +650,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "restore" |             |
 | "set"     |             |
 
-<a id="Permissions_Storage"></a>Permissions_Storage
----------------------------------------------------
+Permissions_Storage{#Permissions_Storage}
+-----------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -672,8 +672,8 @@ Used by: [Permissions](#Permissions).
 | "setsas"        |             |
 | "update"        |             |
 
-<a id="Permissions_Storage_STATUS"></a>Permissions_Storage_STATUS
------------------------------------------------------------------
+Permissions_Storage_STATUS{#Permissions_Storage_STATUS}
+-------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -694,8 +694,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "setsas"        |             |
 | "update"        |             |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -708,8 +708,8 @@ Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectio
 | "Pending"      |             |
 | "Rejected"     |             |
 
-<a id="PrivateLinkServiceConnectionState_ActionsRequired_STATUS"></a>PrivateLinkServiceConnectionState_ActionsRequired_STATUS
------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_ActionsRequired_STATUS{#PrivateLinkServiceConnectionState_ActionsRequired_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectionState_STATUS).
 

--- a/docs/hugo/content/reference/keyvault/v1api20230701.md
+++ b/docs/hugo/content/reference/keyvault/v1api20230701.md
@@ -5,15 +5,15 @@ title: keyvault.azure.com/v1api20230701
 linktitle: v1api20230701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-07-01" |             |
 
-<a id="Vault"></a>Vault
------------------------
+Vault{#Vault}
+-------------
 
 Generator information: - Generated from: /keyvault/resource-manager/Microsoft.KeyVault/stable/2023-07-01/keyvault.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -26,7 +26,7 @@ Used by: [VaultList](#VaultList).
 | spec                                                                                    |             | [Vault_Spec](#Vault_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Vault_STATUS](#Vault_STATUS)<br/><small>Optional</small> |
 
-### <a id="Vault_Spec"></a>Vault_Spec
+### Vault_Spec {#Vault_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [VaultList](#VaultList).
 | properties   | Properties of the vault                                                                                                                                                                                                                                                                      | [VaultProperties](#VaultProperties)<br/><small>Required</small>                                                                                                      |
 | tags         | The tags that will be assigned to the key vault.                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Vault_STATUS"></a>Vault_STATUS
+### Vault_STATUS{#Vault_STATUS}
 
 | Property   | Description                                           | Type                                                                                                                                                    |
 |------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,8 +50,8 @@ Used by: [VaultList](#VaultList).
 | tags       | Tags assigned to the key vault resource.              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type of the key vault resource.              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VaultList"></a>VaultList
--------------------------------
+VaultList{#VaultList}
+---------------------
 
 Generator information: - Generated from: /keyvault/resource-manager/Microsoft.KeyVault/stable/2023-07-01/keyvault.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KeyVault/vaults/{vaultName}
 
@@ -61,8 +61,8 @@ Generator information: - Generated from: /keyvault/resource-manager/Microsoft.Ke
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Vault[]](#Vault)<br/><small>Optional</small> |
 
-<a id="Vault_Spec"></a>Vault_Spec
----------------------------------
+Vault_Spec{#Vault_Spec}
+-----------------------
 
 Used by: [Vault](#Vault).
 
@@ -75,8 +75,8 @@ Used by: [Vault](#Vault).
 | properties   | Properties of the vault                                                                                                                                                                                                                                                                      | [VaultProperties](#VaultProperties)<br/><small>Required</small>                                                                                                      |
 | tags         | The tags that will be assigned to the key vault.                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Vault_STATUS"></a>Vault_STATUS
--------------------------------------
+Vault_STATUS{#Vault_STATUS}
+---------------------------
 
 Resource information with extended details.
 
@@ -93,8 +93,8 @@ Used by: [Vault](#Vault).
 | tags       | Tags assigned to the key vault resource.              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | Resource type of the key vault resource.              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the key vault resource.
 
@@ -109,8 +109,8 @@ Used by: [Vault_STATUS](#Vault_STATUS).
 | lastModifiedBy     | The identity that last modified the key vault resource.          | string<br/><small>Optional</small>                                      |
 | lastModifiedByType | The type of identity that last modified the key vault resource.  | [IdentityType_STATUS](#IdentityType_STATUS)<br/><small>Optional</small> |
 
-<a id="VaultOperatorSpec"></a>VaultOperatorSpec
------------------------------------------------
+VaultOperatorSpec{#VaultOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -121,8 +121,8 @@ Used by: [Vault_Spec](#Vault_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VaultProperties"></a>VaultProperties
--------------------------------------------
+VaultProperties{#VaultProperties}
+---------------------------------
 
 Properties of the vault
 
@@ -147,8 +147,8 @@ Used by: [Vault_Spec](#Vault_Spec).
 | tenantIdFromConfig           | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                                                                                                                                                                                                                                                                                                                                                                                    | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | vaultUri                     | The URI of the vault for performing operations on keys and secrets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="VaultProperties_STATUS"></a>VaultProperties_STATUS
----------------------------------------------------------
+VaultProperties_STATUS{#VaultProperties_STATUS}
+-----------------------------------------------
 
 Properties of the vault
 
@@ -174,8 +174,8 @@ Used by: [Vault_STATUS](#Vault_STATUS).
 | tenantId                     | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                                                                                                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                |
 | vaultUri                     | The URI of the vault for performing operations on keys and secrets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                |
 
-<a id="AccessPolicyEntry"></a>AccessPolicyEntry
------------------------------------------------
+AccessPolicyEntry{#AccessPolicyEntry}
+-------------------------------------
 
 An identity that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
 
@@ -191,8 +191,8 @@ Used by: [VaultProperties](#VaultProperties).
 | tenantId                | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | string<br/><small>Optional</small>                                                                                                                           |
 | tenantIdFromConfig      | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="AccessPolicyEntry_STATUS"></a>AccessPolicyEntry_STATUS
--------------------------------------------------------------
+AccessPolicyEntry_STATUS{#AccessPolicyEntry_STATUS}
+---------------------------------------------------
 
 An identity that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
 
@@ -205,8 +205,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | permissions   | Permissions the identity has for keys, secrets and certificates.                                                                                                               | [Permissions_STATUS](#Permissions_STATUS)<br/><small>Optional</small> |
 | tenantId      | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.                                                                         | string<br/><small>Optional</small>                                    |
 
-<a id="IdentityType_STATUS"></a>IdentityType_STATUS
----------------------------------------------------
+IdentityType_STATUS{#IdentityType_STATUS}
+-----------------------------------------
 
 The type of identity.
 
@@ -219,8 +219,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS), and [SystemData_STATUS](#Syste
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 A set of rules governing the network accessibility of a vault.
 
@@ -233,8 +233,8 @@ Used by: [VaultProperties](#VaultProperties).
 | ipRules             | The list of IP address rules.                                                                                                                    | [IPRule[]](#IPRule)<br/><small>Optional</small>                                           |
 | virtualNetworkRules | The list of virtual network rules.                                                                                                               | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                   |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 A set of rules governing the network accessibility of a vault.
 
@@ -247,8 +247,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | ipRules             | The list of IP address rules.                                                                                                                    | [IPRule_STATUS[]](#IPRule_STATUS)<br/><small>Optional</small>                                           |
 | virtualNetworkRules | The list of virtual network rules.                                                                                                               | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateEndpointConnectionItem_STATUS"></a>PrivateEndpointConnectionItem_STATUS
--------------------------------------------------------------------------------------
+PrivateEndpointConnectionItem_STATUS{#PrivateEndpointConnectionItem_STATUS}
+---------------------------------------------------------------------------
 
 Private endpoint connection item.
 
@@ -262,8 +262,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | privateLinkServiceConnectionState | Approval state of the private link connection.                                   | [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectionState_STATUS)<br/><small>Optional</small>                   |
 | provisioningState                 | Provisioning state of the private endpoint connection.                           | [PrivateEndpointConnectionProvisioningState_STATUS](#PrivateEndpointConnectionProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 SKU details
 
@@ -274,8 +274,8 @@ Used by: [VaultProperties](#VaultProperties).
 | family   | SKU family name                                                                   | [Sku_Family](#Sku_Family)<br/><small>Required</small> |
 | name     | SKU name to specify whether the key vault is a standard vault or a premium vault. | [Sku_Name](#Sku_Name)<br/><small>Required</small>     |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 SKU details
 
@@ -286,8 +286,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | family   | SKU family name                                                                   | [Sku_Family_STATUS](#Sku_Family_STATUS)<br/><small>Optional</small> |
 | name     | SKU name to specify whether the key vault is a standard vault or a premium vault. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small>     |
 
-<a id="VaultProperties_CreateMode"></a>VaultProperties_CreateMode
------------------------------------------------------------------
+VaultProperties_CreateMode{#VaultProperties_CreateMode}
+-------------------------------------------------------
 
 Used by: [VaultProperties](#VaultProperties).
 
@@ -298,8 +298,8 @@ Used by: [VaultProperties](#VaultProperties).
 | "purgeThenCreate" |             |
 | "recover"         |             |
 
-<a id="VaultProperties_CreateMode_STATUS"></a>VaultProperties_CreateMode_STATUS
--------------------------------------------------------------------------------
+VaultProperties_CreateMode_STATUS{#VaultProperties_CreateMode_STATUS}
+---------------------------------------------------------------------
 
 Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 
@@ -310,8 +310,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | "purgeThenCreate" |             |
 | "recover"         |             |
 
-<a id="VaultProperties_ProvisioningState"></a>VaultProperties_ProvisioningState
--------------------------------------------------------------------------------
+VaultProperties_ProvisioningState{#VaultProperties_ProvisioningState}
+---------------------------------------------------------------------
 
 Used by: [VaultProperties](#VaultProperties).
 
@@ -320,8 +320,8 @@ Used by: [VaultProperties](#VaultProperties).
 | "RegisteringDns" |             |
 | "Succeeded"      |             |
 
-<a id="VaultProperties_ProvisioningState_STATUS"></a>VaultProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+VaultProperties_ProvisioningState_STATUS{#VaultProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 
@@ -330,8 +330,8 @@ Used by: [VaultProperties_STATUS](#VaultProperties_STATUS).
 | "RegisteringDns" |             |
 | "Succeeded"      |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 A rule governing the accessibility of a vault from a specific ip address or ip range.
 
@@ -341,8 +341,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). | string<br/><small>Required</small> |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 A rule governing the accessibility of a vault from a specific ip address or ip range.
 
@@ -352,8 +352,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). | string<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet_Bypass"></a>NetworkRuleSet_Bypass
--------------------------------------------------------
+NetworkRuleSet_Bypass{#NetworkRuleSet_Bypass}
+---------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -362,8 +362,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_Bypass_STATUS"></a>NetworkRuleSet_Bypass_STATUS
----------------------------------------------------------------------
+NetworkRuleSet_Bypass_STATUS{#NetworkRuleSet_Bypass_STATUS}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -372,8 +372,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "AzureServices" |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -382,8 +382,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -392,8 +392,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="Permissions"></a>Permissions
------------------------------------
+Permissions{#Permissions}
+-------------------------
 
 Permissions the identity has for keys, secrets, certificates and storage.
 
@@ -406,8 +406,8 @@ Used by: [AccessPolicyEntry](#AccessPolicyEntry).
 | secrets      | Permissions to secrets          | [Permissions_Secrets[]](#Permissions_Secrets)<br/><small>Optional</small>           |
 | storage      | Permissions to storage accounts | [Permissions_Storage[]](#Permissions_Storage)<br/><small>Optional</small>           |
 
-<a id="Permissions_STATUS"></a>Permissions_STATUS
--------------------------------------------------
+Permissions_STATUS{#Permissions_STATUS}
+---------------------------------------
 
 Permissions the identity has for keys, secrets, certificates and storage.
 
@@ -420,8 +420,8 @@ Used by: [AccessPolicyEntry_STATUS](#AccessPolicyEntry_STATUS).
 | secrets      | Permissions to secrets          | [Permissions_Secrets_STATUS[]](#Permissions_Secrets_STATUS)<br/><small>Optional</small>           |
 | storage      | Permissions to storage accounts | [Permissions_Storage_STATUS[]](#Permissions_Storage_STATUS)<br/><small>Optional</small>           |
 
-<a id="PrivateEndpoint_STATUS"></a>PrivateEndpoint_STATUS
----------------------------------------------------------
+PrivateEndpoint_STATUS{#PrivateEndpoint_STATUS}
+-----------------------------------------------
 
 Private endpoint object properties.
 
@@ -431,8 +431,8 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 |----------|---------------------------------------------------|------------------------------------|
 | id       | Full identifier of the private endpoint resource. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnectionProvisioningState_STATUS"></a>PrivateEndpointConnectionProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnectionProvisioningState_STATUS{#PrivateEndpointConnectionProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -447,8 +447,8 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 | "Succeeded"    |             |
 | "Updating"     |             |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 An object that represents the approval state of the private link connection.
 
@@ -460,37 +460,37 @@ Used by: [PrivateEndpointConnectionItem_STATUS](#PrivateEndpointConnectionItem_S
 | description     | The reason for approval or rejection.                                                           | string<br/><small>Optional</small>                                                                                                                |
 | status          | Indicates whether the connection has been approved, rejected or removed by the key vault owner. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small>                       |
 
-<a id="Sku_Family"></a>Sku_Family
+Sku_Family{#Sku_Family}
+-----------------------
+
+Used by: [Sku](#Sku).
+
+| Value | Description |
+|-------|-------------|
+| "A"   |             |
+
+Sku_Family_STATUS{#Sku_Family_STATUS}
+-------------------------------------
+
+Used by: [Sku_STATUS](#Sku_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "A"   |             |
+
+Sku_Name{#Sku_Name}
+-------------------
+
+Used by: [Sku](#Sku).
+
+| Value      | Description |
+|------------|-------------|
+| "premium"  |             |
+| "standard" |             |
+
+Sku_Name_STATUS{#Sku_Name_STATUS}
 ---------------------------------
 
-Used by: [Sku](#Sku).
-
-| Value | Description |
-|-------|-------------|
-| "A"   |             |
-
-<a id="Sku_Family_STATUS"></a>Sku_Family_STATUS
------------------------------------------------
-
-Used by: [Sku_STATUS](#Sku_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "A"   |             |
-
-<a id="Sku_Name"></a>Sku_Name
------------------------------
-
-Used by: [Sku](#Sku).
-
-| Value      | Description |
-|------------|-------------|
-| "premium"  |             |
-| "standard" |             |
-
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
-
 Used by: [Sku_STATUS](#Sku_STATUS).
 
 | Value      | Description |
@@ -498,8 +498,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "premium"  |             |
 | "standard" |             |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 A rule governing the accessibility of a vault from a specific virtual network.
 
@@ -510,8 +510,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | ignoreMissingVnetServiceEndpoint | Property to specify whether NRP will ignore the check if parent subnet has serviceEndpoints configured.                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                           |
 | reference                        | Full resource id of a vnet subnet, such as '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;subid/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;rg1/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 A rule governing the accessibility of a vault from a specific virtual network.
 
@@ -522,8 +522,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | id                               | Full resource id of a vnet subnet, such as '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;subid/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;rg1/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. | string<br/><small>Optional</small> |
 | ignoreMissingVnetServiceEndpoint | Property to specify whether NRP will ignore the check if parent subnet has serviceEndpoints configured.                                                                                                                                                     | bool<br/><small>Optional</small>   |
 
-<a id="Permissions_Certificates"></a>Permissions_Certificates
--------------------------------------------------------------
+Permissions_Certificates{#Permissions_Certificates}
+---------------------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -547,8 +547,8 @@ Used by: [Permissions](#Permissions).
 | "setissuers"     |             |
 | "update"         |             |
 
-<a id="Permissions_Certificates_STATUS"></a>Permissions_Certificates_STATUS
----------------------------------------------------------------------------
+Permissions_Certificates_STATUS{#Permissions_Certificates_STATUS}
+-----------------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -572,8 +572,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "setissuers"     |             |
 | "update"         |             |
 
-<a id="Permissions_Keys"></a>Permissions_Keys
----------------------------------------------
+Permissions_Keys{#Permissions_Keys}
+-----------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -601,8 +601,8 @@ Used by: [Permissions](#Permissions).
 | "verify"            |             |
 | "wrapKey"           |             |
 
-<a id="Permissions_Keys_STATUS"></a>Permissions_Keys_STATUS
------------------------------------------------------------
+Permissions_Keys_STATUS{#Permissions_Keys_STATUS}
+-------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -630,8 +630,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "verify"            |             |
 | "wrapKey"           |             |
 
-<a id="Permissions_Secrets"></a>Permissions_Secrets
----------------------------------------------------
+Permissions_Secrets{#Permissions_Secrets}
+-----------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -647,8 +647,8 @@ Used by: [Permissions](#Permissions).
 | "restore" |             |
 | "set"     |             |
 
-<a id="Permissions_Secrets_STATUS"></a>Permissions_Secrets_STATUS
------------------------------------------------------------------
+Permissions_Secrets_STATUS{#Permissions_Secrets_STATUS}
+-------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -664,8 +664,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "restore" |             |
 | "set"     |             |
 
-<a id="Permissions_Storage"></a>Permissions_Storage
----------------------------------------------------
+Permissions_Storage{#Permissions_Storage}
+-----------------------------------------
 
 Used by: [Permissions](#Permissions).
 
@@ -687,8 +687,8 @@ Used by: [Permissions](#Permissions).
 | "setsas"        |             |
 | "update"        |             |
 
-<a id="Permissions_Storage_STATUS"></a>Permissions_Storage_STATUS
------------------------------------------------------------------
+Permissions_Storage_STATUS{#Permissions_Storage_STATUS}
+-------------------------------------------------------
 
 Used by: [Permissions_STATUS](#Permissions_STATUS).
 
@@ -710,8 +710,8 @@ Used by: [Permissions_STATUS](#Permissions_STATUS).
 | "setsas"        |             |
 | "update"        |             |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -724,8 +724,8 @@ Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectio
 | "Pending"      |             |
 | "Rejected"     |             |
 
-<a id="PrivateLinkServiceConnectionState_ActionsRequired_STATUS"></a>PrivateLinkServiceConnectionState_ActionsRequired_STATUS
------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_ActionsRequired_STATUS{#PrivateLinkServiceConnectionState_ActionsRequired_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceConnectionState_STATUS](#PrivateLinkServiceConnectionState_STATUS).
 

--- a/docs/hugo/content/reference/kubernetesconfiguration/v1api20230501.md
+++ b/docs/hugo/content/reference/kubernetesconfiguration/v1api20230501.md
@@ -5,15 +5,15 @@ title: kubernetesconfiguration.azure.com/v1api20230501
 linktitle: v1api20230501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-05-01" |             |
 
-<a id="Extension"></a>Extension
--------------------------------
+Extension{#Extension}
+---------------------
 
 Generator information: - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/stable/2023-05-01/extensions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{clusterRp}/&ZeroWidthSpace;{clusterResourceName}/&ZeroWidthSpace;{clusterName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KubernetesConfiguration/extensions/{extensionName}
 
@@ -26,7 +26,7 @@ Used by: [ExtensionList](#ExtensionList).
 | spec                                                                                    |             | [Extension_Spec](#Extension_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Extension_STATUS](#Extension_STATUS)<br/><small>Optional</small> |
 
-### <a id="Extension_Spec"></a>Extension_Spec
+### Extension_Spec {#Extension_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [ExtensionList](#ExtensionList).
 | systemData                     | Top level metadata https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-contracts.md#system-metadata-for-all-azure-resources                                                                                                                                                      | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                  |
 | version                        | User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion must be 'false'.                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Extension_STATUS"></a>Extension_STATUS
+### Extension_STATUS{#Extension_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -72,8 +72,8 @@ Used by: [ExtensionList](#ExtensionList).
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion must be 'false'.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ExtensionList"></a>ExtensionList
----------------------------------------
+ExtensionList{#ExtensionList}
+-----------------------------
 
 Generator information: - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/stable/2023-05-01/extensions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{clusterRp}/&ZeroWidthSpace;{clusterResourceName}/&ZeroWidthSpace;{clusterName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KubernetesConfiguration/extensions/{extensionName}
 
@@ -83,8 +83,8 @@ Generator information: - Generated from: /kubernetesconfiguration/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Extension[]](#Extension)<br/><small>Optional</small> |
 
-<a id="FluxConfiguration"></a>FluxConfiguration
------------------------------------------------
+FluxConfiguration{#FluxConfiguration}
+-------------------------------------
 
 Generator information: - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/stable/2023-05-01/fluxconfiguration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{clusterRp}/&ZeroWidthSpace;{clusterResourceName}/&ZeroWidthSpace;{clusterName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KubernetesConfiguration/fluxConfigurations/{fluxConfigurationName}
 
@@ -97,7 +97,7 @@ Used by: [FluxConfigurationList](#FluxConfigurationList).
 | spec                                                                                    |             | [FluxConfiguration_Spec](#FluxConfiguration_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FluxConfiguration_STATUS](#FluxConfiguration_STATUS)<br/><small>Optional</small> |
 
-### <a id="FluxConfiguration_Spec"></a>FluxConfiguration_Spec
+### FluxConfiguration_Spec {#FluxConfiguration_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                   |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -116,7 +116,7 @@ Used by: [FluxConfigurationList](#FluxConfigurationList).
 | suspend                        | Whether this configuration should suspend its reconciliation of its kustomizations and sources.                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                       |
 | waitForReconciliation          | Whether flux configuration deployment should wait for cluster to reconcile the kustomizations.                                                                                                                                                                                                               | bool<br/><small>Optional</small>                                                                                                                                       |
 
-### <a id="FluxConfiguration_STATUS"></a>FluxConfiguration_STATUS
+### FluxConfiguration_STATUS{#FluxConfiguration_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -144,8 +144,8 @@ Used by: [FluxConfigurationList](#FluxConfigurationList).
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | waitForReconciliation          | Whether flux configuration deployment should wait for cluster to reconcile the kustomizations.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="FluxConfigurationList"></a>FluxConfigurationList
--------------------------------------------------------
+FluxConfigurationList{#FluxConfigurationList}
+---------------------------------------------
 
 Generator information: - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/stable/2023-05-01/fluxconfiguration.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{clusterRp}/&ZeroWidthSpace;{clusterResourceName}/&ZeroWidthSpace;{clusterName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.KubernetesConfiguration/fluxConfigurations/{fluxConfigurationName}
 
@@ -155,8 +155,8 @@ Generator information: - Generated from: /kubernetesconfiguration/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [FluxConfiguration[]](#FluxConfiguration)<br/><small>Optional</small> |
 
-<a id="Extension_Spec"></a>Extension_Spec
------------------------------------------
+Extension_Spec{#Extension_Spec}
+-------------------------------
 
 Used by: [Extension](#Extension).
 
@@ -177,8 +177,8 @@ Used by: [Extension](#Extension).
 | systemData                     | Top level metadata https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-contracts.md#system-metadata-for-all-azure-resources                                                                                                                                                      | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                  |
 | version                        | User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion must be 'false'.                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Extension_STATUS"></a>Extension_STATUS
----------------------------------------------
+Extension_STATUS{#Extension_STATUS}
+-----------------------------------
 
 The Extension object.
 
@@ -209,8 +209,8 @@ Used by: [Extension](#Extension).
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion must be 'false'.                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FluxConfiguration_Spec"></a>FluxConfiguration_Spec
----------------------------------------------------------
+FluxConfiguration_Spec{#FluxConfiguration_Spec}
+-----------------------------------------------
 
 Used by: [FluxConfiguration](#FluxConfiguration).
 
@@ -231,8 +231,8 @@ Used by: [FluxConfiguration](#FluxConfiguration).
 | suspend                        | Whether this configuration should suspend its reconciliation of its kustomizations and sources.                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                       |
 | waitForReconciliation          | Whether flux configuration deployment should wait for cluster to reconcile the kustomizations.                                                                                                                                                                                                               | bool<br/><small>Optional</small>                                                                                                                                       |
 
-<a id="FluxConfiguration_STATUS"></a>FluxConfiguration_STATUS
--------------------------------------------------------------
+FluxConfiguration_STATUS{#FluxConfiguration_STATUS}
+---------------------------------------------------
 
 The Flux Configuration object returned in Get & Put response.
 
@@ -264,8 +264,8 @@ Used by: [FluxConfiguration](#FluxConfiguration).
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | waitForReconciliation          | Whether flux configuration deployment should wait for cluster to reconcile the kustomizations.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="AzureBlobDefinition"></a>AzureBlobDefinition
----------------------------------------------------
+AzureBlobDefinition{#AzureBlobDefinition}
+-----------------------------------------
 
 Parameters to reconcile to the AzureBlob source kind type.
 
@@ -283,8 +283,8 @@ Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster Azure Blob source with the remote.                                                              | int<br/><small>Optional</small>                                                                                                                        |
 | url                   | The URL to sync for the flux configuration Azure Blob storage account.                                                                               | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="AzureBlobDefinition_STATUS"></a>AzureBlobDefinition_STATUS
------------------------------------------------------------------
+AzureBlobDefinition_STATUS{#AzureBlobDefinition_STATUS}
+-------------------------------------------------------
 
 Parameters to reconcile to the AzureBlob source kind type.
 
@@ -300,8 +300,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster Azure Blob source with the remote.                                                              | int<br/><small>Optional</small>                                                                     |
 | url                   | The URL to sync for the flux configuration Azure Blob storage account.                                                                               | string<br/><small>Optional</small>                                                                  |
 
-<a id="BucketDefinition"></a>BucketDefinition
----------------------------------------------
+BucketDefinition{#BucketDefinition}
+-----------------------------------
 
 Parameters to reconcile to the Bucket source kind type.
 
@@ -317,8 +317,8 @@ Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster bucket source with the remote.                                                                  | int<br/><small>Optional</small>                                                                                                                        |
 | url                   | The URL to sync for the flux configuration S3 bucket.                                                                                                | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="BucketDefinition_STATUS"></a>BucketDefinition_STATUS
------------------------------------------------------------
+BucketDefinition_STATUS{#BucketDefinition_STATUS}
+-------------------------------------------------
 
 Parameters to reconcile to the Bucket source kind type.
 
@@ -333,8 +333,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster bucket source with the remote.                                                                  | int<br/><small>Optional</small>    |
 | url                   | The URL to sync for the flux configuration S3 bucket.                                                                                                | string<br/><small>Optional</small> |
 
-<a id="ErrorDetail_STATUS"></a>ErrorDetail_STATUS
--------------------------------------------------
+ErrorDetail_STATUS{#ErrorDetail_STATUS}
+---------------------------------------
 
 The error detail.
 
@@ -348,8 +348,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                        |
 | target         | The error target.          | string<br/><small>Optional</small>                                                        |
 
-<a id="Extension_Properties_AksAssignedIdentity_Spec"></a>Extension_Properties_AksAssignedIdentity_Spec
--------------------------------------------------------------------------------------------------------
+Extension_Properties_AksAssignedIdentity_Spec{#Extension_Properties_AksAssignedIdentity_Spec}
+---------------------------------------------------------------------------------------------
 
 Used by: [Extension_Spec](#Extension_Spec).
 
@@ -357,8 +357,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 |----------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | type     | The identity type. | [Extension_Properties_AksAssignedIdentity_Type_Spec](#Extension_Properties_AksAssignedIdentity_Type_Spec)<br/><small>Optional</small> |
 
-<a id="Extension_Properties_AksAssignedIdentity_STATUS"></a>Extension_Properties_AksAssignedIdentity_STATUS
------------------------------------------------------------------------------------------------------------
+Extension_Properties_AksAssignedIdentity_STATUS{#Extension_Properties_AksAssignedIdentity_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [Extension_STATUS](#Extension_STATUS).
 
@@ -368,8 +368,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | tenantId    | The tenant ID of resource.             | string<br/><small>Optional</small>                                                                                                        |
 | type        | The identity type.                     | [Extension_Properties_AksAssignedIdentity_Type_STATUS](#Extension_Properties_AksAssignedIdentity_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtensionOperatorSpec"></a>ExtensionOperatorSpec
--------------------------------------------------------
+ExtensionOperatorSpec{#ExtensionOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -381,8 +381,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [ExtensionOperatorConfigMaps](#ExtensionOperatorConfigMaps)<br/><small>Optional</small>                                                                             |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ExtensionStatus_STATUS"></a>ExtensionStatus_STATUS
----------------------------------------------------------
+ExtensionStatus_STATUS{#ExtensionStatus_STATUS}
+-----------------------------------------------
 
 Status from the extension.
 
@@ -396,8 +396,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | message       | Detailed message of the status from the Extension.                | string<br/><small>Optional</small>                                                        |
 | time          | DateLiteral (per ISO8601) noting the time of installation status. | string<br/><small>Optional</small>                                                        |
 
-<a id="FluxComplianceStateDefinition_STATUS"></a>FluxComplianceStateDefinition_STATUS
--------------------------------------------------------------------------------------
+FluxComplianceStateDefinition_STATUS{#FluxComplianceStateDefinition_STATUS}
+---------------------------------------------------------------------------
 
 Compliance state of the cluster object.
 
@@ -411,8 +411,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS), and [ObjectStatu
 | "Suspended"     |             |
 | "Unknown"       |             |
 
-<a id="FluxConfigurationOperatorSpec"></a>FluxConfigurationOperatorSpec
------------------------------------------------------------------------
+FluxConfigurationOperatorSpec{#FluxConfigurationOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -423,8 +423,8 @@ Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="GitRepositoryDefinition"></a>GitRepositoryDefinition
------------------------------------------------------------
+GitRepositoryDefinition{#GitRepositoryDefinition}
+-------------------------------------------------
 
 Parameters to reconcile to the GitRepository source kind type.
 
@@ -441,8 +441,8 @@ Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster git repository source with the remote.                                                          | int<br/><small>Optional</small>                                                                                                                        |
 | url                   | The URL to sync for the flux configuration git repository.                                                                                           | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="GitRepositoryDefinition_STATUS"></a>GitRepositoryDefinition_STATUS
--------------------------------------------------------------------------
+GitRepositoryDefinition_STATUS{#GitRepositoryDefinition_STATUS}
+---------------------------------------------------------------
 
 Parameters to reconcile to the GitRepository source kind type.
 
@@ -458,8 +458,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | timeoutInSeconds      | The maximum time to attempt to reconcile the cluster git repository source with the remote.                                                          | int<br/><small>Optional</small>                                                               |
 | url                   | The URL to sync for the flux configuration git repository.                                                                                           | string<br/><small>Optional</small>                                                            |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -469,8 +469,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 |----------|--------------------|-------------------------------------------------------------|
 | type     | The identity type. | [Identity_Type](#Identity_Type)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -482,8 +482,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | tenantId    | The tenant ID of resource.             | string<br/><small>Optional</small>                                        |
 | type        | The identity type.                     | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="KustomizationDefinition"></a>KustomizationDefinition
------------------------------------------------------------
+KustomizationDefinition{#KustomizationDefinition}
+-------------------------------------------------
 
 The Kustomization defining how to reconcile the artifact pulled by the source type on the cluster.
 
@@ -501,8 +501,8 @@ Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 | timeoutInSeconds       | The maximum time to attempt to reconcile the Kustomization on the cluster.                                                                                           | int<br/><small>Optional</small>                                         |
 | wait                   | Enable/disable health check for all Kubernetes objects created by this Kustomization.                                                                                | bool<br/><small>Optional</small>                                        |
 
-<a id="KustomizationDefinition_STATUS"></a>KustomizationDefinition_STATUS
--------------------------------------------------------------------------
+KustomizationDefinition_STATUS{#KustomizationDefinition_STATUS}
+---------------------------------------------------------------
 
 The Kustomization defining how to reconcile the artifact pulled by the source type on the cluster.
 
@@ -521,8 +521,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | timeoutInSeconds       | The maximum time to attempt to reconcile the Kustomization on the cluster.                                                                                           | int<br/><small>Optional</small>                                                       |
 | wait                   | Enable/disable health check for all Kubernetes objects created by this Kustomization.                                                                                | bool<br/><small>Optional</small>                                                      |
 
-<a id="ObjectStatusDefinition_STATUS"></a>ObjectStatusDefinition_STATUS
------------------------------------------------------------------------
+ObjectStatusDefinition_STATUS{#ObjectStatusDefinition_STATUS}
+-------------------------------------------------------------
 
 Statuses of objects deployed by the user-specified kustomizations from the git repository.
 
@@ -538,8 +538,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | namespace             | Namespace of the applied object                                                                                       | string<br/><small>Optional</small>                                                                              |
 | statusConditions      | List of Kubernetes object status conditions present on the cluster                                                    | [ObjectStatusConditionDefinition_STATUS[]](#ObjectStatusConditionDefinition_STATUS)<br/><small>Optional</small> |
 
-<a id="Plan"></a>Plan
----------------------
+Plan{#Plan}
+-----------
 
 Plan for the resource.
 
@@ -553,8 +553,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 | publisher     | The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic                                                                                 | string<br/><small>Required</small> |
 | version       | The version of the desired product/artifact.                                                                                                                | string<br/><small>Optional</small> |
 
-<a id="Plan_STATUS"></a>Plan_STATUS
------------------------------------
+Plan_STATUS{#Plan_STATUS}
+-------------------------
 
 Plan for the resource.
 
@@ -568,8 +568,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | publisher     | The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic                                                                                 | string<br/><small>Optional</small> |
 | version       | The version of the desired product/artifact.                                                                                                                | string<br/><small>Optional</small> |
 
-<a id="ProvisioningStateDefinition_STATUS"></a>ProvisioningStateDefinition_STATUS
----------------------------------------------------------------------------------
+ProvisioningStateDefinition_STATUS{#ProvisioningStateDefinition_STATUS}
+-----------------------------------------------------------------------
 
 The provisioning state of the resource.
 
@@ -584,8 +584,8 @@ Used by: [Extension_STATUS](#Extension_STATUS), and [FluxConfiguration_STATUS](#
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="Scope"></a>Scope
------------------------
+Scope{#Scope}
+-------------
 
 Scope of the extension. It can be either Cluster or Namespace; but not both.
 
@@ -596,8 +596,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 | cluster   | Specifies that the scope of the extension is Cluster   | [ScopeCluster](#ScopeCluster)<br/><small>Optional</small>     |
 | namespace | Specifies that the scope of the extension is Namespace | [ScopeNamespace](#ScopeNamespace)<br/><small>Optional</small> |
 
-<a id="Scope_STATUS"></a>Scope_STATUS
--------------------------------------
+Scope_STATUS{#Scope_STATUS}
+---------------------------
 
 Scope of the extension. It can be either Cluster or Namespace; but not both.
 
@@ -608,46 +608,46 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | cluster   | Specifies that the scope of the extension is Cluster   | [ScopeCluster_STATUS](#ScopeCluster_STATUS)<br/><small>Optional</small>     |
 | namespace | Specifies that the scope of the extension is Namespace | [ScopeNamespace_STATUS](#ScopeNamespace_STATUS)<br/><small>Optional</small> |
 
-<a id="ScopeDefinition"></a>ScopeDefinition
+ScopeDefinition{#ScopeDefinition}
+---------------------------------
+
+Scope at which the configuration will be installed.
+
+Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
+
+| Value       | Description |
+|-------------|-------------|
+| "cluster"   |             |
+| "namespace" |             |
+
+ScopeDefinition_STATUS{#ScopeDefinition_STATUS}
+-----------------------------------------------
+
+Scope at which the configuration will be installed.
+
+Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "cluster"   |             |
+| "namespace" |             |
+
+SourceKindDefinition{#SourceKindDefinition}
 -------------------------------------------
 
-Scope at which the configuration will be installed.
+Source Kind to pull the configuration data from.
 
 Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
 
-| Value       | Description |
-|-------------|-------------|
-| "cluster"   |             |
-| "namespace" |             |
+| Value           | Description |
+|-----------------|-------------|
+| "AzureBlob"     |             |
+| "Bucket"        |             |
+| "GitRepository" |             |
 
-<a id="ScopeDefinition_STATUS"></a>ScopeDefinition_STATUS
+SourceKindDefinition_STATUS{#SourceKindDefinition_STATUS}
 ---------------------------------------------------------
 
-Scope at which the configuration will be installed.
-
-Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "cluster"   |             |
-| "namespace" |             |
-
-<a id="SourceKindDefinition"></a>SourceKindDefinition
------------------------------------------------------
-
-Source Kind to pull the configuration data from.
-
-Used by: [FluxConfiguration_Spec](#FluxConfiguration_Spec).
-
-| Value           | Description |
-|-----------------|-------------|
-| "AzureBlob"     |             |
-| "Bucket"        |             |
-| "GitRepository" |             |
-
-<a id="SourceKindDefinition_STATUS"></a>SourceKindDefinition_STATUS
--------------------------------------------------------------------
-
 Source Kind to pull the configuration data from.
 
 Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
@@ -658,8 +658,8 @@ Used by: [FluxConfiguration_STATUS](#FluxConfiguration_STATUS).
 | "Bucket"        |             |
 | "GitRepository" |             |
 
-<a id="SystemData"></a>SystemData
----------------------------------
+SystemData{#SystemData}
+-----------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -674,8 +674,8 @@ Used by: [Extension_Spec](#Extension_Spec).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                          |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType](#SystemData_LastModifiedByType)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -690,8 +690,8 @@ Used by: [Extension_STATUS](#Extension_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ErrorAdditionalInfo_STATUS"></a>ErrorAdditionalInfo_STATUS
------------------------------------------------------------------
+ErrorAdditionalInfo_STATUS{#ErrorAdditionalInfo_STATUS}
+-------------------------------------------------------
 
 The resource management error additional info.
 
@@ -702,8 +702,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS), and [ErrorDetail_STATUS_Unro
 | info     | The additional info.      | map[string]v1.JSON<br/><small>Optional</small> |
 | type     | The additional info type. | string<br/><small>Optional</small>             |
 
-<a id="ErrorDetail_STATUS_Unrolled"></a>ErrorDetail_STATUS_Unrolled
--------------------------------------------------------------------
+ErrorDetail_STATUS_Unrolled{#ErrorDetail_STATUS_Unrolled}
+---------------------------------------------------------
 
 Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 
@@ -714,8 +714,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                      |
 | target         | The error target.          | string<br/><small>Optional</small>                                                      |
 
-<a id="Extension_Properties_AksAssignedIdentity_Type_Spec"></a>Extension_Properties_AksAssignedIdentity_Type_Spec
------------------------------------------------------------------------------------------------------------------
+Extension_Properties_AksAssignedIdentity_Type_Spec{#Extension_Properties_AksAssignedIdentity_Type_Spec}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [Extension_Properties_AksAssignedIdentity_Spec](#Extension_Properties_AksAssignedIdentity_Spec).
 
@@ -724,8 +724,8 @@ Used by: [Extension_Properties_AksAssignedIdentity_Spec](#Extension_Properties_A
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="Extension_Properties_AksAssignedIdentity_Type_STATUS"></a>Extension_Properties_AksAssignedIdentity_Type_STATUS
----------------------------------------------------------------------------------------------------------------------
+Extension_Properties_AksAssignedIdentity_Type_STATUS{#Extension_Properties_AksAssignedIdentity_Type_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [Extension_Properties_AksAssignedIdentity_STATUS](#Extension_Properties_AksAssignedIdentity_STATUS).
 
@@ -734,8 +734,8 @@ Used by: [Extension_Properties_AksAssignedIdentity_STATUS](#Extension_Properties
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ExtensionOperatorConfigMaps"></a>ExtensionOperatorConfigMaps
--------------------------------------------------------------------
+ExtensionOperatorConfigMaps{#ExtensionOperatorConfigMaps}
+---------------------------------------------------------
 
 Used by: [ExtensionOperatorSpec](#ExtensionOperatorSpec).
 
@@ -743,8 +743,8 @@ Used by: [ExtensionOperatorSpec](#ExtensionOperatorSpec).
 |-------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | principalId | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ExtensionStatus_Level_STATUS"></a>ExtensionStatus_Level_STATUS
----------------------------------------------------------------------
+ExtensionStatus_Level_STATUS{#ExtensionStatus_Level_STATUS}
+-----------------------------------------------------------
 
 Used by: [ExtensionStatus_STATUS](#ExtensionStatus_STATUS).
 
@@ -754,8 +754,8 @@ Used by: [ExtensionStatus_STATUS](#ExtensionStatus_STATUS).
 | "Information" |             |
 | "Warning"     |             |
 
-<a id="HelmReleasePropertiesDefinition_STATUS"></a>HelmReleasePropertiesDefinition_STATUS
------------------------------------------------------------------------------------------
+HelmReleasePropertiesDefinition_STATUS{#HelmReleasePropertiesDefinition_STATUS}
+-------------------------------------------------------------------------------
 
 Properties for HelmRelease objects
 
@@ -769,8 +769,8 @@ Used by: [ObjectStatusDefinition_STATUS](#ObjectStatusDefinition_STATUS).
 | lastRevisionApplied | The revision number of the last released object change                       | int<br/><small>Optional</small>                                                                   |
 | upgradeFailureCount | Number of times that the HelmRelease failed to upgrade                       | int<br/><small>Optional</small>                                                                   |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -778,8 +778,8 @@ Used by: [Identity](#Identity).
 |------------------|-------------|
 | "SystemAssigned" |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -787,8 +787,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 |------------------|-------------|
 | "SystemAssigned" |             |
 
-<a id="ManagedIdentityDefinition"></a>ManagedIdentityDefinition
----------------------------------------------------------------
+ManagedIdentityDefinition{#ManagedIdentityDefinition}
+-----------------------------------------------------
 
 Parameters to authenticate using a Managed Identity.
 
@@ -798,8 +798,8 @@ Used by: [AzureBlobDefinition](#AzureBlobDefinition).
 |----------|------------------------------------------------------|------------------------------------|
 | clientId | The client Id for authenticating a Managed Identity. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentityDefinition_STATUS"></a>ManagedIdentityDefinition_STATUS
------------------------------------------------------------------------------
+ManagedIdentityDefinition_STATUS{#ManagedIdentityDefinition_STATUS}
+-------------------------------------------------------------------
 
 Parameters to authenticate using a Managed Identity.
 
@@ -809,8 +809,8 @@ Used by: [AzureBlobDefinition_STATUS](#AzureBlobDefinition_STATUS).
 |----------|------------------------------------------------------|------------------------------------|
 | clientId | The client Id for authenticating a Managed Identity. | string<br/><small>Optional</small> |
 
-<a id="ObjectReferenceDefinition_STATUS"></a>ObjectReferenceDefinition_STATUS
------------------------------------------------------------------------------
+ObjectReferenceDefinition_STATUS{#ObjectReferenceDefinition_STATUS}
+-------------------------------------------------------------------
 
 Object reference to a Kubernetes object on a cluster
 
@@ -821,8 +821,8 @@ Used by: [HelmReleasePropertiesDefinition_STATUS](#HelmReleasePropertiesDefiniti
 | name      | Name of the object      | string<br/><small>Optional</small> |
 | namespace | Namespace of the object | string<br/><small>Optional</small> |
 
-<a id="ObjectStatusConditionDefinition_STATUS"></a>ObjectStatusConditionDefinition_STATUS
------------------------------------------------------------------------------------------
+ObjectStatusConditionDefinition_STATUS{#ObjectStatusConditionDefinition_STATUS}
+-------------------------------------------------------------------------------
 
 Status condition of Kubernetes object
 
@@ -836,8 +836,8 @@ Used by: [ObjectStatusDefinition_STATUS](#ObjectStatusDefinition_STATUS).
 | status             | Status of the Kubernetes object condition type            | string<br/><small>Optional</small> |
 | type               | Object status condition type for this object              | string<br/><small>Optional</small> |
 
-<a id="PostBuildDefinition"></a>PostBuildDefinition
----------------------------------------------------
+PostBuildDefinition{#PostBuildDefinition}
+-----------------------------------------
 
 The postBuild definitions defining variable substitutions for this Kustomization after kustomize build.
 
@@ -848,8 +848,8 @@ Used by: [KustomizationDefinition](#KustomizationDefinition).
 | substitute     | Key/value pairs holding the variables to be substituted in this Kustomization.               | map[string]string<br/><small>Optional</small>                                       |
 | substituteFrom | Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization. | [SubstituteFromDefinition[]](#SubstituteFromDefinition)<br/><small>Optional</small> |
 
-<a id="PostBuildDefinition_STATUS"></a>PostBuildDefinition_STATUS
------------------------------------------------------------------
+PostBuildDefinition_STATUS{#PostBuildDefinition_STATUS}
+-------------------------------------------------------
 
 The postBuild definitions defining variable substitutions for this Kustomization after kustomize build.
 
@@ -860,8 +860,8 @@ Used by: [KustomizationDefinition_STATUS](#KustomizationDefinition_STATUS).
 | substitute     | Key/value pairs holding the variables to be substituted in this Kustomization.               | map[string]string<br/><small>Optional</small>                                                     |
 | substituteFrom | Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization. | [SubstituteFromDefinition_STATUS[]](#SubstituteFromDefinition_STATUS)<br/><small>Optional</small> |
 
-<a id="RepositoryRefDefinition"></a>RepositoryRefDefinition
------------------------------------------------------------
+RepositoryRefDefinition{#RepositoryRefDefinition}
+-------------------------------------------------
 
 The source reference for the GitRepository object.
 
@@ -874,8 +874,8 @@ Used by: [GitRepositoryDefinition](#GitRepositoryDefinition).
 | semver   | The semver range used to match against git repository tags. This takes precedence over tag.                                  | string<br/><small>Optional</small> |
 | tag      | The git repository tag name to checkout. This takes precedence over branch.                                                  | string<br/><small>Optional</small> |
 
-<a id="RepositoryRefDefinition_STATUS"></a>RepositoryRefDefinition_STATUS
--------------------------------------------------------------------------
+RepositoryRefDefinition_STATUS{#RepositoryRefDefinition_STATUS}
+---------------------------------------------------------------
 
 The source reference for the GitRepository object.
 
@@ -888,8 +888,8 @@ Used by: [GitRepositoryDefinition_STATUS](#GitRepositoryDefinition_STATUS).
 | semver   | The semver range used to match against git repository tags. This takes precedence over tag.                                  | string<br/><small>Optional</small> |
 | tag      | The git repository tag name to checkout. This takes precedence over branch.                                                  | string<br/><small>Optional</small> |
 
-<a id="ScopeCluster"></a>ScopeCluster
--------------------------------------
+ScopeCluster{#ScopeCluster}
+---------------------------
 
 Specifies that the scope of the extension is Cluster
 
@@ -899,20 +899,20 @@ Used by: [Scope](#Scope).
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | releaseNamespace | Namespace where the extension Release must be placed, for a Cluster scoped extension. If this namespace does not exist, it will be created | string<br/><small>Optional</small> |
 
-<a id="ScopeCluster_STATUS"></a>ScopeCluster_STATUS
----------------------------------------------------
-
-Specifies that the scope of the extension is Cluster
-
-Used by: [Scope_STATUS](#Scope_STATUS).
-
-| Property         | Description                                                                                                                                | Type                               |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| releaseNamespace | Namespace where the extension Release must be placed, for a Cluster scoped extension. If this namespace does not exist, it will be created | string<br/><small>Optional</small> |
-
-<a id="ScopeNamespace"></a>ScopeNamespace
+ScopeCluster_STATUS{#ScopeCluster_STATUS}
 -----------------------------------------
 
+Specifies that the scope of the extension is Cluster
+
+Used by: [Scope_STATUS](#Scope_STATUS).
+
+| Property         | Description                                                                                                                                | Type                               |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| releaseNamespace | Namespace where the extension Release must be placed, for a Cluster scoped extension. If this namespace does not exist, it will be created | string<br/><small>Optional</small> |
+
+ScopeNamespace{#ScopeNamespace}
+-------------------------------
+
 Specifies that the scope of the extension is Namespace
 
 Used by: [Scope](#Scope).
@@ -921,8 +921,8 @@ Used by: [Scope](#Scope).
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | targetNamespace | Namespace where the extension will be created for an Namespace scoped extension. If this namespace does not exist, it will be created | string<br/><small>Optional</small> |
 
-<a id="ScopeNamespace_STATUS"></a>ScopeNamespace_STATUS
--------------------------------------------------------
+ScopeNamespace_STATUS{#ScopeNamespace_STATUS}
+---------------------------------------------
 
 Specifies that the scope of the extension is Namespace
 
@@ -932,8 +932,8 @@ Used by: [Scope_STATUS](#Scope_STATUS).
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | targetNamespace | Namespace where the extension will be created for an Namespace scoped extension. If this namespace does not exist, it will be created | string<br/><small>Optional</small> |
 
-<a id="ServicePrincipalDefinition"></a>ServicePrincipalDefinition
------------------------------------------------------------------
+ServicePrincipalDefinition{#ServicePrincipalDefinition}
+-------------------------------------------------------
 
 Parameters to authenticate using Service Principal.
 
@@ -950,8 +950,8 @@ Used by: [AzureBlobDefinition](#AzureBlobDefinition).
 | tenantId                   | The tenant Id for authenticating a Service Principal                                                                                                            | string<br/><small>Optional</small>                                                                                                                           |
 | tenantIdFromConfig         | The tenant Id for authenticating a Service Principal                                                                                                            | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="ServicePrincipalDefinition_STATUS"></a>ServicePrincipalDefinition_STATUS
--------------------------------------------------------------------------------
+ServicePrincipalDefinition_STATUS{#ServicePrincipalDefinition_STATUS}
+---------------------------------------------------------------------
 
 Parameters to authenticate using Service Principal.
 
@@ -963,7 +963,31 @@ Used by: [AzureBlobDefinition_STATUS](#AzureBlobDefinition_STATUS).
 | clientId                   | The client Id for authenticating a Service Principal.                                                                                                           | string<br/><small>Optional</small> |
 | tenantId                   | The tenant Id for authenticating a Service Principal                                                                                                            | string<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType"></a>SystemData_CreatedByType
+SystemData_CreatedByType{#SystemData_CreatedByType}
+---------------------------------------------------
+
+Used by: [SystemData](#SystemData).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType{#SystemData_LastModifiedByType}
 -------------------------------------------------------------
 
 Used by: [SystemData](#SystemData).
@@ -975,7 +999,7 @@ Used by: [SystemData](#SystemData).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -987,32 +1011,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType"></a>SystemData_LastModifiedByType
------------------------------------------------------------------------
-
-Used by: [SystemData](#SystemData).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="SubstituteFromDefinition"></a>SubstituteFromDefinition
--------------------------------------------------------------
+SubstituteFromDefinition{#SubstituteFromDefinition}
+---------------------------------------------------
 
 Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization.
 
@@ -1024,8 +1024,8 @@ Used by: [PostBuildDefinition](#PostBuildDefinition).
 | name     | Name of the ConfigMap/Secret that holds the variables to be used in substitution.             | string<br/><small>Optional</small> |
 | optional | Set to True to proceed without ConfigMap/Secret, if it is not present.                        | bool<br/><small>Optional</small>   |
 
-<a id="SubstituteFromDefinition_STATUS"></a>SubstituteFromDefinition_STATUS
----------------------------------------------------------------------------
+SubstituteFromDefinition_STATUS{#SubstituteFromDefinition_STATUS}
+-----------------------------------------------------------------
 
 Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization.
 

--- a/docs/hugo/content/reference/machinelearningservices/v1api20210701.md
+++ b/docs/hugo/content/reference/machinelearningservices/v1api20210701.md
@@ -5,15 +5,15 @@ title: machinelearningservices.azure.com/v1api20210701
 linktitle: v1api20210701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-07-01" |             |
 
-<a id="Workspace"></a>Workspace
--------------------------------
+Workspace{#Workspace}
+---------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}
 
@@ -26,7 +26,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | spec                                                                                    |             | [Workspace_Spec](#Workspace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Workspace_STATUS](#Workspace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Workspace_Spec"></a>Workspace_Spec
+### Workspace_Spec {#Workspace_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -54,7 +54,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | systemData                           | System data                                                                                                                                                                                                                                                                                  | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags                                 | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Workspace_STATUS"></a>Workspace_STATUS
+### Workspace_STATUS{#Workspace_STATUS}
 
 | Property                        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -92,8 +92,8 @@ Used by: [WorkspaceList](#WorkspaceList).
 | type                            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceId                     | The immutable id associated with this workspace.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspaceList"></a>WorkspaceList
----------------------------------------
+WorkspaceList{#WorkspaceList}
+-----------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}
 
@@ -103,8 +103,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Workspace[]](#Workspace)<br/><small>Optional</small> |
 
-<a id="WorkspacesCompute"></a>WorkspacesCompute
------------------------------------------------
+WorkspacesCompute{#WorkspacesCompute}
+-------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}
 
@@ -117,7 +117,7 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | spec                                                                                    |             | [WorkspacesCompute_Spec](#WorkspacesCompute_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS)<br/><small>Optional</small> |
 
-### <a id="WorkspacesCompute_Spec"></a>WorkspacesCompute_Spec
+### WorkspacesCompute_Spec {#WorkspacesCompute_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -131,7 +131,7 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | systemData   | System data                                                                                                                                                                                                                                                                                            | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags         | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="WorkspacesCompute_STATUS"></a>WorkspacesCompute_STATUS
+### WorkspacesCompute_STATUS{#WorkspacesCompute_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -146,8 +146,8 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | tags       | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesComputeList"></a>WorkspacesComputeList
--------------------------------------------------------
+WorkspacesComputeList{#WorkspacesComputeList}
+---------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}
 
@@ -157,8 +157,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [WorkspacesCompute[]](#WorkspacesCompute)<br/><small>Optional</small> |
 
-<a id="WorkspacesConnection"></a>WorkspacesConnection
------------------------------------------------------
+WorkspacesConnection{#WorkspacesConnection}
+-------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/connections/{connectionName}
 
@@ -171,7 +171,7 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | spec                                                                                    |             | [WorkspacesConnection_Spec](#WorkspacesConnection_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS)<br/><small>Optional</small> |
 
-### <a id="WorkspacesConnection_Spec"></a>WorkspacesConnection_Spec
+### WorkspacesConnection_Spec {#WorkspacesConnection_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -184,7 +184,7 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | value        | Value details of the workspace connection.                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 | valueFormat  | format for the workspace connection value                                                                                                                                                                                                                                                              | [WorkspaceConnectionProps_ValueFormat](#WorkspaceConnectionProps_ValueFormat)<br/><small>Optional</small>                                                            |
 
-### <a id="WorkspacesConnection_STATUS"></a>WorkspacesConnection_STATUS
+### WorkspacesConnection_STATUS{#WorkspacesConnection_STATUS}
 
 | Property    | Description                                     | Type                                                                                                                                                    |
 |-------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -198,8 +198,8 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | value       | Value details of the workspace connection.      | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat | format for the workspace connection value       | [WorkspaceConnectionProps_ValueFormat_STATUS](#WorkspaceConnectionProps_ValueFormat_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="WorkspacesConnectionList"></a>WorkspacesConnectionList
--------------------------------------------------------------
+WorkspacesConnectionList{#WorkspacesConnectionList}
+---------------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2021-07-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/connections/{connectionName}
 
@@ -209,8 +209,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [WorkspacesConnection[]](#WorkspacesConnection)<br/><small>Optional</small> |
 
-<a id="Workspace_Spec"></a>Workspace_Spec
------------------------------------------
+Workspace_Spec{#Workspace_Spec}
+-------------------------------
 
 Used by: [Workspace](#Workspace).
 
@@ -240,8 +240,8 @@ Used by: [Workspace](#Workspace).
 | systemData                           | System data                                                                                                                                                                                                                                                                                  | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags                                 | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Workspace_STATUS"></a>Workspace_STATUS
----------------------------------------------
+Workspace_STATUS{#Workspace_STATUS}
+-----------------------------------
 
 An object that represents a machine learning workspace.
 
@@ -283,8 +283,8 @@ Used by: [Workspace](#Workspace).
 | type                            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceId                     | The immutable id associated with this workspace.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesCompute_Spec"></a>WorkspacesCompute_Spec
----------------------------------------------------------
+WorkspacesCompute_Spec{#WorkspacesCompute_Spec}
+-----------------------------------------------
 
 Used by: [WorkspacesCompute](#WorkspacesCompute).
 
@@ -300,8 +300,8 @@ Used by: [WorkspacesCompute](#WorkspacesCompute).
 | systemData   | System data                                                                                                                                                                                                                                                                                            | [SystemData](#SystemData)<br/><small>Optional</small>                                                                                                                |
 | tags         | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WorkspacesCompute_STATUS"></a>WorkspacesCompute_STATUS
--------------------------------------------------------------
+WorkspacesCompute_STATUS{#WorkspacesCompute_STATUS}
+---------------------------------------------------
 
 Used by: [WorkspacesCompute](#WorkspacesCompute).
 
@@ -318,8 +318,8 @@ Used by: [WorkspacesCompute](#WorkspacesCompute).
 | tags       | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesConnection_Spec"></a>WorkspacesConnection_Spec
----------------------------------------------------------------
+WorkspacesConnection_Spec{#WorkspacesConnection_Spec}
+-----------------------------------------------------
 
 Used by: [WorkspacesConnection](#WorkspacesConnection).
 
@@ -334,8 +334,8 @@ Used by: [WorkspacesConnection](#WorkspacesConnection).
 | value        | Value details of the workspace connection.                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 | valueFormat  | format for the workspace connection value                                                                                                                                                                                                                                                              | [WorkspaceConnectionProps_ValueFormat](#WorkspaceConnectionProps_ValueFormat)<br/><small>Optional</small>                                                            |
 
-<a id="WorkspacesConnection_STATUS"></a>WorkspacesConnection_STATUS
--------------------------------------------------------------------
+WorkspacesConnection_STATUS{#WorkspacesConnection_STATUS}
+---------------------------------------------------------
 
 Used by: [WorkspacesConnection](#WorkspacesConnection).
 
@@ -351,8 +351,8 @@ Used by: [WorkspacesConnection](#WorkspacesConnection).
 | value       | Value details of the workspace connection.      | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat | format for the workspace connection value       | [WorkspaceConnectionProps_ValueFormat_STATUS](#WorkspaceConnectionProps_ValueFormat_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="Compute"></a>Compute
----------------------------
+Compute{#Compute}
+-----------------
 
 Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 
@@ -369,8 +369,8 @@ Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 | synapseSpark      | Mutually exclusive with all other properties | [SynapseSpark](#SynapseSpark)<br/><small>Optional</small>           |
 | virtualMachine    | Mutually exclusive with all other properties | [VirtualMachine](#VirtualMachine)<br/><small>Optional</small>       |
 
-<a id="Compute_STATUS"></a>Compute_STATUS
------------------------------------------
+Compute_STATUS{#Compute_STATUS}
+-------------------------------
 
 Used by: [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS).
 
@@ -387,8 +387,8 @@ Used by: [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS).
 | synapseSpark      | Mutually exclusive with all other properties | [SynapseSpark_STATUS](#SynapseSpark_STATUS)<br/><small>Optional</small>           |
 | virtualMachine    | Mutually exclusive with all other properties | [VirtualMachine_STATUS](#VirtualMachine_STATUS)<br/><small>Optional</small>       |
 
-<a id="EncryptionProperty"></a>EncryptionProperty
--------------------------------------------------
+EncryptionProperty{#EncryptionProperty}
+---------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -397,8 +397,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | identity           | The identity that will be used to access the key vault for encryption at rest. | [IdentityForCmk](#IdentityForCmk)<br/><small>Optional</small>         |
 | keyVaultProperties | Customer Key vault properties.                                                 | [KeyVaultProperties](#KeyVaultProperties)<br/><small>Required</small> |
 
-<a id="EncryptionProperty_STATUS"></a>EncryptionProperty_STATUS
----------------------------------------------------------------
+EncryptionProperty_STATUS{#EncryptionProperty_STATUS}
+-----------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -408,8 +408,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | keyVaultProperties | Customer Key vault properties.                                                 | [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS)<br/><small>Optional</small>               |
 | status             | Indicates whether or not the encryption is enabled for the workspace.          | [EncryptionProperty_Status_STATUS](#EncryptionProperty_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -420,8 +420,8 @@ Used by: [Workspace_Spec](#Workspace_Spec), and [WorkspacesCompute_Spec](#Worksp
 | type                   | The identity type.                                         | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | The user assigned identities associated with the resource. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -434,8 +434,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS), and [WorkspacesCompute_STATUS](#
 | type                   | The identity type.                                         | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | The user assigned identities associated with the resource. | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="NotebookResourceInfo_STATUS"></a>NotebookResourceInfo_STATUS
--------------------------------------------------------------------
+NotebookResourceInfo_STATUS{#NotebookResourceInfo_STATUS}
+---------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -445,8 +445,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | notebookPreparationError | The error that occurs when preparing notebook.                       | [NotebookPreparationError_STATUS](#NotebookPreparationError_STATUS)<br/><small>Optional</small> |
 | resourceId               | the data plane resourceId that used to initialize notebook component | string<br/><small>Optional</small>                                                              |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -456,8 +456,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="ServiceManagedResourcesSettings"></a>ServiceManagedResourcesSettings
----------------------------------------------------------------------------
+ServiceManagedResourcesSettings{#ServiceManagedResourcesSettings}
+-----------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -465,8 +465,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |----------|--------------------------------------------------------|-------------------------------------------------------------------|
 | cosmosDb | The settings for the service managed cosmosdb account. | [CosmosDbSettings](#CosmosDbSettings)<br/><small>Optional</small> |
 
-<a id="ServiceManagedResourcesSettings_STATUS"></a>ServiceManagedResourcesSettings_STATUS
------------------------------------------------------------------------------------------
+ServiceManagedResourcesSettings_STATUS{#ServiceManagedResourcesSettings_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -474,8 +474,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |----------|--------------------------------------------------------|---------------------------------------------------------------------------------|
 | cosmosDb | The settings for the service managed cosmosdb account. | [CosmosDbSettings_STATUS](#CosmosDbSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="SharedPrivateLinkResource"></a>SharedPrivateLinkResource
----------------------------------------------------------------
+SharedPrivateLinkResource{#SharedPrivateLinkResource}
+-----------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -487,8 +487,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | requestMessage               | Request message.                                                                                 | string<br/><small>Optional</small>                                                                                                                         |
 | status                       | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus](#PrivateEndpointServiceConnectionStatus)<br/><small>Optional</small>                                              |
 
-<a id="SharedPrivateLinkResource_STATUS"></a>SharedPrivateLinkResource_STATUS
------------------------------------------------------------------------------
+SharedPrivateLinkResource_STATUS{#SharedPrivateLinkResource_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -500,8 +500,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | requestMessage        | Request message.                                                                                 | string<br/><small>Optional</small>                                                                                          |
 | status                | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Sku of the resource
 
@@ -512,8 +512,8 @@ Used by: [Workspace_Spec](#Workspace_Spec), and [WorkspacesCompute_Spec](#Worksp
 | name     | Name of the sku                          | string<br/><small>Optional</small> |
 | tier     | Tier of the sku like Basic or Enterprise | string<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Sku of the resource
 
@@ -524,8 +524,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS), and [WorkspacesCompute_STATUS](#
 | name     | Name of the sku                          | string<br/><small>Optional</small> |
 | tier     | Tier of the sku like Basic or Enterprise | string<br/><small>Optional</small> |
 
-<a id="SystemData"></a>SystemData
----------------------------------
+SystemData{#SystemData}
+-----------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -540,8 +540,8 @@ Used by: [Workspace_Spec](#Workspace_Spec), and [WorkspacesCompute_Spec](#Worksp
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                          |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType](#SystemData_LastModifiedByType)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -556,8 +556,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS), and [WorkspacesCompute_STATUS](#
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionProps_ValueFormat"></a>WorkspaceConnectionProps_ValueFormat
--------------------------------------------------------------------------------------
+WorkspaceConnectionProps_ValueFormat{#WorkspaceConnectionProps_ValueFormat}
+---------------------------------------------------------------------------
 
 Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 
@@ -565,8 +565,8 @@ Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 |--------|-------------|
 | "JSON" |             |
 
-<a id="WorkspaceConnectionProps_ValueFormat_STATUS"></a>WorkspaceConnectionProps_ValueFormat_STATUS
----------------------------------------------------------------------------------------------------
+WorkspaceConnectionProps_ValueFormat_STATUS{#WorkspaceConnectionProps_ValueFormat_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS).
 
@@ -574,8 +574,8 @@ Used by: [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS).
 |--------|-------------|
 | "JSON" |             |
 
-<a id="WorkspaceOperatorSpec"></a>WorkspaceOperatorSpec
--------------------------------------------------------
+WorkspaceOperatorSpec{#WorkspaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -587,8 +587,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [WorkspaceOperatorSecrets](#WorkspaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="WorkspaceProperties_ProvisioningState_STATUS"></a>WorkspaceProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------
+WorkspaceProperties_ProvisioningState_STATUS{#WorkspaceProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -602,8 +602,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="WorkspaceProperties_PublicNetworkAccess"></a>WorkspaceProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess{#WorkspaceProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -612,8 +612,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspaceProperties_PublicNetworkAccess_STATUS"></a>WorkspaceProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess_STATUS{#WorkspaceProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -622,8 +622,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspacesComputeOperatorSpec"></a>WorkspacesComputeOperatorSpec
------------------------------------------------------------------------
+WorkspacesComputeOperatorSpec{#WorkspacesComputeOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -634,8 +634,8 @@ Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WorkspacesConnectionOperatorSpec"></a>WorkspacesConnectionOperatorSpec
------------------------------------------------------------------------------
+WorkspacesConnectionOperatorSpec{#WorkspacesConnectionOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -646,8 +646,8 @@ Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AKS"></a>AKS
--------------------
+AKS{#AKS}
+---------
 
 Used by: [Compute](#Compute).
 
@@ -660,8 +660,8 @@ Used by: [Compute](#Compute).
 | properties        | AKS properties                                                                                                | [AKS_Properties](#AKS_Properties)<br/><small>Optional</small>                                                                                              |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AKS_STATUS"></a>AKS_STATUS
----------------------------------
+AKS_STATUS{#AKS_STATUS}
+-----------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -679,8 +679,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [AKS_ProvisioningState_STATUS](#AKS_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                        |
 
-<a id="AmlCompute"></a>AmlCompute
----------------------------------
+AmlCompute{#AmlCompute}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -693,8 +693,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of AmlCompute                                                                                      | [AmlComputeProperties](#AmlComputeProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AmlCompute_STATUS"></a>AmlCompute_STATUS
------------------------------------------------
+AmlCompute_STATUS{#AmlCompute_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -712,8 +712,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [AmlCompute_ProvisioningState_STATUS](#AmlCompute_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="ComputeInstance"></a>ComputeInstance
--------------------------------------------
+ComputeInstance{#ComputeInstance}
+---------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -726,8 +726,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of ComputeInstance                                                                                 | [ComputeInstanceProperties](#ComputeInstanceProperties)<br/><small>Optional</small>                                                                        |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ComputeInstance_STATUS"></a>ComputeInstance_STATUS
----------------------------------------------------------
+ComputeInstance_STATUS{#ComputeInstance_STATUS}
+-----------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -745,8 +745,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [ComputeInstance_ProvisioningState_STATUS](#ComputeInstance_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                                |
 
-<a id="CosmosDbSettings"></a>CosmosDbSettings
----------------------------------------------
+CosmosDbSettings{#CosmosDbSettings}
+-----------------------------------
 
 Used by: [ServiceManagedResourcesSettings](#ServiceManagedResourcesSettings).
 
@@ -754,8 +754,8 @@ Used by: [ServiceManagedResourcesSettings](#ServiceManagedResourcesSettings).
 |-----------------------|--------------------------------------------------------|---------------------------------|
 | collectionsThroughput | The throughput of the collections in cosmosdb database | int<br/><small>Optional</small> |
 
-<a id="CosmosDbSettings_STATUS"></a>CosmosDbSettings_STATUS
------------------------------------------------------------
+CosmosDbSettings_STATUS{#CosmosDbSettings_STATUS}
+-------------------------------------------------
 
 Used by: [ServiceManagedResourcesSettings_STATUS](#ServiceManagedResourcesSettings_STATUS).
 
@@ -763,8 +763,8 @@ Used by: [ServiceManagedResourcesSettings_STATUS](#ServiceManagedResourcesSettin
 |-----------------------|--------------------------------------------------------|---------------------------------|
 | collectionsThroughput | The throughput of the collections in cosmosdb database | int<br/><small>Optional</small> |
 
-<a id="Databricks"></a>Databricks
----------------------------------
+Databricks{#Databricks}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -777,8 +777,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of Databricks                                                                                      | [DatabricksProperties](#DatabricksProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Databricks_STATUS"></a>Databricks_STATUS
------------------------------------------------
+Databricks_STATUS{#Databricks_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -796,8 +796,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [Databricks_ProvisioningState_STATUS](#Databricks_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="DataFactory"></a>DataFactory
------------------------------------
+DataFactory{#DataFactory}
+-------------------------
 
 Used by: [Compute](#Compute).
 
@@ -809,8 +809,8 @@ Used by: [Compute](#Compute).
 | disableLocalAuth  | Opt-out of local authentication and ensure customers can use only MSI and AAD exclusively for authentication. | bool<br/><small>Optional</small>                                                                                                                           |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="DataFactory_STATUS"></a>DataFactory_STATUS
--------------------------------------------------
+DataFactory_STATUS{#DataFactory_STATUS}
+---------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -827,8 +827,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [DataFactory_ProvisioningState_STATUS](#DataFactory_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                        |
 
-<a id="DataLakeAnalytics"></a>DataLakeAnalytics
------------------------------------------------
+DataLakeAnalytics{#DataLakeAnalytics}
+-------------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -841,8 +841,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [DataLakeAnalytics_Properties](#DataLakeAnalytics_Properties)<br/><small>Optional</small>                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_STATUS"></a>DataLakeAnalytics_STATUS
--------------------------------------------------------------
+DataLakeAnalytics_STATUS{#DataLakeAnalytics_STATUS}
+---------------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -860,8 +860,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [DataLakeAnalytics_ProvisioningState_STATUS](#DataLakeAnalytics_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                                    |
 
-<a id="EncryptionProperty_Status_STATUS"></a>EncryptionProperty_Status_STATUS
------------------------------------------------------------------------------
+EncryptionProperty_Status_STATUS{#EncryptionProperty_Status_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -870,8 +870,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="HDInsight"></a>HDInsight
--------------------------------
+HDInsight{#HDInsight}
+---------------------
 
 Used by: [Compute](#Compute).
 
@@ -884,8 +884,8 @@ Used by: [Compute](#Compute).
 | properties        | HDInsight compute properties                                                                                  | [HDInsightProperties](#HDInsightProperties)<br/><small>Optional</small>                                                                                    |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="HDInsight_STATUS"></a>HDInsight_STATUS
----------------------------------------------
+HDInsight_STATUS{#HDInsight_STATUS}
+-----------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -903,8 +903,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [HDInsight_ProvisioningState_STATUS](#HDInsight_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                    |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -915,8 +915,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -927,8 +927,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="IdentityForCmk"></a>IdentityForCmk
------------------------------------------
+IdentityForCmk{#IdentityForCmk}
+-------------------------------
 
 Identity that will be used to access key vault for encryption at rest
 
@@ -938,8 +938,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 |----------------------|----------------------------------------------------------------------------------------------------|------------------------------------|
 | userAssignedIdentity | The ArmId of the user assigned identity that will be used to access the customer managed key vault | string<br/><small>Optional</small> |
 
-<a id="IdentityForCmk_STATUS"></a>IdentityForCmk_STATUS
--------------------------------------------------------
+IdentityForCmk_STATUS{#IdentityForCmk_STATUS}
+---------------------------------------------
 
 Identity that will be used to access key vault for encryption at rest
 
@@ -949,8 +949,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 |----------------------|----------------------------------------------------------------------------------------------------|------------------------------------|
 | userAssignedIdentity | The ArmId of the user assigned identity that will be used to access the customer managed key vault | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -960,8 +960,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | keyIdentifier    | Key vault uri to access the encryption key.                                            | string<br/><small>Required</small> |
 | keyVaultArmId    | The ArmId of the keyVault where the customer owned encryption key is present.          | string<br/><small>Required</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -971,8 +971,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | keyIdentifier    | Key vault uri to access the encryption key.                                            | string<br/><small>Optional</small> |
 | keyVaultArmId    | The ArmId of the keyVault where the customer owned encryption key is present.          | string<br/><small>Optional</small> |
 
-<a id="Kubernetes"></a>Kubernetes
----------------------------------
+Kubernetes{#Kubernetes}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -985,8 +985,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of Kubernetes                                                                                      | [KubernetesProperties](#KubernetesProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Kubernetes_STATUS"></a>Kubernetes_STATUS
------------------------------------------------
+Kubernetes_STATUS{#Kubernetes_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1004,8 +1004,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [Kubernetes_ProvisioningState_STATUS](#Kubernetes_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="NotebookPreparationError_STATUS"></a>NotebookPreparationError_STATUS
----------------------------------------------------------------------------
+NotebookPreparationError_STATUS{#NotebookPreparationError_STATUS}
+-----------------------------------------------------------------
 
 Used by: [NotebookResourceInfo_STATUS](#NotebookResourceInfo_STATUS).
 
@@ -1014,8 +1014,8 @@ Used by: [NotebookResourceInfo_STATUS](#NotebookResourceInfo_STATUS).
 | errorMessage |             | string<br/><small>Optional</small> |
 | statusCode   |             | int<br/><small>Optional</small>    |
 
-<a id="PrivateEndpointServiceConnectionStatus"></a>PrivateEndpointServiceConnectionStatus
------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus{#PrivateEndpointServiceConnectionStatus}
+-------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -1029,8 +1029,8 @@ Used by: [SharedPrivateLinkResource](#SharedPrivateLinkResource).
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -1044,8 +1044,8 @@ Used by: [SharedPrivateLinkResource_STATUS](#SharedPrivateLinkResource_STATUS).
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="SynapseSpark"></a>SynapseSpark
--------------------------------------
+SynapseSpark{#SynapseSpark}
+---------------------------
 
 Used by: [Compute](#Compute).
 
@@ -1058,8 +1058,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [SynapseSpark_Properties](#SynapseSpark_Properties)<br/><small>Optional</small>                                                                            |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SynapseSpark_STATUS"></a>SynapseSpark_STATUS
----------------------------------------------------
+SynapseSpark_STATUS{#SynapseSpark_STATUS}
+-----------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1077,7 +1077,31 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [SynapseSpark_ProvisioningState_STATUS](#SynapseSpark_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                          |
 
-<a id="SystemData_CreatedByType"></a>SystemData_CreatedByType
+SystemData_CreatedByType{#SystemData_CreatedByType}
+---------------------------------------------------
+
+Used by: [SystemData](#SystemData).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType{#SystemData_LastModifiedByType}
 -------------------------------------------------------------
 
 Used by: [SystemData](#SystemData).
@@ -1089,7 +1113,7 @@ Used by: [SystemData](#SystemData).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1101,32 +1125,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType"></a>SystemData_LastModifiedByType
------------------------------------------------------------------------
-
-Used by: [SystemData](#SystemData).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User Assigned Identity
 
@@ -1138,8 +1138,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | principalId | The principal ID of the user assigned identity.        | string<br/><small>Optional</small> |
 | tenantId    | The tenant ID of the user assigned identity.           | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1149,8 +1149,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualMachine"></a>VirtualMachine
------------------------------------------
+VirtualMachine{#VirtualMachine}
+-------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -1163,8 +1163,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [VirtualMachine_Properties](#VirtualMachine_Properties)<br/><small>Optional</small>                                                                        |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
--------------------------------------------------------
+VirtualMachine_STATUS{#VirtualMachine_STATUS}
+---------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1182,8 +1182,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [VirtualMachine_ProvisioningState_STATUS](#VirtualMachine_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                              |
 
-<a id="WorkspaceOperatorSecrets"></a>WorkspaceOperatorSecrets
--------------------------------------------------------------
+WorkspaceOperatorSecrets{#WorkspaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [WorkspaceOperatorSpec](#WorkspaceOperatorSpec).
 
@@ -1197,8 +1197,8 @@ Used by: [WorkspaceOperatorSpec](#WorkspaceOperatorSpec).
 | secondaryNotebookAccessKey    | indicates where the SecondaryNotebookAccessKey secret should be placed. If omitted, the secret will not be retrieved from Azure.    | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userStorageKey                | indicates where the UserStorageKey secret should be placed. If omitted, the secret will not be retrieved from Azure.                | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="AKS_ComputeType"></a>AKS_ComputeType
--------------------------------------------
+AKS_ComputeType{#AKS_ComputeType}
+---------------------------------
 
 Used by: [AKS](#AKS).
 
@@ -1206,8 +1206,8 @@ Used by: [AKS](#AKS).
 |-------|-------------|
 | "AKS" |             |
 
-<a id="AKS_ComputeType_STATUS"></a>AKS_ComputeType_STATUS
----------------------------------------------------------
+AKS_ComputeType_STATUS{#AKS_ComputeType_STATUS}
+-----------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -1215,8 +1215,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 |-------|-------------|
 | "AKS" |             |
 
-<a id="AKS_Properties"></a>AKS_Properties
------------------------------------------
+AKS_Properties{#AKS_Properties}
+-------------------------------
 
 Used by: [AKS](#AKS).
 
@@ -1231,8 +1231,8 @@ Used by: [AKS](#AKS).
 | loadBalancerType           | Load Balancer Type                    | [AKS_Properties_LoadBalancerType](#AKS_Properties_LoadBalancerType)<br/><small>Optional</small> |
 | sslConfiguration           | SSL configuration                     | [SslConfiguration](#SslConfiguration)<br/><small>Optional</small>                               |
 
-<a id="AKS_Properties_STATUS"></a>AKS_Properties_STATUS
--------------------------------------------------------
+AKS_Properties_STATUS{#AKS_Properties_STATUS}
+---------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -1248,8 +1248,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 | sslConfiguration           | SSL configuration                     | [SslConfiguration_STATUS](#SslConfiguration_STATUS)<br/><small>Optional</small>                               |
 | systemServices             | System services                       | [SystemService_STATUS[]](#SystemService_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="AKS_ProvisioningState_STATUS"></a>AKS_ProvisioningState_STATUS
----------------------------------------------------------------------
+AKS_ProvisioningState_STATUS{#AKS_ProvisioningState_STATUS}
+-----------------------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -1263,8 +1263,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="AmlCompute_ComputeType"></a>AmlCompute_ComputeType
----------------------------------------------------------
+AmlCompute_ComputeType{#AmlCompute_ComputeType}
+-----------------------------------------------
 
 Used by: [AmlCompute](#AmlCompute).
 
@@ -1272,8 +1272,8 @@ Used by: [AmlCompute](#AmlCompute).
 |--------------|-------------|
 | "AmlCompute" |             |
 
-<a id="AmlCompute_ComputeType_STATUS"></a>AmlCompute_ComputeType_STATUS
------------------------------------------------------------------------
+AmlCompute_ComputeType_STATUS{#AmlCompute_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 
@@ -1281,8 +1281,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 |--------------|-------------|
 | "AmlCompute" |             |
 
-<a id="AmlCompute_ProvisioningState_STATUS"></a>AmlCompute_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+AmlCompute_ProvisioningState_STATUS{#AmlCompute_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 
@@ -1296,8 +1296,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="AmlComputeProperties"></a>AmlComputeProperties
------------------------------------------------------
+AmlComputeProperties{#AmlComputeProperties}
+-------------------------------------------
 
 AML Compute properties
 
@@ -1316,8 +1316,8 @@ Used by: [AmlCompute](#AmlCompute).
 | vmPriority                  | Virtual Machine priority                                                                                                                                                                                                                                                                                                                                                                                                                                                        | [AmlComputeProperties_VmPriority](#AmlComputeProperties_VmPriority)<br/><small>Optional</small>                                   |
 | vmSize                      | Virtual Machine Size                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                |
 
-<a id="AmlComputeProperties_STATUS"></a>AmlComputeProperties_STATUS
--------------------------------------------------------------------
+AmlComputeProperties_STATUS{#AmlComputeProperties_STATUS}
+---------------------------------------------------------
 
 AML Compute properties
 
@@ -1342,8 +1342,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 | vmPriority                    | Virtual Machine priority                                                                                                                                                                                                                                                                                                                                                                                                                                                        | [AmlComputeProperties_VmPriority_STATUS](#AmlComputeProperties_VmPriority_STATUS)<br/><small>Optional</small>                                   |
 | vmSize                        | Virtual Machine Size                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                              |
 
-<a id="ComputeInstance_ComputeType"></a>ComputeInstance_ComputeType
--------------------------------------------------------------------
+ComputeInstance_ComputeType{#ComputeInstance_ComputeType}
+---------------------------------------------------------
 
 Used by: [ComputeInstance](#ComputeInstance).
 
@@ -1351,8 +1351,8 @@ Used by: [ComputeInstance](#ComputeInstance).
 |-------------------|-------------|
 | "ComputeInstance" |             |
 
-<a id="ComputeInstance_ComputeType_STATUS"></a>ComputeInstance_ComputeType_STATUS
----------------------------------------------------------------------------------
+ComputeInstance_ComputeType_STATUS{#ComputeInstance_ComputeType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 
@@ -1360,8 +1360,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 |-------------------|-------------|
 | "ComputeInstance" |             |
 
-<a id="ComputeInstance_ProvisioningState_STATUS"></a>ComputeInstance_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+ComputeInstance_ProvisioningState_STATUS{#ComputeInstance_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 
@@ -1375,8 +1375,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="ComputeInstanceProperties"></a>ComputeInstanceProperties
----------------------------------------------------------------
+ComputeInstanceProperties{#ComputeInstanceProperties}
+-----------------------------------------------------
 
 Compute Instance properties
 
@@ -1392,8 +1392,8 @@ Used by: [ComputeInstance](#ComputeInstance).
 | subnet                           | Virtual network subnet resource ID the compute nodes belong to.                                                                                                                                                                                                                        | [ResourceId](#ResourceId)<br/><small>Optional</small>                                                                                                 |
 | vmSize                           | Virtual Machine Size                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ComputeInstanceProperties_STATUS"></a>ComputeInstanceProperties_STATUS
------------------------------------------------------------------------------
+ComputeInstanceProperties_STATUS{#ComputeInstanceProperties_STATUS}
+-------------------------------------------------------------------
 
 Compute Instance properties
 
@@ -1415,8 +1415,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 | subnet                           | Virtual network subnet resource ID the compute nodes belong to.                                                                                                                                                                                                                        | [ResourceId_STATUS](#ResourceId_STATUS)<br/><small>Optional</small>                                                                                                 |
 | vmSize                           | Virtual Machine Size                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="Databricks_ComputeType"></a>Databricks_ComputeType
----------------------------------------------------------
+Databricks_ComputeType{#Databricks_ComputeType}
+-----------------------------------------------
 
 Used by: [Databricks](#Databricks).
 
@@ -1424,8 +1424,8 @@ Used by: [Databricks](#Databricks).
 |--------------|-------------|
 | "Databricks" |             |
 
-<a id="Databricks_ComputeType_STATUS"></a>Databricks_ComputeType_STATUS
------------------------------------------------------------------------
+Databricks_ComputeType_STATUS{#Databricks_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [Databricks_STATUS](#Databricks_STATUS).
 
@@ -1433,8 +1433,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 |--------------|-------------|
 | "Databricks" |             |
 
-<a id="Databricks_ProvisioningState_STATUS"></a>Databricks_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+Databricks_ProvisioningState_STATUS{#Databricks_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Databricks_STATUS](#Databricks_STATUS).
 
@@ -1448,8 +1448,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="DatabricksProperties"></a>DatabricksProperties
------------------------------------------------------
+DatabricksProperties{#DatabricksProperties}
+-------------------------------------------
 
 Properties of Databricks
 
@@ -1460,8 +1460,8 @@ Used by: [Databricks](#Databricks).
 | databricksAccessToken | Databricks access token | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | workspaceUrl          | Workspace Url           | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="DatabricksProperties_STATUS"></a>DatabricksProperties_STATUS
--------------------------------------------------------------------
+DatabricksProperties_STATUS{#DatabricksProperties_STATUS}
+---------------------------------------------------------
 
 Properties of Databricks
 
@@ -1471,8 +1471,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 |--------------|---------------|------------------------------------|
 | workspaceUrl | Workspace Url | string<br/><small>Optional</small> |
 
-<a id="DataFactory_ComputeType"></a>DataFactory_ComputeType
------------------------------------------------------------
+DataFactory_ComputeType{#DataFactory_ComputeType}
+-------------------------------------------------
 
 Used by: [DataFactory](#DataFactory).
 
@@ -1480,8 +1480,8 @@ Used by: [DataFactory](#DataFactory).
 |---------------|-------------|
 | "DataFactory" |             |
 
-<a id="DataFactory_ComputeType_STATUS"></a>DataFactory_ComputeType_STATUS
--------------------------------------------------------------------------
+DataFactory_ComputeType_STATUS{#DataFactory_ComputeType_STATUS}
+---------------------------------------------------------------
 
 Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 
@@ -1489,8 +1489,8 @@ Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 |---------------|-------------|
 | "DataFactory" |             |
 
-<a id="DataFactory_ProvisioningState_STATUS"></a>DataFactory_ProvisioningState_STATUS
--------------------------------------------------------------------------------------
+DataFactory_ProvisioningState_STATUS{#DataFactory_ProvisioningState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 
@@ -1504,8 +1504,8 @@ Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="DataLakeAnalytics_ComputeType"></a>DataLakeAnalytics_ComputeType
------------------------------------------------------------------------
+DataLakeAnalytics_ComputeType{#DataLakeAnalytics_ComputeType}
+-------------------------------------------------------------
 
 Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 
@@ -1513,8 +1513,8 @@ Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 |---------------------|-------------|
 | "DataLakeAnalytics" |             |
 
-<a id="DataLakeAnalytics_ComputeType_STATUS"></a>DataLakeAnalytics_ComputeType_STATUS
--------------------------------------------------------------------------------------
+DataLakeAnalytics_ComputeType_STATUS{#DataLakeAnalytics_ComputeType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -1522,8 +1522,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 |---------------------|-------------|
 | "DataLakeAnalytics" |             |
 
-<a id="DataLakeAnalytics_Properties"></a>DataLakeAnalytics_Properties
----------------------------------------------------------------------
+DataLakeAnalytics_Properties{#DataLakeAnalytics_Properties}
+-----------------------------------------------------------
 
 Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 
@@ -1531,8 +1531,8 @@ Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 |--------------------------|-----------------------------|------------------------------------|
 | dataLakeStoreAccountName | DataLake Store Account Name | string<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_Properties_STATUS"></a>DataLakeAnalytics_Properties_STATUS
------------------------------------------------------------------------------------
+DataLakeAnalytics_Properties_STATUS{#DataLakeAnalytics_Properties_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -1540,8 +1540,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 |--------------------------|-----------------------------|------------------------------------|
 | dataLakeStoreAccountName | DataLake Store Account Name | string<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_ProvisioningState_STATUS"></a>DataLakeAnalytics_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+DataLakeAnalytics_ProvisioningState_STATUS{#DataLakeAnalytics_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -1555,8 +1555,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="ErrorResponse_STATUS"></a>ErrorResponse_STATUS
------------------------------------------------------
+ErrorResponse_STATUS{#ErrorResponse_STATUS}
+-------------------------------------------
 
 Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).
 
@@ -1566,8 +1566,8 @@ Used by: [AKS_STATUS](#AKS_STATUS), [AmlCompute_STATUS](#AmlCompute_STATUS), [Am
 |----------|-------------------|-----------------------------------------------------------------------|
 | error    | The error object. | [ErrorDetail_STATUS](#ErrorDetail_STATUS)<br/><small>Optional</small> |
 
-<a id="HDInsight_ComputeType"></a>HDInsight_ComputeType
--------------------------------------------------------
+HDInsight_ComputeType{#HDInsight_ComputeType}
+---------------------------------------------
 
 Used by: [HDInsight](#HDInsight).
 
@@ -1575,8 +1575,8 @@ Used by: [HDInsight](#HDInsight).
 |-------------|-------------|
 | "HDInsight" |             |
 
-<a id="HDInsight_ComputeType_STATUS"></a>HDInsight_ComputeType_STATUS
----------------------------------------------------------------------
+HDInsight_ComputeType_STATUS{#HDInsight_ComputeType_STATUS}
+-----------------------------------------------------------
 
 Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 
@@ -1584,8 +1584,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 |-------------|-------------|
 | "HDInsight" |             |
 
-<a id="HDInsight_ProvisioningState_STATUS"></a>HDInsight_ProvisioningState_STATUS
----------------------------------------------------------------------------------
+HDInsight_ProvisioningState_STATUS{#HDInsight_ProvisioningState_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 
@@ -1599,8 +1599,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="HDInsightProperties"></a>HDInsightProperties
----------------------------------------------------
+HDInsightProperties{#HDInsightProperties}
+-----------------------------------------
 
 HDInsight compute properties
 
@@ -1612,8 +1612,8 @@ Used by: [HDInsight](#HDInsight).
 | administratorAccount | Admin credentials for master node of the cluster                 | [VirtualMachineSshCredentials](#VirtualMachineSshCredentials)<br/><small>Optional</small> |
 | sshPort              | Port open for ssh connections on the master node of the cluster. | int<br/><small>Optional</small>                                                           |
 
-<a id="HDInsightProperties_STATUS"></a>HDInsightProperties_STATUS
------------------------------------------------------------------
+HDInsightProperties_STATUS{#HDInsightProperties_STATUS}
+-------------------------------------------------------
 
 HDInsight compute properties
 
@@ -1625,8 +1625,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 | administratorAccount | Admin credentials for master node of the cluster                 | [VirtualMachineSshCredentials_STATUS](#VirtualMachineSshCredentials_STATUS)<br/><small>Optional</small> |
 | sshPort              | Port open for ssh connections on the master node of the cluster. | int<br/><small>Optional</small>                                                                         |
 
-<a id="Kubernetes_ComputeType"></a>Kubernetes_ComputeType
----------------------------------------------------------
+Kubernetes_ComputeType{#Kubernetes_ComputeType}
+-----------------------------------------------
 
 Used by: [Kubernetes](#Kubernetes).
 
@@ -1634,8 +1634,8 @@ Used by: [Kubernetes](#Kubernetes).
 |--------------|-------------|
 | "Kubernetes" |             |
 
-<a id="Kubernetes_ComputeType_STATUS"></a>Kubernetes_ComputeType_STATUS
------------------------------------------------------------------------
+Kubernetes_ComputeType_STATUS{#Kubernetes_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 
@@ -1643,8 +1643,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 |--------------|-------------|
 | "Kubernetes" |             |
 
-<a id="Kubernetes_ProvisioningState_STATUS"></a>Kubernetes_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+Kubernetes_ProvisioningState_STATUS{#Kubernetes_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 
@@ -1658,8 +1658,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="KubernetesProperties"></a>KubernetesProperties
------------------------------------------------------
+KubernetesProperties{#KubernetesProperties}
+-------------------------------------------
 
 Kubernetes properties
 
@@ -1676,8 +1676,8 @@ Used by: [Kubernetes](#Kubernetes).
 | serviceBusConnectionString    | ServiceBus connection string.     | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | vcName                        | VC name.                          | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="KubernetesProperties_STATUS"></a>KubernetesProperties_STATUS
--------------------------------------------------------------------
+KubernetesProperties_STATUS{#KubernetesProperties_STATUS}
+---------------------------------------------------------
 
 Kubernetes properties
 
@@ -1692,8 +1692,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 | namespace                     | Compute namespace                 | string<br/><small>Optional</small>                                                             |
 | vcName                        | VC name.                          | string<br/><small>Optional</small>                                                             |
 
-<a id="SynapseSpark_ComputeType"></a>SynapseSpark_ComputeType
--------------------------------------------------------------
+SynapseSpark_ComputeType{#SynapseSpark_ComputeType}
+---------------------------------------------------
 
 Used by: [SynapseSpark](#SynapseSpark).
 
@@ -1701,8 +1701,8 @@ Used by: [SynapseSpark](#SynapseSpark).
 |----------------|-------------|
 | "SynapseSpark" |             |
 
-<a id="SynapseSpark_ComputeType_STATUS"></a>SynapseSpark_ComputeType_STATUS
----------------------------------------------------------------------------
+SynapseSpark_ComputeType_STATUS{#SynapseSpark_ComputeType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -1710,8 +1710,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 |----------------|-------------|
 | "SynapseSpark" |             |
 
-<a id="SynapseSpark_Properties"></a>SynapseSpark_Properties
------------------------------------------------------------
+SynapseSpark_Properties{#SynapseSpark_Properties}
+-------------------------------------------------
 
 Used by: [SynapseSpark](#SynapseSpark).
 
@@ -1728,8 +1728,8 @@ Used by: [SynapseSpark](#SynapseSpark).
 | subscriptionId      | Azure subscription identifier.                                 | string<br/><small>Optional</small>                                      |
 | workspaceName       | Name of Azure Machine Learning workspace.                      | string<br/><small>Optional</small>                                      |
 
-<a id="SynapseSpark_Properties_STATUS"></a>SynapseSpark_Properties_STATUS
--------------------------------------------------------------------------
+SynapseSpark_Properties_STATUS{#SynapseSpark_Properties_STATUS}
+---------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -1746,8 +1746,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 | subscriptionId      | Azure subscription identifier.                                 | string<br/><small>Optional</small>                                                    |
 | workspaceName       | Name of Azure Machine Learning workspace.                      | string<br/><small>Optional</small>                                                    |
 
-<a id="SynapseSpark_ProvisioningState_STATUS"></a>SynapseSpark_ProvisioningState_STATUS
----------------------------------------------------------------------------------------
+SynapseSpark_ProvisioningState_STATUS{#SynapseSpark_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -1761,8 +1761,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="VirtualMachine_ComputeType"></a>VirtualMachine_ComputeType
------------------------------------------------------------------
+VirtualMachine_ComputeType{#VirtualMachine_ComputeType}
+-------------------------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -1770,8 +1770,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 |------------------|-------------|
 | "VirtualMachine" |             |
 
-<a id="VirtualMachine_ComputeType_STATUS"></a>VirtualMachine_ComputeType_STATUS
--------------------------------------------------------------------------------
+VirtualMachine_ComputeType_STATUS{#VirtualMachine_ComputeType_STATUS}
+---------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -1779,8 +1779,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 |------------------|-------------|
 | "VirtualMachine" |             |
 
-<a id="VirtualMachine_Properties"></a>VirtualMachine_Properties
----------------------------------------------------------------
+VirtualMachine_Properties{#VirtualMachine_Properties}
+-----------------------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -1792,8 +1792,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | sshPort                   | Port open for ssh connections.                                     | int<br/><small>Optional</small>                                                           |
 | virtualMachineSize        | Virtual Machine size                                               | string<br/><small>Optional</small>                                                        |
 
-<a id="VirtualMachine_Properties_STATUS"></a>VirtualMachine_Properties_STATUS
------------------------------------------------------------------------------
+VirtualMachine_Properties_STATUS{#VirtualMachine_Properties_STATUS}
+-------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -1805,8 +1805,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | sshPort                   | Port open for ssh connections.                                     | int<br/><small>Optional</small>                                                                         |
 | virtualMachineSize        | Virtual Machine size                                               | string<br/><small>Optional</small>                                                                      |
 
-<a id="VirtualMachine_ProvisioningState_STATUS"></a>VirtualMachine_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------
+VirtualMachine_ProvisioningState_STATUS{#VirtualMachine_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -1820,8 +1820,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="AKS_Properties_ClusterPurpose"></a>AKS_Properties_ClusterPurpose
------------------------------------------------------------------------
+AKS_Properties_ClusterPurpose{#AKS_Properties_ClusterPurpose}
+-------------------------------------------------------------
 
 Used by: [AKS_Properties](#AKS_Properties).
 
@@ -1831,20 +1831,20 @@ Used by: [AKS_Properties](#AKS_Properties).
 | "DevTest"   |             |
 | "FastProd"  |             |
 
-<a id="AKS_Properties_ClusterPurpose_STATUS"></a>AKS_Properties_ClusterPurpose_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "DenseProd" |             |
-| "DevTest"   |             |
-| "FastProd"  |             |
-
-<a id="AKS_Properties_LoadBalancerType"></a>AKS_Properties_LoadBalancerType
+AKS_Properties_ClusterPurpose_STATUS{#AKS_Properties_ClusterPurpose_STATUS}
 ---------------------------------------------------------------------------
 
+Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "DenseProd" |             |
+| "DevTest"   |             |
+| "FastProd"  |             |
+
+AKS_Properties_LoadBalancerType{#AKS_Properties_LoadBalancerType}
+-----------------------------------------------------------------
+
 Used by: [AKS_Properties](#AKS_Properties).
 
 | Value                  | Description |
@@ -1852,8 +1852,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | "InternalLoadBalancer" |             |
 | "PublicIp"             |             |
 
-<a id="AKS_Properties_LoadBalancerType_STATUS"></a>AKS_Properties_LoadBalancerType_STATUS
------------------------------------------------------------------------------------------
+AKS_Properties_LoadBalancerType_STATUS{#AKS_Properties_LoadBalancerType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 
@@ -1862,8 +1862,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | "InternalLoadBalancer" |             |
 | "PublicIp"             |             |
 
-<a id="AksNetworkingConfiguration"></a>AksNetworkingConfiguration
------------------------------------------------------------------
+AksNetworkingConfiguration{#AksNetworkingConfiguration}
+-------------------------------------------------------
 
 Advance configuration for AKS networking
 
@@ -1876,8 +1876,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | serviceCidr      | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                      | string<br/><small>Optional</small>                                                                                                                         |
 | subnetReference  | Virtual network subnet resource ID the compute nodes belong to                                                                                         | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AksNetworkingConfiguration_STATUS"></a>AksNetworkingConfiguration_STATUS
--------------------------------------------------------------------------------
+AksNetworkingConfiguration_STATUS{#AksNetworkingConfiguration_STATUS}
+---------------------------------------------------------------------
 
 Advance configuration for AKS networking
 
@@ -1890,8 +1890,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | serviceCidr      | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                      | string<br/><small>Optional</small> |
 | subnetId         | Virtual network subnet resource ID the compute nodes belong to                                                                                         | string<br/><small>Optional</small> |
 
-<a id="AmlComputeProperties_AllocationState_STATUS"></a>AmlComputeProperties_AllocationState_STATUS
----------------------------------------------------------------------------------------------------
+AmlComputeProperties_AllocationState_STATUS{#AmlComputeProperties_AllocationState_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -1900,8 +1900,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Resizing" |             |
 | "Steady"   |             |
 
-<a id="AmlComputeProperties_OsType"></a>AmlComputeProperties_OsType
--------------------------------------------------------------------
+AmlComputeProperties_OsType{#AmlComputeProperties_OsType}
+---------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -1910,8 +1910,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="AmlComputeProperties_OsType_STATUS"></a>AmlComputeProperties_OsType_STATUS
----------------------------------------------------------------------------------
+AmlComputeProperties_OsType_STATUS{#AmlComputeProperties_OsType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -1920,8 +1920,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="AmlComputeProperties_RemoteLoginPortPublicAccess"></a>AmlComputeProperties_RemoteLoginPortPublicAccess
--------------------------------------------------------------------------------------------------------------
+AmlComputeProperties_RemoteLoginPortPublicAccess{#AmlComputeProperties_RemoteLoginPortPublicAccess}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -1931,8 +1931,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Enabled"      |             |
 | "NotSpecified" |             |
 
-<a id="AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS"></a>AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS{#AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -1942,8 +1942,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Enabled"      |             |
 | "NotSpecified" |             |
 
-<a id="AmlComputeProperties_VmPriority"></a>AmlComputeProperties_VmPriority
----------------------------------------------------------------------------
+AmlComputeProperties_VmPriority{#AmlComputeProperties_VmPriority}
+-----------------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -1952,68 +1952,68 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Dedicated"   |             |
 | "LowPriority" |             |
 
-<a id="AmlComputeProperties_VmPriority_STATUS"></a>AmlComputeProperties_VmPriority_STATUS
------------------------------------------------------------------------------------------
-
-Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "Dedicated"   |             |
-| "LowPriority" |             |
-
-<a id="AutoPauseProperties"></a>AutoPauseProperties
----------------------------------------------------
-
-Auto pause properties
-
-Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
-
-| Property       | Description | Type                             |
-|----------------|-------------|----------------------------------|
-| delayInMinutes |             | int<br/><small>Optional</small>  |
-| enabled        |             | bool<br/><small>Optional</small> |
-
-<a id="AutoPauseProperties_STATUS"></a>AutoPauseProperties_STATUS
------------------------------------------------------------------
-
-Auto pause properties
-
-Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
-
-| Property       | Description | Type                             |
-|----------------|-------------|----------------------------------|
-| delayInMinutes |             | int<br/><small>Optional</small>  |
-| enabled        |             | bool<br/><small>Optional</small> |
-
-<a id="AutoScaleProperties"></a>AutoScaleProperties
----------------------------------------------------
-
-Auto scale properties
-
-Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
-
-| Property     | Description | Type                             |
-|--------------|-------------|----------------------------------|
-| enabled      |             | bool<br/><small>Optional</small> |
-| maxNodeCount |             | int<br/><small>Optional</small>  |
-| minNodeCount |             | int<br/><small>Optional</small>  |
-
-<a id="AutoScaleProperties_STATUS"></a>AutoScaleProperties_STATUS
------------------------------------------------------------------
-
-Auto scale properties
-
-Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
-
-| Property     | Description | Type                             |
-|--------------|-------------|----------------------------------|
-| enabled      |             | bool<br/><small>Optional</small> |
-| maxNodeCount |             | int<br/><small>Optional</small>  |
-| minNodeCount |             | int<br/><small>Optional</small>  |
-
-<a id="ComputeInstanceApplication_STATUS"></a>ComputeInstanceApplication_STATUS
+AmlComputeProperties_VmPriority_STATUS{#AmlComputeProperties_VmPriority_STATUS}
 -------------------------------------------------------------------------------
+
+Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "Dedicated"   |             |
+| "LowPriority" |             |
+
+AutoPauseProperties{#AutoPauseProperties}
+-----------------------------------------
+
+Auto pause properties
+
+Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
+
+| Property       | Description | Type                             |
+|----------------|-------------|----------------------------------|
+| delayInMinutes |             | int<br/><small>Optional</small>  |
+| enabled        |             | bool<br/><small>Optional</small> |
+
+AutoPauseProperties_STATUS{#AutoPauseProperties_STATUS}
+-------------------------------------------------------
+
+Auto pause properties
+
+Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
+
+| Property       | Description | Type                             |
+|----------------|-------------|----------------------------------|
+| delayInMinutes |             | int<br/><small>Optional</small>  |
+| enabled        |             | bool<br/><small>Optional</small> |
+
+AutoScaleProperties{#AutoScaleProperties}
+-----------------------------------------
+
+Auto scale properties
+
+Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
+
+| Property     | Description | Type                             |
+|--------------|-------------|----------------------------------|
+| enabled      |             | bool<br/><small>Optional</small> |
+| maxNodeCount |             | int<br/><small>Optional</small>  |
+| minNodeCount |             | int<br/><small>Optional</small>  |
+
+AutoScaleProperties_STATUS{#AutoScaleProperties_STATUS}
+-------------------------------------------------------
+
+Auto scale properties
+
+Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
+
+| Property     | Description | Type                             |
+|--------------|-------------|----------------------------------|
+| enabled      |             | bool<br/><small>Optional</small> |
+| maxNodeCount |             | int<br/><small>Optional</small>  |
+| minNodeCount |             | int<br/><small>Optional</small>  |
+
+ComputeInstanceApplication_STATUS{#ComputeInstanceApplication_STATUS}
+---------------------------------------------------------------------
 
 Defines an Aml Instance application and its connectivity endpoint URI.
 
@@ -2024,8 +2024,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | displayName | Name of the ComputeInstance application. | string<br/><small>Optional</small> |
 | endpointUri | Application' endpoint URI.               | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceConnectivityEndpoints_STATUS"></a>ComputeInstanceConnectivityEndpoints_STATUS
----------------------------------------------------------------------------------------------------
+ComputeInstanceConnectivityEndpoints_STATUS{#ComputeInstanceConnectivityEndpoints_STATUS}
+-----------------------------------------------------------------------------------------
 
 Defines all connectivity endpoints and properties for an ComputeInstance.
 
@@ -2036,8 +2036,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | privateIpAddress | Private IP Address of this ComputeInstance (local to the VNET in which the compute instance is deployed). | string<br/><small>Optional</small> |
 | publicIpAddress  | Public IP Address of this ComputeInstance.                                                                | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceCreatedBy_STATUS"></a>ComputeInstanceCreatedBy_STATUS
----------------------------------------------------------------------------
+ComputeInstanceCreatedBy_STATUS{#ComputeInstanceCreatedBy_STATUS}
+-----------------------------------------------------------------
 
 Describes information on user who created this ComputeInstance.
 
@@ -2049,8 +2049,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | userName  | Name of the user.                                              | string<br/><small>Optional</small> |
 | userOrgId | Uniquely identifies user' Azure Active Directory organization. | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceLastOperation_STATUS"></a>ComputeInstanceLastOperation_STATUS
------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_STATUS{#ComputeInstanceLastOperation_STATUS}
+-------------------------------------------------------------------------
 
 The last operation on ComputeInstance.
 
@@ -2062,8 +2062,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | operationStatus | Operation status.           | [ComputeInstanceLastOperation_OperationStatus_STATUS](#ComputeInstanceLastOperation_OperationStatus_STATUS)<br/><small>Optional</small> |
 | operationTime   | Time of the last operation. | string<br/><small>Optional</small>                                                                                                      |
 
-<a id="ComputeInstanceProperties_ApplicationSharingPolicy"></a>ComputeInstanceProperties_ApplicationSharingPolicy
------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ApplicationSharingPolicy{#ComputeInstanceProperties_ApplicationSharingPolicy}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 
@@ -2072,8 +2072,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 | "Personal" |             |
 | "Shared"   |             |
 
-<a id="ComputeInstanceProperties_ApplicationSharingPolicy_STATUS"></a>ComputeInstanceProperties_ApplicationSharingPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ApplicationSharingPolicy_STATUS{#ComputeInstanceProperties_ApplicationSharingPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 
@@ -2082,8 +2082,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | "Personal" |             |
 | "Shared"   |             |
 
-<a id="ComputeInstanceProperties_ComputeInstanceAuthorizationType"></a>ComputeInstanceProperties_ComputeInstanceAuthorizationType
----------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ComputeInstanceAuthorizationType{#ComputeInstanceProperties_ComputeInstanceAuthorizationType}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 
@@ -2091,8 +2091,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |------------|-------------|
 | "personal" |             |
 
-<a id="ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS"></a>ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS{#ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 
@@ -2100,8 +2100,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |------------|-------------|
 | "personal" |             |
 
-<a id="ComputeInstanceSshSettings"></a>ComputeInstanceSshSettings
------------------------------------------------------------------
+ComputeInstanceSshSettings{#ComputeInstanceSshSettings}
+-------------------------------------------------------
 
 Specifies policy and settings for SSH access.
 
@@ -2112,8 +2112,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 | adminPublicKey  | Specifies the SSH rsa public key file as a string. Use "ssh-keygen -t rsa -b 2048" to generate your SSH key pairs.                                                                                                                                  | string<br/><small>Optional</small>                                                                                    |
 | sshPublicAccess | State of the public SSH port. Possible values are: Disabled - Indicates that the public ssh port is closed on this instance. Enabled - Indicates that the public ssh port is open and accessible according to the VNet/subnet policy if applicable. | [ComputeInstanceSshSettings_SshPublicAccess](#ComputeInstanceSshSettings_SshPublicAccess)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceSshSettings_STATUS"></a>ComputeInstanceSshSettings_STATUS
--------------------------------------------------------------------------------
+ComputeInstanceSshSettings_STATUS{#ComputeInstanceSshSettings_STATUS}
+---------------------------------------------------------------------
 
 Specifies policy and settings for SSH access.
 
@@ -2126,8 +2126,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | sshPort         | Describes the port for connecting through SSH.                                                                                                                                                                                                      | int<br/><small>Optional</small>                                                                                                     |
 | sshPublicAccess | State of the public SSH port. Possible values are: Disabled - Indicates that the public ssh port is closed on this instance. Enabled - Indicates that the public ssh port is open and accessible according to the VNet/subnet policy if applicable. | [ComputeInstanceSshSettings_SshPublicAccess_STATUS](#ComputeInstanceSshSettings_SshPublicAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceState_STATUS"></a>ComputeInstanceState_STATUS
--------------------------------------------------------------------
+ComputeInstanceState_STATUS{#ComputeInstanceState_STATUS}
+---------------------------------------------------------
 
 Current state of an ComputeInstance.
 
@@ -2151,8 +2151,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | "UserSettingUp"   |             |
 | "UserSetupFailed" |             |
 
-<a id="ErrorDetail_STATUS"></a>ErrorDetail_STATUS
--------------------------------------------------
+ErrorDetail_STATUS{#ErrorDetail_STATUS}
+---------------------------------------
 
 The error detail.
 
@@ -2166,8 +2166,8 @@ Used by: [ErrorResponse_STATUS](#ErrorResponse_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                        |
 | target         | The error target.          | string<br/><small>Optional</small>                                                        |
 
-<a id="InstanceTypeSchema"></a>InstanceTypeSchema
--------------------------------------------------
+InstanceTypeSchema{#InstanceTypeSchema}
+---------------------------------------
 
 Instance type schema.
 
@@ -2178,8 +2178,8 @@ Used by: [KubernetesProperties](#KubernetesProperties).
 | nodeSelector | Node Selector                                   | map[string]string<br/><small>Optional</small>                                             |
 | resources    | Resource requests/limits for this instance type | [InstanceTypeSchema_Resources](#InstanceTypeSchema_Resources)<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema_STATUS"></a>InstanceTypeSchema_STATUS
----------------------------------------------------------------
+InstanceTypeSchema_STATUS{#InstanceTypeSchema_STATUS}
+-----------------------------------------------------
 
 Instance type schema.
 
@@ -2190,8 +2190,8 @@ Used by: [KubernetesProperties_STATUS](#KubernetesProperties_STATUS).
 | nodeSelector | Node Selector                                   | map[string]string<br/><small>Optional</small>                                                           |
 | resources    | Resource requests/limits for this instance type | [InstanceTypeSchema_Resources_STATUS](#InstanceTypeSchema_Resources_STATUS)<br/><small>Optional</small> |
 
-<a id="NodeStateCounts_STATUS"></a>NodeStateCounts_STATUS
----------------------------------------------------------
+NodeStateCounts_STATUS{#NodeStateCounts_STATUS}
+-----------------------------------------------
 
 Counts of various compute node states on the amlCompute.
 
@@ -2206,8 +2206,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | runningNodeCount   | Number of compute nodes which are running jobs.           | int<br/><small>Optional</small> |
 | unusableNodeCount  | Number of compute nodes which are in unusable state.      | int<br/><small>Optional</small> |
 
-<a id="PersonalComputeInstanceSettings"></a>PersonalComputeInstanceSettings
----------------------------------------------------------------------------
+PersonalComputeInstanceSettings{#PersonalComputeInstanceSettings}
+-----------------------------------------------------------------
 
 Settings for a personal compute instance.
 
@@ -2217,8 +2217,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |--------------|------------------------------------------------------------|-----------------------------------------------------------|
 | assignedUser | A user explicitly assigned to a personal compute instance. | [AssignedUser](#AssignedUser)<br/><small>Optional</small> |
 
-<a id="PersonalComputeInstanceSettings_STATUS"></a>PersonalComputeInstanceSettings_STATUS
------------------------------------------------------------------------------------------
+PersonalComputeInstanceSettings_STATUS{#PersonalComputeInstanceSettings_STATUS}
+-------------------------------------------------------------------------------
 
 Settings for a personal compute instance.
 
@@ -2228,8 +2228,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |--------------|------------------------------------------------------------|-------------------------------------------------------------------------|
 | assignedUser | A user explicitly assigned to a personal compute instance. | [AssignedUser_STATUS](#AssignedUser_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceId"></a>ResourceId
----------------------------------
+ResourceId{#ResourceId}
+-----------------------
 
 Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 
@@ -2239,8 +2239,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties), and [ComputeInstanceProp
 |-----------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The ID of the resource | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="ResourceId_STATUS"></a>ResourceId_STATUS
------------------------------------------------
+ResourceId_STATUS{#ResourceId_STATUS}
+-------------------------------------
 
 Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 
@@ -2250,8 +2250,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS), and [Compu
 |----------|------------------------|------------------------------------|
 | id       | The ID of the resource | string<br/><small>Optional</small> |
 
-<a id="ScaleSettings"></a>ScaleSettings
----------------------------------------
+ScaleSettings{#ScaleSettings}
+-----------------------------
 
 scale settings for AML Compute
 
@@ -2263,8 +2263,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | minNodeCount                | Min number of nodes to use                                                                | int<br/><small>Optional</small>    |
 | nodeIdleTimeBeforeScaleDown | Node Idle Time before scaling down amlCompute. This string needs to be in the RFC Format. | string<br/><small>Optional</small> |
 
-<a id="ScaleSettings_STATUS"></a>ScaleSettings_STATUS
------------------------------------------------------
+ScaleSettings_STATUS{#ScaleSettings_STATUS}
+-------------------------------------------
 
 scale settings for AML Compute
 
@@ -2276,8 +2276,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | minNodeCount                | Min number of nodes to use                                                                | int<br/><small>Optional</small>    |
 | nodeIdleTimeBeforeScaleDown | Node Idle Time before scaling down amlCompute. This string needs to be in the RFC Format. | string<br/><small>Optional</small> |
 
-<a id="SetupScripts"></a>SetupScripts
--------------------------------------
+SetupScripts{#SetupScripts}
+---------------------------
 
 Details of customized scripts to execute for setting up the cluster.
 
@@ -2287,8 +2287,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |----------|--------------------------|-------------------------------------------------------------------|
 | scripts  | Customized setup scripts | [ScriptsToExecute](#ScriptsToExecute)<br/><small>Optional</small> |
 
-<a id="SetupScripts_STATUS"></a>SetupScripts_STATUS
----------------------------------------------------
+SetupScripts_STATUS{#SetupScripts_STATUS}
+-----------------------------------------
 
 Details of customized scripts to execute for setting up the cluster.
 
@@ -2298,8 +2298,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |----------|--------------------------|---------------------------------------------------------------------------------|
 | scripts  | Customized setup scripts | [ScriptsToExecute_STATUS](#ScriptsToExecute_STATUS)<br/><small>Optional</small> |
 
-<a id="SslConfiguration"></a>SslConfiguration
----------------------------------------------
+SslConfiguration{#SslConfiguration}
+-----------------------------------
 
 The ssl configuration for scoring
 
@@ -2314,8 +2314,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | overwriteExistingDomain | Indicates whether to overwrite existing domain label. | bool<br/><small>Optional</small>                                                                                                                       |
 | status                  | Enable or disable ssl for scoring                     | [SslConfiguration_Status](#SslConfiguration_Status)<br/><small>Optional</small>                                                                        |
 
-<a id="SslConfiguration_STATUS"></a>SslConfiguration_STATUS
------------------------------------------------------------
+SslConfiguration_STATUS{#SslConfiguration_STATUS}
+-------------------------------------------------
 
 The ssl configuration for scoring
 
@@ -2328,8 +2328,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | overwriteExistingDomain | Indicates whether to overwrite existing domain label. | bool<br/><small>Optional</small>                                                              |
 | status                  | Enable or disable ssl for scoring                     | [SslConfiguration_Status_STATUS](#SslConfiguration_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemService_STATUS"></a>SystemService_STATUS
------------------------------------------------------
+SystemService_STATUS{#SystemService_STATUS}
+-------------------------------------------
 
 A system service running on a compute.
 
@@ -2341,8 +2341,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | systemServiceType | The type of this system service. | string<br/><small>Optional</small> |
 | version           | The version for this type.       | string<br/><small>Optional</small> |
 
-<a id="UserAccountCredentials"></a>UserAccountCredentials
----------------------------------------------------------
+UserAccountCredentials{#UserAccountCredentials}
+-----------------------------------------------
 
 Settings for user account that gets created on each on the nodes of a compute.
 
@@ -2354,8 +2354,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | adminUserPassword     | Password of the administrator user account.                               | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | adminUserSshPublicKey | SSH public key of the administrator user account.                         | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="UserAccountCredentials_STATUS"></a>UserAccountCredentials_STATUS
------------------------------------------------------------------------
+UserAccountCredentials_STATUS{#UserAccountCredentials_STATUS}
+-------------------------------------------------------------
 
 Settings for user account that gets created on each on the nodes of a compute.
 
@@ -2365,8 +2365,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 |---------------|---------------------------------------------------------------------------|------------------------------------|
 | adminUserName | Name of the administrator user account which can be used to SSH to nodes. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineImage"></a>VirtualMachineImage
----------------------------------------------------
+VirtualMachineImage{#VirtualMachineImage}
+-----------------------------------------
 
 Virtual Machine image for Windows AML Compute
 
@@ -2376,8 +2376,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 |-----------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Virtual Machine image path | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="VirtualMachineImage_STATUS"></a>VirtualMachineImage_STATUS
------------------------------------------------------------------
+VirtualMachineImage_STATUS{#VirtualMachineImage_STATUS}
+-------------------------------------------------------
 
 Virtual Machine image for Windows AML Compute
 
@@ -2387,8 +2387,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 |----------|----------------------------|------------------------------------|
 | id       | Virtual Machine image path | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineSshCredentials"></a>VirtualMachineSshCredentials
----------------------------------------------------------------------
+VirtualMachineSshCredentials{#VirtualMachineSshCredentials}
+-----------------------------------------------------------
 
 Admin credentials for virtual machine
 
@@ -2401,8 +2401,8 @@ Used by: [HDInsightProperties](#HDInsightProperties), and [VirtualMachine_Proper
 | publicKeyData  | Public key data           | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | username       | Username of admin account | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="VirtualMachineSshCredentials_STATUS"></a>VirtualMachineSshCredentials_STATUS
------------------------------------------------------------------------------------
+VirtualMachineSshCredentials_STATUS{#VirtualMachineSshCredentials_STATUS}
+-------------------------------------------------------------------------
 
 Admin credentials for virtual machine
 
@@ -2412,8 +2412,8 @@ Used by: [HDInsightProperties_STATUS](#HDInsightProperties_STATUS), and [Virtual
 |----------|---------------------------|------------------------------------|
 | username | Username of admin account | string<br/><small>Optional</small> |
 
-<a id="AssignedUser"></a>AssignedUser
--------------------------------------
+AssignedUser{#AssignedUser}
+---------------------------
 
 A user that can be assigned to a compute instance.
 
@@ -2424,8 +2424,8 @@ Used by: [PersonalComputeInstanceSettings](#PersonalComputeInstanceSettings).
 | objectId | User’s AAD Object Id. | string<br/><small>Required</small> |
 | tenantId | User’s AAD Tenant Id. | string<br/><small>Required</small> |
 
-<a id="AssignedUser_STATUS"></a>AssignedUser_STATUS
----------------------------------------------------
+AssignedUser_STATUS{#AssignedUser_STATUS}
+-----------------------------------------
 
 A user that can be assigned to a compute instance.
 
@@ -2436,8 +2436,8 @@ Used by: [PersonalComputeInstanceSettings_STATUS](#PersonalComputeInstanceSettin
 | objectId | User’s AAD Object Id. | string<br/><small>Optional</small> |
 | tenantId | User’s AAD Tenant Id. | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceLastOperation_OperationName_STATUS"></a>ComputeInstanceLastOperation_OperationName_STATUS
----------------------------------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_OperationName_STATUS{#ComputeInstanceLastOperation_OperationName_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STATUS).
 
@@ -2450,8 +2450,8 @@ Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STA
 | "Start"   |             |
 | "Stop"    |             |
 
-<a id="ComputeInstanceLastOperation_OperationStatus_STATUS"></a>ComputeInstanceLastOperation_OperationStatus_STATUS
--------------------------------------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_OperationStatus_STATUS{#ComputeInstanceLastOperation_OperationStatus_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STATUS).
 
@@ -2466,8 +2466,8 @@ Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STA
 | "StopFailed"    |             |
 | "Succeeded"     |             |
 
-<a id="ComputeInstanceSshSettings_SshPublicAccess"></a>ComputeInstanceSshSettings_SshPublicAccess
--------------------------------------------------------------------------------------------------
+ComputeInstanceSshSettings_SshPublicAccess{#ComputeInstanceSshSettings_SshPublicAccess}
+---------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceSshSettings](#ComputeInstanceSshSettings).
 
@@ -2476,8 +2476,8 @@ Used by: [ComputeInstanceSshSettings](#ComputeInstanceSshSettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ComputeInstanceSshSettings_SshPublicAccess_STATUS"></a>ComputeInstanceSshSettings_SshPublicAccess_STATUS
----------------------------------------------------------------------------------------------------------------
+ComputeInstanceSshSettings_SshPublicAccess_STATUS{#ComputeInstanceSshSettings_SshPublicAccess_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceSshSettings_STATUS](#ComputeInstanceSshSettings_STATUS).
 
@@ -2486,8 +2486,8 @@ Used by: [ComputeInstanceSshSettings_STATUS](#ComputeInstanceSshSettings_STATUS)
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ErrorAdditionalInfo_STATUS"></a>ErrorAdditionalInfo_STATUS
------------------------------------------------------------------
+ErrorAdditionalInfo_STATUS{#ErrorAdditionalInfo_STATUS}
+-------------------------------------------------------
 
 The resource management error additional info.
 
@@ -2498,8 +2498,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS), and [ErrorDetail_STATUS_Unro
 | info     | The additional info.      | map[string]v1.JSON<br/><small>Optional</small> |
 | type     | The additional info type. | string<br/><small>Optional</small>             |
 
-<a id="ErrorDetail_STATUS_Unrolled"></a>ErrorDetail_STATUS_Unrolled
--------------------------------------------------------------------
+ErrorDetail_STATUS_Unrolled{#ErrorDetail_STATUS_Unrolled}
+---------------------------------------------------------
 
 Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 
@@ -2510,8 +2510,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                      |
 | target         | The error target.          | string<br/><small>Optional</small>                                                      |
 
-<a id="InstanceTypeSchema_Resources"></a>InstanceTypeSchema_Resources
----------------------------------------------------------------------
+InstanceTypeSchema_Resources{#InstanceTypeSchema_Resources}
+-----------------------------------------------------------
 
 Used by: [InstanceTypeSchema](#InstanceTypeSchema).
 
@@ -2520,8 +2520,8 @@ Used by: [InstanceTypeSchema](#InstanceTypeSchema).
 | limits   | Resource limits for this instance type   | map[string]string<br/><small>Optional</small> |
 | requests | Resource requests for this instance type | map[string]string<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema_Resources_STATUS"></a>InstanceTypeSchema_Resources_STATUS
------------------------------------------------------------------------------------
+InstanceTypeSchema_Resources_STATUS{#InstanceTypeSchema_Resources_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [InstanceTypeSchema_STATUS](#InstanceTypeSchema_STATUS).
 
@@ -2530,8 +2530,8 @@ Used by: [InstanceTypeSchema_STATUS](#InstanceTypeSchema_STATUS).
 | limits   | Resource limits for this instance type   | map[string]string<br/><small>Optional</small> |
 | requests | Resource requests for this instance type | map[string]string<br/><small>Optional</small> |
 
-<a id="ScriptsToExecute"></a>ScriptsToExecute
----------------------------------------------
+ScriptsToExecute{#ScriptsToExecute}
+-----------------------------------
 
 Customized setup scripts
 
@@ -2542,8 +2542,8 @@ Used by: [SetupScripts](#SetupScripts).
 | creationScript | Script that's run only once during provision of the compute. | [ScriptReference](#ScriptReference)<br/><small>Optional</small> |
 | startupScript  | Script that's run every time the machine starts.             | [ScriptReference](#ScriptReference)<br/><small>Optional</small> |
 
-<a id="ScriptsToExecute_STATUS"></a>ScriptsToExecute_STATUS
------------------------------------------------------------
+ScriptsToExecute_STATUS{#ScriptsToExecute_STATUS}
+-------------------------------------------------
 
 Customized setup scripts
 
@@ -2554,8 +2554,8 @@ Used by: [SetupScripts_STATUS](#SetupScripts_STATUS).
 | creationScript | Script that's run only once during provision of the compute. | [ScriptReference_STATUS](#ScriptReference_STATUS)<br/><small>Optional</small> |
 | startupScript  | Script that's run every time the machine starts.             | [ScriptReference_STATUS](#ScriptReference_STATUS)<br/><small>Optional</small> |
 
-<a id="SslConfiguration_Status"></a>SslConfiguration_Status
------------------------------------------------------------
+SslConfiguration_Status{#SslConfiguration_Status}
+-------------------------------------------------
 
 Used by: [SslConfiguration](#SslConfiguration).
 
@@ -2565,8 +2565,8 @@ Used by: [SslConfiguration](#SslConfiguration).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SslConfiguration_Status_STATUS"></a>SslConfiguration_Status_STATUS
--------------------------------------------------------------------------
+SslConfiguration_Status_STATUS{#SslConfiguration_Status_STATUS}
+---------------------------------------------------------------
 
 Used by: [SslConfiguration_STATUS](#SslConfiguration_STATUS).
 
@@ -2576,8 +2576,8 @@ Used by: [SslConfiguration_STATUS](#SslConfiguration_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ScriptReference"></a>ScriptReference
--------------------------------------------
+ScriptReference{#ScriptReference}
+---------------------------------
 
 Script reference
 
@@ -2590,8 +2590,8 @@ Used by: [ScriptsToExecute](#ScriptsToExecute), and [ScriptsToExecute](#ScriptsT
 | scriptSource    | The storage source of the script: inline, workspace.         | string<br/><small>Optional</small> |
 | timeout         | Optional time period passed to timeout command.              | string<br/><small>Optional</small> |
 
-<a id="ScriptReference_STATUS"></a>ScriptReference_STATUS
----------------------------------------------------------
+ScriptReference_STATUS{#ScriptReference_STATUS}
+-----------------------------------------------
 
 Script reference
 

--- a/docs/hugo/content/reference/machinelearningservices/v1api20240401.md
+++ b/docs/hugo/content/reference/machinelearningservices/v1api20240401.md
@@ -5,15 +5,15 @@ title: machinelearningservices.azure.com/v1api20240401
 linktitle: v1api20240401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-04-01" |             |
 
-<a id="Registry"></a>Registry
------------------------------
+Registry{#Registry}
+-------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/registries.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/registries/{registryName}
 
@@ -26,7 +26,7 @@ Used by: [RegistryList](#RegistryList).
 | spec                                                                                    |             | [Registry_Spec](#Registry_Spec)<br/><small>Optional</small>                                   |
 | status                                                                                  |             | [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS)<br/><small>Optional</small> |
 
-### <a id="Registry_Spec"></a>Registry_Spec
+### Registry_Spec {#Registry_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ Used by: [RegistryList](#RegistryList).
 | sku                                | Sku details required for ARM contract for Autoscaling.                                                                                                                                                                                                                                       | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                               | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="RegistryTrackedResource_STATUS"></a>RegistryTrackedResource_STATUS
+### RegistryTrackedResource_STATUS{#RegistryTrackedResource_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -68,8 +68,8 @@ Used by: [RegistryList](#RegistryList).
 | tags                               | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RegistryList"></a>RegistryList
--------------------------------------
+RegistryList{#RegistryList}
+---------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/registries.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/registries/{registryName}
 
@@ -79,8 +79,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                     |
 | items                                                                               |             | [Registry[]](#Registry)<br/><small>Optional</small> |
 
-<a id="Workspace"></a>Workspace
--------------------------------
+Workspace{#Workspace}
+---------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/workspaceRP.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}
 
@@ -93,7 +93,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | spec                                                                                    |             | [Workspace_Spec](#Workspace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Workspace_STATUS](#Workspace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Workspace_Spec"></a>Workspace_Spec
+### Workspace_Spec {#Workspace_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -129,7 +129,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | v1LegacyMode                         | Enabling v1_legacy_mode may prevent you from using features provided by the v2 API.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                                                                     |
 | workspaceHubConfig                   | WorkspaceHub's configuration object.                                                                                                                                                                                                                                                         | [WorkspaceHubConfig](#WorkspaceHubConfig)<br/><small>Optional</small>                                                                                                |
 
-### <a id="Workspace_STATUS"></a>Workspace_STATUS
+### Workspace_STATUS{#Workspace_STATUS}
 
 | Property                        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,8 +176,8 @@ Used by: [WorkspaceList](#WorkspaceList).
 | workspaceHubConfig              | WorkspaceHub's configuration object.                                                                                                                                                                                                                                                                                      | [WorkspaceHubConfig_STATUS](#WorkspaceHubConfig_STATUS)<br/><small>Optional</small>                                                                     |
 | workspaceId                     | The immutable id associated with this workspace.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspaceList"></a>WorkspaceList
----------------------------------------
+WorkspaceList{#WorkspaceList}
+-----------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/workspaceRP.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}
 
@@ -187,8 +187,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Workspace[]](#Workspace)<br/><small>Optional</small> |
 
-<a id="WorkspacesCompute"></a>WorkspacesCompute
------------------------------------------------
+WorkspacesCompute{#WorkspacesCompute}
+-------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}
 
@@ -201,7 +201,7 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | spec                                                                                    |             | [WorkspacesCompute_Spec](#WorkspacesCompute_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS)<br/><small>Optional</small> |
 
-### <a id="WorkspacesCompute_Spec"></a>WorkspacesCompute_Spec
+### WorkspacesCompute_Spec {#WorkspacesCompute_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -214,7 +214,7 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | sku          | The sku of the workspace.                                                                                                                                                                                                                                                                              | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="WorkspacesCompute_STATUS"></a>WorkspacesCompute_STATUS
+### WorkspacesCompute_STATUS{#WorkspacesCompute_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -229,8 +229,8 @@ Used by: [WorkspacesComputeList](#WorkspacesComputeList).
 | tags       | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesComputeList"></a>WorkspacesComputeList
--------------------------------------------------------
+WorkspacesComputeList{#WorkspacesComputeList}
+---------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/machineLearningServices.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}
 
@@ -240,8 +240,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [WorkspacesCompute[]](#WorkspacesCompute)<br/><small>Optional</small> |
 
-<a id="WorkspacesConnection"></a>WorkspacesConnection
------------------------------------------------------
+WorkspacesConnection{#WorkspacesConnection}
+-------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/workspaceRP.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/connections/{connectionName}
 
@@ -254,7 +254,7 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | spec                                                                                    |             | [WorkspacesConnection_Spec](#WorkspacesConnection_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS)<br/><small>Optional</small> |
 
-### <a id="WorkspacesConnection_Spec"></a>WorkspacesConnection_Spec
+### WorkspacesConnection_Spec {#WorkspacesConnection_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -263,7 +263,7 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a machinelearningservices.azure.com/Workspace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   |                                                                                                                                                                                                                                                                                                        | [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2)<br/><small>Required</small>                                                                      |
 
-### <a id="WorkspacesConnection_STATUS"></a>WorkspacesConnection_STATUS
+### WorkspacesConnection_STATUS{#WorkspacesConnection_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -274,8 +274,8 @@ Used by: [WorkspacesConnectionList](#WorkspacesConnectionList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesConnectionList"></a>WorkspacesConnectionList
--------------------------------------------------------------
+WorkspacesConnectionList{#WorkspacesConnectionList}
+---------------------------------------------------
 
 Generator information: - Generated from: /machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/workspaceRP.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/workspaces/{workspaceName}/connections/{connectionName}
 
@@ -285,8 +285,8 @@ Generator information: - Generated from: /machinelearningservices/resource-manag
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [WorkspacesConnection[]](#WorkspacesConnection)<br/><small>Optional</small> |
 
-<a id="Registry_Spec"></a>Registry_Spec
----------------------------------------
+Registry_Spec{#Registry_Spec}
+-----------------------------
 
 Used by: [Registry](#Registry).
 
@@ -308,8 +308,8 @@ Used by: [Registry](#Registry).
 | sku                                | Sku details required for ARM contract for Autoscaling.                                                                                                                                                                                                                                       | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                               | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="RegistryTrackedResource_STATUS"></a>RegistryTrackedResource_STATUS
--------------------------------------------------------------------------
+RegistryTrackedResource_STATUS{#RegistryTrackedResource_STATUS}
+---------------------------------------------------------------
 
 Used by: [Registry](#Registry).
 
@@ -333,8 +333,8 @@ Used by: [Registry](#Registry).
 | tags                               | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                               | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Workspace_Spec"></a>Workspace_Spec
------------------------------------------
+Workspace_Spec{#Workspace_Spec}
+-------------------------------
 
 Used by: [Workspace](#Workspace).
 
@@ -372,8 +372,8 @@ Used by: [Workspace](#Workspace).
 | v1LegacyMode                         | Enabling v1_legacy_mode may prevent you from using features provided by the v2 API.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                                                                     |
 | workspaceHubConfig                   | WorkspaceHub's configuration object.                                                                                                                                                                                                                                                         | [WorkspaceHubConfig](#WorkspaceHubConfig)<br/><small>Optional</small>                                                                                                |
 
-<a id="Workspace_STATUS"></a>Workspace_STATUS
----------------------------------------------
+Workspace_STATUS{#Workspace_STATUS}
+-----------------------------------
 
 An object that represents a machine learning workspace.
 
@@ -424,8 +424,8 @@ Used by: [Workspace](#Workspace).
 | workspaceHubConfig              | WorkspaceHub's configuration object.                                                                                                                                                                                                                                                                                      | [WorkspaceHubConfig_STATUS](#WorkspaceHubConfig_STATUS)<br/><small>Optional</small>                                                                     |
 | workspaceId                     | The immutable id associated with this workspace.                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesCompute_Spec"></a>WorkspacesCompute_Spec
----------------------------------------------------------
+WorkspacesCompute_Spec{#WorkspacesCompute_Spec}
+-----------------------------------------------
 
 Used by: [WorkspacesCompute](#WorkspacesCompute).
 
@@ -440,8 +440,8 @@ Used by: [WorkspacesCompute](#WorkspacesCompute).
 | sku          | The sku of the workspace.                                                                                                                                                                                                                                                                              | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                     | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WorkspacesCompute_STATUS"></a>WorkspacesCompute_STATUS
--------------------------------------------------------------
+WorkspacesCompute_STATUS{#WorkspacesCompute_STATUS}
+---------------------------------------------------
 
 Used by: [WorkspacesCompute](#WorkspacesCompute).
 
@@ -458,8 +458,8 @@ Used by: [WorkspacesCompute](#WorkspacesCompute).
 | tags       | Contains resource tags defined as key/value pairs.                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesConnection_Spec"></a>WorkspacesConnection_Spec
----------------------------------------------------------------
+WorkspacesConnection_Spec{#WorkspacesConnection_Spec}
+-----------------------------------------------------
 
 Used by: [WorkspacesConnection](#WorkspacesConnection).
 
@@ -470,8 +470,8 @@ Used by: [WorkspacesConnection](#WorkspacesConnection).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a machinelearningservices.azure.com/Workspace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | properties   |                                                                                                                                                                                                                                                                                                        | [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2)<br/><small>Required</small>                                                                      |
 
-<a id="WorkspacesConnection_STATUS"></a>WorkspacesConnection_STATUS
--------------------------------------------------------------------
+WorkspacesConnection_STATUS{#WorkspacesConnection_STATUS}
+---------------------------------------------------------
 
 Used by: [WorkspacesConnection](#WorkspacesConnection).
 
@@ -484,8 +484,8 @@ Used by: [WorkspacesConnection](#WorkspacesConnection).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                          | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ArmResourceId"></a>ArmResourceId
----------------------------------------
+ArmResourceId{#ArmResourceId}
+-----------------------------
 
 ARM ResourceId of a resource
 
@@ -495,8 +495,8 @@ Used by: [Registry_Spec](#Registry_Spec), [UserCreatedAcrAccount](#UserCreatedAc
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | resourceReference | Arm ResourceId is in the format "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{StorageAccountName}" or "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{AcrName}" | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ArmResourceId_STATUS"></a>ArmResourceId_STATUS
------------------------------------------------------
+ArmResourceId_STATUS{#ArmResourceId_STATUS}
+-------------------------------------------
 
 ARM ResourceId of a resource
 
@@ -506,8 +506,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS), [Sys
 |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | resourceId | Arm ResourceId is in the format "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{StorageAccountName}" or "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{SubscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{ResourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ContainerRegistry/registries/{AcrName}" | string<br/><small>Optional</small> |
 
-<a id="Compute"></a>Compute
----------------------------
+Compute{#Compute}
+-----------------
 
 Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 
@@ -524,8 +524,8 @@ Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 | synapseSpark      | Mutually exclusive with all other properties | [SynapseSpark](#SynapseSpark)<br/><small>Optional</small>           |
 | virtualMachine    | Mutually exclusive with all other properties | [VirtualMachine](#VirtualMachine)<br/><small>Optional</small>       |
 
-<a id="Compute_STATUS"></a>Compute_STATUS
------------------------------------------
+Compute_STATUS{#Compute_STATUS}
+-------------------------------
 
 Used by: [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS).
 
@@ -542,8 +542,8 @@ Used by: [WorkspacesCompute_STATUS](#WorkspacesCompute_STATUS).
 | synapseSpark      | Mutually exclusive with all other properties | [SynapseSpark_STATUS](#SynapseSpark_STATUS)<br/><small>Optional</small>           |
 | virtualMachine    | Mutually exclusive with all other properties | [VirtualMachine_STATUS](#VirtualMachine_STATUS)<br/><small>Optional</small>       |
 
-<a id="EncryptionProperty"></a>EncryptionProperty
--------------------------------------------------
+EncryptionProperty{#EncryptionProperty}
+---------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -552,8 +552,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | identity           | The identity that will be used to access the key vault for encryption at rest. | [IdentityForCmk](#IdentityForCmk)<br/><small>Optional</small>                             |
 | keyVaultProperties | Customer Key vault properties.                                                 | [EncryptionKeyVaultProperties](#EncryptionKeyVaultProperties)<br/><small>Required</small> |
 
-<a id="EncryptionProperty_STATUS"></a>EncryptionProperty_STATUS
----------------------------------------------------------------
+EncryptionProperty_STATUS{#EncryptionProperty_STATUS}
+-----------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -563,8 +563,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | keyVaultProperties | Customer Key vault properties.                                                 | [EncryptionKeyVaultProperties_STATUS](#EncryptionKeyVaultProperties_STATUS)<br/><small>Optional</small> |
 | status             | Indicates whether or not the encryption is enabled for the workspace.          | [EncryptionProperty_Status_STATUS](#EncryptionProperty_Status_STATUS)<br/><small>Optional</small>       |
 
-<a id="FeatureStoreSettings"></a>FeatureStoreSettings
------------------------------------------------------
+FeatureStoreSettings{#FeatureStoreSettings}
+-------------------------------------------
 
 Settings for feature store type workspace.
 
@@ -576,8 +576,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | offlineStoreConnectionName |                                                          | string<br/><small>Optional</small>                                  |
 | onlineStoreConnectionName  |                                                          | string<br/><small>Optional</small>                                  |
 
-<a id="FeatureStoreSettings_STATUS"></a>FeatureStoreSettings_STATUS
--------------------------------------------------------------------
+FeatureStoreSettings_STATUS{#FeatureStoreSettings_STATUS}
+---------------------------------------------------------
 
 Settings for feature store type workspace.
 
@@ -589,8 +589,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | offlineStoreConnectionName |                                                          | string<br/><small>Optional</small>                                                |
 | onlineStoreConnectionName  |                                                          | string<br/><small>Optional</small>                                                |
 
-<a id="ManagedNetworkSettings"></a>ManagedNetworkSettings
----------------------------------------------------------
+ManagedNetworkSettings{#ManagedNetworkSettings}
+-----------------------------------------------
 
 Managed Network settings for a machine learning workspace.
 
@@ -602,8 +602,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | outboundRules |                                                                                     | [map[string]OutboundRule](#OutboundRule)<br/><small>Optional</small>                        |
 | status        | Status of the Provisioning for the managed network of a machine learning workspace. | [ManagedNetworkProvisionStatus](#ManagedNetworkProvisionStatus)<br/><small>Optional</small> |
 
-<a id="ManagedNetworkSettings_STATUS"></a>ManagedNetworkSettings_STATUS
------------------------------------------------------------------------
+ManagedNetworkSettings_STATUS{#ManagedNetworkSettings_STATUS}
+-------------------------------------------------------------
 
 Managed Network settings for a machine learning workspace.
 
@@ -616,8 +616,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | outboundRules |                                                                                     | [map[string]OutboundRule_STATUS](#OutboundRule_STATUS)<br/><small>Optional</small>                        |
 | status        | Status of the Provisioning for the managed network of a machine learning workspace. | [ManagedNetworkProvisionStatus_STATUS](#ManagedNetworkProvisionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -628,8 +628,8 @@ Used by: [Registry_Spec](#Registry_Spec), [Workspace_Spec](#Workspace_Spec), and
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). | [ManagedServiceIdentityType](#ManagedServiceIdentityType)<br/><small>Required</small>     |
 | userAssignedIdentities |                                                                                                  | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity (system assigned and/or user assigned identities)
 
@@ -642,8 +642,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS), [Wor
 | type                   | Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).                              | [ManagedServiceIdentityType_STATUS](#ManagedServiceIdentityType_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities |                                                                                                                               | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>  |
 
-<a id="NotebookResourceInfo_STATUS"></a>NotebookResourceInfo_STATUS
--------------------------------------------------------------------
+NotebookResourceInfo_STATUS{#NotebookResourceInfo_STATUS}
+---------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -653,8 +653,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | notebookPreparationError | The error that occurs when preparing notebook.                       | [NotebookPreparationError_STATUS](#NotebookPreparationError_STATUS)<br/><small>Optional</small> |
 | resourceId               | the data plane resourceId that used to initialize notebook component | string<br/><small>Optional</small>                                                              |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -664,8 +664,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RegistryOperatorSpec"></a>RegistryOperatorSpec
------------------------------------------------------
+RegistryOperatorSpec{#RegistryOperatorSpec}
+-------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -677,8 +677,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [RegistryOperatorConfigMaps](#RegistryOperatorConfigMaps)<br/><small>Optional</small>                                                                               |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RegistryPrivateEndpointConnection"></a>RegistryPrivateEndpointConnection
--------------------------------------------------------------------------------
+RegistryPrivateEndpointConnection{#RegistryPrivateEndpointConnection}
+---------------------------------------------------------------------
 
 Private endpoint connection definition.
 
@@ -693,8 +693,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | reference                                 | This is the private endpoint connection name created on SRP Full resource id: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{rgName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.MachineLearningServices/{resourceType}/{resourceName}/registryPrivateEndpointConnections/{peConnectionName} | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | registryPrivateLinkServiceConnectionState | The connection state.                                                                                                                                                                                                                                                                                                                                        | [RegistryPrivateLinkServiceConnectionState](#RegistryPrivateLinkServiceConnectionState)<br/><small>Optional</small>                                        |
 
-<a id="RegistryPrivateEndpointConnection_STATUS"></a>RegistryPrivateEndpointConnection_STATUS
----------------------------------------------------------------------------------------------
+RegistryPrivateEndpointConnection_STATUS{#RegistryPrivateEndpointConnection_STATUS}
+-----------------------------------------------------------------------------------
 
 Private endpoint connection definition.
 
@@ -709,8 +709,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS).
 | provisioningState                         | One of null, "Succeeded", "Provisioning", "Failed". While not approved, it's null.                                                                                                                                                                                                                                                                           | string<br/><small>Optional</small>                                                                                                |
 | registryPrivateLinkServiceConnectionState | The connection state.                                                                                                                                                                                                                                                                                                                                        | [RegistryPrivateLinkServiceConnectionState_STATUS](#RegistryPrivateLinkServiceConnectionState_STATUS)<br/><small>Optional</small> |
 
-<a id="RegistryRegionArmDetails"></a>RegistryRegionArmDetails
--------------------------------------------------------------
+RegistryRegionArmDetails{#RegistryRegionArmDetails}
+---------------------------------------------------
 
 Details for each region the registry is in
 
@@ -722,8 +722,8 @@ Used by: [Registry_Spec](#Registry_Spec).
 | location              | The location where the registry exists | string<br/><small>Optional</small>                                            |
 | storageAccountDetails | List of storage accounts               | [StorageAccountDetails[]](#StorageAccountDetails)<br/><small>Optional</small> |
 
-<a id="RegistryRegionArmDetails_STATUS"></a>RegistryRegionArmDetails_STATUS
----------------------------------------------------------------------------
+RegistryRegionArmDetails_STATUS{#RegistryRegionArmDetails_STATUS}
+-----------------------------------------------------------------
 
 Details for each region the registry is in
 
@@ -735,8 +735,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS).
 | location              | The location where the registry exists | string<br/><small>Optional</small>                                                          |
 | storageAccountDetails | List of storage accounts               | [StorageAccountDetails_STATUS[]](#StorageAccountDetails_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerlessComputeSettings"></a>ServerlessComputeSettings
----------------------------------------------------------------
+ServerlessComputeSettings{#ServerlessComputeSettings}
+-----------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -745,8 +745,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | serverlessComputeCustomSubnetReference | The resource ID of an existing virtual network subnet in which serverless compute nodes should be deployed                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | serverlessComputeNoPublicIP            | The flag to signal if serverless compute nodes deployed in custom vNet would have no public IP addresses for a workspace with private endpoint | bool<br/><small>Optional</small>                                                                                                                           |
 
-<a id="ServerlessComputeSettings_STATUS"></a>ServerlessComputeSettings_STATUS
------------------------------------------------------------------------------
+ServerlessComputeSettings_STATUS{#ServerlessComputeSettings_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -755,8 +755,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | serverlessComputeCustomSubnet | The resource ID of an existing virtual network subnet in which serverless compute nodes should be deployed                                     | string<br/><small>Optional</small> |
 | serverlessComputeNoPublicIP   | The flag to signal if serverless compute nodes deployed in custom vNet would have no public IP addresses for a workspace with private endpoint | bool<br/><small>Optional</small>   |
 
-<a id="ServiceManagedResourcesSettings"></a>ServiceManagedResourcesSettings
----------------------------------------------------------------------------
+ServiceManagedResourcesSettings{#ServiceManagedResourcesSettings}
+-----------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -764,8 +764,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |----------|--------------------------------------------------------|-------------------------------------------------------------------|
 | cosmosDb | The settings for the service managed cosmosdb account. | [CosmosDbSettings](#CosmosDbSettings)<br/><small>Optional</small> |
 
-<a id="ServiceManagedResourcesSettings_STATUS"></a>ServiceManagedResourcesSettings_STATUS
------------------------------------------------------------------------------------------
+ServiceManagedResourcesSettings_STATUS{#ServiceManagedResourcesSettings_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -773,8 +773,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |----------|--------------------------------------------------------|---------------------------------------------------------------------------------|
 | cosmosDb | The settings for the service managed cosmosdb account. | [CosmosDbSettings_STATUS](#CosmosDbSettings_STATUS)<br/><small>Optional</small> |
 
-<a id="SharedPrivateLinkResource"></a>SharedPrivateLinkResource
----------------------------------------------------------------
+SharedPrivateLinkResource{#SharedPrivateLinkResource}
+-----------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -786,8 +786,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | requestMessage               | Request message.                                                                                 | string<br/><small>Optional</small>                                                                                                                         |
 | status                       | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus](#PrivateEndpointServiceConnectionStatus)<br/><small>Optional</small>                                              |
 
-<a id="SharedPrivateLinkResource_STATUS"></a>SharedPrivateLinkResource_STATUS
------------------------------------------------------------------------------
+SharedPrivateLinkResource_STATUS{#SharedPrivateLinkResource_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -799,8 +799,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | requestMessage        | Request message.                                                                                 | string<br/><small>Optional</small>                                                                                          |
 | status                | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | [PrivateEndpointServiceConnectionStatus_STATUS](#PrivateEndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The resource model definition representing SKU
 
@@ -814,8 +814,8 @@ Used by: [Registry_Spec](#Registry_Spec), [Workspace_Spec](#Workspace_Spec), and
 | size     | The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code.                                | string<br/><small>Optional</small>              |
 | tier     | This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.               | [SkuTier](#SkuTier)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The resource model definition representing SKU
 
@@ -829,8 +829,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS), [Wor
 | size     | The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code.                                | string<br/><small>Optional</small>                            |
 | tier     | This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.               | [SkuTier_STATUS](#SkuTier_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -845,8 +845,8 @@ Used by: [RegistryTrackedResource_STATUS](#RegistryTrackedResource_STATUS), [Wor
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionPropertiesV2"></a>WorkspaceConnectionPropertiesV2
----------------------------------------------------------------------------
+WorkspaceConnectionPropertiesV2{#WorkspaceConnectionPropertiesV2}
+-----------------------------------------------------------------
 
 Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 
@@ -865,8 +865,8 @@ Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 | servicePrincipal | Mutually exclusive with all other properties | [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincipalAuthTypeWorkspaceConnectionProperties)<br/><small>Optional</small> |
 | usernamePassword | Mutually exclusive with all other properties | [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswordAuthTypeWorkspaceConnectionProperties)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionPropertiesV2_STATUS"></a>WorkspaceConnectionPropertiesV2_STATUS
------------------------------------------------------------------------------------------
+WorkspaceConnectionPropertiesV2_STATUS{#WorkspaceConnectionPropertiesV2_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS).
 
@@ -885,8 +885,8 @@ Used by: [WorkspacesConnection_STATUS](#WorkspacesConnection_STATUS).
 | servicePrincipal | Mutually exclusive with all other properties | [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS)<br/><small>Optional</small> |
 | usernamePassword | Mutually exclusive with all other properties | [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkspaceHubConfig"></a>WorkspaceHubConfig
--------------------------------------------------
+WorkspaceHubConfig{#WorkspaceHubConfig}
+---------------------------------------
 
 WorkspaceHub's configuration object.
 
@@ -897,8 +897,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | additionalWorkspaceStorageAccounts |             | string[]<br/><small>Optional</small> |
 | defaultWorkspaceResourceGroup      |             | string<br/><small>Optional</small>   |
 
-<a id="WorkspaceHubConfig_STATUS"></a>WorkspaceHubConfig_STATUS
----------------------------------------------------------------
+WorkspaceHubConfig_STATUS{#WorkspaceHubConfig_STATUS}
+-----------------------------------------------------
 
 WorkspaceHub's configuration object.
 
@@ -909,8 +909,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | additionalWorkspaceStorageAccounts |             | string[]<br/><small>Optional</small> |
 | defaultWorkspaceResourceGroup      |             | string<br/><small>Optional</small>   |
 
-<a id="WorkspaceOperatorSpec"></a>WorkspaceOperatorSpec
--------------------------------------------------------
+WorkspaceOperatorSpec{#WorkspaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -922,8 +922,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [WorkspaceOperatorSecrets](#WorkspaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="WorkspaceProperties_ProvisioningState_STATUS"></a>WorkspaceProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------
+WorkspaceProperties_ProvisioningState_STATUS{#WorkspaceProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -937,8 +937,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="WorkspaceProperties_PublicNetworkAccess"></a>WorkspaceProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess{#WorkspaceProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -947,8 +947,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspaceProperties_PublicNetworkAccess_STATUS"></a>WorkspaceProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess_STATUS{#WorkspaceProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -957,8 +957,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspacesComputeOperatorSpec"></a>WorkspacesComputeOperatorSpec
------------------------------------------------------------------------
+WorkspacesComputeOperatorSpec{#WorkspacesComputeOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -969,8 +969,8 @@ Used by: [WorkspacesCompute_Spec](#WorkspacesCompute_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WorkspacesConnectionOperatorSpec"></a>WorkspacesConnectionOperatorSpec
------------------------------------------------------------------------------
+WorkspacesConnectionOperatorSpec{#WorkspacesConnectionOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -981,8 +981,8 @@ Used by: [WorkspacesConnection_Spec](#WorkspacesConnection_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties"></a>AADAuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties{#AADAuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -998,8 +998,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                        |
 | valueFormat    | format for the workspace connection value    | [AADAuthTypeWorkspaceConnectionProperties_ValueFormat](#AADAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties_STATUS"></a>AADAuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties_STATUS{#AADAuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1017,8 +1017,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat             | format for the workspace connection value    | [AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties"></a>AccessKeyAuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------------------
+AccessKeyAuthTypeWorkspaceConnectionProperties{#AccessKeyAuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1035,8 +1035,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                    |
 | valueFormat    | format for the workspace connection value    | [AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat](#AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS"></a>AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------------------
+AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS{#AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1055,8 +1055,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                  |
 | valueFormat             | format for the workspace connection value    | [AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties"></a>AccountKeyAuthTypeWorkspaceConnectionProperties
------------------------------------------------------------------------------------------------------------
+AccountKeyAuthTypeWorkspaceConnectionProperties{#AccountKeyAuthTypeWorkspaceConnectionProperties}
+-------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1073,8 +1073,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat    | format for the workspace connection value    | [AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat](#AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS"></a>AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------
+AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS{#AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1093,8 +1093,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                    |
 | valueFormat             | format for the workspace connection value    | [AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="AcrDetails"></a>AcrDetails
----------------------------------
+AcrDetails{#AcrDetails}
+-----------------------
 
 Details of ACR account to be used for the Registry
 
@@ -1105,8 +1105,8 @@ Used by: [RegistryRegionArmDetails](#RegistryRegionArmDetails).
 | systemCreatedAcrAccount | Details of system created ACR account to be used for the Registry | [SystemCreatedAcrAccount](#SystemCreatedAcrAccount)<br/><small>Optional</small> |
 | userCreatedAcrAccount   | Details of user created ACR account to be used for the Registry   | [UserCreatedAcrAccount](#UserCreatedAcrAccount)<br/><small>Optional</small>     |
 
-<a id="AcrDetails_STATUS"></a>AcrDetails_STATUS
------------------------------------------------
+AcrDetails_STATUS{#AcrDetails_STATUS}
+-------------------------------------
 
 Details of ACR account to be used for the Registry
 
@@ -1117,8 +1117,8 @@ Used by: [RegistryRegionArmDetails_STATUS](#RegistryRegionArmDetails_STATUS).
 | systemCreatedAcrAccount | Details of system created ACR account to be used for the Registry | [SystemCreatedAcrAccount_STATUS](#SystemCreatedAcrAccount_STATUS)<br/><small>Optional</small> |
 | userCreatedAcrAccount   | Details of user created ACR account to be used for the Registry   | [UserCreatedAcrAccount_STATUS](#UserCreatedAcrAccount_STATUS)<br/><small>Optional</small>     |
 
-<a id="AKS"></a>AKS
--------------------
+AKS{#AKS}
+---------
 
 Used by: [Compute](#Compute).
 
@@ -1131,8 +1131,8 @@ Used by: [Compute](#Compute).
 | properties        | AKS properties                                                                                                | [AKS_Properties](#AKS_Properties)<br/><small>Optional</small>                                                                                              |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AKS_STATUS"></a>AKS_STATUS
----------------------------------
+AKS_STATUS{#AKS_STATUS}
+-----------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1150,8 +1150,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [AKS_ProvisioningState_STATUS](#AKS_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                        |
 
-<a id="AmlCompute"></a>AmlCompute
----------------------------------
+AmlCompute{#AmlCompute}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -1164,8 +1164,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of AmlCompute                                                                                      | [AmlComputeProperties](#AmlComputeProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AmlCompute_STATUS"></a>AmlCompute_STATUS
------------------------------------------------
+AmlCompute_STATUS{#AmlCompute_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1183,8 +1183,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [AmlCompute_ProvisioningState_STATUS](#AmlCompute_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties"></a>ApiKeyAuthWorkspaceConnectionProperties
--------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties{#ApiKeyAuthWorkspaceConnectionProperties}
+---------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1201,8 +1201,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.          | string<br/><small>Optional</small>                                                                                                      |
 | valueFormat    | format for the workspace connection value           | [ApiKeyAuthWorkspaceConnectionProperties_ValueFormat](#ApiKeyAuthWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties_STATUS"></a>ApiKeyAuthWorkspaceConnectionProperties_STATUS
----------------------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties_STATUS{#ApiKeyAuthWorkspaceConnectionProperties_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1221,8 +1221,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.          | string<br/><small>Optional</small>                                                                                                                    |
 | valueFormat             | format for the workspace connection value           | [ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS](#ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="ComputeInstance"></a>ComputeInstance
--------------------------------------------
+ComputeInstance{#ComputeInstance}
+---------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -1235,8 +1235,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of ComputeInstance                                                                                 | [ComputeInstanceProperties](#ComputeInstanceProperties)<br/><small>Optional</small>                                                                        |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ComputeInstance_STATUS"></a>ComputeInstance_STATUS
----------------------------------------------------------
+ComputeInstance_STATUS{#ComputeInstance_STATUS}
+-----------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1254,8 +1254,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [ComputeInstance_ProvisioningState_STATUS](#ComputeInstance_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                                |
 
-<a id="ComputeRuntimeDto"></a>ComputeRuntimeDto
------------------------------------------------
+ComputeRuntimeDto{#ComputeRuntimeDto}
+-------------------------------------
 
 Compute runtime config for feature store type workspace.
 
@@ -1265,8 +1265,8 @@ Used by: [FeatureStoreSettings](#FeatureStoreSettings).
 |---------------------|-------------|------------------------------------|
 | sparkRuntimeVersion |             | string<br/><small>Optional</small> |
 
-<a id="ComputeRuntimeDto_STATUS"></a>ComputeRuntimeDto_STATUS
--------------------------------------------------------------
+ComputeRuntimeDto_STATUS{#ComputeRuntimeDto_STATUS}
+---------------------------------------------------
 
 Compute runtime config for feature store type workspace.
 
@@ -1276,8 +1276,8 @@ Used by: [FeatureStoreSettings_STATUS](#FeatureStoreSettings_STATUS).
 |---------------------|-------------|------------------------------------|
 | sparkRuntimeVersion |             | string<br/><small>Optional</small> |
 
-<a id="CosmosDbSettings"></a>CosmosDbSettings
----------------------------------------------
+CosmosDbSettings{#CosmosDbSettings}
+-----------------------------------
 
 Used by: [ServiceManagedResourcesSettings](#ServiceManagedResourcesSettings).
 
@@ -1285,8 +1285,8 @@ Used by: [ServiceManagedResourcesSettings](#ServiceManagedResourcesSettings).
 |-----------------------|--------------------------------------------------------|---------------------------------|
 | collectionsThroughput | The throughput of the collections in cosmosdb database | int<br/><small>Optional</small> |
 
-<a id="CosmosDbSettings_STATUS"></a>CosmosDbSettings_STATUS
------------------------------------------------------------
+CosmosDbSettings_STATUS{#CosmosDbSettings_STATUS}
+-------------------------------------------------
 
 Used by: [ServiceManagedResourcesSettings_STATUS](#ServiceManagedResourcesSettings_STATUS).
 
@@ -1294,8 +1294,8 @@ Used by: [ServiceManagedResourcesSettings_STATUS](#ServiceManagedResourcesSettin
 |-----------------------|--------------------------------------------------------|---------------------------------|
 | collectionsThroughput | The throughput of the collections in cosmosdb database | int<br/><small>Optional</small> |
 
-<a id="CustomKeysWorkspaceConnectionProperties"></a>CustomKeysWorkspaceConnectionProperties
--------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties{#CustomKeysWorkspaceConnectionProperties}
+---------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1312,8 +1312,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                      |
 | valueFormat    | format for the workspace connection value    | [CustomKeysWorkspaceConnectionProperties_ValueFormat](#CustomKeysWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="CustomKeysWorkspaceConnectionProperties_STATUS"></a>CustomKeysWorkspaceConnectionProperties_STATUS
----------------------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties_STATUS{#CustomKeysWorkspaceConnectionProperties_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1332,8 +1332,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                    |
 | valueFormat             | format for the workspace connection value    | [CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS](#CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="Databricks"></a>Databricks
----------------------------------
+Databricks{#Databricks}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -1346,8 +1346,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of Databricks                                                                                      | [DatabricksProperties](#DatabricksProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Databricks_STATUS"></a>Databricks_STATUS
------------------------------------------------
+Databricks_STATUS{#Databricks_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1365,8 +1365,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [Databricks_ProvisioningState_STATUS](#Databricks_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="DataFactory"></a>DataFactory
------------------------------------
+DataFactory{#DataFactory}
+-------------------------
 
 Used by: [Compute](#Compute).
 
@@ -1378,8 +1378,8 @@ Used by: [Compute](#Compute).
 | disableLocalAuth  | Opt-out of local authentication and ensure customers can use only MSI and AAD exclusively for authentication. | bool<br/><small>Optional</small>                                                                                                                           |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="DataFactory_STATUS"></a>DataFactory_STATUS
--------------------------------------------------
+DataFactory_STATUS{#DataFactory_STATUS}
+---------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1396,8 +1396,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [DataFactory_ProvisioningState_STATUS](#DataFactory_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                        |
 
-<a id="DataLakeAnalytics"></a>DataLakeAnalytics
------------------------------------------------
+DataLakeAnalytics{#DataLakeAnalytics}
+-------------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -1410,8 +1410,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [DataLakeAnalytics_Properties](#DataLakeAnalytics_Properties)<br/><small>Optional</small>                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_STATUS"></a>DataLakeAnalytics_STATUS
--------------------------------------------------------------
+DataLakeAnalytics_STATUS{#DataLakeAnalytics_STATUS}
+---------------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1429,8 +1429,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [DataLakeAnalytics_ProvisioningState_STATUS](#DataLakeAnalytics_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                                    |
 
-<a id="EncryptionKeyVaultProperties"></a>EncryptionKeyVaultProperties
----------------------------------------------------------------------
+EncryptionKeyVaultProperties{#EncryptionKeyVaultProperties}
+-----------------------------------------------------------
 
 Used by: [EncryptionProperty](#EncryptionProperty).
 
@@ -1441,8 +1441,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 | keyIdentifier              | Key vault uri to access the encryption key.                                            | string<br/><small>Required</small>                                                                                                                           |
 | keyVaultArmReference       | The ArmId of the keyVault where the customer owned encryption key is present.          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>   |
 
-<a id="EncryptionKeyVaultProperties_STATUS"></a>EncryptionKeyVaultProperties_STATUS
------------------------------------------------------------------------------------
+EncryptionKeyVaultProperties_STATUS{#EncryptionKeyVaultProperties_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -1452,8 +1452,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | keyIdentifier    | Key vault uri to access the encryption key.                                            | string<br/><small>Optional</small> |
 | keyVaultArmId    | The ArmId of the keyVault where the customer owned encryption key is present.          | string<br/><small>Optional</small> |
 
-<a id="EncryptionProperty_Status_STATUS"></a>EncryptionProperty_Status_STATUS
------------------------------------------------------------------------------
+EncryptionProperty_Status_STATUS{#EncryptionProperty_Status_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 
@@ -1462,8 +1462,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="HDInsight"></a>HDInsight
--------------------------------
+HDInsight{#HDInsight}
+---------------------
 
 Used by: [Compute](#Compute).
 
@@ -1476,8 +1476,8 @@ Used by: [Compute](#Compute).
 | properties        | HDInsight compute properties                                                                                  | [HDInsightProperties](#HDInsightProperties)<br/><small>Optional</small>                                                                                    |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="HDInsight_STATUS"></a>HDInsight_STATUS
----------------------------------------------
+HDInsight_STATUS{#HDInsight_STATUS}
+-----------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1495,8 +1495,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [HDInsight_ProvisioningState_STATUS](#HDInsight_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                    |
 
-<a id="IdentityForCmk"></a>IdentityForCmk
------------------------------------------
+IdentityForCmk{#IdentityForCmk}
+-------------------------------
 
 Identity that will be used to access key vault for encryption at rest
 
@@ -1506,8 +1506,8 @@ Used by: [EncryptionProperty](#EncryptionProperty).
 |-------------------------------|----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | The ArmId of the user assigned identity that will be used to access the customer managed key vault | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="IdentityForCmk_STATUS"></a>IdentityForCmk_STATUS
--------------------------------------------------------
+IdentityForCmk_STATUS{#IdentityForCmk_STATUS}
+---------------------------------------------
 
 Identity that will be used to access key vault for encryption at rest
 
@@ -1517,8 +1517,8 @@ Used by: [EncryptionProperty_STATUS](#EncryptionProperty_STATUS).
 |----------------------|----------------------------------------------------------------------------------------------------|------------------------------------|
 | userAssignedIdentity | The ArmId of the user assigned identity that will be used to access the customer managed key vault | string<br/><small>Optional</small> |
 
-<a id="IsolationMode"></a>IsolationMode
----------------------------------------
+IsolationMode{#IsolationMode}
+-----------------------------
 
 Isolation mode for the managed network of a machine learning workspace.
 
@@ -1530,8 +1530,8 @@ Used by: [ManagedNetworkSettings](#ManagedNetworkSettings).
 | "AllowOnlyApprovedOutbound" |             |
 | "Disabled"                  |             |
 
-<a id="IsolationMode_STATUS"></a>IsolationMode_STATUS
------------------------------------------------------
+IsolationMode_STATUS{#IsolationMode_STATUS}
+-------------------------------------------
 
 Isolation mode for the managed network of a machine learning workspace.
 
@@ -1543,8 +1543,8 @@ Used by: [ManagedNetworkSettings_STATUS](#ManagedNetworkSettings_STATUS).
 | "AllowOnlyApprovedOutbound" |             |
 | "Disabled"                  |             |
 
-<a id="Kubernetes"></a>Kubernetes
----------------------------------
+Kubernetes{#Kubernetes}
+-----------------------
 
 Used by: [Compute](#Compute).
 
@@ -1557,8 +1557,8 @@ Used by: [Compute](#Compute).
 | properties        | Properties of Kubernetes                                                                                      | [KubernetesProperties](#KubernetesProperties)<br/><small>Optional</small>                                                                                  |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Kubernetes_STATUS"></a>Kubernetes_STATUS
------------------------------------------------
+Kubernetes_STATUS{#Kubernetes_STATUS}
+-------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -1576,8 +1576,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [Kubernetes_ProvisioningState_STATUS](#Kubernetes_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                      |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties{#ManagedIdentityAuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1594,8 +1594,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                |
 | valueFormat    | format for the workspace connection value    | [ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat](#ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS{#ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1614,8 +1614,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                              |
 | valueFormat             | format for the workspace connection value    | [ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedNetworkProvisionStatus"></a>ManagedNetworkProvisionStatus
------------------------------------------------------------------------
+ManagedNetworkProvisionStatus{#ManagedNetworkProvisionStatus}
+-------------------------------------------------------------
 
 Status of the Provisioning for the managed network of a machine learning workspace.
 
@@ -1626,8 +1626,8 @@ Used by: [ManagedNetworkSettings](#ManagedNetworkSettings).
 | sparkReady |                                                                 | bool<br/><small>Optional</small>                                          |
 | status     | Status for the managed network of a machine learning workspace. | [ManagedNetworkStatus](#ManagedNetworkStatus)<br/><small>Optional</small> |
 
-<a id="ManagedNetworkProvisionStatus_STATUS"></a>ManagedNetworkProvisionStatus_STATUS
--------------------------------------------------------------------------------------
+ManagedNetworkProvisionStatus_STATUS{#ManagedNetworkProvisionStatus_STATUS}
+---------------------------------------------------------------------------
 
 Status of the Provisioning for the managed network of a machine learning workspace.
 
@@ -1638,8 +1638,8 @@ Used by: [ManagedNetworkSettings_STATUS](#ManagedNetworkSettings_STATUS).
 | sparkReady |                                                                 | bool<br/><small>Optional</small>                                                        |
 | status     | Status for the managed network of a machine learning workspace. | [ManagedNetworkStatus_STATUS](#ManagedNetworkStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentityType"></a>ManagedServiceIdentityType
------------------------------------------------------------------
+ManagedServiceIdentityType{#ManagedServiceIdentityType}
+-------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -1652,8 +1652,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ManagedServiceIdentityType_STATUS"></a>ManagedServiceIdentityType_STATUS
--------------------------------------------------------------------------------
+ManagedServiceIdentityType_STATUS{#ManagedServiceIdentityType_STATUS}
+---------------------------------------------------------------------
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
 
@@ -1666,8 +1666,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="NoneAuthTypeWorkspaceConnectionProperties"></a>NoneAuthTypeWorkspaceConnectionProperties
------------------------------------------------------------------------------------------------
+NoneAuthTypeWorkspaceConnectionProperties{#NoneAuthTypeWorkspaceConnectionProperties}
+-------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1683,8 +1683,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                          |
 | valueFormat    | format for the workspace connection value    | [NoneAuthTypeWorkspaceConnectionProperties_ValueFormat](#NoneAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="NoneAuthTypeWorkspaceConnectionProperties_STATUS"></a>NoneAuthTypeWorkspaceConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------
+NoneAuthTypeWorkspaceConnectionProperties_STATUS{#NoneAuthTypeWorkspaceConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1702,8 +1702,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                        |
 | valueFormat             | format for the workspace connection value    | [NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="NotebookPreparationError_STATUS"></a>NotebookPreparationError_STATUS
----------------------------------------------------------------------------
+NotebookPreparationError_STATUS{#NotebookPreparationError_STATUS}
+-----------------------------------------------------------------
 
 Used by: [NotebookResourceInfo_STATUS](#NotebookResourceInfo_STATUS).
 
@@ -1712,8 +1712,8 @@ Used by: [NotebookResourceInfo_STATUS](#NotebookResourceInfo_STATUS).
 | errorMessage |             | string<br/><small>Optional</small> |
 | statusCode   |             | int<br/><small>Optional</small>    |
 
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties"></a>OAuth2AuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------------
+OAuth2AuthTypeWorkspaceConnectionProperties{#OAuth2AuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1730,8 +1730,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.                                                                                | string<br/><small>Optional</small>                                                                                                              |
 | valueFormat    | format for the workspace connection value                                                                                 | [OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat](#OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties_STATUS"></a>OAuth2AuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------------
+OAuth2AuthTypeWorkspaceConnectionProperties_STATUS{#OAuth2AuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1750,8 +1750,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.                                                                                | string<br/><small>Optional</small>                                                                                                                            |
 | valueFormat             | format for the workspace connection value                                                                                 | [OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="OutboundRule"></a>OutboundRule
--------------------------------------
+OutboundRule{#OutboundRule}
+---------------------------
 
 Used by: [ManagedNetworkSettings](#ManagedNetworkSettings).
 
@@ -1761,8 +1761,8 @@ Used by: [ManagedNetworkSettings](#ManagedNetworkSettings).
 | privateEndpoint | Mutually exclusive with all other properties | [PrivateEndpointOutboundRule](#PrivateEndpointOutboundRule)<br/><small>Optional</small> |
 | serviceTag      | Mutually exclusive with all other properties | [ServiceTagOutboundRule](#ServiceTagOutboundRule)<br/><small>Optional</small>           |
 
-<a id="OutboundRule_STATUS"></a>OutboundRule_STATUS
----------------------------------------------------
+OutboundRule_STATUS{#OutboundRule_STATUS}
+-----------------------------------------
 
 Used by: [ManagedNetworkSettings_STATUS](#ManagedNetworkSettings_STATUS).
 
@@ -1772,8 +1772,8 @@ Used by: [ManagedNetworkSettings_STATUS](#ManagedNetworkSettings_STATUS).
 | privateEndpoint | Mutually exclusive with all other properties | [PrivateEndpointOutboundRule_STATUS](#PrivateEndpointOutboundRule_STATUS)<br/><small>Optional</small> |
 | serviceTag      | Mutually exclusive with all other properties | [ServiceTagOutboundRule_STATUS](#ServiceTagOutboundRule_STATUS)<br/><small>Optional</small>           |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties"></a>PATAuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties{#PATAuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1790,8 +1790,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                        |
 | valueFormat    | format for the workspace connection value    | [PATAuthTypeWorkspaceConnectionProperties_ValueFormat](#PATAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties_STATUS"></a>PATAuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties_STATUS{#PATAuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1810,8 +1810,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat             | format for the workspace connection value    | [PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointResource"></a>PrivateEndpointResource
------------------------------------------------------------
+PrivateEndpointResource{#PrivateEndpointResource}
+-------------------------------------------------
 
 The PE network resource that is linked to this PE connection.
 
@@ -1821,8 +1821,8 @@ Used by: [RegistryPrivateEndpointConnection](#RegistryPrivateEndpointConnection)
 |--------------------|---------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | subnetArmReference | The subnetId that the private endpoint is connected to. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointResource_STATUS"></a>PrivateEndpointResource_STATUS
--------------------------------------------------------------------------
+PrivateEndpointResource_STATUS{#PrivateEndpointResource_STATUS}
+---------------------------------------------------------------
 
 The PE network resource that is linked to this PE connection.
 
@@ -1833,8 +1833,8 @@ Used by: [RegistryPrivateEndpointConnection_STATUS](#RegistryPrivateEndpointConn
 | id          | The ARM identifier for Private Endpoint                 | string<br/><small>Optional</small> |
 | subnetArmId | The subnetId that the private endpoint is connected to. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointServiceConnectionStatus"></a>PrivateEndpointServiceConnectionStatus
------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus{#PrivateEndpointServiceConnectionStatus}
+-------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -1848,8 +1848,8 @@ Used by: [SharedPrivateLinkResource](#SharedPrivateLinkResource).
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="PrivateEndpointServiceConnectionStatus_STATUS"></a>PrivateEndpointServiceConnectionStatus_STATUS
--------------------------------------------------------------------------------------------------------
+PrivateEndpointServiceConnectionStatus_STATUS{#PrivateEndpointServiceConnectionStatus_STATUS}
+---------------------------------------------------------------------------------------------
 
 The private endpoint connection status.
 
@@ -1863,8 +1863,8 @@ Used by: [SharedPrivateLinkResource_STATUS](#SharedPrivateLinkResource_STATUS).
 | "Rejected"     |             |
 | "Timeout"      |             |
 
-<a id="RegistryOperatorConfigMaps"></a>RegistryOperatorConfigMaps
------------------------------------------------------------------
+RegistryOperatorConfigMaps{#RegistryOperatorConfigMaps}
+-------------------------------------------------------
 
 Used by: [RegistryOperatorSpec](#RegistryOperatorSpec).
 
@@ -1873,8 +1873,8 @@ Used by: [RegistryOperatorSpec](#RegistryOperatorSpec).
 | discoveryUrl      | indicates where the DiscoveryUrl config map should be placed. If omitted, no config map will be created.      | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | mlFlowRegistryUri | indicates where the MlFlowRegistryUri config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="RegistryPrivateLinkServiceConnectionState"></a>RegistryPrivateLinkServiceConnectionState
------------------------------------------------------------------------------------------------
+RegistryPrivateLinkServiceConnectionState{#RegistryPrivateLinkServiceConnectionState}
+-------------------------------------------------------------------------------------
 
 The connection state.
 
@@ -1886,8 +1886,8 @@ Used by: [RegistryPrivateEndpointConnection](#RegistryPrivateEndpointConnection)
 | description     | User-defined message that, per NRP doc, may be used for approval-related message. | string<br/><small>Optional</small>                                                              |
 | status          | Connection status of the service consumer with the service provider               | [EndpointServiceConnectionStatus](#EndpointServiceConnectionStatus)<br/><small>Optional</small> |
 
-<a id="RegistryPrivateLinkServiceConnectionState_STATUS"></a>RegistryPrivateLinkServiceConnectionState_STATUS
--------------------------------------------------------------------------------------------------------------
+RegistryPrivateLinkServiceConnectionState_STATUS{#RegistryPrivateLinkServiceConnectionState_STATUS}
+---------------------------------------------------------------------------------------------------
 
 The connection state.
 
@@ -1899,8 +1899,8 @@ Used by: [RegistryPrivateEndpointConnection_STATUS](#RegistryPrivateEndpointConn
 | description     | User-defined message that, per NRP doc, may be used for approval-related message. | string<br/><small>Optional</small>                                                                            |
 | status          | Connection status of the service consumer with the service provider               | [EndpointServiceConnectionStatus_STATUS](#EndpointServiceConnectionStatus_STATUS)<br/><small>Optional</small> |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties"></a>SASAuthTypeWorkspaceConnectionProperties
----------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties{#SASAuthTypeWorkspaceConnectionProperties}
+-----------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1917,8 +1917,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                        |
 | valueFormat    | format for the workspace connection value    | [SASAuthTypeWorkspaceConnectionProperties_ValueFormat](#SASAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties_STATUS"></a>SASAuthTypeWorkspaceConnectionProperties_STATUS
------------------------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties_STATUS{#SASAuthTypeWorkspaceConnectionProperties_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1937,8 +1937,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                      |
 | valueFormat             | format for the workspace connection value    | [SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties
------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties{#ServicePrincipalAuthTypeWorkspaceConnectionProperties}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -1955,8 +1955,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                  |
 | valueFormat    | format for the workspace connection value    | [ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS{#ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -1975,8 +1975,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                                |
 | valueFormat             | format for the workspace connection value    | [ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="SkuTier"></a>SkuTier
----------------------------
+SkuTier{#SkuTier}
+-----------------
 
 This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
 
@@ -1989,8 +1989,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SkuTier_STATUS"></a>SkuTier_STATUS
------------------------------------------
+SkuTier_STATUS{#SkuTier_STATUS}
+-------------------------------
 
 This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
 
@@ -2003,8 +2003,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="StorageAccountDetails"></a>StorageAccountDetails
--------------------------------------------------------
+StorageAccountDetails{#StorageAccountDetails}
+---------------------------------------------
 
 Details of storage account to be used for the Registry
 
@@ -2015,8 +2015,8 @@ Used by: [RegistryRegionArmDetails](#RegistryRegionArmDetails).
 | systemCreatedStorageAccount | Details of system created storage account to be used for the registry | [SystemCreatedStorageAccount](#SystemCreatedStorageAccount)<br/><small>Optional</small> |
 | userCreatedStorageAccount   | Details of user created storage account to be used for the registry   | [UserCreatedStorageAccount](#UserCreatedStorageAccount)<br/><small>Optional</small>     |
 
-<a id="StorageAccountDetails_STATUS"></a>StorageAccountDetails_STATUS
----------------------------------------------------------------------
+StorageAccountDetails_STATUS{#StorageAccountDetails_STATUS}
+-----------------------------------------------------------
 
 Details of storage account to be used for the Registry
 
@@ -2027,8 +2027,8 @@ Used by: [RegistryRegionArmDetails_STATUS](#RegistryRegionArmDetails_STATUS).
 | systemCreatedStorageAccount | Details of system created storage account to be used for the registry | [SystemCreatedStorageAccount_STATUS](#SystemCreatedStorageAccount_STATUS)<br/><small>Optional</small> |
 | userCreatedStorageAccount   | Details of user created storage account to be used for the registry   | [UserCreatedStorageAccount_STATUS](#UserCreatedStorageAccount_STATUS)<br/><small>Optional</small>     |
 
-<a id="SynapseSpark"></a>SynapseSpark
--------------------------------------
+SynapseSpark{#SynapseSpark}
+---------------------------
 
 Used by: [Compute](#Compute).
 
@@ -2041,8 +2041,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [SynapseSpark_Properties](#SynapseSpark_Properties)<br/><small>Optional</small>                                                                            |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SynapseSpark_STATUS"></a>SynapseSpark_STATUS
----------------------------------------------------
+SynapseSpark_STATUS{#SynapseSpark_STATUS}
+-----------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -2060,7 +2060,19 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [SynapseSpark_ProvisioningState_STATUS](#SynapseSpark_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                          |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -2072,20 +2084,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User assigned identity properties
 
@@ -2096,8 +2096,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client ID of the assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the assigned identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2107,8 +2107,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties
------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties{#UsernamePasswordAuthTypeWorkspaceConnectionProperties}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 
@@ -2125,8 +2125,8 @@ Used by: [WorkspaceConnectionPropertiesV2](#WorkspaceConnectionPropertiesV2).
 | value          | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                  |
 | valueFormat    | format for the workspace connection value    | [UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat)<br/><small>Optional</small> |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS{#UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionPropertiesV2_STATUS).
 
@@ -2145,8 +2145,8 @@ Used by: [WorkspaceConnectionPropertiesV2_STATUS](#WorkspaceConnectionProperties
 | value                   | Value details of the workspace connection.   | string<br/><small>Optional</small>                                                                                                                                                |
 | valueFormat             | format for the workspace connection value    | [UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualMachine"></a>VirtualMachine
------------------------------------------
+VirtualMachine{#VirtualMachine}
+-------------------------------
 
 Used by: [Compute](#Compute).
 
@@ -2159,8 +2159,8 @@ Used by: [Compute](#Compute).
 | properties        |                                                                                                               | [VirtualMachine_Properties](#VirtualMachine_Properties)<br/><small>Optional</small>                                                                        |
 | resourceReference | ARM resource id of the underlying compute                                                                     | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualMachine_STATUS"></a>VirtualMachine_STATUS
--------------------------------------------------------
+VirtualMachine_STATUS{#VirtualMachine_STATUS}
+---------------------------------------------
 
 Used by: [Compute_STATUS](#Compute_STATUS).
 
@@ -2178,8 +2178,8 @@ Used by: [Compute_STATUS](#Compute_STATUS).
 | provisioningState  | The provision state of the cluster. Valid values are Unknown, Updating, Provisioning, Succeeded, and Failed.                                  | [VirtualMachine_ProvisioningState_STATUS](#VirtualMachine_ProvisioningState_STATUS)<br/><small>Optional</small> |
 | resourceId         | ARM resource id of the underlying compute                                                                                                     | string<br/><small>Optional</small>                                                                              |
 
-<a id="WorkspaceOperatorSecrets"></a>WorkspaceOperatorSecrets
--------------------------------------------------------------
+WorkspaceOperatorSecrets{#WorkspaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [WorkspaceOperatorSpec](#WorkspaceOperatorSpec).
 
@@ -2193,8 +2193,8 @@ Used by: [WorkspaceOperatorSpec](#WorkspaceOperatorSpec).
 | secondaryNotebookAccessKey    | indicates where the SecondaryNotebookAccessKey secret should be placed. If omitted, the secret will not be retrieved from Azure.    | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | userStorageKey                | indicates where the UserStorageKey secret should be placed. If omitted, the secret will not be retrieved from Azure.                | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties_AuthType"></a>AADAuthTypeWorkspaceConnectionProperties_AuthType
----------------------------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties_AuthType{#AADAuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [AADAuthTypeWorkspaceConnectionProperties](#AADAuthTypeWorkspaceConnectionProperties).
 
@@ -2202,8 +2202,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties](#AADAuthTypeWorkspaceConnect
 |-------|-------------|
 | "AAD" |             |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>AADAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#AADAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -2211,8 +2211,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspace
 |-------|-------------|
 | "AAD" |             |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>AADAuthTypeWorkspaceConnectionProperties_ValueFormat
----------------------------------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties_ValueFormat{#AADAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [AADAuthTypeWorkspaceConnectionProperties](#AADAuthTypeWorkspaceConnectionProperties).
 
@@ -2220,8 +2220,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties](#AADAuthTypeWorkspaceConnect
 |--------|-------------|
 | "JSON" |             |
 
-<a id="AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#AADAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -2229,8 +2229,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspace
 |--------|-------------|
 | "JSON" |             |
 
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType"></a>AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType
----------------------------------------------------------------------------------------------------------------------------
+AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType{#AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWorkspaceConnectionProperties).
 
@@ -2238,8 +2238,8 @@ Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWork
 |-------------|-------------|
 | "AccessKey" |             |
 
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#AccessKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -2247,44 +2247,44 @@ Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthT
 |-------------|-------------|
 | "AccessKey" |             |
 
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat
+AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat{#AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------------------
+
+Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWorkspaceConnectionProperties).
+
+| Value  | Description |
+|--------|-------------|
+| "JSON" |             |
+
+AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
+
+Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "JSON" |             |
+
+AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType{#AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWorkspaceConnectionProperties).
+
+| Value        | Description |
+|--------------|-------------|
+| "AccountKey" |             |
+
+AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
 ---------------------------------------------------------------------------------------------------------------------------------
 
-Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWorkspaceConnectionProperties).
-
-| Value  | Description |
-|--------|-------------|
-| "JSON" |             |
-
-<a id="AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>AccessKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "JSON" |             |
-
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType"></a>AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWorkspaceConnectionProperties).
-
-| Value        | Description |
-|--------------|-------------|
-| "AccountKey" |             |
-
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>AccountKeyAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
-
 Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS).
 
 | Value        | Description |
 |--------------|-------------|
 | "AccountKey" |             |
 
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat
------------------------------------------------------------------------------------------------------------------------------------
+AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat{#AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWorkspaceConnectionProperties).
 
@@ -2292,8 +2292,8 @@ Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWo
 |--------|-------------|
 | "JSON" |             |
 
-<a id="AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------
+AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#AccountKeyAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -2301,8 +2301,8 @@ Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccountKeyAut
 |--------|-------------|
 | "JSON" |             |
 
-<a id="AKS_ComputeType"></a>AKS_ComputeType
--------------------------------------------
+AKS_ComputeType{#AKS_ComputeType}
+---------------------------------
 
 Used by: [AKS](#AKS).
 
@@ -2310,8 +2310,8 @@ Used by: [AKS](#AKS).
 |-------|-------------|
 | "AKS" |             |
 
-<a id="AKS_ComputeType_STATUS"></a>AKS_ComputeType_STATUS
----------------------------------------------------------
+AKS_ComputeType_STATUS{#AKS_ComputeType_STATUS}
+-----------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -2319,8 +2319,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 |-------|-------------|
 | "AKS" |             |
 
-<a id="AKS_Properties"></a>AKS_Properties
------------------------------------------
+AKS_Properties{#AKS_Properties}
+-------------------------------
 
 Used by: [AKS](#AKS).
 
@@ -2335,8 +2335,8 @@ Used by: [AKS](#AKS).
 | loadBalancerType            | Load Balancer Type                    | [AKS_Properties_LoadBalancerType](#AKS_Properties_LoadBalancerType)<br/><small>Optional</small>                                                            |
 | sslConfiguration            | SSL configuration                     | [SslConfiguration](#SslConfiguration)<br/><small>Optional</small>                                                                                          |
 
-<a id="AKS_Properties_STATUS"></a>AKS_Properties_STATUS
--------------------------------------------------------
+AKS_Properties_STATUS{#AKS_Properties_STATUS}
+---------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -2352,8 +2352,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 | sslConfiguration           | SSL configuration                     | [SslConfiguration_STATUS](#SslConfiguration_STATUS)<br/><small>Optional</small>                               |
 | systemServices             | System services                       | [SystemService_STATUS[]](#SystemService_STATUS)<br/><small>Optional</small>                                   |
 
-<a id="AKS_ProvisioningState_STATUS"></a>AKS_ProvisioningState_STATUS
----------------------------------------------------------------------
+AKS_ProvisioningState_STATUS{#AKS_ProvisioningState_STATUS}
+-----------------------------------------------------------
 
 Used by: [AKS_STATUS](#AKS_STATUS).
 
@@ -2367,8 +2367,8 @@ Used by: [AKS_STATUS](#AKS_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="AmlCompute_ComputeType"></a>AmlCompute_ComputeType
----------------------------------------------------------
+AmlCompute_ComputeType{#AmlCompute_ComputeType}
+-----------------------------------------------
 
 Used by: [AmlCompute](#AmlCompute).
 
@@ -2376,8 +2376,8 @@ Used by: [AmlCompute](#AmlCompute).
 |--------------|-------------|
 | "AmlCompute" |             |
 
-<a id="AmlCompute_ComputeType_STATUS"></a>AmlCompute_ComputeType_STATUS
------------------------------------------------------------------------
+AmlCompute_ComputeType_STATUS{#AmlCompute_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 
@@ -2385,8 +2385,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 |--------------|-------------|
 | "AmlCompute" |             |
 
-<a id="AmlCompute_ProvisioningState_STATUS"></a>AmlCompute_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+AmlCompute_ProvisioningState_STATUS{#AmlCompute_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 
@@ -2400,8 +2400,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="AmlComputeProperties"></a>AmlComputeProperties
------------------------------------------------------
+AmlComputeProperties{#AmlComputeProperties}
+-------------------------------------------
 
 AML Compute properties
 
@@ -2421,8 +2421,8 @@ Used by: [AmlCompute](#AmlCompute).
 | vmPriority                  | Virtual Machine priority                                                                                                                                                                                                                                                                                                                                                                                                                                                        | [AmlComputeProperties_VmPriority](#AmlComputeProperties_VmPriority)<br/><small>Optional</small>                                   |
 | vmSize                      | Virtual Machine Size                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                |
 
-<a id="AmlComputeProperties_STATUS"></a>AmlComputeProperties_STATUS
--------------------------------------------------------------------
+AmlComputeProperties_STATUS{#AmlComputeProperties_STATUS}
+---------------------------------------------------------
 
 AML Compute properties
 
@@ -2448,8 +2448,8 @@ Used by: [AmlCompute_STATUS](#AmlCompute_STATUS).
 | vmPriority                    | Virtual Machine priority                                                                                                                                                                                                                                                                                                                                                                                                                                                        | [AmlComputeProperties_VmPriority_STATUS](#AmlComputeProperties_VmPriority_STATUS)<br/><small>Optional</small>                                   |
 | vmSize                        | Virtual Machine Size                                                                                                                                                                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                              |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties_AuthType"></a>ApiKeyAuthWorkspaceConnectionProperties_AuthType
--------------------------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties_AuthType{#ApiKeyAuthWorkspaceConnectionProperties_AuthType}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ApiKeyAuthWorkspaceConnectionProperties](#ApiKeyAuthWorkspaceConnectionProperties).
 
@@ -2457,8 +2457,8 @@ Used by: [ApiKeyAuthWorkspaceConnectionProperties](#ApiKeyAuthWorkspaceConnectio
 |----------|-------------|
 | "ApiKey" |             |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties_AuthType_STATUS"></a>ApiKeyAuthWorkspaceConnectionProperties_AuthType_STATUS
----------------------------------------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties_AuthType_STATUS{#ApiKeyAuthWorkspaceConnectionProperties_AuthType_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [ApiKeyAuthWorkspaceConnectionProperties_STATUS](#ApiKeyAuthWorkspaceConnectionProperties_STATUS).
 
@@ -2466,8 +2466,8 @@ Used by: [ApiKeyAuthWorkspaceConnectionProperties_STATUS](#ApiKeyAuthWorkspaceCo
 |----------|-------------|
 | "ApiKey" |             |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties_ValueFormat"></a>ApiKeyAuthWorkspaceConnectionProperties_ValueFormat
--------------------------------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties_ValueFormat{#ApiKeyAuthWorkspaceConnectionProperties_ValueFormat}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ApiKeyAuthWorkspaceConnectionProperties](#ApiKeyAuthWorkspaceConnectionProperties).
 
@@ -2475,8 +2475,8 @@ Used by: [ApiKeyAuthWorkspaceConnectionProperties](#ApiKeyAuthWorkspaceConnectio
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS"></a>ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS{#ApiKeyAuthWorkspaceConnectionProperties_ValueFormat_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApiKeyAuthWorkspaceConnectionProperties_STATUS](#ApiKeyAuthWorkspaceConnectionProperties_STATUS).
 
@@ -2484,8 +2484,8 @@ Used by: [ApiKeyAuthWorkspaceConnectionProperties_STATUS](#ApiKeyAuthWorkspaceCo
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ComputeInstance_ComputeType"></a>ComputeInstance_ComputeType
--------------------------------------------------------------------
+ComputeInstance_ComputeType{#ComputeInstance_ComputeType}
+---------------------------------------------------------
 
 Used by: [ComputeInstance](#ComputeInstance).
 
@@ -2493,8 +2493,8 @@ Used by: [ComputeInstance](#ComputeInstance).
 |-------------------|-------------|
 | "ComputeInstance" |             |
 
-<a id="ComputeInstance_ComputeType_STATUS"></a>ComputeInstance_ComputeType_STATUS
----------------------------------------------------------------------------------
+ComputeInstance_ComputeType_STATUS{#ComputeInstance_ComputeType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 
@@ -2502,8 +2502,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 |-------------------|-------------|
 | "ComputeInstance" |             |
 
-<a id="ComputeInstance_ProvisioningState_STATUS"></a>ComputeInstance_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------
+ComputeInstance_ProvisioningState_STATUS{#ComputeInstance_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 
@@ -2517,8 +2517,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="ComputeInstanceProperties"></a>ComputeInstanceProperties
----------------------------------------------------------------
+ComputeInstanceProperties{#ComputeInstanceProperties}
+-----------------------------------------------------
 
 Compute Instance properties
 
@@ -2537,8 +2537,8 @@ Used by: [ComputeInstance](#ComputeInstance).
 | subnet                           | Virtual network subnet resource ID the compute nodes belong to.                                                                                                                                                                                                                        | [ResourceId](#ResourceId)<br/><small>Optional</small>                                                                                                 |
 | vmSize                           | Virtual Machine Size                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ComputeInstanceProperties_STATUS"></a>ComputeInstanceProperties_STATUS
------------------------------------------------------------------------------
+ComputeInstanceProperties_STATUS{#ComputeInstanceProperties_STATUS}
+-------------------------------------------------------------------
 
 Compute Instance properties
 
@@ -2568,8 +2568,8 @@ Used by: [ComputeInstance_STATUS](#ComputeInstance_STATUS).
 | versions                         | ComputeInstance version.                                                                                                                                                                                                                                                               | [ComputeInstanceVersion_STATUS](#ComputeInstanceVersion_STATUS)<br/><small>Optional</small>                                                                         |
 | vmSize                           | Virtual Machine Size                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="ConnectionCategory"></a>ConnectionCategory
--------------------------------------------------
+ConnectionCategory{#ConnectionCategory}
+---------------------------------------
 
 Category of the connection
 
@@ -2680,8 +2680,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties](#AADAuthTypeWorkspaceConnect
 | "Xero"                     |             |
 | "Zoho"                     |             |
 
-<a id="ConnectionCategory_STATUS"></a>ConnectionCategory_STATUS
----------------------------------------------------------------
+ConnectionCategory_STATUS{#ConnectionCategory_STATUS}
+-----------------------------------------------------
 
 Category of the connection
 
@@ -2792,8 +2792,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspace
 | "Xero"                     |             |
 | "Zoho"                     |             |
 
-<a id="ConnectionGroup_STATUS"></a>ConnectionGroup_STATUS
----------------------------------------------------------
+ConnectionGroup_STATUS{#ConnectionGroup_STATUS}
+-----------------------------------------------
 
 Group based on connection category
 
@@ -2809,8 +2809,8 @@ Used by: [AADAuthTypeWorkspaceConnectionProperties_STATUS](#AADAuthTypeWorkspace
 | "NoSQL"           |             |
 | "ServicesAndApps" |             |
 
-<a id="CustomKeys"></a>CustomKeys
----------------------------------
+CustomKeys{#CustomKeys}
+-----------------------
 
 Custom Keys credential object
 
@@ -2820,8 +2820,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties](#CustomKeysWorkspaceConnectio
 |----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | keys     |             | [genruntime.SecretMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretMapReference)<br/><small>Optional</small> |
 
-<a id="CustomKeys_STATUS"></a>CustomKeys_STATUS
------------------------------------------------
+CustomKeys_STATUS{#CustomKeys_STATUS}
+-------------------------------------
 
 Custom Keys credential object
 
@@ -2831,8 +2831,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties_STATUS](#CustomKeysWorkspaceCo
 |----------|-------------|-----------------------------------------------|
 | keys     |             | map[string]string<br/><small>Optional</small> |
 
-<a id="CustomKeysWorkspaceConnectionProperties_AuthType"></a>CustomKeysWorkspaceConnectionProperties_AuthType
--------------------------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties_AuthType{#CustomKeysWorkspaceConnectionProperties_AuthType}
+---------------------------------------------------------------------------------------------------
 
 Used by: [CustomKeysWorkspaceConnectionProperties](#CustomKeysWorkspaceConnectionProperties).
 
@@ -2840,8 +2840,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties](#CustomKeysWorkspaceConnectio
 |--------------|-------------|
 | "CustomKeys" |             |
 
-<a id="CustomKeysWorkspaceConnectionProperties_AuthType_STATUS"></a>CustomKeysWorkspaceConnectionProperties_AuthType_STATUS
----------------------------------------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties_AuthType_STATUS{#CustomKeysWorkspaceConnectionProperties_AuthType_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [CustomKeysWorkspaceConnectionProperties_STATUS](#CustomKeysWorkspaceConnectionProperties_STATUS).
 
@@ -2849,8 +2849,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties_STATUS](#CustomKeysWorkspaceCo
 |--------------|-------------|
 | "CustomKeys" |             |
 
-<a id="CustomKeysWorkspaceConnectionProperties_ValueFormat"></a>CustomKeysWorkspaceConnectionProperties_ValueFormat
--------------------------------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties_ValueFormat{#CustomKeysWorkspaceConnectionProperties_ValueFormat}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [CustomKeysWorkspaceConnectionProperties](#CustomKeysWorkspaceConnectionProperties).
 
@@ -2858,8 +2858,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties](#CustomKeysWorkspaceConnectio
 |--------|-------------|
 | "JSON" |             |
 
-<a id="CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS"></a>CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS{#CustomKeysWorkspaceConnectionProperties_ValueFormat_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [CustomKeysWorkspaceConnectionProperties_STATUS](#CustomKeysWorkspaceConnectionProperties_STATUS).
 
@@ -2867,8 +2867,8 @@ Used by: [CustomKeysWorkspaceConnectionProperties_STATUS](#CustomKeysWorkspaceCo
 |--------|-------------|
 | "JSON" |             |
 
-<a id="Databricks_ComputeType"></a>Databricks_ComputeType
----------------------------------------------------------
+Databricks_ComputeType{#Databricks_ComputeType}
+-----------------------------------------------
 
 Used by: [Databricks](#Databricks).
 
@@ -2876,8 +2876,8 @@ Used by: [Databricks](#Databricks).
 |--------------|-------------|
 | "Databricks" |             |
 
-<a id="Databricks_ComputeType_STATUS"></a>Databricks_ComputeType_STATUS
------------------------------------------------------------------------
+Databricks_ComputeType_STATUS{#Databricks_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [Databricks_STATUS](#Databricks_STATUS).
 
@@ -2885,8 +2885,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 |--------------|-------------|
 | "Databricks" |             |
 
-<a id="Databricks_ProvisioningState_STATUS"></a>Databricks_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+Databricks_ProvisioningState_STATUS{#Databricks_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Databricks_STATUS](#Databricks_STATUS).
 
@@ -2900,8 +2900,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="DatabricksProperties"></a>DatabricksProperties
------------------------------------------------------
+DatabricksProperties{#DatabricksProperties}
+-------------------------------------------
 
 Properties of Databricks
 
@@ -2912,8 +2912,8 @@ Used by: [Databricks](#Databricks).
 | databricksAccessToken | Databricks access token | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | workspaceUrl          | Workspace Url           | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="DatabricksProperties_STATUS"></a>DatabricksProperties_STATUS
--------------------------------------------------------------------
+DatabricksProperties_STATUS{#DatabricksProperties_STATUS}
+---------------------------------------------------------
 
 Properties of Databricks
 
@@ -2923,8 +2923,8 @@ Used by: [Databricks_STATUS](#Databricks_STATUS).
 |--------------|---------------|------------------------------------|
 | workspaceUrl | Workspace Url | string<br/><small>Optional</small> |
 
-<a id="DataFactory_ComputeType"></a>DataFactory_ComputeType
------------------------------------------------------------
+DataFactory_ComputeType{#DataFactory_ComputeType}
+-------------------------------------------------
 
 Used by: [DataFactory](#DataFactory).
 
@@ -2932,8 +2932,8 @@ Used by: [DataFactory](#DataFactory).
 |---------------|-------------|
 | "DataFactory" |             |
 
-<a id="DataFactory_ComputeType_STATUS"></a>DataFactory_ComputeType_STATUS
--------------------------------------------------------------------------
+DataFactory_ComputeType_STATUS{#DataFactory_ComputeType_STATUS}
+---------------------------------------------------------------
 
 Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 
@@ -2941,8 +2941,8 @@ Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 |---------------|-------------|
 | "DataFactory" |             |
 
-<a id="DataFactory_ProvisioningState_STATUS"></a>DataFactory_ProvisioningState_STATUS
--------------------------------------------------------------------------------------
+DataFactory_ProvisioningState_STATUS{#DataFactory_ProvisioningState_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 
@@ -2956,8 +2956,8 @@ Used by: [DataFactory_STATUS](#DataFactory_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="DataLakeAnalytics_ComputeType"></a>DataLakeAnalytics_ComputeType
------------------------------------------------------------------------
+DataLakeAnalytics_ComputeType{#DataLakeAnalytics_ComputeType}
+-------------------------------------------------------------
 
 Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 
@@ -2965,8 +2965,8 @@ Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 |---------------------|-------------|
 | "DataLakeAnalytics" |             |
 
-<a id="DataLakeAnalytics_ComputeType_STATUS"></a>DataLakeAnalytics_ComputeType_STATUS
--------------------------------------------------------------------------------------
+DataLakeAnalytics_ComputeType_STATUS{#DataLakeAnalytics_ComputeType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -2974,8 +2974,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 |---------------------|-------------|
 | "DataLakeAnalytics" |             |
 
-<a id="DataLakeAnalytics_Properties"></a>DataLakeAnalytics_Properties
----------------------------------------------------------------------
+DataLakeAnalytics_Properties{#DataLakeAnalytics_Properties}
+-----------------------------------------------------------
 
 Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 
@@ -2983,8 +2983,8 @@ Used by: [DataLakeAnalytics](#DataLakeAnalytics).
 |--------------------------|-----------------------------|------------------------------------|
 | dataLakeStoreAccountName | DataLake Store Account Name | string<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_Properties_STATUS"></a>DataLakeAnalytics_Properties_STATUS
------------------------------------------------------------------------------------
+DataLakeAnalytics_Properties_STATUS{#DataLakeAnalytics_Properties_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -2992,8 +2992,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 |--------------------------|-----------------------------|------------------------------------|
 | dataLakeStoreAccountName | DataLake Store Account Name | string<br/><small>Optional</small> |
 
-<a id="DataLakeAnalytics_ProvisioningState_STATUS"></a>DataLakeAnalytics_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+DataLakeAnalytics_ProvisioningState_STATUS{#DataLakeAnalytics_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 
@@ -3007,8 +3007,8 @@ Used by: [DataLakeAnalytics_STATUS](#DataLakeAnalytics_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="EndpointServiceConnectionStatus"></a>EndpointServiceConnectionStatus
----------------------------------------------------------------------------
+EndpointServiceConnectionStatus{#EndpointServiceConnectionStatus}
+-----------------------------------------------------------------
 
 Connection status of the service consumer with the service provider
 
@@ -3021,8 +3021,8 @@ Used by: [RegistryPrivateLinkServiceConnectionState](#RegistryPrivateLinkService
 | "Pending"      |             |
 | "Rejected"     |             |
 
-<a id="EndpointServiceConnectionStatus_STATUS"></a>EndpointServiceConnectionStatus_STATUS
------------------------------------------------------------------------------------------
+EndpointServiceConnectionStatus_STATUS{#EndpointServiceConnectionStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Connection status of the service consumer with the service provider
 
@@ -3035,8 +3035,8 @@ Used by: [RegistryPrivateLinkServiceConnectionState_STATUS](#RegistryPrivateLink
 | "Pending"      |             |
 | "Rejected"     |             |
 
-<a id="ErrorResponse_STATUS"></a>ErrorResponse_STATUS
------------------------------------------------------
+ErrorResponse_STATUS{#ErrorResponse_STATUS}
+-------------------------------------------
 
 Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).
 
@@ -3046,8 +3046,8 @@ Used by: [AKS_STATUS](#AKS_STATUS), [AmlCompute_STATUS](#AmlCompute_STATUS), [Am
 |----------|-------------------|-----------------------------------------------------------------------|
 | error    | The error object. | [ErrorDetail_STATUS](#ErrorDetail_STATUS)<br/><small>Optional</small> |
 
-<a id="FqdnOutboundRule"></a>FqdnOutboundRule
----------------------------------------------
+FqdnOutboundRule{#FqdnOutboundRule}
+-----------------------------------
 
 Used by: [OutboundRule](#OutboundRule).
 
@@ -3058,8 +3058,8 @@ Used by: [OutboundRule](#OutboundRule).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.     | [RuleStatus](#RuleStatus)<br/><small>Optional</small>                       |
 | type        |                                                                              | [FqdnOutboundRule_Type](#FqdnOutboundRule_Type)<br/><small>Required</small> |
 
-<a id="FqdnOutboundRule_STATUS"></a>FqdnOutboundRule_STATUS
------------------------------------------------------------
+FqdnOutboundRule_STATUS{#FqdnOutboundRule_STATUS}
+-------------------------------------------------
 
 Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 
@@ -3070,8 +3070,8 @@ Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.     | [RuleStatus_STATUS](#RuleStatus_STATUS)<br/><small>Optional</small>                       |
 | type        |                                                                              | [FqdnOutboundRule_Type_STATUS](#FqdnOutboundRule_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="HDInsight_ComputeType"></a>HDInsight_ComputeType
--------------------------------------------------------
+HDInsight_ComputeType{#HDInsight_ComputeType}
+---------------------------------------------
 
 Used by: [HDInsight](#HDInsight).
 
@@ -3079,8 +3079,8 @@ Used by: [HDInsight](#HDInsight).
 |-------------|-------------|
 | "HDInsight" |             |
 
-<a id="HDInsight_ComputeType_STATUS"></a>HDInsight_ComputeType_STATUS
----------------------------------------------------------------------
+HDInsight_ComputeType_STATUS{#HDInsight_ComputeType_STATUS}
+-----------------------------------------------------------
 
 Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 
@@ -3088,8 +3088,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 |-------------|-------------|
 | "HDInsight" |             |
 
-<a id="HDInsight_ProvisioningState_STATUS"></a>HDInsight_ProvisioningState_STATUS
----------------------------------------------------------------------------------
+HDInsight_ProvisioningState_STATUS{#HDInsight_ProvisioningState_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 
@@ -3103,8 +3103,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="HDInsightProperties"></a>HDInsightProperties
----------------------------------------------------
+HDInsightProperties{#HDInsightProperties}
+-----------------------------------------
 
 HDInsight compute properties
 
@@ -3116,8 +3116,8 @@ Used by: [HDInsight](#HDInsight).
 | administratorAccount | Admin credentials for master node of the cluster                 | [VirtualMachineSshCredentials](#VirtualMachineSshCredentials)<br/><small>Optional</small> |
 | sshPort              | Port open for ssh connections on the master node of the cluster. | int<br/><small>Optional</small>                                                           |
 
-<a id="HDInsightProperties_STATUS"></a>HDInsightProperties_STATUS
------------------------------------------------------------------
+HDInsightProperties_STATUS{#HDInsightProperties_STATUS}
+-------------------------------------------------------
 
 HDInsight compute properties
 
@@ -3129,8 +3129,8 @@ Used by: [HDInsight_STATUS](#HDInsight_STATUS).
 | administratorAccount | Admin credentials for master node of the cluster                 | [VirtualMachineSshCredentials_STATUS](#VirtualMachineSshCredentials_STATUS)<br/><small>Optional</small> |
 | sshPort              | Port open for ssh connections on the master node of the cluster. | int<br/><small>Optional</small>                                                                         |
 
-<a id="Kubernetes_ComputeType"></a>Kubernetes_ComputeType
----------------------------------------------------------
+Kubernetes_ComputeType{#Kubernetes_ComputeType}
+-----------------------------------------------
 
 Used by: [Kubernetes](#Kubernetes).
 
@@ -3138,8 +3138,8 @@ Used by: [Kubernetes](#Kubernetes).
 |--------------|-------------|
 | "Kubernetes" |             |
 
-<a id="Kubernetes_ComputeType_STATUS"></a>Kubernetes_ComputeType_STATUS
------------------------------------------------------------------------
+Kubernetes_ComputeType_STATUS{#Kubernetes_ComputeType_STATUS}
+-------------------------------------------------------------
 
 Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 
@@ -3147,8 +3147,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 |--------------|-------------|
 | "Kubernetes" |             |
 
-<a id="Kubernetes_ProvisioningState_STATUS"></a>Kubernetes_ProvisioningState_STATUS
------------------------------------------------------------------------------------
+Kubernetes_ProvisioningState_STATUS{#Kubernetes_ProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 
@@ -3162,8 +3162,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="KubernetesProperties"></a>KubernetesProperties
------------------------------------------------------
+KubernetesProperties{#KubernetesProperties}
+-------------------------------------------
 
 Kubernetes properties
 
@@ -3181,8 +3181,8 @@ Used by: [Kubernetes](#Kubernetes).
 | serviceBusConnectionString     | ServiceBus connection string.     | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>       |
 | vcName                         | VC name.                          | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="KubernetesProperties_STATUS"></a>KubernetesProperties_STATUS
--------------------------------------------------------------------
+KubernetesProperties_STATUS{#KubernetesProperties_STATUS}
+---------------------------------------------------------
 
 Kubernetes properties
 
@@ -3197,8 +3197,8 @@ Used by: [Kubernetes_STATUS](#Kubernetes_STATUS).
 | namespace                     | Compute namespace                 | string<br/><small>Optional</small>                                                             |
 | vcName                        | VC name.                          | string<br/><small>Optional</small>                                                             |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType
----------------------------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType{#ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentityAuthTypeWorkspaceConnectionProperties).
 
@@ -3206,8 +3206,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentity
 |-------------------|-------------|
 | "ManagedIdentity" |             |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#ManagedIdentityAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3215,8 +3215,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedI
 |-------------------|-------------|
 | "ManagedIdentity" |             |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat
----------------------------------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat{#ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentityAuthTypeWorkspaceConnectionProperties).
 
@@ -3224,8 +3224,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentity
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------------
+ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#ManagedIdentityAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3233,8 +3233,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedI
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ManagedNetworkStatus"></a>ManagedNetworkStatus
------------------------------------------------------
+ManagedNetworkStatus{#ManagedNetworkStatus}
+-------------------------------------------
 
 Status for the managed network of a machine learning workspace.
 
@@ -3245,8 +3245,8 @@ Used by: [ManagedNetworkProvisionStatus](#ManagedNetworkProvisionStatus).
 | "Active"   |             |
 | "Inactive" |             |
 
-<a id="ManagedNetworkStatus_STATUS"></a>ManagedNetworkStatus_STATUS
--------------------------------------------------------------------
+ManagedNetworkStatus_STATUS{#ManagedNetworkStatus_STATUS}
+---------------------------------------------------------
 
 Status for the managed network of a machine learning workspace.
 
@@ -3257,8 +3257,8 @@ Used by: [ManagedNetworkProvisionStatus_STATUS](#ManagedNetworkProvisionStatus_S
 | "Active"   |             |
 | "Inactive" |             |
 
-<a id="NoneAuthTypeWorkspaceConnectionProperties_AuthType"></a>NoneAuthTypeWorkspaceConnectionProperties_AuthType
------------------------------------------------------------------------------------------------------------------
+NoneAuthTypeWorkspaceConnectionProperties_AuthType{#NoneAuthTypeWorkspaceConnectionProperties_AuthType}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [NoneAuthTypeWorkspaceConnectionProperties](#NoneAuthTypeWorkspaceConnectionProperties).
 
@@ -3266,62 +3266,62 @@ Used by: [NoneAuthTypeWorkspaceConnectionProperties](#NoneAuthTypeWorkspaceConne
 |--------|-------------|
 | "None" |             |
 
-<a id="NoneAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>NoneAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
--------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [NoneAuthTypeWorkspaceConnectionProperties_STATUS](#NoneAuthTypeWorkspaceConnectionProperties_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "None" |             |
-
-<a id="NoneAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>NoneAuthTypeWorkspaceConnectionProperties_ValueFormat
------------------------------------------------------------------------------------------------------------------------
-
-Used by: [NoneAuthTypeWorkspaceConnectionProperties](#NoneAuthTypeWorkspaceConnectionProperties).
-
-| Value  | Description |
-|--------|-------------|
-| "JSON" |             |
-
-<a id="NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [NoneAuthTypeWorkspaceConnectionProperties_STATUS](#NoneAuthTypeWorkspaceConnectionProperties_STATUS).
-
-| Value  | Description |
-|--------|-------------|
-| "JSON" |             |
-
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties_AuthType"></a>OAuth2AuthTypeWorkspaceConnectionProperties_AuthType
+NoneAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#NoneAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
 ---------------------------------------------------------------------------------------------------------------------
 
-Used by: [OAuth2AuthTypeWorkspaceConnectionProperties](#OAuth2AuthTypeWorkspaceConnectionProperties).
+Used by: [NoneAuthTypeWorkspaceConnectionProperties_STATUS](#NoneAuthTypeWorkspaceConnectionProperties_STATUS).
 
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
+| Value  | Description |
+|--------|-------------|
+| "None" |             |
 
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>OAuth2AuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+NoneAuthTypeWorkspaceConnectionProperties_ValueFormat{#NoneAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-------------------------------------------------------------------------------------------------------------
 
-Used by: [OAuth2AuthTypeWorkspaceConnectionProperties_STATUS](#OAuth2AuthTypeWorkspaceConnectionProperties_STATUS).
+Used by: [NoneAuthTypeWorkspaceConnectionProperties](#NoneAuthTypeWorkspaceConnectionProperties).
 
-| Value    | Description |
-|----------|-------------|
-| "OAuth2" |             |
+| Value  | Description |
+|--------|-------------|
+| "JSON" |             |
 
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat"></a>OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat
+NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#NoneAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
 ---------------------------------------------------------------------------------------------------------------------------
 
+Used by: [NoneAuthTypeWorkspaceConnectionProperties_STATUS](#NoneAuthTypeWorkspaceConnectionProperties_STATUS).
+
+| Value  | Description |
+|--------|-------------|
+| "JSON" |             |
+
+OAuth2AuthTypeWorkspaceConnectionProperties_AuthType{#OAuth2AuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [OAuth2AuthTypeWorkspaceConnectionProperties](#OAuth2AuthTypeWorkspaceConnectionProperties).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+OAuth2AuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#OAuth2AuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
+
+Used by: [OAuth2AuthTypeWorkspaceConnectionProperties_STATUS](#OAuth2AuthTypeWorkspaceConnectionProperties_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "OAuth2" |             |
+
+OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat{#OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------------
+
 Used by: [OAuth2AuthTypeWorkspaceConnectionProperties](#OAuth2AuthTypeWorkspaceConnectionProperties).
 
 | Value  | Description |
 |--------|-------------|
 | "JSON" |             |
 
-<a id="OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------------
+OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#OAuth2AuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [OAuth2AuthTypeWorkspaceConnectionProperties_STATUS](#OAuth2AuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3329,8 +3329,8 @@ Used by: [OAuth2AuthTypeWorkspaceConnectionProperties_STATUS](#OAuth2AuthTypeWor
 |--------|-------------|
 | "JSON" |             |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties_AuthType"></a>PATAuthTypeWorkspaceConnectionProperties_AuthType
----------------------------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties_AuthType{#PATAuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnectionProperties).
 
@@ -3338,8 +3338,8 @@ Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnect
 |-------|-------------|
 | "PAT" |             |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>PATAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#PATAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [PATAuthTypeWorkspaceConnectionProperties_STATUS](#PATAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3347,8 +3347,8 @@ Used by: [PATAuthTypeWorkspaceConnectionProperties_STATUS](#PATAuthTypeWorkspace
 |-------|-------------|
 | "PAT" |             |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>PATAuthTypeWorkspaceConnectionProperties_ValueFormat
----------------------------------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties_ValueFormat{#PATAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnectionProperties).
 
@@ -3356,8 +3356,8 @@ Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnect
 |--------|-------------|
 | "JSON" |             |
 
-<a id="PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#PATAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [PATAuthTypeWorkspaceConnectionProperties_STATUS](#PATAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3365,8 +3365,8 @@ Used by: [PATAuthTypeWorkspaceConnectionProperties_STATUS](#PATAuthTypeWorkspace
 |--------|-------------|
 | "JSON" |             |
 
-<a id="PrivateEndpointOutboundRule"></a>PrivateEndpointOutboundRule
--------------------------------------------------------------------
+PrivateEndpointOutboundRule{#PrivateEndpointOutboundRule}
+---------------------------------------------------------
 
 Used by: [OutboundRule](#OutboundRule).
 
@@ -3377,8 +3377,8 @@ Used by: [OutboundRule](#OutboundRule).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.                                                   | [RuleStatus](#RuleStatus)<br/><small>Optional</small>                                             |
 | type        |                                                                                                                            | [PrivateEndpointOutboundRule_Type](#PrivateEndpointOutboundRule_Type)<br/><small>Required</small> |
 
-<a id="PrivateEndpointOutboundRule_STATUS"></a>PrivateEndpointOutboundRule_STATUS
----------------------------------------------------------------------------------
+PrivateEndpointOutboundRule_STATUS{#PrivateEndpointOutboundRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 
@@ -3389,8 +3389,8 @@ Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.                                                   | [RuleStatus_STATUS](#RuleStatus_STATUS)<br/><small>Optional</small>                                             |
 | type        |                                                                                                                            | [PrivateEndpointOutboundRule_Type_STATUS](#PrivateEndpointOutboundRule_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties_AuthType"></a>SASAuthTypeWorkspaceConnectionProperties_AuthType
----------------------------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties_AuthType{#SASAuthTypeWorkspaceConnectionProperties_AuthType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnectionProperties).
 
@@ -3398,8 +3398,8 @@ Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnect
 |-------|-------------|
 | "SAS" |             |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>SASAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#SASAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [SASAuthTypeWorkspaceConnectionProperties_STATUS](#SASAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3407,8 +3407,8 @@ Used by: [SASAuthTypeWorkspaceConnectionProperties_STATUS](#SASAuthTypeWorkspace
 |-------|-------------|
 | "SAS" |             |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>SASAuthTypeWorkspaceConnectionProperties_ValueFormat
----------------------------------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties_ValueFormat{#SASAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnectionProperties).
 
@@ -3416,8 +3416,8 @@ Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnect
 |--------|-------------|
 | "JSON" |             |
 
-<a id="SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#SASAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [SASAuthTypeWorkspaceConnectionProperties_STATUS](#SASAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3425,8 +3425,8 @@ Used by: [SASAuthTypeWorkspaceConnectionProperties_STATUS](#SASAuthTypeWorkspace
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType
------------------------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType{#ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincipalAuthTypeWorkspaceConnectionProperties).
 
@@ -3434,8 +3434,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincip
 |--------------------|-------------|
 | "ServicePrincipal" |             |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#ServicePrincipalAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3443,8 +3443,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#Service
 |--------------------|-------------|
 | "ServicePrincipal" |             |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat
------------------------------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat{#ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincipalAuthTypeWorkspaceConnectionProperties).
 
@@ -3452,8 +3452,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincip
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#ServicePrincipalAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3461,8 +3461,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#Service
 |--------|-------------|
 | "JSON" |             |
 
-<a id="ServiceTagOutboundRule"></a>ServiceTagOutboundRule
----------------------------------------------------------
+ServiceTagOutboundRule{#ServiceTagOutboundRule}
+-----------------------------------------------
 
 Used by: [OutboundRule](#OutboundRule).
 
@@ -3473,8 +3473,8 @@ Used by: [OutboundRule](#OutboundRule).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.                                         | [RuleStatus](#RuleStatus)<br/><small>Optional</small>                                   |
 | type        |                                                                                                                  | [ServiceTagOutboundRule_Type](#ServiceTagOutboundRule_Type)<br/><small>Required</small> |
 
-<a id="ServiceTagOutboundRule_STATUS"></a>ServiceTagOutboundRule_STATUS
------------------------------------------------------------------------
+ServiceTagOutboundRule_STATUS{#ServiceTagOutboundRule_STATUS}
+-------------------------------------------------------------
 
 Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 
@@ -3485,8 +3485,8 @@ Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 | status      | Type of a managed network Outbound Rule of a machine learning workspace.                                         | [RuleStatus_STATUS](#RuleStatus_STATUS)<br/><small>Optional</small>                                   |
 | type        |                                                                                                                  | [ServiceTagOutboundRule_Type_STATUS](#ServiceTagOutboundRule_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="SynapseSpark_ComputeType"></a>SynapseSpark_ComputeType
--------------------------------------------------------------
+SynapseSpark_ComputeType{#SynapseSpark_ComputeType}
+---------------------------------------------------
 
 Used by: [SynapseSpark](#SynapseSpark).
 
@@ -3494,8 +3494,8 @@ Used by: [SynapseSpark](#SynapseSpark).
 |----------------|-------------|
 | "SynapseSpark" |             |
 
-<a id="SynapseSpark_ComputeType_STATUS"></a>SynapseSpark_ComputeType_STATUS
----------------------------------------------------------------------------
+SynapseSpark_ComputeType_STATUS{#SynapseSpark_ComputeType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -3503,8 +3503,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 |----------------|-------------|
 | "SynapseSpark" |             |
 
-<a id="SynapseSpark_Properties"></a>SynapseSpark_Properties
------------------------------------------------------------
+SynapseSpark_Properties{#SynapseSpark_Properties}
+-------------------------------------------------
 
 Used by: [SynapseSpark](#SynapseSpark).
 
@@ -3521,8 +3521,8 @@ Used by: [SynapseSpark](#SynapseSpark).
 | subscriptionId      | Azure subscription identifier.                                 | string<br/><small>Optional</small>                                      |
 | workspaceName       | Name of Azure Machine Learning workspace.                      | string<br/><small>Optional</small>                                      |
 
-<a id="SynapseSpark_Properties_STATUS"></a>SynapseSpark_Properties_STATUS
--------------------------------------------------------------------------
+SynapseSpark_Properties_STATUS{#SynapseSpark_Properties_STATUS}
+---------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -3539,8 +3539,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 | subscriptionId      | Azure subscription identifier.                                 | string<br/><small>Optional</small>                                                    |
 | workspaceName       | Name of Azure Machine Learning workspace.                      | string<br/><small>Optional</small>                                                    |
 
-<a id="SynapseSpark_ProvisioningState_STATUS"></a>SynapseSpark_ProvisioningState_STATUS
----------------------------------------------------------------------------------------
+SynapseSpark_ProvisioningState_STATUS{#SynapseSpark_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 
@@ -3554,8 +3554,8 @@ Used by: [SynapseSpark_STATUS](#SynapseSpark_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="SystemCreatedAcrAccount"></a>SystemCreatedAcrAccount
------------------------------------------------------------
+SystemCreatedAcrAccount{#SystemCreatedAcrAccount}
+-------------------------------------------------
 
 Used by: [AcrDetails](#AcrDetails).
 
@@ -3564,8 +3564,8 @@ Used by: [AcrDetails](#AcrDetails).
 | acrAccountName | Name of the ACR account | string<br/><small>Optional</small> |
 | acrAccountSku  | SKU of the ACR account  | string<br/><small>Optional</small> |
 
-<a id="SystemCreatedAcrAccount_STATUS"></a>SystemCreatedAcrAccount_STATUS
--------------------------------------------------------------------------
+SystemCreatedAcrAccount_STATUS{#SystemCreatedAcrAccount_STATUS}
+---------------------------------------------------------------
 
 Used by: [AcrDetails_STATUS](#AcrDetails_STATUS).
 
@@ -3575,8 +3575,8 @@ Used by: [AcrDetails_STATUS](#AcrDetails_STATUS).
 | acrAccountSku  | SKU of the ACR account                             | string<br/><small>Optional</small>                                        |
 | armResourceId  | This is populated once the ACR account is created. | [ArmResourceId_STATUS](#ArmResourceId_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemCreatedStorageAccount"></a>SystemCreatedStorageAccount
--------------------------------------------------------------------
+SystemCreatedStorageAccount{#SystemCreatedStorageAccount}
+---------------------------------------------------------
 
 Used by: [StorageAccountDetails](#StorageAccountDetails).
 
@@ -3587,8 +3587,8 @@ Used by: [StorageAccountDetails](#StorageAccountDetails).
 | storageAccountName       | Name of the storage account                                                                                                                        | string<br/><small>Optional</small> |
 | storageAccountType       | Allowed values: "Standard_LRS", "Standard_GRS", "Standard_RAGRS", "Standard_ZRS", "Standard_GZRS", "Standard_RAGZRS", "Premium_LRS", "Premium_ZRS" | string<br/><small>Optional</small> |
 
-<a id="SystemCreatedStorageAccount_STATUS"></a>SystemCreatedStorageAccount_STATUS
----------------------------------------------------------------------------------
+SystemCreatedStorageAccount_STATUS{#SystemCreatedStorageAccount_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountDetails_STATUS](#StorageAccountDetails_STATUS).
 
@@ -3600,8 +3600,8 @@ Used by: [StorageAccountDetails_STATUS](#StorageAccountDetails_STATUS).
 | storageAccountName       | Name of the storage account                                                                                                                        | string<br/><small>Optional</small>                                        |
 | storageAccountType       | Allowed values: "Standard_LRS", "Standard_GRS", "Standard_RAGRS", "Standard_ZRS", "Standard_GZRS", "Standard_RAGZRS", "Premium_LRS", "Premium_ZRS" | string<br/><small>Optional</small>                                        |
 
-<a id="UserCreatedAcrAccount"></a>UserCreatedAcrAccount
--------------------------------------------------------
+UserCreatedAcrAccount{#UserCreatedAcrAccount}
+---------------------------------------------
 
 Used by: [AcrDetails](#AcrDetails).
 
@@ -3609,8 +3609,8 @@ Used by: [AcrDetails](#AcrDetails).
 |---------------|------------------------------|-------------------------------------------------------------|
 | armResourceId | ARM ResourceId of a resource | [ArmResourceId](#ArmResourceId)<br/><small>Optional</small> |
 
-<a id="UserCreatedAcrAccount_STATUS"></a>UserCreatedAcrAccount_STATUS
----------------------------------------------------------------------
+UserCreatedAcrAccount_STATUS{#UserCreatedAcrAccount_STATUS}
+-----------------------------------------------------------
 
 Used by: [AcrDetails_STATUS](#AcrDetails_STATUS).
 
@@ -3618,8 +3618,8 @@ Used by: [AcrDetails_STATUS](#AcrDetails_STATUS).
 |---------------|------------------------------|---------------------------------------------------------------------------|
 | armResourceId | ARM ResourceId of a resource | [ArmResourceId_STATUS](#ArmResourceId_STATUS)<br/><small>Optional</small> |
 
-<a id="UserCreatedStorageAccount"></a>UserCreatedStorageAccount
----------------------------------------------------------------
+UserCreatedStorageAccount{#UserCreatedStorageAccount}
+-----------------------------------------------------
 
 Used by: [StorageAccountDetails](#StorageAccountDetails).
 
@@ -3627,8 +3627,8 @@ Used by: [StorageAccountDetails](#StorageAccountDetails).
 |---------------|------------------------------|-------------------------------------------------------------|
 | armResourceId | ARM ResourceId of a resource | [ArmResourceId](#ArmResourceId)<br/><small>Optional</small> |
 
-<a id="UserCreatedStorageAccount_STATUS"></a>UserCreatedStorageAccount_STATUS
------------------------------------------------------------------------------
+UserCreatedStorageAccount_STATUS{#UserCreatedStorageAccount_STATUS}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountDetails_STATUS](#StorageAccountDetails_STATUS).
 
@@ -3636,8 +3636,8 @@ Used by: [StorageAccountDetails_STATUS](#StorageAccountDetails_STATUS).
 |---------------|------------------------------|---------------------------------------------------------------------------|
 | armResourceId | ARM ResourceId of a resource | [ArmResourceId_STATUS](#ArmResourceId_STATUS)<br/><small>Optional</small> |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType
------------------------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType{#UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswordAuthTypeWorkspaceConnectionProperties).
 
@@ -3645,8 +3645,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswo
 |--------------------|-------------|
 | "UsernamePassword" |             |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType_STATUS"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType_STATUS{#UsernamePasswordAuthTypeWorkspaceConnectionProperties_AuthType_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3654,8 +3654,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#Usernam
 |--------------------|-------------|
 | "UsernamePassword" |             |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat
------------------------------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat{#UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswordAuthTypeWorkspaceConnectionProperties).
 
@@ -3663,8 +3663,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswo
 |--------|-------------|
 | "JSON" |             |
 
-<a id="UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS"></a>UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS{#UsernamePasswordAuthTypeWorkspaceConnectionProperties_ValueFormat_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3672,8 +3672,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#Usernam
 |--------|-------------|
 | "JSON" |             |
 
-<a id="VirtualMachine_ComputeType"></a>VirtualMachine_ComputeType
------------------------------------------------------------------
+VirtualMachine_ComputeType{#VirtualMachine_ComputeType}
+-------------------------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -3681,8 +3681,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 |------------------|-------------|
 | "VirtualMachine" |             |
 
-<a id="VirtualMachine_ComputeType_STATUS"></a>VirtualMachine_ComputeType_STATUS
--------------------------------------------------------------------------------
+VirtualMachine_ComputeType_STATUS{#VirtualMachine_ComputeType_STATUS}
+---------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -3690,8 +3690,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 |------------------|-------------|
 | "VirtualMachine" |             |
 
-<a id="VirtualMachine_Properties"></a>VirtualMachine_Properties
----------------------------------------------------------------
+VirtualMachine_Properties{#VirtualMachine_Properties}
+-----------------------------------------------------
 
 Used by: [VirtualMachine](#VirtualMachine).
 
@@ -3704,8 +3704,8 @@ Used by: [VirtualMachine](#VirtualMachine).
 | sshPort                   | Port open for ssh connections.                                     | int<br/><small>Optional</small>                                                           |
 | virtualMachineSize        | Virtual Machine size                                               | string<br/><small>Optional</small>                                                        |
 
-<a id="VirtualMachine_Properties_STATUS"></a>VirtualMachine_Properties_STATUS
------------------------------------------------------------------------------
+VirtualMachine_Properties_STATUS{#VirtualMachine_Properties_STATUS}
+-------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -3718,8 +3718,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | sshPort                   | Port open for ssh connections.                                     | int<br/><small>Optional</small>                                                                         |
 | virtualMachineSize        | Virtual Machine size                                               | string<br/><small>Optional</small>                                                                      |
 
-<a id="VirtualMachine_ProvisioningState_STATUS"></a>VirtualMachine_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------
+VirtualMachine_ProvisioningState_STATUS{#VirtualMachine_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 
@@ -3733,8 +3733,8 @@ Used by: [VirtualMachine_STATUS](#VirtualMachine_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="WorkspaceConnectionAccessKey"></a>WorkspaceConnectionAccessKey
----------------------------------------------------------------------
+WorkspaceConnectionAccessKey{#WorkspaceConnectionAccessKey}
+-----------------------------------------------------------
 
 Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWorkspaceConnectionProperties).
 
@@ -3743,8 +3743,8 @@ Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties](#AccessKeyAuthTypeWork
 | accessKeyId     |             | string<br/><small>Optional</small>                                                                                                                     |
 | secretAccessKey |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionAccessKey_STATUS"></a>WorkspaceConnectionAccessKey_STATUS
------------------------------------------------------------------------------------
+WorkspaceConnectionAccessKey_STATUS{#WorkspaceConnectionAccessKey_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3752,8 +3752,8 @@ Used by: [AccessKeyAuthTypeWorkspaceConnectionProperties_STATUS](#AccessKeyAuthT
 |-------------|-------------|------------------------------------|
 | accessKeyId |             | string<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionAccountKey"></a>WorkspaceConnectionAccountKey
------------------------------------------------------------------------
+WorkspaceConnectionAccountKey{#WorkspaceConnectionAccountKey}
+-------------------------------------------------------------
 
 Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWorkspaceConnectionProperties).
 
@@ -3761,8 +3761,8 @@ Used by: [AccountKeyAuthTypeWorkspaceConnectionProperties](#AccountKeyAuthTypeWo
 |----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | key      |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionApiKey"></a>WorkspaceConnectionApiKey
----------------------------------------------------------------
+WorkspaceConnectionApiKey{#WorkspaceConnectionApiKey}
+-----------------------------------------------------
 
 Api key object for workspace connection credential.
 
@@ -3772,8 +3772,8 @@ Used by: [ApiKeyAuthWorkspaceConnectionProperties](#ApiKeyAuthWorkspaceConnectio
 |----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | key      |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionManagedIdentity"></a>WorkspaceConnectionManagedIdentity
----------------------------------------------------------------------------------
+WorkspaceConnectionManagedIdentity{#WorkspaceConnectionManagedIdentity}
+-----------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentityAuthTypeWorkspaceConnectionProperties).
 
@@ -3783,8 +3783,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties](#ManagedIdentity
 | clientIdFromConfig |             | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | resourceReference  |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>   |
 
-<a id="WorkspaceConnectionManagedIdentity_STATUS"></a>WorkspaceConnectionManagedIdentity_STATUS
------------------------------------------------------------------------------------------------
+WorkspaceConnectionManagedIdentity_STATUS{#WorkspaceConnectionManagedIdentity_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3793,8 +3793,8 @@ Used by: [ManagedIdentityAuthTypeWorkspaceConnectionProperties_STATUS](#ManagedI
 | clientId   |             | string<br/><small>Optional</small> |
 | resourceId |             | string<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionOAuth2"></a>WorkspaceConnectionOAuth2
----------------------------------------------------------------
+WorkspaceConnectionOAuth2{#WorkspaceConnectionOAuth2}
+-----------------------------------------------------
 
 ClientId and ClientSecret are required. Other properties are optional depending on each OAuth2 provider's implementation.
 
@@ -3813,8 +3813,8 @@ Used by: [OAuth2AuthTypeWorkspaceConnectionProperties](#OAuth2AuthTypeWorkspaceC
 | tenantIdFromConfig | Required by QuickBooks and Xero connection categories                                                                           | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | username           | Concur, ServiceNow auth server AccessToken grant type is 'Password' which requires UsernamePassword                             | string<br/><small>Optional</small>                                                                                                                           |
 
-<a id="WorkspaceConnectionOAuth2_STATUS"></a>WorkspaceConnectionOAuth2_STATUS
------------------------------------------------------------------------------
+WorkspaceConnectionOAuth2_STATUS{#WorkspaceConnectionOAuth2_STATUS}
+-------------------------------------------------------------------
 
 ClientId and ClientSecret are required. Other properties are optional depending on each OAuth2 provider's implementation.
 
@@ -3827,8 +3827,8 @@ Used by: [OAuth2AuthTypeWorkspaceConnectionProperties_STATUS](#OAuth2AuthTypeWor
 | tenantId | Required by QuickBooks and Xero connection categories                                               | string<br/><small>Optional</small> |
 | username | Concur, ServiceNow auth server AccessToken grant type is 'Password' which requires UsernamePassword | string<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionPersonalAccessToken"></a>WorkspaceConnectionPersonalAccessToken
------------------------------------------------------------------------------------------
+WorkspaceConnectionPersonalAccessToken{#WorkspaceConnectionPersonalAccessToken}
+-------------------------------------------------------------------------------
 
 Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnectionProperties).
 
@@ -3836,8 +3836,8 @@ Used by: [PATAuthTypeWorkspaceConnectionProperties](#PATAuthTypeWorkspaceConnect
 |----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | pat      |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionServicePrincipal"></a>WorkspaceConnectionServicePrincipal
------------------------------------------------------------------------------------
+WorkspaceConnectionServicePrincipal{#WorkspaceConnectionServicePrincipal}
+-------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincipalAuthTypeWorkspaceConnectionProperties).
 
@@ -3849,8 +3849,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties](#ServicePrincip
 | tenantId           |             | string<br/><small>Optional</small>                                                                                                                           |
 | tenantIdFromConfig |             | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionServicePrincipal_STATUS"></a>WorkspaceConnectionServicePrincipal_STATUS
--------------------------------------------------------------------------------------------------
+WorkspaceConnectionServicePrincipal_STATUS{#WorkspaceConnectionServicePrincipal_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3859,8 +3859,8 @@ Used by: [ServicePrincipalAuthTypeWorkspaceConnectionProperties_STATUS](#Service
 | clientId |             | string<br/><small>Optional</small> |
 | tenantId |             | string<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionSharedAccessSignature"></a>WorkspaceConnectionSharedAccessSignature
----------------------------------------------------------------------------------------------
+WorkspaceConnectionSharedAccessSignature{#WorkspaceConnectionSharedAccessSignature}
+-----------------------------------------------------------------------------------
 
 Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnectionProperties).
 
@@ -3868,8 +3868,8 @@ Used by: [SASAuthTypeWorkspaceConnectionProperties](#SASAuthTypeWorkspaceConnect
 |----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sas      |             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="WorkspaceConnectionUsernamePassword"></a>WorkspaceConnectionUsernamePassword
------------------------------------------------------------------------------------
+WorkspaceConnectionUsernamePassword{#WorkspaceConnectionUsernamePassword}
+-------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswordAuthTypeWorkspaceConnectionProperties).
 
@@ -3879,8 +3879,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties](#UsernamePasswo
 | securityToken | Optional, required by connections like SalesForce for extra security in addition to UsernamePassword | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | username      |                                                                                                      | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="WorkspaceConnectionUsernamePassword_STATUS"></a>WorkspaceConnectionUsernamePassword_STATUS
--------------------------------------------------------------------------------------------------
+WorkspaceConnectionUsernamePassword_STATUS{#WorkspaceConnectionUsernamePassword_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS).
 
@@ -3888,8 +3888,8 @@ Used by: [UsernamePasswordAuthTypeWorkspaceConnectionProperties_STATUS](#Usernam
 |----------|-------------|------------------------------------|
 | username |             | string<br/><small>Optional</small> |
 
-<a id="AKS_Properties_ClusterPurpose"></a>AKS_Properties_ClusterPurpose
------------------------------------------------------------------------
+AKS_Properties_ClusterPurpose{#AKS_Properties_ClusterPurpose}
+-------------------------------------------------------------
 
 Used by: [AKS_Properties](#AKS_Properties).
 
@@ -3899,20 +3899,20 @@ Used by: [AKS_Properties](#AKS_Properties).
 | "DevTest"   |             |
 | "FastProd"  |             |
 
-<a id="AKS_Properties_ClusterPurpose_STATUS"></a>AKS_Properties_ClusterPurpose_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "DenseProd" |             |
-| "DevTest"   |             |
-| "FastProd"  |             |
-
-<a id="AKS_Properties_LoadBalancerType"></a>AKS_Properties_LoadBalancerType
+AKS_Properties_ClusterPurpose_STATUS{#AKS_Properties_ClusterPurpose_STATUS}
 ---------------------------------------------------------------------------
 
+Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "DenseProd" |             |
+| "DevTest"   |             |
+| "FastProd"  |             |
+
+AKS_Properties_LoadBalancerType{#AKS_Properties_LoadBalancerType}
+-----------------------------------------------------------------
+
 Used by: [AKS_Properties](#AKS_Properties).
 
 | Value                  | Description |
@@ -3920,8 +3920,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | "InternalLoadBalancer" |             |
 | "PublicIp"             |             |
 
-<a id="AKS_Properties_LoadBalancerType_STATUS"></a>AKS_Properties_LoadBalancerType_STATUS
------------------------------------------------------------------------------------------
+AKS_Properties_LoadBalancerType_STATUS{#AKS_Properties_LoadBalancerType_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 
@@ -3930,8 +3930,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | "InternalLoadBalancer" |             |
 | "PublicIp"             |             |
 
-<a id="AksNetworkingConfiguration"></a>AksNetworkingConfiguration
------------------------------------------------------------------
+AksNetworkingConfiguration{#AksNetworkingConfiguration}
+-------------------------------------------------------
 
 Advance configuration for AKS networking
 
@@ -3944,8 +3944,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | serviceCidr      | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                      | string<br/><small>Optional</small>                                                                                                                         |
 | subnetReference  | Virtual network subnet resource ID the compute nodes belong to                                                                                         | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="AksNetworkingConfiguration_STATUS"></a>AksNetworkingConfiguration_STATUS
--------------------------------------------------------------------------------
+AksNetworkingConfiguration_STATUS{#AksNetworkingConfiguration_STATUS}
+---------------------------------------------------------------------
 
 Advance configuration for AKS networking
 
@@ -3958,8 +3958,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | serviceCidr      | A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.                                      | string<br/><small>Optional</small> |
 | subnetId         | Virtual network subnet resource ID the compute nodes belong to                                                                                         | string<br/><small>Optional</small> |
 
-<a id="AmlComputeProperties_AllocationState_STATUS"></a>AmlComputeProperties_AllocationState_STATUS
----------------------------------------------------------------------------------------------------
+AmlComputeProperties_AllocationState_STATUS{#AmlComputeProperties_AllocationState_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -3968,8 +3968,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Resizing" |             |
 | "Steady"   |             |
 
-<a id="AmlComputeProperties_OsType"></a>AmlComputeProperties_OsType
--------------------------------------------------------------------
+AmlComputeProperties_OsType{#AmlComputeProperties_OsType}
+---------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -3978,8 +3978,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="AmlComputeProperties_OsType_STATUS"></a>AmlComputeProperties_OsType_STATUS
----------------------------------------------------------------------------------
+AmlComputeProperties_OsType_STATUS{#AmlComputeProperties_OsType_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -3988,8 +3988,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Linux"   |             |
 | "Windows" |             |
 
-<a id="AmlComputeProperties_RemoteLoginPortPublicAccess"></a>AmlComputeProperties_RemoteLoginPortPublicAccess
--------------------------------------------------------------------------------------------------------------
+AmlComputeProperties_RemoteLoginPortPublicAccess{#AmlComputeProperties_RemoteLoginPortPublicAccess}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -3999,8 +3999,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Enabled"      |             |
 | "NotSpecified" |             |
 
-<a id="AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS"></a>AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS
----------------------------------------------------------------------------------------------------------------------------
+AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS{#AmlComputeProperties_RemoteLoginPortPublicAccess_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 
@@ -4010,8 +4010,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | "Enabled"      |             |
 | "NotSpecified" |             |
 
-<a id="AmlComputeProperties_VmPriority"></a>AmlComputeProperties_VmPriority
----------------------------------------------------------------------------
+AmlComputeProperties_VmPriority{#AmlComputeProperties_VmPriority}
+-----------------------------------------------------------------
 
 Used by: [AmlComputeProperties](#AmlComputeProperties).
 
@@ -4020,68 +4020,68 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | "Dedicated"   |             |
 | "LowPriority" |             |
 
-<a id="AmlComputeProperties_VmPriority_STATUS"></a>AmlComputeProperties_VmPriority_STATUS
------------------------------------------------------------------------------------------
-
-Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "Dedicated"   |             |
-| "LowPriority" |             |
-
-<a id="AutoPauseProperties"></a>AutoPauseProperties
----------------------------------------------------
-
-Auto pause properties
-
-Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
-
-| Property       | Description | Type                             |
-|----------------|-------------|----------------------------------|
-| delayInMinutes |             | int<br/><small>Optional</small>  |
-| enabled        |             | bool<br/><small>Optional</small> |
-
-<a id="AutoPauseProperties_STATUS"></a>AutoPauseProperties_STATUS
------------------------------------------------------------------
-
-Auto pause properties
-
-Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
-
-| Property       | Description | Type                             |
-|----------------|-------------|----------------------------------|
-| delayInMinutes |             | int<br/><small>Optional</small>  |
-| enabled        |             | bool<br/><small>Optional</small> |
-
-<a id="AutoScaleProperties"></a>AutoScaleProperties
----------------------------------------------------
-
-Auto scale properties
-
-Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
-
-| Property     | Description | Type                             |
-|--------------|-------------|----------------------------------|
-| enabled      |             | bool<br/><small>Optional</small> |
-| maxNodeCount |             | int<br/><small>Optional</small>  |
-| minNodeCount |             | int<br/><small>Optional</small>  |
-
-<a id="AutoScaleProperties_STATUS"></a>AutoScaleProperties_STATUS
------------------------------------------------------------------
-
-Auto scale properties
-
-Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
-
-| Property     | Description | Type                             |
-|--------------|-------------|----------------------------------|
-| enabled      |             | bool<br/><small>Optional</small> |
-| maxNodeCount |             | int<br/><small>Optional</small>  |
-| minNodeCount |             | int<br/><small>Optional</small>  |
-
-<a id="ComputeInstanceApplication_STATUS"></a>ComputeInstanceApplication_STATUS
+AmlComputeProperties_VmPriority_STATUS{#AmlComputeProperties_VmPriority_STATUS}
 -------------------------------------------------------------------------------
+
+Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "Dedicated"   |             |
+| "LowPriority" |             |
+
+AutoPauseProperties{#AutoPauseProperties}
+-----------------------------------------
+
+Auto pause properties
+
+Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
+
+| Property       | Description | Type                             |
+|----------------|-------------|----------------------------------|
+| delayInMinutes |             | int<br/><small>Optional</small>  |
+| enabled        |             | bool<br/><small>Optional</small> |
+
+AutoPauseProperties_STATUS{#AutoPauseProperties_STATUS}
+-------------------------------------------------------
+
+Auto pause properties
+
+Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
+
+| Property       | Description | Type                             |
+|----------------|-------------|----------------------------------|
+| delayInMinutes |             | int<br/><small>Optional</small>  |
+| enabled        |             | bool<br/><small>Optional</small> |
+
+AutoScaleProperties{#AutoScaleProperties}
+-----------------------------------------
+
+Auto scale properties
+
+Used by: [SynapseSpark_Properties](#SynapseSpark_Properties).
+
+| Property     | Description | Type                             |
+|--------------|-------------|----------------------------------|
+| enabled      |             | bool<br/><small>Optional</small> |
+| maxNodeCount |             | int<br/><small>Optional</small>  |
+| minNodeCount |             | int<br/><small>Optional</small>  |
+
+AutoScaleProperties_STATUS{#AutoScaleProperties_STATUS}
+-------------------------------------------------------
+
+Auto scale properties
+
+Used by: [SynapseSpark_Properties_STATUS](#SynapseSpark_Properties_STATUS).
+
+| Property     | Description | Type                             |
+|--------------|-------------|----------------------------------|
+| enabled      |             | bool<br/><small>Optional</small> |
+| maxNodeCount |             | int<br/><small>Optional</small>  |
+| minNodeCount |             | int<br/><small>Optional</small>  |
+
+ComputeInstanceApplication_STATUS{#ComputeInstanceApplication_STATUS}
+---------------------------------------------------------------------
 
 Defines an Aml Instance application and its connectivity endpoint URI.
 
@@ -4092,8 +4092,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | displayName | Name of the ComputeInstance application. | string<br/><small>Optional</small> |
 | endpointUri | Application' endpoint URI.               | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceConnectivityEndpoints_STATUS"></a>ComputeInstanceConnectivityEndpoints_STATUS
----------------------------------------------------------------------------------------------------
+ComputeInstanceConnectivityEndpoints_STATUS{#ComputeInstanceConnectivityEndpoints_STATUS}
+-----------------------------------------------------------------------------------------
 
 Defines all connectivity endpoints and properties for an ComputeInstance.
 
@@ -4104,8 +4104,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | privateIpAddress | Private IP Address of this ComputeInstance (local to the VNET in which the compute instance is deployed). | string<br/><small>Optional</small> |
 | publicIpAddress  | Public IP Address of this ComputeInstance.                                                                | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceContainer_STATUS"></a>ComputeInstanceContainer_STATUS
----------------------------------------------------------------------------
+ComputeInstanceContainer_STATUS{#ComputeInstanceContainer_STATUS}
+-----------------------------------------------------------------
 
 Defines an Aml Instance container.
 
@@ -4120,8 +4120,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | network     | network of this container.                 | [ComputeInstanceContainer_Network_STATUS](#ComputeInstanceContainer_Network_STATUS)<br/><small>Optional</small>   |
 | services    | services of this containers.               | map[string]v1.JSON[]<br/><small>Optional</small>                                                                  |
 
-<a id="ComputeInstanceCreatedBy_STATUS"></a>ComputeInstanceCreatedBy_STATUS
----------------------------------------------------------------------------
+ComputeInstanceCreatedBy_STATUS{#ComputeInstanceCreatedBy_STATUS}
+-----------------------------------------------------------------
 
 Describes information on user who created this ComputeInstance.
 
@@ -4133,8 +4133,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | userName  | Name of the user.                                              | string<br/><small>Optional</small> |
 | userOrgId | Uniquely identifies user' Azure Active Directory organization. | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceDataDisk_STATUS"></a>ComputeInstanceDataDisk_STATUS
--------------------------------------------------------------------------
+ComputeInstanceDataDisk_STATUS{#ComputeInstanceDataDisk_STATUS}
+---------------------------------------------------------------
 
 Defines an Aml Instance DataDisk.
 
@@ -4147,8 +4147,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | lun                | The lun is used to uniquely identify each data disk. If attaching multiple disks, each should have a distinct lun. | int<br/><small>Optional</small>                                                                                                     |
 | storageAccountType | type of this storage account.                                                                                      | [ComputeInstanceDataDisk_StorageAccountType_STATUS](#ComputeInstanceDataDisk_StorageAccountType_STATUS)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceDataMount_STATUS"></a>ComputeInstanceDataMount_STATUS
----------------------------------------------------------------------------
+ComputeInstanceDataMount_STATUS{#ComputeInstanceDataMount_STATUS}
+-----------------------------------------------------------------
 
 Defines an Aml Instance DataMount.
 
@@ -4166,8 +4166,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | source      | Source of the ComputeInstance data mount. | string<br/><small>Optional</small>                                                                                      |
 | sourceType  | Data source type.                         | [ComputeInstanceDataMount_SourceType_STATUS](#ComputeInstanceDataMount_SourceType_STATUS)<br/><small>Optional</small>   |
 
-<a id="ComputeInstanceLastOperation_STATUS"></a>ComputeInstanceLastOperation_STATUS
------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_STATUS{#ComputeInstanceLastOperation_STATUS}
+-------------------------------------------------------------------------
 
 The last operation on ComputeInstance.
 
@@ -4180,8 +4180,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | operationTime    | Time of the last operation. | string<br/><small>Optional</small>                                                                                                        |
 | operationTrigger | Trigger of operation.       | [ComputeInstanceLastOperation_OperationTrigger_STATUS](#ComputeInstanceLastOperation_OperationTrigger_STATUS)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceProperties_ApplicationSharingPolicy"></a>ComputeInstanceProperties_ApplicationSharingPolicy
------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ApplicationSharingPolicy{#ComputeInstanceProperties_ApplicationSharingPolicy}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 
@@ -4190,8 +4190,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 | "Personal" |             |
 | "Shared"   |             |
 
-<a id="ComputeInstanceProperties_ApplicationSharingPolicy_STATUS"></a>ComputeInstanceProperties_ApplicationSharingPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ApplicationSharingPolicy_STATUS{#ComputeInstanceProperties_ApplicationSharingPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 
@@ -4200,8 +4200,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | "Personal" |             |
 | "Shared"   |             |
 
-<a id="ComputeInstanceProperties_ComputeInstanceAuthorizationType"></a>ComputeInstanceProperties_ComputeInstanceAuthorizationType
----------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ComputeInstanceAuthorizationType{#ComputeInstanceProperties_ComputeInstanceAuthorizationType}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 
@@ -4209,8 +4209,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |------------|-------------|
 | "personal" |             |
 
-<a id="ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS"></a>ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS{#ComputeInstanceProperties_ComputeInstanceAuthorizationType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 
@@ -4218,8 +4218,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |------------|-------------|
 | "personal" |             |
 
-<a id="ComputeInstanceSshSettings"></a>ComputeInstanceSshSettings
------------------------------------------------------------------
+ComputeInstanceSshSettings{#ComputeInstanceSshSettings}
+-------------------------------------------------------
 
 Specifies policy and settings for SSH access.
 
@@ -4230,8 +4230,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 | adminPublicKey  | Specifies the SSH rsa public key file as a string. Use "ssh-keygen -t rsa -b 2048" to generate your SSH key pairs.                                                                                                                                  | string<br/><small>Optional</small>                                                                                    |
 | sshPublicAccess | State of the public SSH port. Possible values are: Disabled - Indicates that the public ssh port is closed on this instance. Enabled - Indicates that the public ssh port is open and accessible according to the VNet/subnet policy if applicable. | [ComputeInstanceSshSettings_SshPublicAccess](#ComputeInstanceSshSettings_SshPublicAccess)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceSshSettings_STATUS"></a>ComputeInstanceSshSettings_STATUS
--------------------------------------------------------------------------------
+ComputeInstanceSshSettings_STATUS{#ComputeInstanceSshSettings_STATUS}
+---------------------------------------------------------------------
 
 Specifies policy and settings for SSH access.
 
@@ -4244,8 +4244,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | sshPort         | Describes the port for connecting through SSH.                                                                                                                                                                                                      | int<br/><small>Optional</small>                                                                                                     |
 | sshPublicAccess | State of the public SSH port. Possible values are: Disabled - Indicates that the public ssh port is closed on this instance. Enabled - Indicates that the public ssh port is open and accessible according to the VNet/subnet policy if applicable. | [ComputeInstanceSshSettings_SshPublicAccess_STATUS](#ComputeInstanceSshSettings_SshPublicAccess_STATUS)<br/><small>Optional</small> |
 
-<a id="ComputeInstanceState_STATUS"></a>ComputeInstanceState_STATUS
--------------------------------------------------------------------
+ComputeInstanceState_STATUS{#ComputeInstanceState_STATUS}
+---------------------------------------------------------
 
 Current state of an ComputeInstance.
 
@@ -4269,8 +4269,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | "UserSettingUp"   |             |
 | "UserSetupFailed" |             |
 
-<a id="ComputeInstanceVersion_STATUS"></a>ComputeInstanceVersion_STATUS
------------------------------------------------------------------------
+ComputeInstanceVersion_STATUS{#ComputeInstanceVersion_STATUS}
+-------------------------------------------------------------
 
 Version of computeInstance.
 
@@ -4280,8 +4280,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |----------|------------------------------|------------------------------------|
 | runtime  | Runtime of compute instance. | string<br/><small>Optional</small> |
 
-<a id="ComputeSchedules"></a>ComputeSchedules
----------------------------------------------
+ComputeSchedules{#ComputeSchedules}
+-----------------------------------
 
 The list of schedules to be applied on the computes
 
@@ -4291,8 +4291,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |------------------|---------------------------------------------------------|-------------------------------------------------------------------------------------|
 | computeStartStop | The list of compute start stop schedules to be applied. | [ComputeStartStopSchedule[]](#ComputeStartStopSchedule)<br/><small>Optional</small> |
 
-<a id="ComputeSchedules_STATUS"></a>ComputeSchedules_STATUS
------------------------------------------------------------
+ComputeSchedules_STATUS{#ComputeSchedules_STATUS}
+-------------------------------------------------
 
 The list of schedules to be applied on the computes
 
@@ -4302,8 +4302,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | computeStartStop | The list of compute start stop schedules to be applied. | [ComputeStartStopSchedule_STATUS[]](#ComputeStartStopSchedule_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomService"></a>CustomService
----------------------------------------
+CustomService{#CustomService}
+-----------------------------
 
 Specifies the custom service configuration
 
@@ -4318,8 +4318,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 | name                 | Name of the Custom Service                  | string<br/><small>Optional</small>                                                 |
 | volumes              | Configuring the volumes for the container   | [VolumeDefinition[]](#VolumeDefinition)<br/><small>Optional</small>                |
 
-<a id="CustomService_STATUS"></a>CustomService_STATUS
------------------------------------------------------
+CustomService_STATUS{#CustomService_STATUS}
+-------------------------------------------
 
 Specifies the custom service configuration
 
@@ -4334,8 +4334,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | name                 | Name of the Custom Service                  | string<br/><small>Optional</small>                                                               |
 | volumes              | Configuring the volumes for the container   | [VolumeDefinition_STATUS[]](#VolumeDefinition_STATUS)<br/><small>Optional</small>                |
 
-<a id="ErrorDetail_STATUS"></a>ErrorDetail_STATUS
--------------------------------------------------
+ErrorDetail_STATUS{#ErrorDetail_STATUS}
+---------------------------------------
 
 The error detail.
 
@@ -4349,8 +4349,8 @@ Used by: [ErrorResponse_STATUS](#ErrorResponse_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                        |
 | target         | The error target.          | string<br/><small>Optional</small>                                                        |
 
-<a id="FqdnOutboundRule_Type"></a>FqdnOutboundRule_Type
--------------------------------------------------------
+FqdnOutboundRule_Type{#FqdnOutboundRule_Type}
+---------------------------------------------
 
 Used by: [FqdnOutboundRule](#FqdnOutboundRule).
 
@@ -4358,8 +4358,8 @@ Used by: [FqdnOutboundRule](#FqdnOutboundRule).
 |--------|-------------|
 | "FQDN" |             |
 
-<a id="FqdnOutboundRule_Type_STATUS"></a>FqdnOutboundRule_Type_STATUS
----------------------------------------------------------------------
+FqdnOutboundRule_Type_STATUS{#FqdnOutboundRule_Type_STATUS}
+-----------------------------------------------------------
 
 Used by: [FqdnOutboundRule_STATUS](#FqdnOutboundRule_STATUS).
 
@@ -4367,8 +4367,8 @@ Used by: [FqdnOutboundRule_STATUS](#FqdnOutboundRule_STATUS).
 |--------|-------------|
 | "FQDN" |             |
 
-<a id="ImageMetadata_STATUS"></a>ImageMetadata_STATUS
------------------------------------------------------
+ImageMetadata_STATUS{#ImageMetadata_STATUS}
+-------------------------------------------
 
 Returns metadata about the operating system image for this compute instance.
 
@@ -4380,8 +4380,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 | isLatestOsImageVersion | Specifies whether this compute instance is running on the latest operating system image.  | bool<br/><small>Optional</small>   |
 | latestImageVersion     | Specifies the latest available operating system image version.                            | string<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema"></a>InstanceTypeSchema
--------------------------------------------------
+InstanceTypeSchema{#InstanceTypeSchema}
+---------------------------------------
 
 Instance type schema.
 
@@ -4392,8 +4392,8 @@ Used by: [KubernetesProperties](#KubernetesProperties).
 | nodeSelector | Node Selector                                   | map[string]string<br/><small>Optional</small>                                             |
 | resources    | Resource requests/limits for this instance type | [InstanceTypeSchema_Resources](#InstanceTypeSchema_Resources)<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema_STATUS"></a>InstanceTypeSchema_STATUS
----------------------------------------------------------------
+InstanceTypeSchema_STATUS{#InstanceTypeSchema_STATUS}
+-----------------------------------------------------
 
 Instance type schema.
 
@@ -4404,8 +4404,8 @@ Used by: [KubernetesProperties_STATUS](#KubernetesProperties_STATUS).
 | nodeSelector | Node Selector                                   | map[string]string<br/><small>Optional</small>                                                           |
 | resources    | Resource requests/limits for this instance type | [InstanceTypeSchema_Resources_STATUS](#InstanceTypeSchema_Resources_STATUS)<br/><small>Optional</small> |
 
-<a id="NodeStateCounts_STATUS"></a>NodeStateCounts_STATUS
----------------------------------------------------------
+NodeStateCounts_STATUS{#NodeStateCounts_STATUS}
+-----------------------------------------------
 
 Counts of various compute node states on the amlCompute.
 
@@ -4420,8 +4420,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | runningNodeCount   | Number of compute nodes which are running jobs.           | int<br/><small>Optional</small> |
 | unusableNodeCount  | Number of compute nodes which are in unusable state.      | int<br/><small>Optional</small> |
 
-<a id="PersonalComputeInstanceSettings"></a>PersonalComputeInstanceSettings
----------------------------------------------------------------------------
+PersonalComputeInstanceSettings{#PersonalComputeInstanceSettings}
+-----------------------------------------------------------------
 
 Settings for a personal compute instance.
 
@@ -4431,8 +4431,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |--------------|------------------------------------------------------------|-----------------------------------------------------------|
 | assignedUser | A user explicitly assigned to a personal compute instance. | [AssignedUser](#AssignedUser)<br/><small>Optional</small> |
 
-<a id="PersonalComputeInstanceSettings_STATUS"></a>PersonalComputeInstanceSettings_STATUS
------------------------------------------------------------------------------------------
+PersonalComputeInstanceSettings_STATUS{#PersonalComputeInstanceSettings_STATUS}
+-------------------------------------------------------------------------------
 
 Settings for a personal compute instance.
 
@@ -4442,8 +4442,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |--------------|------------------------------------------------------------|-------------------------------------------------------------------------|
 | assignedUser | A user explicitly assigned to a personal compute instance. | [AssignedUser_STATUS](#AssignedUser_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointDestination"></a>PrivateEndpointDestination
------------------------------------------------------------------
+PrivateEndpointDestination{#PrivateEndpointDestination}
+-------------------------------------------------------
 
 Private Endpoint destination for a Private Endpoint Outbound Rule for the managed network of a machine learning workspace.
 
@@ -4456,8 +4456,8 @@ Used by: [PrivateEndpointOutboundRule](#PrivateEndpointOutboundRule).
 | sparkStatus                | Type of a managed network Outbound Rule of a machine learning workspace. | [RuleStatus](#RuleStatus)<br/><small>Optional</small>                                                                                                      |
 | subresourceTargetReference |                                                                          | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointDestination_STATUS"></a>PrivateEndpointDestination_STATUS
--------------------------------------------------------------------------------
+PrivateEndpointDestination_STATUS{#PrivateEndpointDestination_STATUS}
+---------------------------------------------------------------------
 
 Private Endpoint destination for a Private Endpoint Outbound Rule for the managed network of a machine learning workspace.
 
@@ -4470,8 +4470,8 @@ Used by: [PrivateEndpointOutboundRule_STATUS](#PrivateEndpointOutboundRule_STATU
 | sparkStatus       | Type of a managed network Outbound Rule of a machine learning workspace. | [RuleStatus_STATUS](#RuleStatus_STATUS)<br/><small>Optional</small> |
 | subresourceTarget |                                                                          | string<br/><small>Optional</small>                                  |
 
-<a id="PrivateEndpointOutboundRule_Type"></a>PrivateEndpointOutboundRule_Type
------------------------------------------------------------------------------
+PrivateEndpointOutboundRule_Type{#PrivateEndpointOutboundRule_Type}
+-------------------------------------------------------------------
 
 Used by: [PrivateEndpointOutboundRule](#PrivateEndpointOutboundRule).
 
@@ -4479,8 +4479,8 @@ Used by: [PrivateEndpointOutboundRule](#PrivateEndpointOutboundRule).
 |-------------------|-------------|
 | "PrivateEndpoint" |             |
 
-<a id="PrivateEndpointOutboundRule_Type_STATUS"></a>PrivateEndpointOutboundRule_Type_STATUS
--------------------------------------------------------------------------------------------
+PrivateEndpointOutboundRule_Type_STATUS{#PrivateEndpointOutboundRule_Type_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointOutboundRule_STATUS](#PrivateEndpointOutboundRule_STATUS).
 
@@ -4488,8 +4488,8 @@ Used by: [PrivateEndpointOutboundRule_STATUS](#PrivateEndpointOutboundRule_STATU
 |-------------------|-------------|
 | "PrivateEndpoint" |             |
 
-<a id="ResourceId"></a>ResourceId
----------------------------------
+ResourceId{#ResourceId}
+-----------------------
 
 Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 
@@ -4499,8 +4499,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties), and [ComputeInstanceProp
 |-----------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | The ID of the resource | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="ResourceId_STATUS"></a>ResourceId_STATUS
------------------------------------------------
+ResourceId_STATUS{#ResourceId_STATUS}
+-------------------------------------
 
 Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 
@@ -4510,8 +4510,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS), and [Compu
 |----------|------------------------|------------------------------------|
 | id       | The ID of the resource | string<br/><small>Optional</small> |
 
-<a id="RuleCategory"></a>RuleCategory
--------------------------------------
+RuleCategory{#RuleCategory}
+---------------------------
 
 Category of a managed network Outbound Rule of a machine learning workspace.
 
@@ -4524,8 +4524,8 @@ Used by: [FqdnOutboundRule](#FqdnOutboundRule), [PrivateEndpointOutboundRule](#P
 | "Required"    |             |
 | "UserDefined" |             |
 
-<a id="RuleCategory_STATUS"></a>RuleCategory_STATUS
----------------------------------------------------
+RuleCategory_STATUS{#RuleCategory_STATUS}
+-----------------------------------------
 
 Category of a managed network Outbound Rule of a machine learning workspace.
 
@@ -4538,8 +4538,8 @@ Used by: [FqdnOutboundRule_STATUS](#FqdnOutboundRule_STATUS), [PrivateEndpointOu
 | "Required"    |             |
 | "UserDefined" |             |
 
-<a id="RuleStatus"></a>RuleStatus
----------------------------------
+RuleStatus{#RuleStatus}
+-----------------------
 
 Type of a managed network Outbound Rule of a machine learning workspace.
 
@@ -4550,8 +4550,8 @@ Used by: [FqdnOutboundRule](#FqdnOutboundRule), [PrivateEndpointDestination](#Pr
 | "Active"   |             |
 | "Inactive" |             |
 
-<a id="RuleStatus_STATUS"></a>RuleStatus_STATUS
------------------------------------------------
+RuleStatus_STATUS{#RuleStatus_STATUS}
+-------------------------------------
 
 Type of a managed network Outbound Rule of a machine learning workspace.
 
@@ -4562,8 +4562,8 @@ Used by: [FqdnOutboundRule_STATUS](#FqdnOutboundRule_STATUS), [PrivateEndpointDe
 | "Active"   |             |
 | "Inactive" |             |
 
-<a id="ScaleSettings"></a>ScaleSettings
----------------------------------------
+ScaleSettings{#ScaleSettings}
+-----------------------------
 
 scale settings for AML Compute
 
@@ -4575,8 +4575,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | minNodeCount                | Min number of nodes to use                                                                | int<br/><small>Optional</small>    |
 | nodeIdleTimeBeforeScaleDown | Node Idle Time before scaling down amlCompute. This string needs to be in the RFC Format. | string<br/><small>Optional</small> |
 
-<a id="ScaleSettings_STATUS"></a>ScaleSettings_STATUS
------------------------------------------------------
+ScaleSettings_STATUS{#ScaleSettings_STATUS}
+-------------------------------------------
 
 scale settings for AML Compute
 
@@ -4588,8 +4588,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 | minNodeCount                | Min number of nodes to use                                                                | int<br/><small>Optional</small>    |
 | nodeIdleTimeBeforeScaleDown | Node Idle Time before scaling down amlCompute. This string needs to be in the RFC Format. | string<br/><small>Optional</small> |
 
-<a id="ServiceTagDestination"></a>ServiceTagDestination
--------------------------------------------------------
+ServiceTagDestination{#ServiceTagDestination}
+---------------------------------------------
 
 Service Tag destination for a Service Tag Outbound Rule for the managed network of a machine learning workspace.
 
@@ -4602,8 +4602,8 @@ Used by: [ServiceTagOutboundRule](#ServiceTagOutboundRule).
 | protocol   |                                      | string<br/><small>Optional</small>                    |
 | serviceTag |                                      | string<br/><small>Optional</small>                    |
 
-<a id="ServiceTagDestination_STATUS"></a>ServiceTagDestination_STATUS
----------------------------------------------------------------------
+ServiceTagDestination_STATUS{#ServiceTagDestination_STATUS}
+-----------------------------------------------------------
 
 Service Tag destination for a Service Tag Outbound Rule for the managed network of a machine learning workspace.
 
@@ -4617,8 +4617,8 @@ Used by: [ServiceTagOutboundRule_STATUS](#ServiceTagOutboundRule_STATUS).
 | protocol        |                                                                 | string<br/><small>Optional</small>                                  |
 | serviceTag      |                                                                 | string<br/><small>Optional</small>                                  |
 
-<a id="ServiceTagOutboundRule_Type"></a>ServiceTagOutboundRule_Type
--------------------------------------------------------------------
+ServiceTagOutboundRule_Type{#ServiceTagOutboundRule_Type}
+---------------------------------------------------------
 
 Used by: [ServiceTagOutboundRule](#ServiceTagOutboundRule).
 
@@ -4626,8 +4626,8 @@ Used by: [ServiceTagOutboundRule](#ServiceTagOutboundRule).
 |--------------|-------------|
 | "ServiceTag" |             |
 
-<a id="ServiceTagOutboundRule_Type_STATUS"></a>ServiceTagOutboundRule_Type_STATUS
----------------------------------------------------------------------------------
+ServiceTagOutboundRule_Type_STATUS{#ServiceTagOutboundRule_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ServiceTagOutboundRule_STATUS](#ServiceTagOutboundRule_STATUS).
 
@@ -4635,8 +4635,8 @@ Used by: [ServiceTagOutboundRule_STATUS](#ServiceTagOutboundRule_STATUS).
 |--------------|-------------|
 | "ServiceTag" |             |
 
-<a id="SetupScripts"></a>SetupScripts
--------------------------------------
+SetupScripts{#SetupScripts}
+---------------------------
 
 Details of customized scripts to execute for setting up the cluster.
 
@@ -4646,8 +4646,8 @@ Used by: [ComputeInstanceProperties](#ComputeInstanceProperties).
 |----------|--------------------------|-------------------------------------------------------------------|
 | scripts  | Customized setup scripts | [ScriptsToExecute](#ScriptsToExecute)<br/><small>Optional</small> |
 
-<a id="SetupScripts_STATUS"></a>SetupScripts_STATUS
----------------------------------------------------
+SetupScripts_STATUS{#SetupScripts_STATUS}
+-----------------------------------------
 
 Details of customized scripts to execute for setting up the cluster.
 
@@ -4657,8 +4657,8 @@ Used by: [ComputeInstanceProperties_STATUS](#ComputeInstanceProperties_STATUS).
 |----------|--------------------------|---------------------------------------------------------------------------------|
 | scripts  | Customized setup scripts | [ScriptsToExecute_STATUS](#ScriptsToExecute_STATUS)<br/><small>Optional</small> |
 
-<a id="SslConfiguration"></a>SslConfiguration
----------------------------------------------
+SslConfiguration{#SslConfiguration}
+-----------------------------------
 
 The ssl configuration for scoring
 
@@ -4673,8 +4673,8 @@ Used by: [AKS_Properties](#AKS_Properties).
 | overwriteExistingDomain | Indicates whether to overwrite existing domain label. | bool<br/><small>Optional</small>                                                                                                                       |
 | status                  | Enable or disable ssl for scoring                     | [SslConfiguration_Status](#SslConfiguration_Status)<br/><small>Optional</small>                                                                        |
 
-<a id="SslConfiguration_STATUS"></a>SslConfiguration_STATUS
------------------------------------------------------------
+SslConfiguration_STATUS{#SslConfiguration_STATUS}
+-------------------------------------------------
 
 The ssl configuration for scoring
 
@@ -4687,8 +4687,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | overwriteExistingDomain | Indicates whether to overwrite existing domain label. | bool<br/><small>Optional</small>                                                              |
 | status                  | Enable or disable ssl for scoring                     | [SslConfiguration_Status_STATUS](#SslConfiguration_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemService_STATUS"></a>SystemService_STATUS
------------------------------------------------------
+SystemService_STATUS{#SystemService_STATUS}
+-------------------------------------------
 
 A system service running on a compute.
 
@@ -4700,8 +4700,8 @@ Used by: [AKS_Properties_STATUS](#AKS_Properties_STATUS).
 | systemServiceType | The type of this system service. | string<br/><small>Optional</small> |
 | version           | The version for this type.       | string<br/><small>Optional</small> |
 
-<a id="UserAccountCredentials"></a>UserAccountCredentials
----------------------------------------------------------
+UserAccountCredentials{#UserAccountCredentials}
+-----------------------------------------------
 
 Settings for user account that gets created on each on the nodes of a compute.
 
@@ -4713,8 +4713,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 | adminUserPassword     | Password of the administrator user account.                               | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | adminUserSshPublicKey | SSH public key of the administrator user account.                         | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="UserAccountCredentials_STATUS"></a>UserAccountCredentials_STATUS
------------------------------------------------------------------------
+UserAccountCredentials_STATUS{#UserAccountCredentials_STATUS}
+-------------------------------------------------------------
 
 Settings for user account that gets created on each on the nodes of a compute.
 
@@ -4724,8 +4724,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 |---------------|---------------------------------------------------------------------------|------------------------------------|
 | adminUserName | Name of the administrator user account which can be used to SSH to nodes. | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineImage"></a>VirtualMachineImage
----------------------------------------------------
+VirtualMachineImage{#VirtualMachineImage}
+-----------------------------------------
 
 Virtual Machine image for Windows AML Compute
 
@@ -4735,8 +4735,8 @@ Used by: [AmlComputeProperties](#AmlComputeProperties).
 |-----------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Virtual Machine image path | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="VirtualMachineImage_STATUS"></a>VirtualMachineImage_STATUS
------------------------------------------------------------------
+VirtualMachineImage_STATUS{#VirtualMachineImage_STATUS}
+-------------------------------------------------------
 
 Virtual Machine image for Windows AML Compute
 
@@ -4746,8 +4746,8 @@ Used by: [AmlComputeProperties_STATUS](#AmlComputeProperties_STATUS).
 |----------|----------------------------|------------------------------------|
 | id       | Virtual Machine image path | string<br/><small>Optional</small> |
 
-<a id="VirtualMachineSshCredentials"></a>VirtualMachineSshCredentials
----------------------------------------------------------------------
+VirtualMachineSshCredentials{#VirtualMachineSshCredentials}
+-----------------------------------------------------------
 
 Admin credentials for virtual machine
 
@@ -4760,8 +4760,8 @@ Used by: [HDInsightProperties](#HDInsightProperties), and [VirtualMachine_Proper
 | publicKeyData  | Public key data           | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | username       | Username of admin account | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="VirtualMachineSshCredentials_STATUS"></a>VirtualMachineSshCredentials_STATUS
------------------------------------------------------------------------------------
+VirtualMachineSshCredentials_STATUS{#VirtualMachineSshCredentials_STATUS}
+-------------------------------------------------------------------------
 
 Admin credentials for virtual machine
 
@@ -4771,8 +4771,8 @@ Used by: [HDInsightProperties_STATUS](#HDInsightProperties_STATUS), and [Virtual
 |----------|---------------------------|------------------------------------|
 | username | Username of admin account | string<br/><small>Optional</small> |
 
-<a id="AssignedUser"></a>AssignedUser
--------------------------------------
+AssignedUser{#AssignedUser}
+---------------------------
 
 A user that can be assigned to a compute instance.
 
@@ -4785,8 +4785,8 @@ Used by: [PersonalComputeInstanceSettings](#PersonalComputeInstanceSettings).
 | tenantId           | User’s AAD Tenant Id. | string<br/><small>Optional</small>                                                                                                                           |
 | tenantIdFromConfig | User’s AAD Tenant Id. | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 
-<a id="AssignedUser_STATUS"></a>AssignedUser_STATUS
----------------------------------------------------
+AssignedUser_STATUS{#AssignedUser_STATUS}
+-----------------------------------------
 
 A user that can be assigned to a compute instance.
 
@@ -4797,8 +4797,8 @@ Used by: [PersonalComputeInstanceSettings_STATUS](#PersonalComputeInstanceSettin
 | objectId | User’s AAD Object Id. | string<br/><small>Optional</small> |
 | tenantId | User’s AAD Tenant Id. | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceContainer_Autosave_STATUS"></a>ComputeInstanceContainer_Autosave_STATUS
----------------------------------------------------------------------------------------------
+ComputeInstanceContainer_Autosave_STATUS{#ComputeInstanceContainer_Autosave_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceContainer_STATUS](#ComputeInstanceContainer_STATUS).
 
@@ -4808,8 +4808,8 @@ Used by: [ComputeInstanceContainer_STATUS](#ComputeInstanceContainer_STATUS).
 | "None"   |             |
 | "Remote" |             |
 
-<a id="ComputeInstanceContainer_Network_STATUS"></a>ComputeInstanceContainer_Network_STATUS
--------------------------------------------------------------------------------------------
+ComputeInstanceContainer_Network_STATUS{#ComputeInstanceContainer_Network_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceContainer_STATUS](#ComputeInstanceContainer_STATUS).
 
@@ -4818,8 +4818,8 @@ Used by: [ComputeInstanceContainer_STATUS](#ComputeInstanceContainer_STATUS).
 | "Bridge" |             |
 | "Host"   |             |
 
-<a id="ComputeInstanceDataDisk_Caching_STATUS"></a>ComputeInstanceDataDisk_Caching_STATUS
------------------------------------------------------------------------------------------
+ComputeInstanceDataDisk_Caching_STATUS{#ComputeInstanceDataDisk_Caching_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceDataDisk_STATUS](#ComputeInstanceDataDisk_STATUS).
 
@@ -4829,8 +4829,8 @@ Used by: [ComputeInstanceDataDisk_STATUS](#ComputeInstanceDataDisk_STATUS).
 | "ReadOnly"  |             |
 | "ReadWrite" |             |
 
-<a id="ComputeInstanceDataDisk_StorageAccountType_STATUS"></a>ComputeInstanceDataDisk_StorageAccountType_STATUS
----------------------------------------------------------------------------------------------------------------
+ComputeInstanceDataDisk_StorageAccountType_STATUS{#ComputeInstanceDataDisk_StorageAccountType_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceDataDisk_STATUS](#ComputeInstanceDataDisk_STATUS).
 
@@ -4839,8 +4839,8 @@ Used by: [ComputeInstanceDataDisk_STATUS](#ComputeInstanceDataDisk_STATUS).
 | "Premium_LRS"  |             |
 | "Standard_LRS" |             |
 
-<a id="ComputeInstanceDataMount_MountAction_STATUS"></a>ComputeInstanceDataMount_MountAction_STATUS
----------------------------------------------------------------------------------------------------
+ComputeInstanceDataMount_MountAction_STATUS{#ComputeInstanceDataMount_MountAction_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 
@@ -4849,8 +4849,8 @@ Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 | "Mount"   |             |
 | "Unmount" |             |
 
-<a id="ComputeInstanceDataMount_MountState_STATUS"></a>ComputeInstanceDataMount_MountState_STATUS
--------------------------------------------------------------------------------------------------
+ComputeInstanceDataMount_MountState_STATUS{#ComputeInstanceDataMount_MountState_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 
@@ -4863,8 +4863,8 @@ Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 | "UnmountRequested" |             |
 | "Unmounted"        |             |
 
-<a id="ComputeInstanceDataMount_SourceType_STATUS"></a>ComputeInstanceDataMount_SourceType_STATUS
--------------------------------------------------------------------------------------------------
+ComputeInstanceDataMount_SourceType_STATUS{#ComputeInstanceDataMount_SourceType_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 
@@ -4874,8 +4874,8 @@ Used by: [ComputeInstanceDataMount_STATUS](#ComputeInstanceDataMount_STATUS).
 | "Datastore" |             |
 | "URI"       |             |
 
-<a id="ComputeInstanceEnvironmentInfo_STATUS"></a>ComputeInstanceEnvironmentInfo_STATUS
----------------------------------------------------------------------------------------
+ComputeInstanceEnvironmentInfo_STATUS{#ComputeInstanceEnvironmentInfo_STATUS}
+-----------------------------------------------------------------------------
 
 Environment information
 
@@ -4886,8 +4886,8 @@ Used by: [ComputeInstanceContainer_STATUS](#ComputeInstanceContainer_STATUS).
 | name     | name of environment.    | string<br/><small>Optional</small> |
 | version  | version of environment. | string<br/><small>Optional</small> |
 
-<a id="ComputeInstanceLastOperation_OperationName_STATUS"></a>ComputeInstanceLastOperation_OperationName_STATUS
----------------------------------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_OperationName_STATUS{#ComputeInstanceLastOperation_OperationName_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STATUS).
 
@@ -4900,8 +4900,8 @@ Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STA
 | "Start"   |             |
 | "Stop"    |             |
 
-<a id="ComputeInstanceLastOperation_OperationStatus_STATUS"></a>ComputeInstanceLastOperation_OperationStatus_STATUS
--------------------------------------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_OperationStatus_STATUS{#ComputeInstanceLastOperation_OperationStatus_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STATUS).
 
@@ -4916,8 +4916,8 @@ Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STA
 | "StopFailed"    |             |
 | "Succeeded"     |             |
 
-<a id="ComputeInstanceLastOperation_OperationTrigger_STATUS"></a>ComputeInstanceLastOperation_OperationTrigger_STATUS
----------------------------------------------------------------------------------------------------------------------
+ComputeInstanceLastOperation_OperationTrigger_STATUS{#ComputeInstanceLastOperation_OperationTrigger_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STATUS).
 
@@ -4927,8 +4927,8 @@ Used by: [ComputeInstanceLastOperation_STATUS](#ComputeInstanceLastOperation_STA
 | "Schedule"     |             |
 | "User"         |             |
 
-<a id="ComputeInstanceSshSettings_SshPublicAccess"></a>ComputeInstanceSshSettings_SshPublicAccess
--------------------------------------------------------------------------------------------------
+ComputeInstanceSshSettings_SshPublicAccess{#ComputeInstanceSshSettings_SshPublicAccess}
+---------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceSshSettings](#ComputeInstanceSshSettings).
 
@@ -4937,8 +4937,8 @@ Used by: [ComputeInstanceSshSettings](#ComputeInstanceSshSettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ComputeInstanceSshSettings_SshPublicAccess_STATUS"></a>ComputeInstanceSshSettings_SshPublicAccess_STATUS
----------------------------------------------------------------------------------------------------------------
+ComputeInstanceSshSettings_SshPublicAccess_STATUS{#ComputeInstanceSshSettings_SshPublicAccess_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ComputeInstanceSshSettings_STATUS](#ComputeInstanceSshSettings_STATUS).
 
@@ -4947,8 +4947,8 @@ Used by: [ComputeInstanceSshSettings_STATUS](#ComputeInstanceSshSettings_STATUS)
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ComputeStartStopSchedule"></a>ComputeStartStopSchedule
--------------------------------------------------------------
+ComputeStartStopSchedule{#ComputeStartStopSchedule}
+---------------------------------------------------
 
 Compute start stop schedule properties
 
@@ -4963,8 +4963,8 @@ Used by: [ComputeSchedules](#ComputeSchedules).
 | status      | Is the schedule enabled or disabled?   | [ScheduleStatus](#ScheduleStatus)<br/><small>Optional</small>         |
 | triggerType | [Required] The schedule trigger type.  | [ComputeTriggerType](#ComputeTriggerType)<br/><small>Optional</small> |
 
-<a id="ComputeStartStopSchedule_STATUS"></a>ComputeStartStopSchedule_STATUS
----------------------------------------------------------------------------
+ComputeStartStopSchedule_STATUS{#ComputeStartStopSchedule_STATUS}
+-----------------------------------------------------------------
 
 Compute start stop schedule properties
 
@@ -4981,8 +4981,8 @@ Used by: [ComputeSchedules_STATUS](#ComputeSchedules_STATUS).
 | status             | Is the schedule enabled or disabled?      | [ScheduleStatus_STATUS](#ScheduleStatus_STATUS)<br/><small>Optional</small>                                                           |
 | triggerType        | [Required] The schedule trigger type.     | [ComputeTriggerType_STATUS](#ComputeTriggerType_STATUS)<br/><small>Optional</small>                                                   |
 
-<a id="Docker"></a>Docker
--------------------------
+Docker{#Docker}
+---------------
 
 Docker container configuration
 
@@ -4992,8 +4992,8 @@ Used by: [CustomService](#CustomService).
 |------------|----------------------------------------------------------------------------|----------------------------------|
 | privileged | Indicate whether container shall run in privileged or non-privileged mode. | bool<br/><small>Optional</small> |
 
-<a id="Docker_STATUS"></a>Docker_STATUS
----------------------------------------
+Docker_STATUS{#Docker_STATUS}
+-----------------------------
 
 Docker container configuration
 
@@ -5003,8 +5003,8 @@ Used by: [CustomService_STATUS](#CustomService_STATUS).
 |------------|----------------------------------------------------------------------------|----------------------------------|
 | privileged | Indicate whether container shall run in privileged or non-privileged mode. | bool<br/><small>Optional</small> |
 
-<a id="Endpoint"></a>Endpoint
------------------------------
+Endpoint{#Endpoint}
+-------------------
 
 Describes the endpoint configuration for the container
 
@@ -5018,8 +5018,8 @@ Used by: [CustomService](#CustomService).
 | published | Port over which the application is exposed from container.       | int<br/><small>Optional</small>                                     |
 | target    | Application port inside the container.                           | int<br/><small>Optional</small>                                     |
 
-<a id="Endpoint_STATUS"></a>Endpoint_STATUS
--------------------------------------------
+Endpoint_STATUS{#Endpoint_STATUS}
+---------------------------------
 
 Describes the endpoint configuration for the container
 
@@ -5033,8 +5033,8 @@ Used by: [CustomService_STATUS](#CustomService_STATUS).
 | published | Port over which the application is exposed from container.       | int<br/><small>Optional</small>                                                   |
 | target    | Application port inside the container.                           | int<br/><small>Optional</small>                                                   |
 
-<a id="EnvironmentVariable"></a>EnvironmentVariable
----------------------------------------------------
+EnvironmentVariable{#EnvironmentVariable}
+-----------------------------------------
 
 Environment Variables for the container
 
@@ -5045,8 +5045,8 @@ Used by: [CustomService](#CustomService).
 | type     | Type of the Environment Variable. Possible values are: local - For local variable | [EnvironmentVariable_Type](#EnvironmentVariable_Type)<br/><small>Optional</small> |
 | value    | Value of the Environment variable                                                 | string<br/><small>Optional</small>                                                |
 
-<a id="EnvironmentVariable_STATUS"></a>EnvironmentVariable_STATUS
------------------------------------------------------------------
+EnvironmentVariable_STATUS{#EnvironmentVariable_STATUS}
+-------------------------------------------------------
 
 Environment Variables for the container
 
@@ -5057,8 +5057,8 @@ Used by: [CustomService_STATUS](#CustomService_STATUS).
 | type     | Type of the Environment Variable. Possible values are: local - For local variable | [EnvironmentVariable_Type_STATUS](#EnvironmentVariable_Type_STATUS)<br/><small>Optional</small> |
 | value    | Value of the Environment variable                                                 | string<br/><small>Optional</small>                                                              |
 
-<a id="ErrorAdditionalInfo_STATUS"></a>ErrorAdditionalInfo_STATUS
------------------------------------------------------------------
+ErrorAdditionalInfo_STATUS{#ErrorAdditionalInfo_STATUS}
+-------------------------------------------------------
 
 The resource management error additional info.
 
@@ -5069,8 +5069,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS), and [ErrorDetail_STATUS_Unro
 | info     | The additional info.      | map[string]v1.JSON<br/><small>Optional</small> |
 | type     | The additional info type. | string<br/><small>Optional</small>             |
 
-<a id="ErrorDetail_STATUS_Unrolled"></a>ErrorDetail_STATUS_Unrolled
--------------------------------------------------------------------
+ErrorDetail_STATUS_Unrolled{#ErrorDetail_STATUS_Unrolled}
+---------------------------------------------------------
 
 Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 
@@ -5081,8 +5081,8 @@ Used by: [ErrorDetail_STATUS](#ErrorDetail_STATUS).
 | message        | The error message.         | string<br/><small>Optional</small>                                                      |
 | target         | The error target.          | string<br/><small>Optional</small>                                                      |
 
-<a id="Image"></a>Image
------------------------
+Image{#Image}
+-------------
 
 Describes the Image Specifications
 
@@ -5093,8 +5093,8 @@ Used by: [CustomService](#CustomService).
 | reference | Image reference                                                                                  | string<br/><small>Optional</small>                    |
 | type      | Type of the image. Possible values are: docker - For docker images. azureml - For AzureML images | [Image_Type](#Image_Type)<br/><small>Optional</small> |
 
-<a id="Image_STATUS"></a>Image_STATUS
--------------------------------------
+Image_STATUS{#Image_STATUS}
+---------------------------
 
 Describes the Image Specifications
 
@@ -5105,8 +5105,8 @@ Used by: [CustomService_STATUS](#CustomService_STATUS).
 | reference | Image reference                                                                                  | string<br/><small>Optional</small>                                  |
 | type      | Type of the image. Possible values are: docker - For docker images. azureml - For AzureML images | [Image_Type_STATUS](#Image_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema_Resources"></a>InstanceTypeSchema_Resources
----------------------------------------------------------------------
+InstanceTypeSchema_Resources{#InstanceTypeSchema_Resources}
+-----------------------------------------------------------
 
 Used by: [InstanceTypeSchema](#InstanceTypeSchema).
 
@@ -5115,8 +5115,8 @@ Used by: [InstanceTypeSchema](#InstanceTypeSchema).
 | limits   | Resource limits for this instance type   | map[string]string<br/><small>Optional</small> |
 | requests | Resource requests for this instance type | map[string]string<br/><small>Optional</small> |
 
-<a id="InstanceTypeSchema_Resources_STATUS"></a>InstanceTypeSchema_Resources_STATUS
------------------------------------------------------------------------------------
+InstanceTypeSchema_Resources_STATUS{#InstanceTypeSchema_Resources_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [InstanceTypeSchema_STATUS](#InstanceTypeSchema_STATUS).
 
@@ -5125,8 +5125,8 @@ Used by: [InstanceTypeSchema_STATUS](#InstanceTypeSchema_STATUS).
 | limits   | Resource limits for this instance type   | map[string]string<br/><small>Optional</small> |
 | requests | Resource requests for this instance type | map[string]string<br/><small>Optional</small> |
 
-<a id="RuleAction"></a>RuleAction
----------------------------------
+RuleAction{#RuleAction}
+-----------------------
 
 The action enum for networking rule.
 
@@ -5137,8 +5137,8 @@ Used by: [ServiceTagDestination](#ServiceTagDestination).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="RuleAction_STATUS"></a>RuleAction_STATUS
------------------------------------------------
+RuleAction_STATUS{#RuleAction_STATUS}
+-------------------------------------
 
 The action enum for networking rule.
 
@@ -5149,8 +5149,8 @@ Used by: [ServiceTagDestination_STATUS](#ServiceTagDestination_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ScriptsToExecute"></a>ScriptsToExecute
----------------------------------------------
+ScriptsToExecute{#ScriptsToExecute}
+-----------------------------------
 
 Customized setup scripts
 
@@ -5161,8 +5161,8 @@ Used by: [SetupScripts](#SetupScripts).
 | creationScript | Script that's run only once during provision of the compute. | [ScriptReference](#ScriptReference)<br/><small>Optional</small> |
 | startupScript  | Script that's run every time the machine starts.             | [ScriptReference](#ScriptReference)<br/><small>Optional</small> |
 
-<a id="ScriptsToExecute_STATUS"></a>ScriptsToExecute_STATUS
------------------------------------------------------------
+ScriptsToExecute_STATUS{#ScriptsToExecute_STATUS}
+-------------------------------------------------
 
 Customized setup scripts
 
@@ -5173,8 +5173,8 @@ Used by: [SetupScripts_STATUS](#SetupScripts_STATUS).
 | creationScript | Script that's run only once during provision of the compute. | [ScriptReference_STATUS](#ScriptReference_STATUS)<br/><small>Optional</small> |
 | startupScript  | Script that's run every time the machine starts.             | [ScriptReference_STATUS](#ScriptReference_STATUS)<br/><small>Optional</small> |
 
-<a id="SslConfiguration_Status"></a>SslConfiguration_Status
------------------------------------------------------------
+SslConfiguration_Status{#SslConfiguration_Status}
+-------------------------------------------------
 
 Used by: [SslConfiguration](#SslConfiguration).
 
@@ -5184,8 +5184,8 @@ Used by: [SslConfiguration](#SslConfiguration).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SslConfiguration_Status_STATUS"></a>SslConfiguration_Status_STATUS
--------------------------------------------------------------------------
+SslConfiguration_Status_STATUS{#SslConfiguration_Status_STATUS}
+---------------------------------------------------------------
 
 Used by: [SslConfiguration_STATUS](#SslConfiguration_STATUS).
 
@@ -5195,8 +5195,8 @@ Used by: [SslConfiguration_STATUS](#SslConfiguration_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="VolumeDefinition"></a>VolumeDefinition
----------------------------------------------
+VolumeDefinition{#VolumeDefinition}
+-----------------------------------
 
 Describes the volume configuration for the container
 
@@ -5213,8 +5213,8 @@ Used by: [CustomService](#CustomService).
 | type        | Type of Volume Definition. Possible Values: bind,volume,tmpfs,npipe            | [VolumeDefinition_Type](#VolumeDefinition_Type)<br/><small>Optional</small> |
 | volume      | Volume Options of the mount                                                    | [VolumeOptions](#VolumeOptions)<br/><small>Optional</small>                 |
 
-<a id="VolumeDefinition_STATUS"></a>VolumeDefinition_STATUS
------------------------------------------------------------
+VolumeDefinition_STATUS{#VolumeDefinition_STATUS}
+-------------------------------------------------
 
 Describes the volume configuration for the container
 
@@ -5231,8 +5231,8 @@ Used by: [CustomService_STATUS](#CustomService_STATUS).
 | type        | Type of Volume Definition. Possible Values: bind,volume,tmpfs,npipe            | [VolumeDefinition_Type_STATUS](#VolumeDefinition_Type_STATUS)<br/><small>Optional</small> |
 | volume      | Volume Options of the mount                                                    | [VolumeOptions_STATUS](#VolumeOptions_STATUS)<br/><small>Optional</small>                 |
 
-<a id="BindOptions"></a>BindOptions
------------------------------------
+BindOptions{#BindOptions}
+-------------------------
 
 Describes the bind options for the container
 
@@ -5244,8 +5244,8 @@ Used by: [VolumeDefinition](#VolumeDefinition).
 | propagation    | Type of Bind Option                   | string<br/><small>Optional</small> |
 | selinux        | Mention the selinux options.          | string<br/><small>Optional</small> |
 
-<a id="BindOptions_STATUS"></a>BindOptions_STATUS
--------------------------------------------------
+BindOptions_STATUS{#BindOptions_STATUS}
+---------------------------------------
 
 Describes the bind options for the container
 
@@ -5257,8 +5257,8 @@ Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
 | propagation    | Type of Bind Option                   | string<br/><small>Optional</small> |
 | selinux        | Mention the selinux options.          | string<br/><small>Optional</small> |
 
-<a id="ComputePowerAction"></a>ComputePowerAction
--------------------------------------------------
+ComputePowerAction{#ComputePowerAction}
+---------------------------------------
 
 The compute power action.
 
@@ -5269,8 +5269,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 | "Start" |             |
 | "Stop"  |             |
 
-<a id="ComputePowerAction_STATUS"></a>ComputePowerAction_STATUS
----------------------------------------------------------------
+ComputePowerAction_STATUS{#ComputePowerAction_STATUS}
+-----------------------------------------------------
 
 The compute power action.
 
@@ -5281,8 +5281,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | "Start" |             |
 | "Stop"  |             |
 
-<a id="ComputeStartStopSchedule_ProvisioningStatus_STATUS"></a>ComputeStartStopSchedule_ProvisioningStatus_STATUS
------------------------------------------------------------------------------------------------------------------
+ComputeStartStopSchedule_ProvisioningStatus_STATUS{#ComputeStartStopSchedule_ProvisioningStatus_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 
@@ -5292,8 +5292,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | "Failed"       |             |
 | "Provisioning" |             |
 
-<a id="ComputeTriggerType"></a>ComputeTriggerType
--------------------------------------------------
+ComputeTriggerType{#ComputeTriggerType}
+---------------------------------------
 
 Is the trigger type recurrence or cron.
 
@@ -5304,8 +5304,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 | "Cron"       |             |
 | "Recurrence" |             |
 
-<a id="ComputeTriggerType_STATUS"></a>ComputeTriggerType_STATUS
----------------------------------------------------------------
+ComputeTriggerType_STATUS{#ComputeTriggerType_STATUS}
+-----------------------------------------------------
 
 Is the trigger type recurrence or cron.
 
@@ -5316,8 +5316,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | "Cron"       |             |
 | "Recurrence" |             |
 
-<a id="Cron"></a>Cron
----------------------
+Cron{#Cron}
+-----------
 
 The workflow trigger cron for ComputeStartStop schedule type.
 
@@ -5329,8 +5329,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 | startTime  | The start time in yyyy-MM-ddTHH:mm:ss format.                                                                                                                                                                    | string<br/><small>Optional</small> |
 | timeZone   | Specifies time zone in which the schedule runs. TimeZone should follow Windows time zone format. Refer: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones?view=windows-11 | string<br/><small>Optional</small> |
 
-<a id="Cron_STATUS"></a>Cron_STATUS
------------------------------------
+Cron_STATUS{#Cron_STATUS}
+-------------------------
 
 The workflow trigger cron for ComputeStartStop schedule type.
 
@@ -5342,8 +5342,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | startTime  | The start time in yyyy-MM-ddTHH:mm:ss format.                                                                                                                                                                    | string<br/><small>Optional</small> |
 | timeZone   | Specifies time zone in which the schedule runs. TimeZone should follow Windows time zone format. Refer: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones?view=windows-11 | string<br/><small>Optional</small> |
 
-<a id="Endpoint_Protocol"></a>Endpoint_Protocol
------------------------------------------------
+Endpoint_Protocol{#Endpoint_Protocol}
+-------------------------------------
 
 Used by: [Endpoint](#Endpoint).
 
@@ -5353,8 +5353,8 @@ Used by: [Endpoint](#Endpoint).
 | "tcp"  |             |
 | "udp"  |             |
 
-<a id="Endpoint_Protocol_STATUS"></a>Endpoint_Protocol_STATUS
--------------------------------------------------------------
+Endpoint_Protocol_STATUS{#Endpoint_Protocol_STATUS}
+---------------------------------------------------
 
 Used by: [Endpoint_STATUS](#Endpoint_STATUS).
 
@@ -5364,8 +5364,8 @@ Used by: [Endpoint_STATUS](#Endpoint_STATUS).
 | "tcp"  |             |
 | "udp"  |             |
 
-<a id="EnvironmentVariable_Type"></a>EnvironmentVariable_Type
--------------------------------------------------------------
+EnvironmentVariable_Type{#EnvironmentVariable_Type}
+---------------------------------------------------
 
 Used by: [EnvironmentVariable](#EnvironmentVariable).
 
@@ -5373,8 +5373,8 @@ Used by: [EnvironmentVariable](#EnvironmentVariable).
 |---------|-------------|
 | "local" |             |
 
-<a id="EnvironmentVariable_Type_STATUS"></a>EnvironmentVariable_Type_STATUS
----------------------------------------------------------------------------
+EnvironmentVariable_Type_STATUS{#EnvironmentVariable_Type_STATUS}
+-----------------------------------------------------------------
 
 Used by: [EnvironmentVariable_STATUS](#EnvironmentVariable_STATUS).
 
@@ -5382,8 +5382,8 @@ Used by: [EnvironmentVariable_STATUS](#EnvironmentVariable_STATUS).
 |---------|-------------|
 | "local" |             |
 
-<a id="Image_Type"></a>Image_Type
----------------------------------
+Image_Type{#Image_Type}
+-----------------------
 
 Used by: [Image](#Image).
 
@@ -5392,8 +5392,8 @@ Used by: [Image](#Image).
 | "azureml" |             |
 | "docker"  |             |
 
-<a id="Image_Type_STATUS"></a>Image_Type_STATUS
------------------------------------------------
+Image_Type_STATUS{#Image_Type_STATUS}
+-------------------------------------
 
 Used by: [Image_STATUS](#Image_STATUS).
 
@@ -5402,8 +5402,8 @@ Used by: [Image_STATUS](#Image_STATUS).
 | "azureml" |             |
 | "docker"  |             |
 
-<a id="Recurrence"></a>Recurrence
----------------------------------
+Recurrence{#Recurrence}
+-----------------------
 
 The workflow trigger recurrence for ComputeStartStop schedule type.
 
@@ -5417,8 +5417,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 | startTime | The start time in yyyy-MM-ddTHH:mm:ss format.                                                                                                                                                                    | string<br/><small>Optional</small>                                                    |
 | timeZone  | Specifies time zone in which the schedule runs. TimeZone should follow Windows time zone format. Refer: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones?view=windows-11 | string<br/><small>Optional</small>                                                    |
 
-<a id="Recurrence_STATUS"></a>Recurrence_STATUS
------------------------------------------------
+Recurrence_STATUS{#Recurrence_STATUS}
+-------------------------------------
 
 The workflow trigger recurrence for ComputeStartStop schedule type.
 
@@ -5432,8 +5432,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | startTime | The start time in yyyy-MM-ddTHH:mm:ss format.                                                                                                                                                                    | string<br/><small>Optional</small>                                                                  |
 | timeZone  | Specifies time zone in which the schedule runs. TimeZone should follow Windows time zone format. Refer: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones?view=windows-11 | string<br/><small>Optional</small>                                                                  |
 
-<a id="ScheduleBase"></a>ScheduleBase
--------------------------------------
+ScheduleBase{#ScheduleBase}
+---------------------------
 
 Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 
@@ -5443,8 +5443,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule).
 | reference          | A system assigned id for the schedule.    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | status             | Is the schedule enabled or disabled?      | [ScheduleStatus](#ScheduleStatus)<br/><small>Optional</small>                                                                                              |
 
-<a id="ScheduleBase_STATUS"></a>ScheduleBase_STATUS
----------------------------------------------------
+ScheduleBase_STATUS{#ScheduleBase_STATUS}
+-----------------------------------------
 
 Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 
@@ -5454,8 +5454,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS).
 | provisioningStatus | The current deployment state of schedule. | [ScheduleProvisioningState_STATUS](#ScheduleProvisioningState_STATUS)<br/><small>Optional</small> |
 | status             | Is the schedule enabled or disabled?      | [ScheduleStatus_STATUS](#ScheduleStatus_STATUS)<br/><small>Optional</small>                       |
 
-<a id="ScheduleStatus"></a>ScheduleStatus
------------------------------------------
+ScheduleStatus{#ScheduleStatus}
+-------------------------------
 
 Is the schedule enabled or disabled?
 
@@ -5466,8 +5466,8 @@ Used by: [ComputeStartStopSchedule](#ComputeStartStopSchedule), and [ScheduleBas
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ScheduleStatus_STATUS"></a>ScheduleStatus_STATUS
--------------------------------------------------------
+ScheduleStatus_STATUS{#ScheduleStatus_STATUS}
+---------------------------------------------
 
 Is the schedule enabled or disabled?
 
@@ -5478,8 +5478,8 @@ Used by: [ComputeStartStopSchedule_STATUS](#ComputeStartStopSchedule_STATUS), an
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ScriptReference"></a>ScriptReference
--------------------------------------------
+ScriptReference{#ScriptReference}
+---------------------------------
 
 Script reference
 
@@ -5492,8 +5492,8 @@ Used by: [ScriptsToExecute](#ScriptsToExecute), and [ScriptsToExecute](#ScriptsT
 | scriptSource    | The storage source of the script: workspace.                 | string<br/><small>Optional</small> |
 | timeout         | Optional time period passed to timeout command.              | string<br/><small>Optional</small> |
 
-<a id="ScriptReference_STATUS"></a>ScriptReference_STATUS
----------------------------------------------------------
+ScriptReference_STATUS{#ScriptReference_STATUS}
+-----------------------------------------------
 
 Script reference
 
@@ -5506,8 +5506,8 @@ Used by: [ScriptsToExecute_STATUS](#ScriptsToExecute_STATUS), and [ScriptsToExec
 | scriptSource    | The storage source of the script: workspace.                 | string<br/><small>Optional</small> |
 | timeout         | Optional time period passed to timeout command.              | string<br/><small>Optional</small> |
 
-<a id="TmpfsOptions"></a>TmpfsOptions
--------------------------------------
+TmpfsOptions{#TmpfsOptions}
+---------------------------
 
 Describes the tmpfs options for the container
 
@@ -5517,8 +5517,8 @@ Used by: [VolumeDefinition](#VolumeDefinition).
 |----------|------------------------|---------------------------------|
 | size     | Mention the Tmpfs size | int<br/><small>Optional</small> |
 
-<a id="TmpfsOptions_STATUS"></a>TmpfsOptions_STATUS
----------------------------------------------------
+TmpfsOptions_STATUS{#TmpfsOptions_STATUS}
+-----------------------------------------
 
 Describes the tmpfs options for the container
 
@@ -5528,54 +5528,54 @@ Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
 |----------|------------------------|---------------------------------|
 | size     | Mention the Tmpfs size | int<br/><small>Optional</small> |
 
-<a id="VolumeDefinition_Type"></a>VolumeDefinition_Type
+VolumeDefinition_Type{#VolumeDefinition_Type}
+---------------------------------------------
+
+Used by: [VolumeDefinition](#VolumeDefinition).
+
+| Value    | Description |
+|----------|-------------|
+| "bind"   |             |
+| "npipe"  |             |
+| "tmpfs"  |             |
+| "volume" |             |
+
+VolumeDefinition_Type_STATUS{#VolumeDefinition_Type_STATUS}
+-----------------------------------------------------------
+
+Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
+
+| Value    | Description |
+|----------|-------------|
+| "bind"   |             |
+| "npipe"  |             |
+| "tmpfs"  |             |
+| "volume" |             |
+
+VolumeOptions{#VolumeOptions}
+-----------------------------
+
+Describes the volume options for the container
+
+Used by: [VolumeDefinition](#VolumeDefinition).
+
+| Property | Description                       | Type                             |
+|----------|-----------------------------------|----------------------------------|
+| nocopy   | Indicate whether volume is nocopy | bool<br/><small>Optional</small> |
+
+VolumeOptions_STATUS{#VolumeOptions_STATUS}
+-------------------------------------------
+
+Describes the volume options for the container
+
+Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
+
+| Property | Description                       | Type                             |
+|----------|-----------------------------------|----------------------------------|
+| nocopy   | Indicate whether volume is nocopy | bool<br/><small>Optional</small> |
+
+ComputeRecurrenceFrequency{#ComputeRecurrenceFrequency}
 -------------------------------------------------------
-
-Used by: [VolumeDefinition](#VolumeDefinition).
-
-| Value    | Description |
-|----------|-------------|
-| "bind"   |             |
-| "npipe"  |             |
-| "tmpfs"  |             |
-| "volume" |             |
-
-<a id="VolumeDefinition_Type_STATUS"></a>VolumeDefinition_Type_STATUS
----------------------------------------------------------------------
-
-Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
-
-| Value    | Description |
-|----------|-------------|
-| "bind"   |             |
-| "npipe"  |             |
-| "tmpfs"  |             |
-| "volume" |             |
-
-<a id="VolumeOptions"></a>VolumeOptions
----------------------------------------
-
-Describes the volume options for the container
-
-Used by: [VolumeDefinition](#VolumeDefinition).
-
-| Property | Description                       | Type                             |
-|----------|-----------------------------------|----------------------------------|
-| nocopy   | Indicate whether volume is nocopy | bool<br/><small>Optional</small> |
-
-<a id="VolumeOptions_STATUS"></a>VolumeOptions_STATUS
------------------------------------------------------
-
-Describes the volume options for the container
-
-Used by: [VolumeDefinition_STATUS](#VolumeDefinition_STATUS).
-
-| Property | Description                       | Type                             |
-|----------|-----------------------------------|----------------------------------|
-| nocopy   | Indicate whether volume is nocopy | bool<br/><small>Optional</small> |
-
-<a id="ComputeRecurrenceFrequency"></a>ComputeRecurrenceFrequency
------------------------------------------------------------------
 
 Enum to describe the frequency of a compute recurrence schedule
 
@@ -5589,8 +5589,8 @@ Used by: [Recurrence](#Recurrence).
 | "Month"  |             |
 | "Week"   |             |
 
-<a id="ComputeRecurrenceFrequency_STATUS"></a>ComputeRecurrenceFrequency_STATUS
--------------------------------------------------------------------------------
+ComputeRecurrenceFrequency_STATUS{#ComputeRecurrenceFrequency_STATUS}
+---------------------------------------------------------------------
 
 Enum to describe the frequency of a compute recurrence schedule
 
@@ -5604,8 +5604,8 @@ Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 | "Month"  |             |
 | "Week"   |             |
 
-<a id="ComputeRecurrenceSchedule"></a>ComputeRecurrenceSchedule
----------------------------------------------------------------
+ComputeRecurrenceSchedule{#ComputeRecurrenceSchedule}
+-----------------------------------------------------
 
 Used by: [Recurrence](#Recurrence).
 
@@ -5616,8 +5616,8 @@ Used by: [Recurrence](#Recurrence).
 | monthDays | List of month days for the schedule          | int[]<br/><small>Optional</small>                               |
 | weekDays  | List of days for the schedule.               | [ComputeWeekDay[]](#ComputeWeekDay)<br/><small>Optional</small> |
 
-<a id="ComputeRecurrenceSchedule_STATUS"></a>ComputeRecurrenceSchedule_STATUS
------------------------------------------------------------------------------
+ComputeRecurrenceSchedule_STATUS{#ComputeRecurrenceSchedule_STATUS}
+-------------------------------------------------------------------
 
 Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 
@@ -5628,8 +5628,8 @@ Used by: [Recurrence_STATUS](#Recurrence_STATUS).
 | monthDays | List of month days for the schedule          | int[]<br/><small>Optional</small>                                             |
 | weekDays  | List of days for the schedule.               | [ComputeWeekDay_STATUS[]](#ComputeWeekDay_STATUS)<br/><small>Optional</small> |
 
-<a id="ScheduleProvisioningState"></a>ScheduleProvisioningState
----------------------------------------------------------------
+ScheduleProvisioningState{#ScheduleProvisioningState}
+-----------------------------------------------------
 
 The current deployment state of schedule.
 
@@ -5641,8 +5641,8 @@ Used by: [ScheduleBase](#ScheduleBase).
 | "Failed"       |             |
 | "Provisioning" |             |
 
-<a id="ScheduleProvisioningState_STATUS"></a>ScheduleProvisioningState_STATUS
------------------------------------------------------------------------------
+ScheduleProvisioningState_STATUS{#ScheduleProvisioningState_STATUS}
+-------------------------------------------------------------------
 
 The current deployment state of schedule.
 
@@ -5654,8 +5654,8 @@ Used by: [ScheduleBase_STATUS](#ScheduleBase_STATUS).
 | "Failed"       |             |
 | "Provisioning" |             |
 
-<a id="ComputeWeekDay"></a>ComputeWeekDay
------------------------------------------
+ComputeWeekDay{#ComputeWeekDay}
+-------------------------------
 
 Enum of weekday
 
@@ -5671,8 +5671,8 @@ Used by: [ComputeRecurrenceSchedule](#ComputeRecurrenceSchedule).
 | "Tuesday"   |             |
 | "Wednesday" |             |
 
-<a id="ComputeWeekDay_STATUS"></a>ComputeWeekDay_STATUS
--------------------------------------------------------
+ComputeWeekDay_STATUS{#ComputeWeekDay_STATUS}
+---------------------------------------------
 
 Enum of weekday
 

--- a/docs/hugo/content/reference/managedidentity/v1api20181130.md
+++ b/docs/hugo/content/reference/managedidentity/v1api20181130.md
@@ -5,15 +5,15 @@ title: managedidentity.azure.com/v1api20181130
 linktitle: v1api20181130
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-11-30" |             |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2018-11-30/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | spec                                                                                    |             | [UserAssignedIdentity_Spec](#UserAssignedIdentity_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-### <a id="UserAssignedIdentity_Spec"></a>UserAssignedIdentity_Spec
+### UserAssignedIdentity_Spec {#UserAssignedIdentity_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -36,7 +36,7 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
+### UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,8 +50,8 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | tenantId    | The id of the tenant which the identity belongs to.                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="UserAssignedIdentityList"></a>UserAssignedIdentityList
--------------------------------------------------------------
+UserAssignedIdentityList{#UserAssignedIdentityList}
+---------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2018-11-30/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}
 
@@ -61,8 +61,8 @@ Generator information: - Generated from: /msi/resource-manager/Microsoft.Managed
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [UserAssignedIdentity[]](#UserAssignedIdentity)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_Spec"></a>UserAssignedIdentity_Spec
----------------------------------------------------------------
+UserAssignedIdentity_Spec{#UserAssignedIdentity_Spec}
+-----------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -74,8 +74,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -91,8 +91,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | tenantId    | The id of the tenant which the identity belongs to.                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="UserAssignedIdentityOperatorSpec"></a>UserAssignedIdentityOperatorSpec
------------------------------------------------------------------------------
+UserAssignedIdentityOperatorSpec{#UserAssignedIdentityOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -104,8 +104,8 @@ Used by: [UserAssignedIdentity_Spec](#UserAssignedIdentity_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [UserAssignedIdentityOperatorConfigMaps](#UserAssignedIdentityOperatorConfigMaps)<br/><small>Optional</small>                                                       |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityOperatorConfigMaps"></a>UserAssignedIdentityOperatorConfigMaps
------------------------------------------------------------------------------------------
+UserAssignedIdentityOperatorConfigMaps{#UserAssignedIdentityOperatorConfigMaps}
+-------------------------------------------------------------------------------
 
 Used by: [UserAssignedIdentityOperatorSpec](#UserAssignedIdentityOperatorSpec).
 

--- a/docs/hugo/content/reference/managedidentity/v1api20220131preview.md
+++ b/docs/hugo/content/reference/managedidentity/v1api20220131preview.md
@@ -5,15 +5,15 @@ title: managedidentity.azure.com/v1api20220131preview
 linktitle: v1api20220131preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2022-01-31-preview" |             |
 
-<a id="FederatedIdentityCredential"></a>FederatedIdentityCredential
--------------------------------------------------------------------
+FederatedIdentityCredential{#FederatedIdentityCredential}
+---------------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/preview/2022-01-31-preview/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}/federatedIdentityCredentials/{federatedIdentityCredentialResourceName}
 
@@ -26,7 +26,7 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | spec                                                                                    |             | [FederatedIdentityCredential_Spec](#FederatedIdentityCredential_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FederatedIdentityCredential_STATUS](#FederatedIdentityCredential_STATUS)<br/><small>Optional</small> |
 
-### <a id="FederatedIdentityCredential_Spec"></a>FederatedIdentityCredential_Spec
+### FederatedIdentityCredential_Spec {#FederatedIdentityCredential_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | subject           | The identifier of the external identity.                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | subjectFromConfig | The identifier of the external identity.                                                                                                                                                                                                                                                                  | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="FederatedIdentityCredential_STATUS"></a>FederatedIdentityCredential_STATUS
+### FederatedIdentityCredential_STATUS{#FederatedIdentityCredential_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -51,8 +51,8 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | subject    | The identifier of the external identity.                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FederatedIdentityCredentialList"></a>FederatedIdentityCredentialList
----------------------------------------------------------------------------
+FederatedIdentityCredentialList{#FederatedIdentityCredentialList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/preview/2022-01-31-preview/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}/federatedIdentityCredentials/{federatedIdentityCredentialResourceName}
 
@@ -62,8 +62,8 @@ Generator information: - Generated from: /msi/resource-manager/Microsoft.Managed
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FederatedIdentityCredential[]](#FederatedIdentityCredential)<br/><small>Optional</small> |
 
-<a id="FederatedIdentityCredential_Spec"></a>FederatedIdentityCredential_Spec
------------------------------------------------------------------------------
+FederatedIdentityCredential_Spec{#FederatedIdentityCredential_Spec}
+-------------------------------------------------------------------
 
 Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 
@@ -78,8 +78,8 @@ Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 | subject           | The identifier of the external identity.                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | subjectFromConfig | The identifier of the external identity.                                                                                                                                                                                                                                                                  | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="FederatedIdentityCredential_STATUS"></a>FederatedIdentityCredential_STATUS
----------------------------------------------------------------------------------
+FederatedIdentityCredential_STATUS{#FederatedIdentityCredential_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 
@@ -93,8 +93,8 @@ Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 | subject    | The identifier of the external identity.                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FederatedIdentityCredentialOperatorSpec"></a>FederatedIdentityCredentialOperatorSpec
--------------------------------------------------------------------------------------------
+FederatedIdentityCredentialOperatorSpec{#FederatedIdentityCredentialOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 

--- a/docs/hugo/content/reference/managedidentity/v1api20230131.md
+++ b/docs/hugo/content/reference/managedidentity/v1api20230131.md
@@ -5,15 +5,15 @@ title: managedidentity.azure.com/v1api20230131
 linktitle: v1api20230131
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-01-31" |             |
 
-<a id="FederatedIdentityCredential"></a>FederatedIdentityCredential
--------------------------------------------------------------------
+FederatedIdentityCredential{#FederatedIdentityCredential}
+---------------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2023-01-31/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}/federatedIdentityCredentials/{federatedIdentityCredentialResourceName}
 
@@ -26,7 +26,7 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | spec                                                                                    |             | [FederatedIdentityCredential_Spec](#FederatedIdentityCredential_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [FederatedIdentityCredential_STATUS](#FederatedIdentityCredential_STATUS)<br/><small>Optional</small> |
 
-### <a id="FederatedIdentityCredential_Spec"></a>FederatedIdentityCredential_Spec
+### FederatedIdentityCredential_Spec {#FederatedIdentityCredential_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | subject           | The identifier of the external identity.                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | subjectFromConfig | The identifier of the external identity.                                                                                                                                                                                                                                                                  | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="FederatedIdentityCredential_STATUS"></a>FederatedIdentityCredential_STATUS
+### FederatedIdentityCredential_STATUS{#FederatedIdentityCredential_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,8 +52,8 @@ Used by: [FederatedIdentityCredentialList](#FederatedIdentityCredentialList).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FederatedIdentityCredentialList"></a>FederatedIdentityCredentialList
----------------------------------------------------------------------------
+FederatedIdentityCredentialList{#FederatedIdentityCredentialList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2023-01-31/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}/federatedIdentityCredentials/{federatedIdentityCredentialResourceName}
 
@@ -63,8 +63,8 @@ Generator information: - Generated from: /msi/resource-manager/Microsoft.Managed
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [FederatedIdentityCredential[]](#FederatedIdentityCredential)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity"></a>UserAssignedIdentity
------------------------------------------------------
+UserAssignedIdentity{#UserAssignedIdentity}
+-------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2023-01-31/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}
 
@@ -77,7 +77,7 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | spec                                                                                    |             | [UserAssignedIdentity_Spec](#UserAssignedIdentity_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-### <a id="UserAssignedIdentity_Spec"></a>UserAssignedIdentity_Spec
+### UserAssignedIdentity_Spec {#UserAssignedIdentity_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -87,7 +87,7 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
+### UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
 
 | Property    | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -102,8 +102,8 @@ Used by: [UserAssignedIdentityList](#UserAssignedIdentityList).
 | tenantId    | The id of the tenant which the identity belongs to.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="UserAssignedIdentityList"></a>UserAssignedIdentityList
--------------------------------------------------------------
+UserAssignedIdentityList{#UserAssignedIdentityList}
+---------------------------------------------------
 
 Generator information: - Generated from: /msi/resource-manager/Microsoft.ManagedIdentity/stable/2023-01-31/ManagedIdentity.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}
 
@@ -113,8 +113,8 @@ Generator information: - Generated from: /msi/resource-manager/Microsoft.Managed
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [UserAssignedIdentity[]](#UserAssignedIdentity)<br/><small>Optional</small> |
 
-<a id="FederatedIdentityCredential_Spec"></a>FederatedIdentityCredential_Spec
------------------------------------------------------------------------------
+FederatedIdentityCredential_Spec{#FederatedIdentityCredential_Spec}
+-------------------------------------------------------------------
 
 Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 
@@ -129,8 +129,8 @@ Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 | subject           | The identifier of the external identity.                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                   |
 | subjectFromConfig | The identifier of the external identity.                                                                                                                                                                                                                                                                  | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="FederatedIdentityCredential_STATUS"></a>FederatedIdentityCredential_STATUS
----------------------------------------------------------------------------------
+FederatedIdentityCredential_STATUS{#FederatedIdentityCredential_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 
@@ -145,8 +145,8 @@ Used by: [FederatedIdentityCredential](#FederatedIdentityCredential).
 | systemData | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="UserAssignedIdentity_Spec"></a>UserAssignedIdentity_Spec
----------------------------------------------------------------
+UserAssignedIdentity_Spec{#UserAssignedIdentity_Spec}
+-----------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -158,8 +158,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 
@@ -176,8 +176,8 @@ Used by: [UserAssignedIdentity](#UserAssignedIdentity).
 | tenantId    | The id of the tenant which the identity belongs to.                                                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                      |
 | type        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="FederatedIdentityCredentialOperatorSpec"></a>FederatedIdentityCredentialOperatorSpec
--------------------------------------------------------------------------------------------
+FederatedIdentityCredentialOperatorSpec{#FederatedIdentityCredentialOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -188,8 +188,8 @@ Used by: [FederatedIdentityCredential_Spec](#FederatedIdentityCredential_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -204,8 +204,8 @@ Used by: [FederatedIdentityCredential_STATUS](#FederatedIdentityCredential_STATU
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityOperatorSpec"></a>UserAssignedIdentityOperatorSpec
------------------------------------------------------------------------------
+UserAssignedIdentityOperatorSpec{#UserAssignedIdentityOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -218,7 +218,19 @@ Used by: [UserAssignedIdentity_Spec](#UserAssignedIdentity_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [UserAssignedIdentityOperatorSecrets](#UserAssignedIdentityOperatorSecrets)<br/><small>Optional</small>                                                             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -230,20 +242,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityOperatorConfigMaps"></a>UserAssignedIdentityOperatorConfigMaps
------------------------------------------------------------------------------------------
+UserAssignedIdentityOperatorConfigMaps{#UserAssignedIdentityOperatorConfigMaps}
+-------------------------------------------------------------------------------
 
 Used by: [UserAssignedIdentityOperatorSpec](#UserAssignedIdentityOperatorSpec).
 
@@ -253,8 +253,8 @@ Used by: [UserAssignedIdentityOperatorSpec](#UserAssignedIdentityOperatorSpec).
 | principalId | indicates where the PrincipalId config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | tenantId    | indicates where the TenantId config map should be placed. If omitted, no config map will be created.    | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityOperatorSecrets"></a>UserAssignedIdentityOperatorSecrets
------------------------------------------------------------------------------------
+UserAssignedIdentityOperatorSecrets{#UserAssignedIdentityOperatorSecrets}
+-------------------------------------------------------------------------
 
 Used by: [UserAssignedIdentityOperatorSpec](#UserAssignedIdentityOperatorSpec).
 

--- a/docs/hugo/content/reference/monitor/v1api20230403.md
+++ b/docs/hugo/content/reference/monitor/v1api20230403.md
@@ -5,8 +5,8 @@ title: monitor.azure.com/v1api20230403
 linktitle: v1api20230403
 ------------------------
 
-<a id="Account"></a>Account
----------------------------
+Account{#Account}
+-----------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Monitor/stable/2023-04-03/monitoringAccounts_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Monitor/accounts/{azureMonitorWorkspaceName}
 
@@ -19,7 +19,7 @@ Used by: [AccountList](#AccountList).
 | spec                                                                                    |             | [Account_Spec](#Account_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Account_STATUS](#Account_STATUS)<br/><small>Optional</small> |
 
-### <a id="Account_Spec"></a>Account_Spec
+### Account_Spec {#Account_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -30,7 +30,7 @@ Used by: [AccountList](#AccountList).
 | publicNetworkAccess | Gets or sets allow or disallow public network access to Azure Monitor Workspace                                                                                                                                                                                                              | [AzureMonitorWorkspace_PublicNetworkAccess](#AzureMonitorWorkspace_PublicNetworkAccess)<br/><small>Optional</small>                                                  |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Account_STATUS"></a>Account_STATUS
+### Account_STATUS{#Account_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,8 +49,8 @@ Used by: [AccountList](#AccountList).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AccountList"></a>AccountList
------------------------------------
+AccountList{#AccountList}
+-------------------------
 
 Generator information: - Generated from: /monitor/resource-manager/Microsoft.Monitor/stable/2023-04-03/monitoringAccounts_API.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Monitor/accounts/{azureMonitorWorkspaceName}
 
@@ -60,15 +60,15 @@ Generator information: - Generated from: /monitor/resource-manager/Microsoft.Mon
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Account[]](#Account)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-04-03" |             |
 
-<a id="Account_Spec"></a>Account_Spec
--------------------------------------
+Account_Spec{#Account_Spec}
+---------------------------
 
 Used by: [Account](#Account).
 
@@ -81,8 +81,8 @@ Used by: [Account](#Account).
 | publicNetworkAccess | Gets or sets allow or disallow public network access to Azure Monitor Workspace                                                                                                                                                                                                              | [AzureMonitorWorkspace_PublicNetworkAccess](#AzureMonitorWorkspace_PublicNetworkAccess)<br/><small>Optional</small>                                                  |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Account_STATUS"></a>Account_STATUS
------------------------------------------
+Account_STATUS{#Account_STATUS}
+-------------------------------
 
 Used by: [Account](#Account).
 
@@ -103,8 +103,8 @@ Used by: [Account](#Account).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AccountOperatorSpec"></a>AccountOperatorSpec
----------------------------------------------------
+AccountOperatorSpec{#AccountOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -115,8 +115,8 @@ Used by: [Account_Spec](#Account_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="AzureMonitorWorkspace_ProvisioningState_STATUS"></a>AzureMonitorWorkspace_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+AzureMonitorWorkspace_ProvisioningState_STATUS{#AzureMonitorWorkspace_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Account_STATUS](#Account_STATUS).
 
@@ -128,8 +128,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 | "Failed"    |             |
 | "Succeeded" |             |
 
-<a id="AzureMonitorWorkspace_PublicNetworkAccess"></a>AzureMonitorWorkspace_PublicNetworkAccess
------------------------------------------------------------------------------------------------
+AzureMonitorWorkspace_PublicNetworkAccess{#AzureMonitorWorkspace_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
 
 Used by: [Account_Spec](#Account_Spec).
 
@@ -138,8 +138,8 @@ Used by: [Account_Spec](#Account_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AzureMonitorWorkspace_PublicNetworkAccess_STATUS"></a>AzureMonitorWorkspace_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------
+AzureMonitorWorkspace_PublicNetworkAccess_STATUS{#AzureMonitorWorkspace_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [Account_STATUS](#Account_STATUS).
 
@@ -148,8 +148,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="IngestionSettings_STATUS"></a>IngestionSettings_STATUS
--------------------------------------------------------------
+IngestionSettings_STATUS{#IngestionSettings_STATUS}
+---------------------------------------------------
 
 Settings for data ingestion
 
@@ -160,8 +160,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 | dataCollectionEndpointResourceId | The Azure resource Id of the default data collection endpoint for this Azure Monitor Workspace. | string<br/><small>Optional</small> |
 | dataCollectionRuleResourceId     | The Azure resource Id of the default data collection rule for this Azure Monitor Workspace.     | string<br/><small>Optional</small> |
 
-<a id="Metrics_STATUS"></a>Metrics_STATUS
------------------------------------------
+Metrics_STATUS{#Metrics_STATUS}
+-------------------------------
 
 Properties related to the metrics container in the Azure Monitor Workspace
 
@@ -172,8 +172,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 | internalId              | An internal identifier for the metrics container. Only to be used by the system | string<br/><small>Optional</small> |
 | prometheusQueryEndpoint | The Prometheus query endpoint for the Azure Monitor Workspace                   | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The private endpoint connection resource.
 
@@ -183,8 +183,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -199,8 +199,8 @@ Used by: [Account_STATUS](#Account_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
----------------------------------------------------------------------------
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 
@@ -211,8 +211,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
 

--- a/docs/hugo/content/reference/network.frontdoor/v1api20220501.md
+++ b/docs/hugo/content/reference/network.frontdoor/v1api20220501.md
@@ -5,15 +5,15 @@ title: network.frontdoor.azure.com/v1api20220501
 linktitle: v1api20220501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-05-01" |             |
 
-<a id="WebApplicationFirewallPolicy"></a>WebApplicationFirewallPolicy
----------------------------------------------------------------------
+WebApplicationFirewallPolicy{#WebApplicationFirewallPolicy}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /frontdoor/resource-manager/Microsoft.Network/stable/2022-05-01/webapplicationfirewall.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/{policyName}
 
@@ -26,7 +26,7 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | spec                                                                                    |             | [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="WebApplicationFirewallPolicy_Spec"></a>WebApplicationFirewallPolicy_Spec
+### WebApplicationFirewallPolicy_Spec {#WebApplicationFirewallPolicy_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -41,7 +41,7 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | sku            | The pricing tier of web application firewall policy. Defaults to Classic_AzureFrontDoor if not specified.                                                                                                                                                                                    | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="WebApplicationFirewallPolicy_STATUS"></a>WebApplicationFirewallPolicy_STATUS
+### WebApplicationFirewallPolicy_STATUS{#WebApplicationFirewallPolicy_STATUS}
 
 | Property              | Description                                                                                               | Type                                                                                                                                                    |
 |-----------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -62,8 +62,8 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | tags                  | Resource tags.                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                  | Resource type.                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WebApplicationFirewallPolicyList"></a>WebApplicationFirewallPolicyList
------------------------------------------------------------------------------
+WebApplicationFirewallPolicyList{#WebApplicationFirewallPolicyList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /frontdoor/resource-manager/Microsoft.Network/stable/2022-05-01/webapplicationfirewall.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/{policyName}
 
@@ -73,8 +73,8 @@ Generator information: - Generated from: /frontdoor/resource-manager/Microsoft.N
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [WebApplicationFirewallPolicy[]](#WebApplicationFirewallPolicy)<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallPolicy_Spec"></a>WebApplicationFirewallPolicy_Spec
--------------------------------------------------------------------------------
+WebApplicationFirewallPolicy_Spec{#WebApplicationFirewallPolicy_Spec}
+---------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 
@@ -91,8 +91,8 @@ Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 | sku            | The pricing tier of web application firewall policy. Defaults to Classic_AzureFrontDoor if not specified.                                                                                                                                                                                    | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WebApplicationFirewallPolicy_STATUS"></a>WebApplicationFirewallPolicy_STATUS
------------------------------------------------------------------------------------
+WebApplicationFirewallPolicy_STATUS{#WebApplicationFirewallPolicy_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 
@@ -115,8 +115,8 @@ Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 | tags                  | Resource tags.                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                  | Resource type.                                                                                            | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CustomRuleList"></a>CustomRuleList
------------------------------------------
+CustomRuleList{#CustomRuleList}
+-------------------------------
 
 Defines contents of custom rules
 
@@ -126,8 +126,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 |----------|---------------|---------------------------------------------------------|
 | rules    | List of rules | [CustomRule[]](#CustomRule)<br/><small>Optional</small> |
 
-<a id="CustomRuleList_STATUS"></a>CustomRuleList_STATUS
--------------------------------------------------------
+CustomRuleList_STATUS{#CustomRuleList_STATUS}
+---------------------------------------------
 
 Defines contents of custom rules
 
@@ -137,8 +137,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|---------------|-----------------------------------------------------------------------|
 | rules    | List of rules | [CustomRule_STATUS[]](#CustomRule_STATUS)<br/><small>Optional</small> |
 
-<a id="FrontendEndpointLink_STATUS"></a>FrontendEndpointLink_STATUS
--------------------------------------------------------------------
+FrontendEndpointLink_STATUS{#FrontendEndpointLink_STATUS}
+---------------------------------------------------------
 
 Defines the Resource ID for a Frontend Endpoint.
 
@@ -148,8 +148,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ManagedRuleSetList"></a>ManagedRuleSetList
--------------------------------------------------
+ManagedRuleSetList{#ManagedRuleSetList}
+---------------------------------------
 
 Defines the list of managed rule sets for the policy.
 
@@ -159,8 +159,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 |-----------------|--------------------|-----------------------------------------------------------------|
 | managedRuleSets | List of rule sets. | [ManagedRuleSet[]](#ManagedRuleSet)<br/><small>Optional</small> |
 
-<a id="ManagedRuleSetList_STATUS"></a>ManagedRuleSetList_STATUS
----------------------------------------------------------------
+ManagedRuleSetList_STATUS{#ManagedRuleSetList_STATUS}
+-----------------------------------------------------
 
 Defines the list of managed rule sets for the policy.
 
@@ -170,8 +170,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |-----------------|--------------------|-------------------------------------------------------------------------------|
 | managedRuleSets | List of rule sets. | [ManagedRuleSet_STATUS[]](#ManagedRuleSet_STATUS)<br/><small>Optional</small> |
 
-<a id="PolicySettings"></a>PolicySettings
------------------------------------------
+PolicySettings{#PolicySettings}
+-------------------------------
 
 Defines top-level WebApplicationFirewallPolicy configuration settings.
 
@@ -186,8 +186,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | redirectUrl                   | If action type is redirect, this field represents redirect URL for the client.                                       | string<br/><small>Optional</small>                                                              |
 | requestBodyCheck              | Describes if policy managed rules will inspect the request body content.                                             | [PolicySettings_RequestBodyCheck](#PolicySettings_RequestBodyCheck)<br/><small>Optional</small> |
 
-<a id="PolicySettings_STATUS"></a>PolicySettings_STATUS
--------------------------------------------------------
+PolicySettings_STATUS{#PolicySettings_STATUS}
+---------------------------------------------
 
 Defines top-level WebApplicationFirewallPolicy configuration settings.
 
@@ -202,8 +202,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | redirectUrl                   | If action type is redirect, this field represents redirect URL for the client.                                       | string<br/><small>Optional</small>                                                                            |
 | requestBodyCheck              | Describes if policy managed rules will inspect the request body content.                                             | [PolicySettings_RequestBodyCheck_STATUS](#PolicySettings_RequestBodyCheck_STATUS)<br/><small>Optional</small> |
 
-<a id="RoutingRuleLink_STATUS"></a>RoutingRuleLink_STATUS
----------------------------------------------------------
+RoutingRuleLink_STATUS{#RoutingRuleLink_STATUS}
+-----------------------------------------------
 
 Defines the Resource ID for a Routing Rule.
 
@@ -213,8 +213,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SecurityPolicyLink_STATUS"></a>SecurityPolicyLink_STATUS
----------------------------------------------------------------
+SecurityPolicyLink_STATUS{#SecurityPolicyLink_STATUS}
+-----------------------------------------------------
 
 Defines the Resource ID for a Security Policy.
 
@@ -224,8 +224,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The pricing tier of the web application firewall policy.
 
@@ -235,8 +235,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 |----------|---------------------------|---------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The pricing tier of the web application firewall policy.
 
@@ -246,8 +246,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|---------------------------|-----------------------------------------------------------------|
 | name     | Name of the pricing tier. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallPolicyOperatorSpec"></a>WebApplicationFirewallPolicyOperatorSpec
----------------------------------------------------------------------------------------------
+WebApplicationFirewallPolicyOperatorSpec{#WebApplicationFirewallPolicyOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -258,8 +258,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallPolicyProperties_ResourceState_STATUS"></a>WebApplicationFirewallPolicyProperties_ResourceState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallPolicyProperties_ResourceState_STATUS{#WebApplicationFirewallPolicyProperties_ResourceState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STATUS).
 
@@ -272,8 +272,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | "Enabled"   |             |
 | "Enabling"  |             |
 
-<a id="CustomRule"></a>CustomRule
----------------------------------
+CustomRule{#CustomRule}
+-----------------------
 
 Defines contents of a web application rule
 
@@ -290,8 +290,8 @@ Used by: [CustomRuleList](#CustomRuleList).
 | rateLimitThreshold         | Number of allowed requests per client within the time window.                                                | int<br/><small>Optional</small>                                                 |
 | ruleType                   | Describes type of rule.                                                                                      | [CustomRule_RuleType](#CustomRule_RuleType)<br/><small>Required</small>         |
 
-<a id="CustomRule_STATUS"></a>CustomRule_STATUS
------------------------------------------------
+CustomRule_STATUS{#CustomRule_STATUS}
+-------------------------------------
 
 Defines contents of a web application rule
 
@@ -308,8 +308,8 @@ Used by: [CustomRuleList_STATUS](#CustomRuleList_STATUS).
 | rateLimitThreshold         | Number of allowed requests per client within the time window.                                                | int<br/><small>Optional</small>                                                               |
 | ruleType                   | Describes type of rule.                                                                                      | [CustomRule_RuleType_STATUS](#CustomRule_RuleType_STATUS)<br/><small>Optional</small>         |
 
-<a id="ManagedRuleSet"></a>ManagedRuleSet
------------------------------------------
+ManagedRuleSet{#ManagedRuleSet}
+-------------------------------
 
 Defines a managed rule set.
 
@@ -323,8 +323,8 @@ Used by: [ManagedRuleSetList](#ManagedRuleSetList).
 | ruleSetType        | Defines the rule set type to use.                                  | string<br/><small>Required</small>                                                  |
 | ruleSetVersion     | Defines the version of the rule set to use.                        | string<br/><small>Required</small>                                                  |
 
-<a id="ManagedRuleSet_STATUS"></a>ManagedRuleSet_STATUS
--------------------------------------------------------
+ManagedRuleSet_STATUS{#ManagedRuleSet_STATUS}
+---------------------------------------------
 
 Defines a managed rule set.
 
@@ -338,8 +338,8 @@ Used by: [ManagedRuleSetList_STATUS](#ManagedRuleSetList_STATUS).
 | ruleSetType        | Defines the rule set type to use.                                  | string<br/><small>Optional</small>                                                                |
 | ruleSetVersion     | Defines the version of the rule set to use.                        | string<br/><small>Optional</small>                                                                |
 
-<a id="PolicySettings_EnabledState"></a>PolicySettings_EnabledState
--------------------------------------------------------------------
+PolicySettings_EnabledState{#PolicySettings_EnabledState}
+---------------------------------------------------------
 
 Used by: [PolicySettings](#PolicySettings).
 
@@ -348,8 +348,8 @@ Used by: [PolicySettings](#PolicySettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PolicySettings_EnabledState_STATUS"></a>PolicySettings_EnabledState_STATUS
----------------------------------------------------------------------------------
+PolicySettings_EnabledState_STATUS{#PolicySettings_EnabledState_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 
@@ -358,8 +358,8 @@ Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PolicySettings_Mode"></a>PolicySettings_Mode
----------------------------------------------------
+PolicySettings_Mode{#PolicySettings_Mode}
+-----------------------------------------
 
 Used by: [PolicySettings](#PolicySettings).
 
@@ -368,19 +368,19 @@ Used by: [PolicySettings](#PolicySettings).
 | "Detection"  |             |
 | "Prevention" |             |
 
-<a id="PolicySettings_Mode_STATUS"></a>PolicySettings_Mode_STATUS
+PolicySettings_Mode_STATUS{#PolicySettings_Mode_STATUS}
+-------------------------------------------------------
+
+Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Detection"  |             |
+| "Prevention" |             |
+
+PolicySettings_RequestBodyCheck{#PolicySettings_RequestBodyCheck}
 -----------------------------------------------------------------
 
-Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Detection"  |             |
-| "Prevention" |             |
-
-<a id="PolicySettings_RequestBodyCheck"></a>PolicySettings_RequestBodyCheck
----------------------------------------------------------------------------
-
 Used by: [PolicySettings](#PolicySettings).
 
 | Value      | Description |
@@ -388,8 +388,8 @@ Used by: [PolicySettings](#PolicySettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PolicySettings_RequestBodyCheck_STATUS"></a>PolicySettings_RequestBodyCheck_STATUS
------------------------------------------------------------------------------------------
+PolicySettings_RequestBodyCheck_STATUS{#PolicySettings_RequestBodyCheck_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 
@@ -398,8 +398,8 @@ Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -409,8 +409,8 @@ Used by: [Sku](#Sku).
 | "Premium_AzureFrontDoor"  |             |
 | "Standard_AzureFrontDoor" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -420,8 +420,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium_AzureFrontDoor"  |             |
 | "Standard_AzureFrontDoor" |             |
 
-<a id="ActionType"></a>ActionType
----------------------------------
+ActionType{#ActionType}
+-----------------------
 
 Defines the action to take on rule match.
 
@@ -435,8 +435,8 @@ Used by: [CustomRule](#CustomRule), and [ManagedRuleOverride](#ManagedRuleOverri
 | "Log"            |             |
 | "Redirect"       |             |
 
-<a id="ActionType_STATUS"></a>ActionType_STATUS
------------------------------------------------
+ActionType_STATUS{#ActionType_STATUS}
+-------------------------------------
 
 Defines the action to take on rule match.
 
@@ -450,8 +450,8 @@ Used by: [CustomRule_STATUS](#CustomRule_STATUS), and [ManagedRuleOverride_STATU
 | "Log"            |             |
 | "Redirect"       |             |
 
-<a id="CustomRule_EnabledState"></a>CustomRule_EnabledState
------------------------------------------------------------
+CustomRule_EnabledState{#CustomRule_EnabledState}
+-------------------------------------------------
 
 Used by: [CustomRule](#CustomRule).
 
@@ -460,8 +460,8 @@ Used by: [CustomRule](#CustomRule).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CustomRule_EnabledState_STATUS"></a>CustomRule_EnabledState_STATUS
--------------------------------------------------------------------------
+CustomRule_EnabledState_STATUS{#CustomRule_EnabledState_STATUS}
+---------------------------------------------------------------
 
 Used by: [CustomRule_STATUS](#CustomRule_STATUS).
 
@@ -470,8 +470,8 @@ Used by: [CustomRule_STATUS](#CustomRule_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="CustomRule_RuleType"></a>CustomRule_RuleType
----------------------------------------------------
+CustomRule_RuleType{#CustomRule_RuleType}
+-----------------------------------------
 
 Used by: [CustomRule](#CustomRule).
 
@@ -480,8 +480,8 @@ Used by: [CustomRule](#CustomRule).
 | "MatchRule"     |             |
 | "RateLimitRule" |             |
 
-<a id="CustomRule_RuleType_STATUS"></a>CustomRule_RuleType_STATUS
------------------------------------------------------------------
+CustomRule_RuleType_STATUS{#CustomRule_RuleType_STATUS}
+-------------------------------------------------------
 
 Used by: [CustomRule_STATUS](#CustomRule_STATUS).
 
@@ -490,8 +490,8 @@ Used by: [CustomRule_STATUS](#CustomRule_STATUS).
 | "MatchRule"     |             |
 | "RateLimitRule" |             |
 
-<a id="ManagedRuleExclusion"></a>ManagedRuleExclusion
------------------------------------------------------
+ManagedRuleExclusion{#ManagedRuleExclusion}
+-------------------------------------------
 
 Exclude variables from managed rule evaluation.
 
@@ -503,8 +503,8 @@ Used by: [ManagedRuleGroupOverride](#ManagedRuleGroupOverride), [ManagedRuleOver
 | selector              | Selector value for which elements in the collection this exclusion applies to.                                           | string<br/><small>Required</small>                                                                                    |
 | selectorMatchOperator | Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to. | [ManagedRuleExclusion_SelectorMatchOperator](#ManagedRuleExclusion_SelectorMatchOperator)<br/><small>Required</small> |
 
-<a id="ManagedRuleExclusion_STATUS"></a>ManagedRuleExclusion_STATUS
--------------------------------------------------------------------
+ManagedRuleExclusion_STATUS{#ManagedRuleExclusion_STATUS}
+---------------------------------------------------------
 
 Exclude variables from managed rule evaluation.
 
@@ -516,8 +516,8 @@ Used by: [ManagedRuleGroupOverride_STATUS](#ManagedRuleGroupOverride_STATUS), [M
 | selector              | Selector value for which elements in the collection this exclusion applies to.                                           | string<br/><small>Optional</small>                                                                                                  |
 | selectorMatchOperator | Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to. | [ManagedRuleExclusion_SelectorMatchOperator_STATUS](#ManagedRuleExclusion_SelectorMatchOperator_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedRuleGroupOverride"></a>ManagedRuleGroupOverride
--------------------------------------------------------------
+ManagedRuleGroupOverride{#ManagedRuleGroupOverride}
+---------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -529,8 +529,8 @@ Used by: [ManagedRuleSet](#ManagedRuleSet).
 | ruleGroupName | Describes the managed rule group to override.                                                    | string<br/><small>Required</small>                                          |
 | rules         | List of rules that will be disabled. If none specified, all rules in the group will be disabled. | [ManagedRuleOverride[]](#ManagedRuleOverride)<br/><small>Optional</small>   |
 
-<a id="ManagedRuleGroupOverride_STATUS"></a>ManagedRuleGroupOverride_STATUS
----------------------------------------------------------------------------
+ManagedRuleGroupOverride_STATUS{#ManagedRuleGroupOverride_STATUS}
+-----------------------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -542,8 +542,8 @@ Used by: [ManagedRuleSet_STATUS](#ManagedRuleSet_STATUS).
 | ruleGroupName | Describes the managed rule group to override.                                                    | string<br/><small>Optional</small>                                                        |
 | rules         | List of rules that will be disabled. If none specified, all rules in the group will be disabled. | [ManagedRuleOverride_STATUS[]](#ManagedRuleOverride_STATUS)<br/><small>Optional</small>   |
 
-<a id="ManagedRuleSetActionType"></a>ManagedRuleSetActionType
--------------------------------------------------------------
+ManagedRuleSetActionType{#ManagedRuleSetActionType}
+---------------------------------------------------
 
 Defines the action to take when a managed rule set score threshold is met.
 
@@ -555,8 +555,8 @@ Used by: [ManagedRuleSet](#ManagedRuleSet).
 | "Log"      |             |
 | "Redirect" |             |
 
-<a id="ManagedRuleSetActionType_STATUS"></a>ManagedRuleSetActionType_STATUS
----------------------------------------------------------------------------
+ManagedRuleSetActionType_STATUS{#ManagedRuleSetActionType_STATUS}
+-----------------------------------------------------------------
 
 Defines the action to take when a managed rule set score threshold is met.
 
@@ -568,8 +568,8 @@ Used by: [ManagedRuleSet_STATUS](#ManagedRuleSet_STATUS).
 | "Log"      |             |
 | "Redirect" |             |
 
-<a id="MatchCondition"></a>MatchCondition
------------------------------------------
+MatchCondition{#MatchCondition}
+-------------------------------
 
 Define a match condition.
 
@@ -584,8 +584,8 @@ Used by: [CustomRule](#CustomRule).
 | selector        | Match against a specific key from the QueryString, PostArgs, RequestHeader or Cookies variables. Default is null. | string<br/><small>Optional</small>                                                        |
 | transforms      | List of transforms.                                                                                               | [TransformType[]](#TransformType)<br/><small>Optional</small>                             |
 
-<a id="MatchCondition_STATUS"></a>MatchCondition_STATUS
--------------------------------------------------------
+MatchCondition_STATUS{#MatchCondition_STATUS}
+---------------------------------------------
 
 Define a match condition.
 
@@ -600,8 +600,8 @@ Used by: [CustomRule_STATUS](#CustomRule_STATUS).
 | selector        | Match against a specific key from the QueryString, PostArgs, RequestHeader or Cookies variables. Default is null. | string<br/><small>Optional</small>                                                                      |
 | transforms      | List of transforms.                                                                                               | [TransformType_STATUS[]](#TransformType_STATUS)<br/><small>Optional</small>                             |
 
-<a id="ManagedRuleExclusion_MatchVariable"></a>ManagedRuleExclusion_MatchVariable
----------------------------------------------------------------------------------
+ManagedRuleExclusion_MatchVariable{#ManagedRuleExclusion_MatchVariable}
+-----------------------------------------------------------------------
 
 Used by: [ManagedRuleExclusion](#ManagedRuleExclusion).
 
@@ -613,8 +613,8 @@ Used by: [ManagedRuleExclusion](#ManagedRuleExclusion).
 | "RequestCookieNames"      |             |
 | "RequestHeaderNames"      |             |
 
-<a id="ManagedRuleExclusion_MatchVariable_STATUS"></a>ManagedRuleExclusion_MatchVariable_STATUS
------------------------------------------------------------------------------------------------
+ManagedRuleExclusion_MatchVariable_STATUS{#ManagedRuleExclusion_MatchVariable_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ManagedRuleExclusion_STATUS](#ManagedRuleExclusion_STATUS).
 
@@ -626,8 +626,8 @@ Used by: [ManagedRuleExclusion_STATUS](#ManagedRuleExclusion_STATUS).
 | "RequestCookieNames"      |             |
 | "RequestHeaderNames"      |             |
 
-<a id="ManagedRuleExclusion_SelectorMatchOperator"></a>ManagedRuleExclusion_SelectorMatchOperator
--------------------------------------------------------------------------------------------------
+ManagedRuleExclusion_SelectorMatchOperator{#ManagedRuleExclusion_SelectorMatchOperator}
+---------------------------------------------------------------------------------------
 
 Used by: [ManagedRuleExclusion](#ManagedRuleExclusion).
 
@@ -639,8 +639,8 @@ Used by: [ManagedRuleExclusion](#ManagedRuleExclusion).
 | "EqualsAny"  |             |
 | "StartsWith" |             |
 
-<a id="ManagedRuleExclusion_SelectorMatchOperator_STATUS"></a>ManagedRuleExclusion_SelectorMatchOperator_STATUS
----------------------------------------------------------------------------------------------------------------
+ManagedRuleExclusion_SelectorMatchOperator_STATUS{#ManagedRuleExclusion_SelectorMatchOperator_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ManagedRuleExclusion_STATUS](#ManagedRuleExclusion_STATUS).
 
@@ -652,8 +652,8 @@ Used by: [ManagedRuleExclusion_STATUS](#ManagedRuleExclusion_STATUS).
 | "EqualsAny"  |             |
 | "StartsWith" |             |
 
-<a id="ManagedRuleOverride"></a>ManagedRuleOverride
----------------------------------------------------
+ManagedRuleOverride{#ManagedRuleOverride}
+-----------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -666,8 +666,8 @@ Used by: [ManagedRuleGroupOverride](#ManagedRuleGroupOverride).
 | exclusions   | Describes the exclusions that are applied to this specific rule.                                      | [ManagedRuleExclusion[]](#ManagedRuleExclusion)<br/><small>Optional</small>     |
 | ruleId       | Identifier for the managed rule.                                                                      | string<br/><small>Required</small>                                              |
 
-<a id="ManagedRuleOverride_STATUS"></a>ManagedRuleOverride_STATUS
------------------------------------------------------------------
+ManagedRuleOverride_STATUS{#ManagedRuleOverride_STATUS}
+-------------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -680,65 +680,45 @@ Used by: [ManagedRuleGroupOverride_STATUS](#ManagedRuleGroupOverride_STATUS).
 | exclusions   | Describes the exclusions that are applied to this specific rule.                                      | [ManagedRuleExclusion_STATUS[]](#ManagedRuleExclusion_STATUS)<br/><small>Optional</small>     |
 | ruleId       | Identifier for the managed rule.                                                                      | string<br/><small>Optional</small>                                                            |
 
-<a id="MatchCondition_MatchVariable"></a>MatchCondition_MatchVariable
----------------------------------------------------------------------
-
-Used by: [MatchCondition](#MatchCondition).
-
-| Value           | Description |
-|-----------------|-------------|
-| "Cookies"       |             |
-| "PostArgs"      |             |
-| "QueryString"   |             |
-| "RemoteAddr"    |             |
-| "RequestBody"   |             |
-| "RequestHeader" |             |
-| "RequestMethod" |             |
-| "RequestUri"    |             |
-| "SocketAddr"    |             |
-
-<a id="MatchCondition_MatchVariable_STATUS"></a>MatchCondition_MatchVariable_STATUS
------------------------------------------------------------------------------------
-
-Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
-
-| Value           | Description |
-|-----------------|-------------|
-| "Cookies"       |             |
-| "PostArgs"      |             |
-| "QueryString"   |             |
-| "RemoteAddr"    |             |
-| "RequestBody"   |             |
-| "RequestHeader" |             |
-| "RequestMethod" |             |
-| "RequestUri"    |             |
-| "SocketAddr"    |             |
-
-<a id="MatchCondition_Operator"></a>MatchCondition_Operator
+MatchCondition_MatchVariable{#MatchCondition_MatchVariable}
 -----------------------------------------------------------
 
 Used by: [MatchCondition](#MatchCondition).
 
-| Value                | Description |
-|----------------------|-------------|
-| "Any"                |             |
-| "BeginsWith"         |             |
-| "Contains"           |             |
-| "EndsWith"           |             |
-| "Equal"              |             |
-| "GeoMatch"           |             |
-| "GreaterThan"        |             |
-| "GreaterThanOrEqual" |             |
-| "IPMatch"            |             |
-| "LessThan"           |             |
-| "LessThanOrEqual"    |             |
-| "RegEx"              |             |
+| Value           | Description |
+|-----------------|-------------|
+| "Cookies"       |             |
+| "PostArgs"      |             |
+| "QueryString"   |             |
+| "RemoteAddr"    |             |
+| "RequestBody"   |             |
+| "RequestHeader" |             |
+| "RequestMethod" |             |
+| "RequestUri"    |             |
+| "SocketAddr"    |             |
 
-<a id="MatchCondition_Operator_STATUS"></a>MatchCondition_Operator_STATUS
+MatchCondition_MatchVariable_STATUS{#MatchCondition_MatchVariable_STATUS}
 -------------------------------------------------------------------------
 
 Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 
+| Value           | Description |
+|-----------------|-------------|
+| "Cookies"       |             |
+| "PostArgs"      |             |
+| "QueryString"   |             |
+| "RemoteAddr"    |             |
+| "RequestBody"   |             |
+| "RequestHeader" |             |
+| "RequestMethod" |             |
+| "RequestUri"    |             |
+| "SocketAddr"    |             |
+
+MatchCondition_Operator{#MatchCondition_Operator}
+-------------------------------------------------
+
+Used by: [MatchCondition](#MatchCondition).
+
 | Value                | Description |
 |----------------------|-------------|
 | "Any"                |             |
@@ -754,8 +734,28 @@ Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 | "LessThanOrEqual"    |             |
 | "RegEx"              |             |
 
-<a id="TransformType"></a>TransformType
----------------------------------------
+MatchCondition_Operator_STATUS{#MatchCondition_Operator_STATUS}
+---------------------------------------------------------------
+
+Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
+
+| Value                | Description |
+|----------------------|-------------|
+| "Any"                |             |
+| "BeginsWith"         |             |
+| "Contains"           |             |
+| "EndsWith"           |             |
+| "Equal"              |             |
+| "GeoMatch"           |             |
+| "GreaterThan"        |             |
+| "GreaterThanOrEqual" |             |
+| "IPMatch"            |             |
+| "LessThan"           |             |
+| "LessThanOrEqual"    |             |
+| "RegEx"              |             |
+
+TransformType{#TransformType}
+-----------------------------
 
 Describes what transforms applied before matching.
 
@@ -770,8 +770,8 @@ Used by: [MatchCondition](#MatchCondition).
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="TransformType_STATUS"></a>TransformType_STATUS
------------------------------------------------------
+TransformType_STATUS{#TransformType_STATUS}
+-------------------------------------------
 
 Describes what transforms applied before matching.
 
@@ -786,8 +786,8 @@ Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 | "UrlDecode"   |             |
 | "UrlEncode"   |             |
 
-<a id="ManagedRuleEnabledState"></a>ManagedRuleEnabledState
------------------------------------------------------------
+ManagedRuleEnabledState{#ManagedRuleEnabledState}
+-------------------------------------------------
 
 Describes if the managed rule is in enabled or disabled state.
 
@@ -798,8 +798,8 @@ Used by: [ManagedRuleOverride](#ManagedRuleOverride).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedRuleEnabledState_STATUS"></a>ManagedRuleEnabledState_STATUS
--------------------------------------------------------------------------
+ManagedRuleEnabledState_STATUS{#ManagedRuleEnabledState_STATUS}
+---------------------------------------------------------------
 
 Describes if the managed rule is in enabled or disabled state.
 

--- a/docs/hugo/content/reference/network/v1api20180501.md
+++ b/docs/hugo/content/reference/network/v1api20180501.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20180501
 linktitle: v1api20180501
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-05-01" |             |
 
-<a id="DnsZone"></a>DnsZone
----------------------------
+DnsZone{#DnsZone}
+-----------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}
 
@@ -26,7 +26,7 @@ Used by: [DnsZoneList](#DnsZoneList).
 | spec                                                                                    |             | [DnsZone_Spec](#DnsZone_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZone_STATUS](#DnsZone_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZone_Spec"></a>DnsZone_Spec
+### DnsZone_Spec {#DnsZone_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Used by: [DnsZoneList](#DnsZoneList).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneType                    | The type of this DNS zone (Public or Private).                                                                                                                                                                                                                                               | [ZoneProperties_ZoneType](#ZoneProperties_ZoneType)<br/><small>Optional</small>                                                                                      |
 
-### <a id="DnsZone_STATUS"></a>DnsZone_STATUS
+### DnsZone_STATUS{#DnsZone_STATUS}
 
 | Property                       | Description                                                                                                                                                        | Type                                                                                                                                                    |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -58,8 +58,8 @@ Used by: [DnsZoneList](#DnsZoneList).
 | type                           | Resource type.                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneType                       | The type of this DNS zone (Public or Private).                                                                                                                     | [ZoneProperties_ZoneType_STATUS](#ZoneProperties_ZoneType_STATUS)<br/><small>Optional</small>                                                           |
 
-<a id="DnsZoneList"></a>DnsZoneList
------------------------------------
+DnsZoneList{#DnsZoneList}
+-------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}
 
@@ -69,8 +69,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [DnsZone[]](#DnsZone)<br/><small>Optional</small> |
 
-<a id="DnsZonesAAAARecord"></a>DnsZonesAAAARecord
--------------------------------------------------
+DnsZonesAAAARecord{#DnsZonesAAAARecord}
+---------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/AAAA/{relativeRecordSetName}
 
@@ -83,7 +83,7 @@ Used by: [DnsZonesAAAARecordList](#DnsZonesAAAARecordList).
 | spec                                                                                    |             | [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesAAAARecord_Spec"></a>DnsZonesAAAARecord_Spec
+### DnsZonesAAAARecord_Spec {#DnsZonesAAAARecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -104,7 +104,7 @@ Used by: [DnsZonesAAAARecordList](#DnsZonesAAAARecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesAAAARecord_STATUS"></a>DnsZonesAAAARecord_STATUS
+### DnsZonesAAAARecord_STATUS{#DnsZonesAAAARecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -129,8 +129,8 @@ Used by: [DnsZonesAAAARecordList](#DnsZonesAAAARecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesAAAARecordList"></a>DnsZonesAAAARecordList
----------------------------------------------------------
+DnsZonesAAAARecordList{#DnsZonesAAAARecordList}
+-----------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/AAAA/{relativeRecordSetName}
 
@@ -140,8 +140,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [DnsZonesAAAARecord[]](#DnsZonesAAAARecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesARecord"></a>DnsZonesARecord
--------------------------------------------
+DnsZonesARecord{#DnsZonesARecord}
+---------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/A/{relativeRecordSetName}
 
@@ -154,7 +154,7 @@ Used by: [DnsZonesARecordList](#DnsZonesARecordList).
 | spec                                                                                    |             | [DnsZonesARecord_Spec](#DnsZonesARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesARecord_Spec"></a>DnsZonesARecord_Spec
+### DnsZonesARecord_Spec {#DnsZonesARecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,7 +176,7 @@ Used by: [DnsZonesARecordList](#DnsZonesARecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesARecord_STATUS"></a>DnsZonesARecord_STATUS
+### DnsZonesARecord_STATUS{#DnsZonesARecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -201,8 +201,8 @@ Used by: [DnsZonesARecordList](#DnsZonesARecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesARecordList"></a>DnsZonesARecordList
----------------------------------------------------
+DnsZonesARecordList{#DnsZonesARecordList}
+-----------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/A/{relativeRecordSetName}
 
@@ -212,8 +212,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [DnsZonesARecord[]](#DnsZonesARecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesCAARecord"></a>DnsZonesCAARecord
------------------------------------------------
+DnsZonesCAARecord{#DnsZonesCAARecord}
+-------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/CAA/{relativeRecordSetName}
 
@@ -226,7 +226,7 @@ Used by: [DnsZonesCAARecordList](#DnsZonesCAARecordList).
 | spec                                                                                    |             | [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesCAARecord_Spec"></a>DnsZonesCAARecord_Spec
+### DnsZonesCAARecord_Spec {#DnsZonesCAARecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -247,7 +247,7 @@ Used by: [DnsZonesCAARecordList](#DnsZonesCAARecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesCAARecord_STATUS"></a>DnsZonesCAARecord_STATUS
+### DnsZonesCAARecord_STATUS{#DnsZonesCAARecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -272,8 +272,8 @@ Used by: [DnsZonesCAARecordList](#DnsZonesCAARecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesCAARecordList"></a>DnsZonesCAARecordList
--------------------------------------------------------
+DnsZonesCAARecordList{#DnsZonesCAARecordList}
+---------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/CAA/{relativeRecordSetName}
 
@@ -283,8 +283,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DnsZonesCAARecord[]](#DnsZonesCAARecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesCNAMERecord"></a>DnsZonesCNAMERecord
----------------------------------------------------
+DnsZonesCNAMERecord{#DnsZonesCNAMERecord}
+-----------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/CNAME/{relativeRecordSetName}
 
@@ -297,7 +297,7 @@ Used by: [DnsZonesCNAMERecordList](#DnsZonesCNAMERecordList).
 | spec                                                                                    |             | [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesCNAMERecord_Spec"></a>DnsZonesCNAMERecord_Spec
+### DnsZonesCNAMERecord_Spec {#DnsZonesCNAMERecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -318,7 +318,7 @@ Used by: [DnsZonesCNAMERecordList](#DnsZonesCNAMERecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesCNAMERecord_STATUS"></a>DnsZonesCNAMERecord_STATUS
+### DnsZonesCNAMERecord_STATUS{#DnsZonesCNAMERecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -343,8 +343,8 @@ Used by: [DnsZonesCNAMERecordList](#DnsZonesCNAMERecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesCNAMERecordList"></a>DnsZonesCNAMERecordList
------------------------------------------------------------
+DnsZonesCNAMERecordList{#DnsZonesCNAMERecordList}
+-------------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/CNAME/{relativeRecordSetName}
 
@@ -354,8 +354,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                           |
 | items                                                                               |             | [DnsZonesCNAMERecord[]](#DnsZonesCNAMERecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesMXRecord"></a>DnsZonesMXRecord
----------------------------------------------
+DnsZonesMXRecord{#DnsZonesMXRecord}
+-----------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/MX/{relativeRecordSetName}
 
@@ -368,7 +368,7 @@ Used by: [DnsZonesMXRecordList](#DnsZonesMXRecordList).
 | spec                                                                                    |             | [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesMXRecord_Spec"></a>DnsZonesMXRecord_Spec
+### DnsZonesMXRecord_Spec {#DnsZonesMXRecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -389,7 +389,7 @@ Used by: [DnsZonesMXRecordList](#DnsZonesMXRecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesMXRecord_STATUS"></a>DnsZonesMXRecord_STATUS
+### DnsZonesMXRecord_STATUS{#DnsZonesMXRecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -414,8 +414,8 @@ Used by: [DnsZonesMXRecordList](#DnsZonesMXRecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesMXRecordList"></a>DnsZonesMXRecordList
------------------------------------------------------
+DnsZonesMXRecordList{#DnsZonesMXRecordList}
+-------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/MX/{relativeRecordSetName}
 
@@ -425,8 +425,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [DnsZonesMXRecord[]](#DnsZonesMXRecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesNSRecord"></a>DnsZonesNSRecord
----------------------------------------------
+DnsZonesNSRecord{#DnsZonesNSRecord}
+-----------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/NS/{relativeRecordSetName}
 
@@ -439,7 +439,7 @@ Used by: [DnsZonesNSRecordList](#DnsZonesNSRecordList).
 | spec                                                                                    |             | [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesNSRecord_Spec"></a>DnsZonesNSRecord_Spec
+### DnsZonesNSRecord_Spec {#DnsZonesNSRecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -460,7 +460,7 @@ Used by: [DnsZonesNSRecordList](#DnsZonesNSRecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesNSRecord_STATUS"></a>DnsZonesNSRecord_STATUS
+### DnsZonesNSRecord_STATUS{#DnsZonesNSRecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -485,8 +485,8 @@ Used by: [DnsZonesNSRecordList](#DnsZonesNSRecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesNSRecordList"></a>DnsZonesNSRecordList
------------------------------------------------------
+DnsZonesNSRecordList{#DnsZonesNSRecordList}
+-------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/NS/{relativeRecordSetName}
 
@@ -496,8 +496,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [DnsZonesNSRecord[]](#DnsZonesNSRecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesPTRRecord"></a>DnsZonesPTRRecord
------------------------------------------------
+DnsZonesPTRRecord{#DnsZonesPTRRecord}
+-------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/PTR/{relativeRecordSetName}
 
@@ -510,7 +510,7 @@ Used by: [DnsZonesPTRRecordList](#DnsZonesPTRRecordList).
 | spec                                                                                    |             | [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesPTRRecord_Spec"></a>DnsZonesPTRRecord_Spec
+### DnsZonesPTRRecord_Spec {#DnsZonesPTRRecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -531,7 +531,7 @@ Used by: [DnsZonesPTRRecordList](#DnsZonesPTRRecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesPTRRecord_STATUS"></a>DnsZonesPTRRecord_STATUS
+### DnsZonesPTRRecord_STATUS{#DnsZonesPTRRecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -556,8 +556,8 @@ Used by: [DnsZonesPTRRecordList](#DnsZonesPTRRecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesPTRRecordList"></a>DnsZonesPTRRecordList
--------------------------------------------------------
+DnsZonesPTRRecordList{#DnsZonesPTRRecordList}
+---------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/PTR/{relativeRecordSetName}
 
@@ -567,8 +567,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DnsZonesPTRRecord[]](#DnsZonesPTRRecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesSRVRecord"></a>DnsZonesSRVRecord
------------------------------------------------
+DnsZonesSRVRecord{#DnsZonesSRVRecord}
+-------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/SRV/{relativeRecordSetName}
 
@@ -581,7 +581,7 @@ Used by: [DnsZonesSRVRecordList](#DnsZonesSRVRecordList).
 | spec                                                                                    |             | [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesSRVRecord_Spec"></a>DnsZonesSRVRecord_Spec
+### DnsZonesSRVRecord_Spec {#DnsZonesSRVRecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -602,7 +602,7 @@ Used by: [DnsZonesSRVRecordList](#DnsZonesSRVRecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesSRVRecord_STATUS"></a>DnsZonesSRVRecord_STATUS
+### DnsZonesSRVRecord_STATUS{#DnsZonesSRVRecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -627,8 +627,8 @@ Used by: [DnsZonesSRVRecordList](#DnsZonesSRVRecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesSRVRecordList"></a>DnsZonesSRVRecordList
--------------------------------------------------------
+DnsZonesSRVRecordList{#DnsZonesSRVRecordList}
+---------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/SRV/{relativeRecordSetName}
 
@@ -638,8 +638,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DnsZonesSRVRecord[]](#DnsZonesSRVRecord)<br/><small>Optional</small> |
 
-<a id="DnsZonesTXTRecord"></a>DnsZonesTXTRecord
------------------------------------------------
+DnsZonesTXTRecord{#DnsZonesTXTRecord}
+-------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/TXT/{relativeRecordSetName}
 
@@ -652,7 +652,7 @@ Used by: [DnsZonesTXTRecordList](#DnsZonesTXTRecordList).
 | spec                                                                                    |             | [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsZonesTXTRecord_Spec"></a>DnsZonesTXTRecord_Spec
+### DnsZonesTXTRecord_Spec {#DnsZonesTXTRecord_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -673,7 +673,7 @@ Used by: [DnsZonesTXTRecordList](#DnsZonesTXTRecordList).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="DnsZonesTXTRecord_STATUS"></a>DnsZonesTXTRecord_STATUS
+### DnsZonesTXTRecord_STATUS{#DnsZonesTXTRecord_STATUS}
 
 | Property          | Description                                                                  | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -698,8 +698,8 @@ Used by: [DnsZonesTXTRecordList](#DnsZonesTXTRecordList).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesTXTRecordList"></a>DnsZonesTXTRecordList
--------------------------------------------------------
+DnsZonesTXTRecordList{#DnsZonesTXTRecordList}
+---------------------------------------------
 
 Generator information: - Generated from: /dns/resource-manager/Microsoft.Network/stable/2018-05-01/dns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsZones/{zoneName}/TXT/{relativeRecordSetName}
 
@@ -709,8 +709,8 @@ Generator information: - Generated from: /dns/resource-manager/Microsoft.Network
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [DnsZonesTXTRecord[]](#DnsZonesTXTRecord)<br/><small>Optional</small> |
 
-<a id="DnsZone_Spec"></a>DnsZone_Spec
--------------------------------------
+DnsZone_Spec{#DnsZone_Spec}
+---------------------------
 
 Used by: [DnsZone](#DnsZone).
 
@@ -725,8 +725,8 @@ Used by: [DnsZone](#DnsZone).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneType                    | The type of this DNS zone (Public or Private).                                                                                                                                                                                                                                               | [ZoneProperties_ZoneType](#ZoneProperties_ZoneType)<br/><small>Optional</small>                                                                                      |
 
-<a id="DnsZone_STATUS"></a>DnsZone_STATUS
------------------------------------------
+DnsZone_STATUS{#DnsZone_STATUS}
+-------------------------------
 
 Used by: [DnsZone](#DnsZone).
 
@@ -747,8 +747,8 @@ Used by: [DnsZone](#DnsZone).
 | type                           | Resource type.                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneType                       | The type of this DNS zone (Public or Private).                                                                                                                     | [ZoneProperties_ZoneType_STATUS](#ZoneProperties_ZoneType_STATUS)<br/><small>Optional</small>                                                           |
 
-<a id="DnsZonesAAAARecord_Spec"></a>DnsZonesAAAARecord_Spec
------------------------------------------------------------
+DnsZonesAAAARecord_Spec{#DnsZonesAAAARecord_Spec}
+-------------------------------------------------
 
 Used by: [DnsZonesAAAARecord](#DnsZonesAAAARecord).
 
@@ -771,8 +771,8 @@ Used by: [DnsZonesAAAARecord](#DnsZonesAAAARecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesAAAARecord_STATUS"></a>DnsZonesAAAARecord_STATUS
----------------------------------------------------------------
+DnsZonesAAAARecord_STATUS{#DnsZonesAAAARecord_STATUS}
+-----------------------------------------------------
 
 Used by: [DnsZonesAAAARecord](#DnsZonesAAAARecord).
 
@@ -799,8 +799,8 @@ Used by: [DnsZonesAAAARecord](#DnsZonesAAAARecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesARecord_Spec"></a>DnsZonesARecord_Spec
------------------------------------------------------
+DnsZonesARecord_Spec{#DnsZonesARecord_Spec}
+-------------------------------------------
 
 Used by: [DnsZonesARecord](#DnsZonesARecord).
 
@@ -824,8 +824,8 @@ Used by: [DnsZonesARecord](#DnsZonesARecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesARecord_STATUS"></a>DnsZonesARecord_STATUS
----------------------------------------------------------
+DnsZonesARecord_STATUS{#DnsZonesARecord_STATUS}
+-----------------------------------------------
 
 Used by: [DnsZonesARecord](#DnsZonesARecord).
 
@@ -852,8 +852,8 @@ Used by: [DnsZonesARecord](#DnsZonesARecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesCAARecord_Spec"></a>DnsZonesCAARecord_Spec
----------------------------------------------------------
+DnsZonesCAARecord_Spec{#DnsZonesCAARecord_Spec}
+-----------------------------------------------
 
 Used by: [DnsZonesCAARecord](#DnsZonesCAARecord).
 
@@ -876,8 +876,8 @@ Used by: [DnsZonesCAARecord](#DnsZonesCAARecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesCAARecord_STATUS"></a>DnsZonesCAARecord_STATUS
--------------------------------------------------------------
+DnsZonesCAARecord_STATUS{#DnsZonesCAARecord_STATUS}
+---------------------------------------------------
 
 Used by: [DnsZonesCAARecord](#DnsZonesCAARecord).
 
@@ -904,8 +904,8 @@ Used by: [DnsZonesCAARecord](#DnsZonesCAARecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesCNAMERecord_Spec"></a>DnsZonesCNAMERecord_Spec
--------------------------------------------------------------
+DnsZonesCNAMERecord_Spec{#DnsZonesCNAMERecord_Spec}
+---------------------------------------------------
 
 Used by: [DnsZonesCNAMERecord](#DnsZonesCNAMERecord).
 
@@ -928,8 +928,8 @@ Used by: [DnsZonesCNAMERecord](#DnsZonesCNAMERecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesCNAMERecord_STATUS"></a>DnsZonesCNAMERecord_STATUS
------------------------------------------------------------------
+DnsZonesCNAMERecord_STATUS{#DnsZonesCNAMERecord_STATUS}
+-------------------------------------------------------
 
 Used by: [DnsZonesCNAMERecord](#DnsZonesCNAMERecord).
 
@@ -956,8 +956,8 @@ Used by: [DnsZonesCNAMERecord](#DnsZonesCNAMERecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesMXRecord_Spec"></a>DnsZonesMXRecord_Spec
--------------------------------------------------------
+DnsZonesMXRecord_Spec{#DnsZonesMXRecord_Spec}
+---------------------------------------------
 
 Used by: [DnsZonesMXRecord](#DnsZonesMXRecord).
 
@@ -980,8 +980,8 @@ Used by: [DnsZonesMXRecord](#DnsZonesMXRecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesMXRecord_STATUS"></a>DnsZonesMXRecord_STATUS
------------------------------------------------------------
+DnsZonesMXRecord_STATUS{#DnsZonesMXRecord_STATUS}
+-------------------------------------------------
 
 Used by: [DnsZonesMXRecord](#DnsZonesMXRecord).
 
@@ -1008,8 +1008,8 @@ Used by: [DnsZonesMXRecord](#DnsZonesMXRecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesNSRecord_Spec"></a>DnsZonesNSRecord_Spec
--------------------------------------------------------
+DnsZonesNSRecord_Spec{#DnsZonesNSRecord_Spec}
+---------------------------------------------
 
 Used by: [DnsZonesNSRecord](#DnsZonesNSRecord).
 
@@ -1032,8 +1032,8 @@ Used by: [DnsZonesNSRecord](#DnsZonesNSRecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesNSRecord_STATUS"></a>DnsZonesNSRecord_STATUS
------------------------------------------------------------
+DnsZonesNSRecord_STATUS{#DnsZonesNSRecord_STATUS}
+-------------------------------------------------
 
 Used by: [DnsZonesNSRecord](#DnsZonesNSRecord).
 
@@ -1060,8 +1060,8 @@ Used by: [DnsZonesNSRecord](#DnsZonesNSRecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesPTRRecord_Spec"></a>DnsZonesPTRRecord_Spec
----------------------------------------------------------
+DnsZonesPTRRecord_Spec{#DnsZonesPTRRecord_Spec}
+-----------------------------------------------
 
 Used by: [DnsZonesPTRRecord](#DnsZonesPTRRecord).
 
@@ -1084,8 +1084,8 @@ Used by: [DnsZonesPTRRecord](#DnsZonesPTRRecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesPTRRecord_STATUS"></a>DnsZonesPTRRecord_STATUS
--------------------------------------------------------------
+DnsZonesPTRRecord_STATUS{#DnsZonesPTRRecord_STATUS}
+---------------------------------------------------
 
 Used by: [DnsZonesPTRRecord](#DnsZonesPTRRecord).
 
@@ -1112,8 +1112,8 @@ Used by: [DnsZonesPTRRecord](#DnsZonesPTRRecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesSRVRecord_Spec"></a>DnsZonesSRVRecord_Spec
----------------------------------------------------------
+DnsZonesSRVRecord_Spec{#DnsZonesSRVRecord_Spec}
+-----------------------------------------------
 
 Used by: [DnsZonesSRVRecord](#DnsZonesSRVRecord).
 
@@ -1136,8 +1136,8 @@ Used by: [DnsZonesSRVRecord](#DnsZonesSRVRecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesSRVRecord_STATUS"></a>DnsZonesSRVRecord_STATUS
--------------------------------------------------------------
+DnsZonesSRVRecord_STATUS{#DnsZonesSRVRecord_STATUS}
+---------------------------------------------------
 
 Used by: [DnsZonesSRVRecord](#DnsZonesSRVRecord).
 
@@ -1164,8 +1164,8 @@ Used by: [DnsZonesSRVRecord](#DnsZonesSRVRecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsZonesTXTRecord_Spec"></a>DnsZonesTXTRecord_Spec
----------------------------------------------------------
+DnsZonesTXTRecord_Spec{#DnsZonesTXTRecord_Spec}
+-----------------------------------------------
 
 Used by: [DnsZonesTXTRecord](#DnsZonesTXTRecord).
 
@@ -1188,8 +1188,8 @@ Used by: [DnsZonesTXTRecord](#DnsZonesTXTRecord).
 | TTL            | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                             | int<br/><small>Optional</small>                                                                                                                                      |
 | TXTRecords     | The list of TXT records in the record set.                                                                                                                                                                                                                                           | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="DnsZonesTXTRecord_STATUS"></a>DnsZonesTXTRecord_STATUS
--------------------------------------------------------------
+DnsZonesTXTRecord_STATUS{#DnsZonesTXTRecord_STATUS}
+---------------------------------------------------
 
 Used by: [DnsZonesTXTRecord](#DnsZonesTXTRecord).
 
@@ -1216,8 +1216,8 @@ Used by: [DnsZonesTXTRecord](#DnsZonesTXTRecord).
 | TXTRecords        | The list of TXT records in the record set.                                   | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the record set.                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AaaaRecord"></a>AaaaRecord
----------------------------------
+AaaaRecord{#AaaaRecord}
+-----------------------
 
 An AAAA record.
 
@@ -1227,8 +1227,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |-------------|---------------------------------------|------------------------------------|
 | ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
 
-<a id="AaaaRecord_STATUS"></a>AaaaRecord_STATUS
------------------------------------------------
+AaaaRecord_STATUS{#AaaaRecord_STATUS}
+-------------------------------------
 
 An AAAA record.
 
@@ -1238,8 +1238,8 @@ Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesAReco
 |-------------|---------------------------------------|------------------------------------|
 | ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
 
-<a id="ARecord"></a>ARecord
----------------------------
+ARecord{#ARecord}
+-----------------
 
 An A record.
 
@@ -1249,20 +1249,20 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |-------------|------------------------------------|------------------------------------|
 | ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
 
-<a id="ARecord_STATUS"></a>ARecord_STATUS
------------------------------------------
-
-An A record.
-
-Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
-
-| Property    | Description                        | Type                               |
-|-------------|------------------------------------|------------------------------------|
-| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
-
-<a id="CaaRecord"></a>CaaRecord
+ARecord_STATUS{#ARecord_STATUS}
 -------------------------------
 
+An A record.
+
+Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
+
+| Property    | Description                        | Type                               |
+|-------------|------------------------------------|------------------------------------|
+| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
+
+CaaRecord{#CaaRecord}
+---------------------
+
 A CAA record.
 
 Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
@@ -1273,22 +1273,22 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 | tag      | The tag for this CAA record.                                   | string<br/><small>Optional</small> |
 | value    | The value for this CAA record.                                 | string<br/><small>Optional</small> |
 
-<a id="CaaRecord_STATUS"></a>CaaRecord_STATUS
----------------------------------------------
-
-A CAA record.
-
-Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
-
-| Property | Description                                                    | Type                               |
-|----------|----------------------------------------------------------------|------------------------------------|
-| flags    | The flags for this CAA record as an integer between 0 and 255. | int<br/><small>Optional</small>    |
-| tag      | The tag for this CAA record.                                   | string<br/><small>Optional</small> |
-| value    | The value for this CAA record.                                 | string<br/><small>Optional</small> |
-
-<a id="CnameRecord"></a>CnameRecord
+CaaRecord_STATUS{#CaaRecord_STATUS}
 -----------------------------------
 
+A CAA record.
+
+Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
+
+| Property | Description                                                    | Type                               |
+|----------|----------------------------------------------------------------|------------------------------------|
+| flags    | The flags for this CAA record as an integer between 0 and 255. | int<br/><small>Optional</small>    |
+| tag      | The tag for this CAA record.                                   | string<br/><small>Optional</small> |
+| value    | The value for this CAA record.                                 | string<br/><small>Optional</small> |
+
+CnameRecord{#CnameRecord}
+-------------------------
+
 A CNAME record.
 
 Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
@@ -1297,8 +1297,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |----------|-------------------------------------------|------------------------------------|
 | cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
 
-<a id="CnameRecord_STATUS"></a>CnameRecord_STATUS
--------------------------------------------------
+CnameRecord_STATUS{#CnameRecord_STATUS}
+---------------------------------------
 
 A CNAME record.
 
@@ -1308,8 +1308,8 @@ Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesAReco
 |----------|-------------------------------------------|------------------------------------|
 | cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
 
-<a id="DnsZoneOperatorSpec"></a>DnsZoneOperatorSpec
----------------------------------------------------
+DnsZoneOperatorSpec{#DnsZoneOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1320,8 +1320,8 @@ Used by: [DnsZone_Spec](#DnsZone_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesAAAARecordOperatorSpec"></a>DnsZonesAAAARecordOperatorSpec
--------------------------------------------------------------------------
+DnsZonesAAAARecordOperatorSpec{#DnsZonesAAAARecordOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1332,8 +1332,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesARecordOperatorSpec"></a>DnsZonesARecordOperatorSpec
--------------------------------------------------------------------
+DnsZonesARecordOperatorSpec{#DnsZonesARecordOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1344,8 +1344,8 @@ Used by: [DnsZonesARecord_Spec](#DnsZonesARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesCAARecordOperatorSpec"></a>DnsZonesCAARecordOperatorSpec
------------------------------------------------------------------------
+DnsZonesCAARecordOperatorSpec{#DnsZonesCAARecordOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1356,8 +1356,8 @@ Used by: [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesCNAMERecordOperatorSpec"></a>DnsZonesCNAMERecordOperatorSpec
----------------------------------------------------------------------------
+DnsZonesCNAMERecordOperatorSpec{#DnsZonesCNAMERecordOperatorSpec}
+-----------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1368,8 +1368,8 @@ Used by: [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesMXRecordOperatorSpec"></a>DnsZonesMXRecordOperatorSpec
----------------------------------------------------------------------
+DnsZonesMXRecordOperatorSpec{#DnsZonesMXRecordOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1380,8 +1380,8 @@ Used by: [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesNSRecordOperatorSpec"></a>DnsZonesNSRecordOperatorSpec
----------------------------------------------------------------------
+DnsZonesNSRecordOperatorSpec{#DnsZonesNSRecordOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1392,8 +1392,8 @@ Used by: [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesPTRRecordOperatorSpec"></a>DnsZonesPTRRecordOperatorSpec
------------------------------------------------------------------------
+DnsZonesPTRRecordOperatorSpec{#DnsZonesPTRRecordOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1404,8 +1404,8 @@ Used by: [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesSRVRecordOperatorSpec"></a>DnsZonesSRVRecordOperatorSpec
------------------------------------------------------------------------
+DnsZonesSRVRecordOperatorSpec{#DnsZonesSRVRecordOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1416,8 +1416,8 @@ Used by: [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsZonesTXTRecordOperatorSpec"></a>DnsZonesTXTRecordOperatorSpec
------------------------------------------------------------------------
+DnsZonesTXTRecordOperatorSpec{#DnsZonesTXTRecordOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1428,8 +1428,8 @@ Used by: [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MxRecord"></a>MxRecord
------------------------------
+MxRecord{#MxRecord}
+-------------------
 
 An MX record.
 
@@ -1440,8 +1440,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 | exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
 | preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
 
-<a id="MxRecord_STATUS"></a>MxRecord_STATUS
--------------------------------------------
+MxRecord_STATUS{#MxRecord_STATUS}
+---------------------------------
 
 An MX record.
 
@@ -1452,8 +1452,8 @@ Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesAReco
 | exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
 | preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
 
-<a id="NsRecord"></a>NsRecord
------------------------------
+NsRecord{#NsRecord}
+-------------------
 
 An NS record.
 
@@ -1463,8 +1463,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |----------|------------------------------------------|------------------------------------|
 | nsdname  | The name server name for this NS record. | string<br/><small>Optional</small> |
 
-<a id="NsRecord_STATUS"></a>NsRecord_STATUS
--------------------------------------------
+NsRecord_STATUS{#NsRecord_STATUS}
+---------------------------------
 
 An NS record.
 
@@ -1474,8 +1474,8 @@ Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesAReco
 |----------|------------------------------------------|------------------------------------|
 | nsdname  | The name server name for this NS record. | string<br/><small>Optional</small> |
 
-<a id="PtrRecord"></a>PtrRecord
--------------------------------
+PtrRecord{#PtrRecord}
+---------------------
 
 A PTR record.
 
@@ -1485,81 +1485,81 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |----------|-------------------------------------------------|------------------------------------|
 | ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
 
-<a id="PtrRecord_STATUS"></a>PtrRecord_STATUS
----------------------------------------------
-
-A PTR record.
-
-Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
-
-| Property | Description                                     | Type                               |
-|----------|-------------------------------------------------|------------------------------------|
-| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
-
-<a id="SoaRecord"></a>SoaRecord
--------------------------------
-
-An SOA record.
-
-Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTTL   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SoaRecord_STATUS"></a>SoaRecord_STATUS
----------------------------------------------
-
-An SOA record.
-
-Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTTL   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord"></a>SrvRecord
--------------------------------
-
-An SRV record.
-
-Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord_STATUS"></a>SrvRecord_STATUS
----------------------------------------------
-
-An SRV record.
-
-Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SubResource"></a>SubResource
+PtrRecord_STATUS{#PtrRecord_STATUS}
 -----------------------------------
+
+A PTR record.
+
+Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
+
+| Property | Description                                     | Type                               |
+|----------|-------------------------------------------------|------------------------------------|
+| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
+
+SoaRecord{#SoaRecord}
+---------------------
+
+An SOA record.
+
+Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTTL   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SoaRecord_STATUS{#SoaRecord_STATUS}
+-----------------------------------
+
+An SOA record.
+
+Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTTL   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SrvRecord{#SrvRecord}
+---------------------
+
+An SRV record.
+
+Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_Spec](#DnsZonesARecord_Spec), [DnsZonesCAARecord_Spec](#DnsZonesCAARecord_Spec), [DnsZonesCNAMERecord_Spec](#DnsZonesCNAMERecord_Spec), [DnsZonesMXRecord_Spec](#DnsZonesMXRecord_Spec), [DnsZonesNSRecord_Spec](#DnsZonesNSRecord_Spec), [DnsZonesPTRRecord_Spec](#DnsZonesPTRRecord_Spec), [DnsZonesSRVRecord_Spec](#DnsZonesSRVRecord_Spec), and [DnsZonesTXTRecord_Spec](#DnsZonesTXTRecord_Spec).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SrvRecord_STATUS{#SrvRecord_STATUS}
+-----------------------------------
+
+An SRV record.
+
+Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesARecord_STATUS](#DnsZonesARecord_STATUS), [DnsZonesCAARecord_STATUS](#DnsZonesCAARecord_STATUS), [DnsZonesCNAMERecord_STATUS](#DnsZonesCNAMERecord_STATUS), [DnsZonesMXRecord_STATUS](#DnsZonesMXRecord_STATUS), [DnsZonesNSRecord_STATUS](#DnsZonesNSRecord_STATUS), [DnsZonesPTRRecord_STATUS](#DnsZonesPTRRecord_STATUS), [DnsZonesSRVRecord_STATUS](#DnsZonesSRVRecord_STATUS), and [DnsZonesTXTRecord_STATUS](#DnsZonesTXTRecord_STATUS).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SubResource{#SubResource}
+-------------------------
 
 A reference to a another resource
 
@@ -1569,8 +1569,8 @@ Used by: [DnsZone_Spec](#DnsZone_Spec), [DnsZone_Spec](#DnsZone_Spec), [DnsZones
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource Id. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 A reference to a another resource
 
@@ -1580,8 +1580,8 @@ Used by: [DnsZone_STATUS](#DnsZone_STATUS), [DnsZone_STATUS](#DnsZone_STATUS), [
 |----------|--------------|------------------------------------|
 | id       | Resource Id. | string<br/><small>Optional</small> |
 
-<a id="TxtRecord"></a>TxtRecord
--------------------------------
+TxtRecord{#TxtRecord}
+---------------------
 
 A TXT record.
 
@@ -1591,8 +1591,8 @@ Used by: [DnsZonesAAAARecord_Spec](#DnsZonesAAAARecord_Spec), [DnsZonesARecord_S
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="TxtRecord_STATUS"></a>TxtRecord_STATUS
----------------------------------------------
+TxtRecord_STATUS{#TxtRecord_STATUS}
+-----------------------------------
 
 A TXT record.
 
@@ -1602,8 +1602,8 @@ Used by: [DnsZonesAAAARecord_STATUS](#DnsZonesAAAARecord_STATUS), [DnsZonesAReco
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="ZoneProperties_ZoneType"></a>ZoneProperties_ZoneType
------------------------------------------------------------
+ZoneProperties_ZoneType{#ZoneProperties_ZoneType}
+-------------------------------------------------
 
 Used by: [DnsZone_Spec](#DnsZone_Spec).
 
@@ -1612,8 +1612,8 @@ Used by: [DnsZone_Spec](#DnsZone_Spec).
 | "Private" |             |
 | "Public"  |             |
 
-<a id="ZoneProperties_ZoneType_STATUS"></a>ZoneProperties_ZoneType_STATUS
--------------------------------------------------------------------------
+ZoneProperties_ZoneType_STATUS{#ZoneProperties_ZoneType_STATUS}
+---------------------------------------------------------------
 
 Used by: [DnsZone_STATUS](#DnsZone_STATUS).
 

--- a/docs/hugo/content/reference/network/v1api20180901.md
+++ b/docs/hugo/content/reference/network/v1api20180901.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20180901
 linktitle: v1api20180901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2018-09-01" |             |
 
-<a id="PrivateDnsZone"></a>PrivateDnsZone
------------------------------------------
+PrivateDnsZone{#PrivateDnsZone}
+-------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2018-09-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}
 
@@ -26,7 +26,7 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | spec                                                                                    |             | [PrivateDnsZone_Spec](#PrivateDnsZone_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZone_STATUS](#PrivateDnsZone_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZone_Spec"></a>PrivateDnsZone_Spec
+### PrivateDnsZone_Spec {#PrivateDnsZone_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="PrivateDnsZone_STATUS"></a>PrivateDnsZone_STATUS
+### PrivateDnsZone_STATUS{#PrivateDnsZone_STATUS}
 
 | Property                                       | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,8 +56,8 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | tags                                           | Resource tags.                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                           | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZoneList"></a>PrivateDnsZoneList
--------------------------------------------------
+PrivateDnsZoneList{#PrivateDnsZoneList}
+---------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2018-09-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}
 
@@ -67,8 +67,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PrivateDnsZone[]](#PrivateDnsZone)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZone_Spec"></a>PrivateDnsZone_Spec
----------------------------------------------------
+PrivateDnsZone_Spec{#PrivateDnsZone_Spec}
+-----------------------------------------
 
 Used by: [PrivateDnsZone](#PrivateDnsZone).
 
@@ -81,8 +81,8 @@ Used by: [PrivateDnsZone](#PrivateDnsZone).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="PrivateDnsZone_STATUS"></a>PrivateDnsZone_STATUS
--------------------------------------------------------
+PrivateDnsZone_STATUS{#PrivateDnsZone_STATUS}
+---------------------------------------------
 
 Used by: [PrivateDnsZone](#PrivateDnsZone).
 
@@ -103,8 +103,8 @@ Used by: [PrivateDnsZone](#PrivateDnsZone).
 | tags                                           | Resource tags.                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                           | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZoneOperatorSpec"></a>PrivateDnsZoneOperatorSpec
------------------------------------------------------------------
+PrivateDnsZoneOperatorSpec{#PrivateDnsZoneOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -115,8 +115,8 @@ Used by: [PrivateDnsZone_Spec](#PrivateDnsZone_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateZoneProperties_ProvisioningState_STATUS"></a>PrivateZoneProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+PrivateZoneProperties_ProvisioningState_STATUS{#PrivateZoneProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZone_STATUS](#PrivateDnsZone_STATUS).
 

--- a/docs/hugo/content/reference/network/v1api20200601.md
+++ b/docs/hugo/content/reference/network/v1api20200601.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20200601
 linktitle: v1api20200601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-06-01" |             |
 
-<a id="PrivateDnsZonesAAAARecord"></a>PrivateDnsZonesAAAARecord
----------------------------------------------------------------
+PrivateDnsZonesAAAARecord{#PrivateDnsZonesAAAARecord}
+-----------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/AAAA/{relativeRecordSetName}
 
@@ -26,7 +26,7 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | spec                                                                                    |             | [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesAAAARecord_Spec"></a>PrivateDnsZonesAAAARecord_Spec
+### PrivateDnsZonesAAAARecord_Spec {#PrivateDnsZonesAAAARecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesAAAARecord_STATUS"></a>PrivateDnsZonesAAAARecord_STATUS
+### PrivateDnsZonesAAAARecord_STATUS{#PrivateDnsZonesAAAARecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -67,8 +67,8 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesAAAARecordList"></a>PrivateDnsZonesAAAARecordList
------------------------------------------------------------------------
+PrivateDnsZonesAAAARecordList{#PrivateDnsZonesAAAARecordList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/AAAA/{relativeRecordSetName}
 
@@ -78,8 +78,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [PrivateDnsZonesAAAARecord[]](#PrivateDnsZonesAAAARecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesARecord"></a>PrivateDnsZonesARecord
----------------------------------------------------------
+PrivateDnsZonesARecord{#PrivateDnsZonesARecord}
+-----------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/A/{relativeRecordSetName}
 
@@ -92,7 +92,7 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | spec                                                                                    |             | [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesARecord_Spec"></a>PrivateDnsZonesARecord_Spec
+### PrivateDnsZonesARecord_Spec {#PrivateDnsZonesARecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesARecord_STATUS"></a>PrivateDnsZonesARecord_STATUS
+### PrivateDnsZonesARecord_STATUS{#PrivateDnsZonesARecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -133,8 +133,8 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesARecordList"></a>PrivateDnsZonesARecordList
------------------------------------------------------------------
+PrivateDnsZonesARecordList{#PrivateDnsZonesARecordList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/A/{relativeRecordSetName}
 
@@ -144,8 +144,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [PrivateDnsZonesARecord[]](#PrivateDnsZonesARecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesCNAMERecord"></a>PrivateDnsZonesCNAMERecord
------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord{#PrivateDnsZonesCNAMERecord}
+-------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/CNAME/{relativeRecordSetName}
 
@@ -158,7 +158,7 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | spec                                                                                    |             | [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesCNAMERecord_Spec"></a>PrivateDnsZonesCNAMERecord_Spec
+### PrivateDnsZonesCNAMERecord_Spec {#PrivateDnsZonesCNAMERecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -177,7 +177,7 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesCNAMERecord_STATUS"></a>PrivateDnsZonesCNAMERecord_STATUS
+### PrivateDnsZonesCNAMERecord_STATUS{#PrivateDnsZonesCNAMERecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -199,8 +199,8 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesCNAMERecordList"></a>PrivateDnsZonesCNAMERecordList
--------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecordList{#PrivateDnsZonesCNAMERecordList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/CNAME/{relativeRecordSetName}
 
@@ -210,8 +210,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [PrivateDnsZonesCNAMERecord[]](#PrivateDnsZonesCNAMERecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesMXRecord"></a>PrivateDnsZonesMXRecord
------------------------------------------------------------
+PrivateDnsZonesMXRecord{#PrivateDnsZonesMXRecord}
+-------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/MX/{relativeRecordSetName}
 
@@ -224,7 +224,7 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesMXRecord_Spec"></a>PrivateDnsZonesMXRecord_Spec
+### PrivateDnsZonesMXRecord_Spec {#PrivateDnsZonesMXRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,7 +243,7 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesMXRecord_STATUS"></a>PrivateDnsZonesMXRecord_STATUS
+### PrivateDnsZonesMXRecord_STATUS{#PrivateDnsZonesMXRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -265,8 +265,8 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesMXRecordList"></a>PrivateDnsZonesMXRecordList
--------------------------------------------------------------------
+PrivateDnsZonesMXRecordList{#PrivateDnsZonesMXRecordList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/MX/{relativeRecordSetName}
 
@@ -276,8 +276,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [PrivateDnsZonesMXRecord[]](#PrivateDnsZonesMXRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesPTRRecord"></a>PrivateDnsZonesPTRRecord
--------------------------------------------------------------
+PrivateDnsZonesPTRRecord{#PrivateDnsZonesPTRRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/PTR/{relativeRecordSetName}
 
@@ -290,7 +290,7 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesPTRRecord_Spec"></a>PrivateDnsZonesPTRRecord_Spec
+### PrivateDnsZonesPTRRecord_Spec {#PrivateDnsZonesPTRRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -309,7 +309,7 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesPTRRecord_STATUS"></a>PrivateDnsZonesPTRRecord_STATUS
+### PrivateDnsZonesPTRRecord_STATUS{#PrivateDnsZonesPTRRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -331,8 +331,8 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesPTRRecordList"></a>PrivateDnsZonesPTRRecordList
----------------------------------------------------------------------
+PrivateDnsZonesPTRRecordList{#PrivateDnsZonesPTRRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/PTR/{relativeRecordSetName}
 
@@ -342,8 +342,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesPTRRecord[]](#PrivateDnsZonesPTRRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesSRVRecord"></a>PrivateDnsZonesSRVRecord
--------------------------------------------------------------
+PrivateDnsZonesSRVRecord{#PrivateDnsZonesSRVRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/SRV/{relativeRecordSetName}
 
@@ -356,7 +356,7 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesSRVRecord_Spec"></a>PrivateDnsZonesSRVRecord_Spec
+### PrivateDnsZonesSRVRecord_Spec {#PrivateDnsZonesSRVRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -375,7 +375,7 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesSRVRecord_STATUS"></a>PrivateDnsZonesSRVRecord_STATUS
+### PrivateDnsZonesSRVRecord_STATUS{#PrivateDnsZonesSRVRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -397,8 +397,8 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesSRVRecordList"></a>PrivateDnsZonesSRVRecordList
----------------------------------------------------------------------
+PrivateDnsZonesSRVRecordList{#PrivateDnsZonesSRVRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/SRV/{relativeRecordSetName}
 
@@ -408,8 +408,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesSRVRecord[]](#PrivateDnsZonesSRVRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesTXTRecord"></a>PrivateDnsZonesTXTRecord
--------------------------------------------------------------
+PrivateDnsZonesTXTRecord{#PrivateDnsZonesTXTRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/TXT/{relativeRecordSetName}
 
@@ -422,7 +422,7 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesTXTRecord_Spec"></a>PrivateDnsZonesTXTRecord_Spec
+### PrivateDnsZonesTXTRecord_Spec {#PrivateDnsZonesTXTRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -441,7 +441,7 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesTXTRecord_STATUS"></a>PrivateDnsZonesTXTRecord_STATUS
+### PrivateDnsZonesTXTRecord_STATUS{#PrivateDnsZonesTXTRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -463,8 +463,8 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesTXTRecordList"></a>PrivateDnsZonesTXTRecordList
----------------------------------------------------------------------
+PrivateDnsZonesTXTRecordList{#PrivateDnsZonesTXTRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/TXT/{relativeRecordSetName}
 
@@ -474,8 +474,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesTXTRecord[]](#PrivateDnsZonesTXTRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLink"></a>PrivateDnsZonesVirtualNetworkLink
--------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink{#PrivateDnsZonesVirtualNetworkLink}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -488,7 +488,7 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | spec                                                                                    |             | [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetworkLink_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesVirtualNetworkLink_Spec"></a>PrivateDnsZonesVirtualNetworkLink_Spec
+### PrivateDnsZonesVirtualNetworkLink_Spec {#PrivateDnsZonesVirtualNetworkLink_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -501,7 +501,7 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | tags                | Resource tags.                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork      | The reference of the virtual network.                                                                                                                                                                                                                                                       | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 
-### <a id="PrivateDnsZonesVirtualNetworkLink_STATUS"></a>PrivateDnsZonesVirtualNetworkLink_STATUS
+### PrivateDnsZonesVirtualNetworkLink_STATUS{#PrivateDnsZonesVirtualNetworkLink_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -517,8 +517,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | virtualNetwork          | The reference of the virtual network.                                                                                                                                                                                                                                                          | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | virtualNetworkLinkState | The status of the virtual network link to the Private DNS zone. Possible values are 'InProgress' and 'Done'. This is a read-only property and any attempt to set this value will be ignored.                                                                                                   | [VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS](#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLinkList"></a>PrivateDnsZonesVirtualNetworkLinkList
----------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLinkList{#PrivateDnsZonesVirtualNetworkLinkList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -528,8 +528,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [PrivateDnsZonesVirtualNetworkLink[]](#PrivateDnsZonesVirtualNetworkLink)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesAAAARecord_Spec"></a>PrivateDnsZonesAAAARecord_Spec
--------------------------------------------------------------------------
+PrivateDnsZonesAAAARecord_Spec{#PrivateDnsZonesAAAARecord_Spec}
+---------------------------------------------------------------
 
 Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 
@@ -550,8 +550,8 @@ Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesAAAARecord_STATUS"></a>PrivateDnsZonesAAAARecord_STATUS
------------------------------------------------------------------------------
+PrivateDnsZonesAAAARecord_STATUS{#PrivateDnsZonesAAAARecord_STATUS}
+-------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 
@@ -575,8 +575,8 @@ Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesARecord_Spec"></a>PrivateDnsZonesARecord_Spec
--------------------------------------------------------------------
+PrivateDnsZonesARecord_Spec{#PrivateDnsZonesARecord_Spec}
+---------------------------------------------------------
 
 Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 
@@ -597,8 +597,8 @@ Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesARecord_STATUS"></a>PrivateDnsZonesARecord_STATUS
------------------------------------------------------------------------
+PrivateDnsZonesARecord_STATUS{#PrivateDnsZonesARecord_STATUS}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 
@@ -622,8 +622,8 @@ Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesCNAMERecord_Spec"></a>PrivateDnsZonesCNAMERecord_Spec
----------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord_Spec{#PrivateDnsZonesCNAMERecord_Spec}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 
@@ -644,8 +644,8 @@ Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesCNAMERecord_STATUS"></a>PrivateDnsZonesCNAMERecord_STATUS
--------------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord_STATUS{#PrivateDnsZonesCNAMERecord_STATUS}
+---------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 
@@ -669,8 +669,8 @@ Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesMXRecord_Spec"></a>PrivateDnsZonesMXRecord_Spec
----------------------------------------------------------------------
+PrivateDnsZonesMXRecord_Spec{#PrivateDnsZonesMXRecord_Spec}
+-----------------------------------------------------------
 
 Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 
@@ -691,8 +691,8 @@ Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesMXRecord_STATUS"></a>PrivateDnsZonesMXRecord_STATUS
--------------------------------------------------------------------------
+PrivateDnsZonesMXRecord_STATUS{#PrivateDnsZonesMXRecord_STATUS}
+---------------------------------------------------------------
 
 Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 
@@ -716,8 +716,8 @@ Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesPTRRecord_Spec"></a>PrivateDnsZonesPTRRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesPTRRecord_Spec{#PrivateDnsZonesPTRRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 
@@ -738,8 +738,8 @@ Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesPTRRecord_STATUS"></a>PrivateDnsZonesPTRRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesPTRRecord_STATUS{#PrivateDnsZonesPTRRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 
@@ -763,8 +763,8 @@ Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesSRVRecord_Spec"></a>PrivateDnsZonesSRVRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesSRVRecord_Spec{#PrivateDnsZonesSRVRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 
@@ -785,8 +785,8 @@ Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesSRVRecord_STATUS"></a>PrivateDnsZonesSRVRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesSRVRecord_STATUS{#PrivateDnsZonesSRVRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 
@@ -810,8 +810,8 @@ Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesTXTRecord_Spec"></a>PrivateDnsZonesTXTRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesTXTRecord_Spec{#PrivateDnsZonesTXTRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 
@@ -832,8 +832,8 @@ Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesTXTRecord_STATUS"></a>PrivateDnsZonesTXTRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesTXTRecord_STATUS{#PrivateDnsZonesTXTRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 
@@ -857,8 +857,8 @@ Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesVirtualNetworkLink_Spec"></a>PrivateDnsZonesVirtualNetworkLink_Spec
------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink_Spec{#PrivateDnsZonesVirtualNetworkLink_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink).
 
@@ -873,8 +873,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink)
 | tags                | Resource tags.                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork      | The reference of the virtual network.                                                                                                                                                                                                                                                       | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 
-<a id="PrivateDnsZonesVirtualNetworkLink_STATUS"></a>PrivateDnsZonesVirtualNetworkLink_STATUS
----------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink_STATUS{#PrivateDnsZonesVirtualNetworkLink_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink).
 
@@ -892,87 +892,87 @@ Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink)
 | virtualNetwork          | The reference of the virtual network.                                                                                                                                                                                                                                                          | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | virtualNetworkLinkState | The status of the virtual network link to the Private DNS zone. Possible values are 'InProgress' and 'Done'. This is a read-only property and any attempt to set this value will be ignored.                                                                                                   | [VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS](#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS)<br/><small>Optional</small> |
 
-<a id="AaaaRecord"></a>AaaaRecord
+AaaaRecord{#AaaaRecord}
+-----------------------
+
+An AAAA record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property    | Description                           | Type                               |
+|-------------|---------------------------------------|------------------------------------|
+| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
+
+AaaaRecord_STATUS{#AaaaRecord_STATUS}
+-------------------------------------
+
+An AAAA record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property    | Description                           | Type                               |
+|-------------|---------------------------------------|------------------------------------|
+| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
+
+ARecord{#ARecord}
+-----------------
+
+An A record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property    | Description                        | Type                               |
+|-------------|------------------------------------|------------------------------------|
+| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
+
+ARecord_STATUS{#ARecord_STATUS}
+-------------------------------
+
+An A record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property    | Description                        | Type                               |
+|-------------|------------------------------------|------------------------------------|
+| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
+
+CnameRecord{#CnameRecord}
+-------------------------
+
+A CNAME record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property | Description                               | Type                               |
+|----------|-------------------------------------------|------------------------------------|
+| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
+
+CnameRecord_STATUS{#CnameRecord_STATUS}
+---------------------------------------
+
+A CNAME record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                               | Type                               |
+|----------|-------------------------------------------|------------------------------------|
+| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
+
+MxRecord{#MxRecord}
+-------------------
+
+An MX record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property   | Description                                          | Type                               |
+|------------|------------------------------------------------------|------------------------------------|
+| exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
+| preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
+
+MxRecord_STATUS{#MxRecord_STATUS}
 ---------------------------------
 
-An AAAA record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property    | Description                           | Type                               |
-|-------------|---------------------------------------|------------------------------------|
-| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
-
-<a id="AaaaRecord_STATUS"></a>AaaaRecord_STATUS
------------------------------------------------
-
-An AAAA record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property    | Description                           | Type                               |
-|-------------|---------------------------------------|------------------------------------|
-| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
-
-<a id="ARecord"></a>ARecord
----------------------------
-
-An A record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property    | Description                        | Type                               |
-|-------------|------------------------------------|------------------------------------|
-| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
-
-<a id="ARecord_STATUS"></a>ARecord_STATUS
------------------------------------------
-
-An A record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property    | Description                        | Type                               |
-|-------------|------------------------------------|------------------------------------|
-| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
-
-<a id="CnameRecord"></a>CnameRecord
------------------------------------
-
-A CNAME record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property | Description                               | Type                               |
-|----------|-------------------------------------------|------------------------------------|
-| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
-
-<a id="CnameRecord_STATUS"></a>CnameRecord_STATUS
--------------------------------------------------
-
-A CNAME record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                               | Type                               |
-|----------|-------------------------------------------|------------------------------------|
-| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
-
-<a id="MxRecord"></a>MxRecord
------------------------------
-
-An MX record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property   | Description                                          | Type                               |
-|------------|------------------------------------------------------|------------------------------------|
-| exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
-| preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
-
-<a id="MxRecord_STATUS"></a>MxRecord_STATUS
--------------------------------------------
-
 An MX record.
 
 Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
@@ -982,8 +982,8 @@ Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), 
 | exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
 | preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
 
-<a id="PrivateDnsZonesAAAARecordOperatorSpec"></a>PrivateDnsZonesAAAARecordOperatorSpec
----------------------------------------------------------------------------------------
+PrivateDnsZonesAAAARecordOperatorSpec{#PrivateDnsZonesAAAARecordOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -994,8 +994,8 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesARecordOperatorSpec"></a>PrivateDnsZonesARecordOperatorSpec
----------------------------------------------------------------------------------
+PrivateDnsZonesARecordOperatorSpec{#PrivateDnsZonesARecordOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1006,8 +1006,8 @@ Used by: [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesCNAMERecordOperatorSpec"></a>PrivateDnsZonesCNAMERecordOperatorSpec
------------------------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecordOperatorSpec{#PrivateDnsZonesCNAMERecordOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1018,8 +1018,8 @@ Used by: [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesMXRecordOperatorSpec"></a>PrivateDnsZonesMXRecordOperatorSpec
------------------------------------------------------------------------------------
+PrivateDnsZonesMXRecordOperatorSpec{#PrivateDnsZonesMXRecordOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1030,8 +1030,8 @@ Used by: [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesPTRRecordOperatorSpec"></a>PrivateDnsZonesPTRRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesPTRRecordOperatorSpec{#PrivateDnsZonesPTRRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1042,8 +1042,8 @@ Used by: [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesSRVRecordOperatorSpec"></a>PrivateDnsZonesSRVRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesSRVRecordOperatorSpec{#PrivateDnsZonesSRVRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1054,8 +1054,8 @@ Used by: [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesTXTRecordOperatorSpec"></a>PrivateDnsZonesTXTRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesTXTRecordOperatorSpec{#PrivateDnsZonesTXTRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1066,8 +1066,8 @@ Used by: [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLinkOperatorSpec"></a>PrivateDnsZonesVirtualNetworkLinkOperatorSpec
--------------------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLinkOperatorSpec{#PrivateDnsZonesVirtualNetworkLinkOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1078,8 +1078,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetwork
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PtrRecord"></a>PtrRecord
--------------------------------
+PtrRecord{#PtrRecord}
+---------------------
 
 A PTR record.
 
@@ -1089,81 +1089,81 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [Pri
 |----------|-------------------------------------------------|------------------------------------|
 | ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
 
-<a id="PtrRecord_STATUS"></a>PtrRecord_STATUS
----------------------------------------------
-
-A PTR record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                                     | Type                               |
-|----------|-------------------------------------------------|------------------------------------|
-| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
-
-<a id="SoaRecord"></a>SoaRecord
--------------------------------
-
-An SOA record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SoaRecord_STATUS"></a>SoaRecord_STATUS
----------------------------------------------
-
-An SOA record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord"></a>SrvRecord
--------------------------------
-
-An SRV record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord_STATUS"></a>SrvRecord_STATUS
----------------------------------------------
-
-An SRV record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SubResource"></a>SubResource
+PtrRecord_STATUS{#PtrRecord_STATUS}
 -----------------------------------
+
+A PTR record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                                     | Type                               |
+|----------|-------------------------------------------------|------------------------------------|
+| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
+
+SoaRecord{#SoaRecord}
+---------------------
+
+An SOA record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SoaRecord_STATUS{#SoaRecord_STATUS}
+-----------------------------------
+
+An SOA record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SrvRecord{#SrvRecord}
+---------------------
+
+An SRV record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SrvRecord_STATUS{#SrvRecord_STATUS}
+-----------------------------------
+
+An SRV record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SubResource{#SubResource}
+-------------------------
 
 Reference to another subresource.
 
@@ -1173,8 +1173,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetwork
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another subresource.
 
@@ -1184,8 +1184,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetwo
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="TxtRecord"></a>TxtRecord
--------------------------------
+TxtRecord{#TxtRecord}
+---------------------
 
 A TXT record.
 
@@ -1195,8 +1195,8 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [Pri
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="TxtRecord_STATUS"></a>TxtRecord_STATUS
----------------------------------------------
+TxtRecord_STATUS{#TxtRecord_STATUS}
+-----------------------------------
 
 A TXT record.
 
@@ -1206,8 +1206,8 @@ Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), 
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="VirtualNetworkLinkProperties_ProvisioningState_STATUS"></a>VirtualNetworkLinkProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_ProvisioningState_STATUS{#VirtualNetworkLinkProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS).
 
@@ -1220,8 +1220,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetwo
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS"></a>VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS{#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS).
 

--- a/docs/hugo/content/reference/network/v1api20201101.md
+++ b/docs/hugo/content/reference/network/v1api20201101.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20201101
 linktitle: v1api20201101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-11-01" |             |
 
-<a id="LoadBalancer"></a>LoadBalancer
--------------------------------------
+LoadBalancer{#LoadBalancer}
+---------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}
 
@@ -26,7 +26,7 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | spec                                                                                    |             | [LoadBalancer_Spec](#LoadBalancer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [LoadBalancer_STATUS](#LoadBalancer_STATUS)<br/><small>Optional</small> |
 
-### <a id="LoadBalancer_Spec"></a>LoadBalancer_Spec
+### LoadBalancer_Spec {#LoadBalancer_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | sku                      | The load balancer SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [LoadBalancerSku](#LoadBalancerSku)<br/><small>Optional</small>                                                                                                      |
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="LoadBalancer_STATUS"></a>LoadBalancer_STATUS
+### LoadBalancer_STATUS{#LoadBalancer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                              |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -68,8 +68,8 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                     |
 | type                     | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="LoadBalancerList"></a>LoadBalancerList
----------------------------------------------
+LoadBalancerList{#LoadBalancerList}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}
 
@@ -79,8 +79,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [LoadBalancer[]](#LoadBalancer)<br/><small>Optional</small> |
 
-<a id="LoadBalancersInboundNatRule"></a>LoadBalancersInboundNatRule
--------------------------------------------------------------------
+LoadBalancersInboundNatRule{#LoadBalancersInboundNatRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}
 
@@ -93,7 +93,7 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | spec                                                                                    |             | [LoadBalancersInboundNatRule_Spec](#LoadBalancersInboundNatRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [LoadBalancersInboundNatRule_STATUS](#LoadBalancersInboundNatRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="LoadBalancersInboundNatRule_Spec"></a>LoadBalancersInboundNatRule_Spec
+### LoadBalancersInboundNatRule_Spec {#LoadBalancersInboundNatRule_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -108,7 +108,7 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/LoadBalancer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                                  | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small>                                                                                                  |
 
-### <a id="LoadBalancersInboundNatRule_STATUS"></a>LoadBalancersInboundNatRule_STATUS
+### LoadBalancersInboundNatRule_STATUS{#LoadBalancersInboundNatRule_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                                                            |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -127,8 +127,8 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="LoadBalancersInboundNatRuleList"></a>LoadBalancersInboundNatRuleList
----------------------------------------------------------------------------
+LoadBalancersInboundNatRuleList{#LoadBalancersInboundNatRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}
 
@@ -138,8 +138,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [LoadBalancersInboundNatRule[]](#LoadBalancersInboundNatRule)<br/><small>Optional</small> |
 
-<a id="NetworkInterface"></a>NetworkInterface
----------------------------------------------
+NetworkInterface{#NetworkInterface}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkInterface.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkInterfaces/{networkInterfaceName}
 
@@ -152,7 +152,7 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | spec                                                                                    |             | [NetworkInterface_Spec](#NetworkInterface_Spec)<br/><small>Optional</small>                                                                               |
 | status                                                                                  |             | [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="NetworkInterface_Spec"></a>NetworkInterface_Spec
+### NetworkInterface_Spec {#NetworkInterface_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                        |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -170,7 +170,7 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | privateLinkService          | Privatelinkservice of the network interface resource.                                                                                                                                                                                                                                        | [PrivateLinkServiceSpec](#PrivateLinkServiceSpec)<br/><small>Optional</small>                                                                                               |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                               |
 
-### <a id="NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded
+### NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded}
 
 | Property                    | Description                                                                     | Type                                                                                                                                                                                        |
 |-----------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -200,8 +200,8 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | type                        | Resource type.                                                                  | string<br/><small>Optional</small>                                                                                                                                                          |
 | virtualMachine              | The reference to a virtual machine.                                             | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                       |
 
-<a id="NetworkInterfaceList"></a>NetworkInterfaceList
------------------------------------------------------
+NetworkInterfaceList{#NetworkInterfaceList}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkInterface.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkInterfaces/{networkInterfaceName}
 
@@ -211,8 +211,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [NetworkInterface[]](#NetworkInterface)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup"></a>NetworkSecurityGroup
------------------------------------------------------
+NetworkSecurityGroup{#NetworkSecurityGroup}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}
 
@@ -225,7 +225,7 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | spec                                                                                    |             | [NetworkSecurityGroup_Spec](#NetworkSecurityGroup_Spec)<br/><small>Optional</small>                                                                                       |
 | status                                                                                  |             | [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="NetworkSecurityGroup_Spec"></a>NetworkSecurityGroup_Spec
+### NetworkSecurityGroup_Spec {#NetworkSecurityGroup_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -235,7 +235,7 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded
+### NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
 
 | Property             | Description                                                              | Type                                                                                                                                                                |
 |----------------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -253,8 +253,8 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | tags                 | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                                       |
 | type                 | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="NetworkSecurityGroupList"></a>NetworkSecurityGroupList
--------------------------------------------------------------
+NetworkSecurityGroupList{#NetworkSecurityGroupList}
+---------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}
 
@@ -264,8 +264,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [NetworkSecurityGroup[]](#NetworkSecurityGroup)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupsSecurityRule"></a>NetworkSecurityGroupsSecurityRule
--------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule{#NetworkSecurityGroupsSecurityRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}
 
@@ -278,7 +278,7 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | spec                                                                                    |             | [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurityRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecurityRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NetworkSecurityGroupsSecurityRule_Spec"></a>NetworkSecurityGroupsSecurityRule_Spec
+### NetworkSecurityGroupsSecurityRule_Spec {#NetworkSecurityGroupsSecurityRule_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                                                      |
 |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -301,7 +301,7 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | sourcePortRange                      | The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                        |
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                                                      |
 
-### <a id="NetworkSecurityGroupsSecurityRule_STATUS"></a>NetworkSecurityGroupsSecurityRule_STATUS
+### NetworkSecurityGroupsSecurityRule_STATUS{#NetworkSecurityGroupsSecurityRule_STATUS}
 
 | Property                             | Description                                                                                                                                                                                                                                                  | Type                                                                                                                                                                                                            |
 |--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -327,8 +327,8 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                                                            |
 | type                                 | The type of the resource.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="NetworkSecurityGroupsSecurityRuleList"></a>NetworkSecurityGroupsSecurityRuleList
----------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRuleList{#NetworkSecurityGroupsSecurityRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}
 
@@ -338,8 +338,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NetworkSecurityGroupsSecurityRule[]](#NetworkSecurityGroupsSecurityRule)<br/><small>Optional</small> |
 
-<a id="PublicIPAddress"></a>PublicIPAddress
--------------------------------------------
+PublicIPAddress{#PublicIPAddress}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/publicIpAddress.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPAddresses/{publicIpAddressName}
 
@@ -352,7 +352,7 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | spec                                                                                    |             | [PublicIPAddress_Spec](#PublicIPAddress_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PublicIPAddress_STATUS](#PublicIPAddress_STATUS)<br/><small>Optional</small> |
 
-### <a id="PublicIPAddress_Spec"></a>PublicIPAddress_Spec
+### PublicIPAddress_Spec {#PublicIPAddress_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -376,7 +376,7 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="PublicIPAddress_STATUS"></a>PublicIPAddress_STATUS
+### PublicIPAddress_STATUS{#PublicIPAddress_STATUS}
 
 | Property                 | Description                                                                                 | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -404,8 +404,8 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | type                     | Resource type.                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PublicIPAddressList"></a>PublicIPAddressList
----------------------------------------------------
+PublicIPAddressList{#PublicIPAddressList}
+-----------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/publicIpAddress.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPAddresses/{publicIpAddressName}
 
@@ -415,8 +415,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [PublicIPAddress[]](#PublicIPAddress)<br/><small>Optional</small> |
 
-<a id="RouteTable"></a>RouteTable
----------------------------------
+RouteTable{#RouteTable}
+-----------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}
 
@@ -429,7 +429,7 @@ Used by: [RouteTableList](#RouteTableList).
 | spec                                                                                    |             | [RouteTable_Spec](#RouteTable_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RouteTable_STATUS](#RouteTable_STATUS)<br/><small>Optional</small> |
 
-### <a id="RouteTable_Spec"></a>RouteTable_Spec
+### RouteTable_Spec {#RouteTable_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -440,7 +440,7 @@ Used by: [RouteTableList](#RouteTableList).
 | owner                      | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="RouteTable_STATUS"></a>RouteTable_STATUS
+### RouteTable_STATUS{#RouteTable_STATUS}
 
 | Property                   | Description                                                                           | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -455,8 +455,8 @@ Used by: [RouteTableList](#RouteTableList).
 | tags                       | Resource tags.                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Resource type.                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTableList"></a>RouteTableList
------------------------------------------
+RouteTableList{#RouteTableList}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}
 
@@ -466,8 +466,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [RouteTable[]](#RouteTable)<br/><small>Optional</small> |
 
-<a id="RouteTablesRoute"></a>RouteTablesRoute
----------------------------------------------
+RouteTablesRoute{#RouteTablesRoute}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}
 
@@ -480,7 +480,7 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | spec                                                                                    |             | [RouteTablesRoute_Spec](#RouteTablesRoute_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RouteTablesRoute_STATUS](#RouteTablesRoute_STATUS)<br/><small>Optional</small> |
 
-### <a id="RouteTablesRoute_Spec"></a>RouteTablesRoute_Spec
+### RouteTablesRoute_Spec {#RouteTablesRoute_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -491,7 +491,7 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                         | [RouteTablesRouteOperatorSpec](#RouteTablesRouteOperatorSpec)<br/><small>Optional</small>                                                                            |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/RouteTable resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="RouteTablesRoute_STATUS"></a>RouteTablesRoute_STATUS
+### RouteTablesRoute_STATUS{#RouteTablesRoute_STATUS}
 
 | Property          | Description                                                                                                                            | Type                                                                                                                                                    |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -506,8 +506,8 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | provisioningState | The provisioning state of the route resource.                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 | type              | The type of the resource.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTablesRouteList"></a>RouteTablesRouteList
------------------------------------------------------
+RouteTablesRouteList{#RouteTablesRouteList}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}
 
@@ -517,8 +517,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [RouteTablesRoute[]](#RouteTablesRoute)<br/><small>Optional</small> |
 
-<a id="VirtualNetwork"></a>VirtualNetwork
------------------------------------------
+VirtualNetwork{#VirtualNetwork}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}
 
@@ -531,7 +531,7 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | spec                                                                                    |             | [VirtualNetwork_Spec](#VirtualNetwork_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetwork_STATUS](#VirtualNetwork_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetwork_Spec"></a>VirtualNetwork_Spec
+### VirtualNetwork_Spec {#VirtualNetwork_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -549,7 +549,7 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | owner                | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="VirtualNetwork_STATUS"></a>VirtualNetwork_STATUS
+### VirtualNetwork_STATUS{#VirtualNetwork_STATUS}
 
 | Property             | Description                                                                                                                                                      | Type                                                                                                                                                    |
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -571,8 +571,8 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | tags                 | Resource tags.                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetworkGateway"></a>VirtualNetworkGateway
--------------------------------------------------------
+VirtualNetworkGateway{#VirtualNetworkGateway}
+---------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetworkGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}
 
@@ -585,7 +585,7 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | spec                                                                                    |             | [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworkGateway_Spec"></a>VirtualNetworkGateway_Spec
+### VirtualNetworkGateway_Spec {#VirtualNetworkGateway_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -610,7 +610,7 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | vpnGatewayGeneration                  | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                                                                                                                                       | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration)<br/><small>Optional</small>                |
 | vpnType                               | The type of this virtual network gateway.                                                                                                                                                                                                                                                    | [VirtualNetworkGatewayPropertiesFormat_VpnType](#VirtualNetworkGatewayPropertiesFormat_VpnType)<br/><small>Optional</small>                                          |
 
-### <a id="VirtualNetworkGateway_STATUS"></a>VirtualNetworkGateway_STATUS
+### VirtualNetworkGateway_STATUS{#VirtualNetworkGateway_STATUS}
 
 | Property                       | Description                                                                                                                                                                       | Type                                                                                                                                                                |
 |--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -640,8 +640,8 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | vpnGatewayGeneration           | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                            | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS)<br/><small>Optional</small> |
 | vpnType                        | The type of this virtual network gateway.                                                                                                                                         | [VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS)<br/><small>Optional</small>                           |
 
-<a id="VirtualNetworkGatewayList"></a>VirtualNetworkGatewayList
----------------------------------------------------------------
+VirtualNetworkGatewayList{#VirtualNetworkGatewayList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetworkGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}
 
@@ -651,8 +651,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [VirtualNetworkGateway[]](#VirtualNetworkGateway)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkList"></a>VirtualNetworkList
--------------------------------------------------
+VirtualNetworkList{#VirtualNetworkList}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}
 
@@ -662,8 +662,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [VirtualNetwork[]](#VirtualNetwork)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksSubnet"></a>VirtualNetworksSubnet
--------------------------------------------------------
+VirtualNetworksSubnet{#VirtualNetworksSubnet}
+---------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 
@@ -676,7 +676,7 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | spec                                                                                    |             | [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworksSubnet_Spec"></a>VirtualNetworksSubnet_Spec
+### VirtualNetworksSubnet_Spec {#VirtualNetworksSubnet_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                                        |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -696,7 +696,7 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | serviceEndpointPolicies            | An array of service endpoint policies.                                                                                                                                                                                                                                                      | [ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded[]](#ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded)<br/><small>Optional</small>                 |
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                                                                                                                                                              | [ServiceEndpointPropertiesFormat[]](#ServiceEndpointPropertiesFormat)<br/><small>Optional</small>                                                                                           |
 
-### <a id="VirtualNetworksSubnet_STATUS"></a>VirtualNetworksSubnet_STATUS
+### VirtualNetworksSubnet_STATUS{#VirtualNetworksSubnet_STATUS}
 
 | Property                           | Description                                                                                                                                     | Type                                                                                                                                                                                                      |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -725,8 +725,8 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                  | [ServiceEndpointPropertiesFormat_STATUS[]](#ServiceEndpointPropertiesFormat_STATUS)<br/><small>Optional</small>                                                                                           |
 | type                               | Resource type.                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                                                        |
 
-<a id="VirtualNetworksSubnetList"></a>VirtualNetworksSubnetList
----------------------------------------------------------------
+VirtualNetworksSubnetList{#VirtualNetworksSubnetList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 
@@ -736,8 +736,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [VirtualNetworksSubnet[]](#VirtualNetworksSubnet)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksVirtualNetworkPeering"></a>VirtualNetworksVirtualNetworkPeering
--------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering{#VirtualNetworksVirtualNetworkPeering}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}
 
@@ -750,7 +750,7 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | spec                                                                                    |             | [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetworkPeering_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNetworkPeering_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworksVirtualNetworkPeering_Spec"></a>VirtualNetworksVirtualNetworkPeering_Spec
+### VirtualNetworksVirtualNetworkPeering_Spec {#VirtualNetworksVirtualNetworkPeering_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -767,7 +767,7 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | remoteVirtualNetwork      | The reference to the remote virtual network. The remote virtual network can be in the same or different region (preview). See here to register for the preview and learn more (https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-create-peering).                                                                  | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | useRemoteGateways         | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="VirtualNetworksVirtualNetworkPeering_STATUS"></a>VirtualNetworksVirtualNetworkPeering_STATUS
+### VirtualNetworksVirtualNetworkPeering_STATUS{#VirtualNetworksVirtualNetworkPeering_STATUS}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -788,8 +788,8 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | type                      | Resource type.                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | useRemoteGateways         | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="VirtualNetworksVirtualNetworkPeeringList"></a>VirtualNetworksVirtualNetworkPeeringList
----------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeeringList{#VirtualNetworksVirtualNetworkPeeringList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}
 
@@ -799,8 +799,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [VirtualNetworksVirtualNetworkPeering[]](#VirtualNetworksVirtualNetworkPeering)<br/><small>Optional</small> |
 
-<a id="LoadBalancer_Spec"></a>LoadBalancer_Spec
------------------------------------------------
+LoadBalancer_Spec{#LoadBalancer_Spec}
+-------------------------------------
 
 Used by: [LoadBalancer](#LoadBalancer).
 
@@ -821,8 +821,8 @@ Used by: [LoadBalancer](#LoadBalancer).
 | sku                      | The load balancer SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [LoadBalancerSku](#LoadBalancerSku)<br/><small>Optional</small>                                                                                                      |
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="LoadBalancer_STATUS"></a>LoadBalancer_STATUS
----------------------------------------------------
+LoadBalancer_STATUS{#LoadBalancer_STATUS}
+-----------------------------------------
 
 LoadBalancer resource.
 
@@ -849,8 +849,8 @@ Used by: [LoadBalancer](#LoadBalancer).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                     |
 | type                     | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="LoadBalancersInboundNatRule_Spec"></a>LoadBalancersInboundNatRule_Spec
------------------------------------------------------------------------------
+LoadBalancersInboundNatRule_Spec{#LoadBalancersInboundNatRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 
@@ -867,8 +867,8 @@ Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/LoadBalancer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                                  | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small>                                                                                                  |
 
-<a id="LoadBalancersInboundNatRule_STATUS"></a>LoadBalancersInboundNatRule_STATUS
----------------------------------------------------------------------------------
+LoadBalancersInboundNatRule_STATUS{#LoadBalancersInboundNatRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 
@@ -889,8 +889,8 @@ Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="NetworkInterface_Spec"></a>NetworkInterface_Spec
--------------------------------------------------------
+NetworkInterface_Spec{#NetworkInterface_Spec}
+---------------------------------------------
 
 Used by: [NetworkInterface](#NetworkInterface).
 
@@ -910,8 +910,8 @@ Used by: [NetworkInterface](#NetworkInterface).
 | privateLinkService          | Privatelinkservice of the network interface resource.                                                                                                                                                                                                                                        | [PrivateLinkServiceSpec](#PrivateLinkServiceSpec)<br/><small>Optional</small>                                                                                               |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                               |
 
-<a id="NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -945,8 +945,8 @@ Used by: [NetworkInterface](#NetworkInterface).
 | type                        | Resource type.                                                                  | string<br/><small>Optional</small>                                                                                                                                                          |
 | virtualMachine              | The reference to a virtual machine.                                             | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                                       |
 
-<a id="NetworkSecurityGroup_Spec"></a>NetworkSecurityGroup_Spec
----------------------------------------------------------------
+NetworkSecurityGroup_Spec{#NetworkSecurityGroup_Spec}
+-----------------------------------------------------
 
 Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 
@@ -958,8 +958,8 @@ Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -981,8 +981,8 @@ Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 | tags                 | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                                       |
 | type                 | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="NetworkSecurityGroupsSecurityRule_Spec"></a>NetworkSecurityGroupsSecurityRule_Spec
------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule_Spec{#NetworkSecurityGroupsSecurityRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule).
 
@@ -1007,8 +1007,8 @@ Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule)
 | sourcePortRange                      | The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                        |
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                                                      |
 
-<a id="NetworkSecurityGroupsSecurityRule_STATUS"></a>NetworkSecurityGroupsSecurityRule_STATUS
----------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule_STATUS{#NetworkSecurityGroupsSecurityRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule).
 
@@ -1036,8 +1036,8 @@ Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule)
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                                                            |
 | type                                 | The type of the resource.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="PublicIPAddress_Spec"></a>PublicIPAddress_Spec
------------------------------------------------------
+PublicIPAddress_Spec{#PublicIPAddress_Spec}
+-------------------------------------------
 
 Used by: [PublicIPAddress](#PublicIPAddress).
 
@@ -1063,8 +1063,8 @@ Used by: [PublicIPAddress](#PublicIPAddress).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="PublicIPAddress_STATUS"></a>PublicIPAddress_STATUS
----------------------------------------------------------
+PublicIPAddress_STATUS{#PublicIPAddress_STATUS}
+-----------------------------------------------
 
 Public IP address resource.
 
@@ -1096,8 +1096,8 @@ Used by: [PublicIPAddress](#PublicIPAddress).
 | type                     | Resource type.                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RouteTable_Spec"></a>RouteTable_Spec
--------------------------------------------
+RouteTable_Spec{#RouteTable_Spec}
+---------------------------------
 
 Used by: [RouteTable](#RouteTable).
 
@@ -1110,8 +1110,8 @@ Used by: [RouteTable](#RouteTable).
 | owner                      | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="RouteTable_STATUS"></a>RouteTable_STATUS
------------------------------------------------
+RouteTable_STATUS{#RouteTable_STATUS}
+-------------------------------------
 
 Route table resource.
 
@@ -1130,8 +1130,8 @@ Used by: [RouteTable](#RouteTable).
 | tags                       | Resource tags.                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Resource type.                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTablesRoute_Spec"></a>RouteTablesRoute_Spec
--------------------------------------------------------
+RouteTablesRoute_Spec{#RouteTablesRoute_Spec}
+---------------------------------------------
 
 Used by: [RouteTablesRoute](#RouteTablesRoute).
 
@@ -1144,8 +1144,8 @@ Used by: [RouteTablesRoute](#RouteTablesRoute).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                         | [RouteTablesRouteOperatorSpec](#RouteTablesRouteOperatorSpec)<br/><small>Optional</small>                                                                            |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/RouteTable resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="RouteTablesRoute_STATUS"></a>RouteTablesRoute_STATUS
------------------------------------------------------------
+RouteTablesRoute_STATUS{#RouteTablesRoute_STATUS}
+-------------------------------------------------
 
 Used by: [RouteTablesRoute](#RouteTablesRoute).
 
@@ -1162,8 +1162,8 @@ Used by: [RouteTablesRoute](#RouteTablesRoute).
 | provisioningState | The provisioning state of the route resource.                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 | type              | The type of the resource.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetwork_Spec"></a>VirtualNetwork_Spec
----------------------------------------------------
+VirtualNetwork_Spec{#VirtualNetwork_Spec}
+-----------------------------------------
 
 Used by: [VirtualNetwork](#VirtualNetwork).
 
@@ -1183,8 +1183,8 @@ Used by: [VirtualNetwork](#VirtualNetwork).
 | owner                | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="VirtualNetwork_STATUS"></a>VirtualNetwork_STATUS
--------------------------------------------------------
+VirtualNetwork_STATUS{#VirtualNetwork_STATUS}
+---------------------------------------------
 
 Virtual Network resource.
 
@@ -1210,8 +1210,8 @@ Used by: [VirtualNetwork](#VirtualNetwork).
 | tags                 | Resource tags.                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                 | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetworkGateway_Spec"></a>VirtualNetworkGateway_Spec
------------------------------------------------------------------
+VirtualNetworkGateway_Spec{#VirtualNetworkGateway_Spec}
+-------------------------------------------------------
 
 Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 
@@ -1238,8 +1238,8 @@ Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 | vpnGatewayGeneration                  | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                                                                                                                                       | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration)<br/><small>Optional</small>                |
 | vpnType                               | The type of this virtual network gateway.                                                                                                                                                                                                                                                    | [VirtualNetworkGatewayPropertiesFormat_VpnType](#VirtualNetworkGatewayPropertiesFormat_VpnType)<br/><small>Optional</small>                                          |
 
-<a id="VirtualNetworkGateway_STATUS"></a>VirtualNetworkGateway_STATUS
----------------------------------------------------------------------
+VirtualNetworkGateway_STATUS{#VirtualNetworkGateway_STATUS}
+-----------------------------------------------------------
 
 A common class for general resource information.
 
@@ -1273,8 +1273,8 @@ Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 | vpnGatewayGeneration           | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                            | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS)<br/><small>Optional</small> |
 | vpnType                        | The type of this virtual network gateway.                                                                                                                                         | [VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS)<br/><small>Optional</small>                           |
 
-<a id="VirtualNetworksSubnet_Spec"></a>VirtualNetworksSubnet_Spec
------------------------------------------------------------------
+VirtualNetworksSubnet_Spec{#VirtualNetworksSubnet_Spec}
+-------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 
@@ -1296,8 +1296,8 @@ Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 | serviceEndpointPolicies            | An array of service endpoint policies.                                                                                                                                                                                                                                                      | [ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded[]](#ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded)<br/><small>Optional</small>                 |
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                                                                                                                                                              | [ServiceEndpointPropertiesFormat[]](#ServiceEndpointPropertiesFormat)<br/><small>Optional</small>                                                                                           |
 
-<a id="VirtualNetworksSubnet_STATUS"></a>VirtualNetworksSubnet_STATUS
----------------------------------------------------------------------
+VirtualNetworksSubnet_STATUS{#VirtualNetworksSubnet_STATUS}
+-----------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 
@@ -1328,8 +1328,8 @@ Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                  | [ServiceEndpointPropertiesFormat_STATUS[]](#ServiceEndpointPropertiesFormat_STATUS)<br/><small>Optional</small>                                                                                           |
 | type                               | Resource type.                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                                                        |
 
-<a id="VirtualNetworksVirtualNetworkPeering_Spec"></a>VirtualNetworksVirtualNetworkPeering_Spec
------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering_Spec{#VirtualNetworksVirtualNetworkPeering_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPeering).
 
@@ -1348,8 +1348,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPe
 | remoteVirtualNetwork      | The reference to the remote virtual network. The remote virtual network can be in the same or different region (preview). See here to register for the preview and learn more (https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-create-peering).                                                                  | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | useRemoteGateways         | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="VirtualNetworksVirtualNetworkPeering_STATUS"></a>VirtualNetworksVirtualNetworkPeering_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering_STATUS{#VirtualNetworksVirtualNetworkPeering_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPeering).
 
@@ -1372,8 +1372,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPe
 | type                      | Resource type.                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | useRemoteGateways         | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="AddressSpace"></a>AddressSpace
--------------------------------------
+AddressSpace{#AddressSpace}
+---------------------------
 
 AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 
@@ -1383,8 +1383,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec), [VirtualNetworkGateway_Spe
 |-----------------|------------------------------------------------------------------------------|--------------------------------------|
 | addressPrefixes | A list of address blocks reserved for this virtual network in CIDR notation. | string[]<br/><small>Optional</small> |
 
-<a id="AddressSpace_STATUS"></a>AddressSpace_STATUS
----------------------------------------------------
+AddressSpace_STATUS{#AddressSpace_STATUS}
+-----------------------------------------
 
 AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 
@@ -1394,8 +1394,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS), [VirtualNetworkGateway
 |-----------------|------------------------------------------------------------------------------|--------------------------------------|
 | addressPrefixes | A list of address blocks reserved for this virtual network in CIDR notation. | string[]<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -1405,8 +1405,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -1416,8 +1416,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -1427,8 +1427,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded{#ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -1438,8 +1438,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_LoadBalancer_SubResourceEmbedded"></a>BackendAddressPool_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_LoadBalancer_SubResourceEmbedded{#BackendAddressPool_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -1450,8 +1450,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | loadBalancerBackendAddresses | An array of backend addresses.                                                                                                                           | [LoadBalancerBackendAddress[]](#LoadBalancerBackendAddress)<br/><small>Optional</small> |
 | name                         | The name of the resource that is unique within the set of backend address pools used by the load balancer. This name can be used to access the resource. | string<br/><small>Optional</small>                                                      |
 
-<a id="BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded"></a>BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded{#BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -1470,8 +1470,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState            | The provisioning state of the backend address pool resource.                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                                 |
 | type                         | Type of the resource.                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                |
 
-<a id="BgpSettings"></a>BgpSettings
------------------------------------
+BgpSettings{#BgpSettings}
+-------------------------
 
 BGP settings details.
 
@@ -1484,8 +1484,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | bgpPeeringAddresses | BGP peering address with IP configuration ID for virtual network gateway. | [IPConfigurationBgpPeeringAddress[]](#IPConfigurationBgpPeeringAddress)<br/><small>Optional</small> |
 | peerWeight          | The weight added to routes learned from this BGP speaker.                 | int<br/><small>Optional</small>                                                                     |
 
-<a id="BgpSettings_STATUS"></a>BgpSettings_STATUS
--------------------------------------------------
+BgpSettings_STATUS{#BgpSettings_STATUS}
+---------------------------------------
 
 BGP settings details.
 
@@ -1498,8 +1498,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | bgpPeeringAddresses | BGP peering address with IP configuration ID for virtual network gateway. | [IPConfigurationBgpPeeringAddress_STATUS[]](#IPConfigurationBgpPeeringAddress_STATUS)<br/><small>Optional</small> |
 | peerWeight          | The weight added to routes learned from this BGP speaker.                 | int<br/><small>Optional</small>                                                                                   |
 
-<a id="DdosSettings"></a>DdosSettings
--------------------------------------
+DdosSettings{#DdosSettings}
+---------------------------
 
 Contains the DDoS protection settings of the public IP.
 
@@ -1511,8 +1511,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | protectedIP        | Enables DDoS protection on the public IP.                                                                                   | bool<br/><small>Optional</small>                                                                |
 | protectionCoverage | The DDoS protection policy customizability of the public IP. Only standard coverage will have the ability to be customized. | [DdosSettings_ProtectionCoverage](#DdosSettings_ProtectionCoverage)<br/><small>Optional</small> |
 
-<a id="DdosSettings_STATUS"></a>DdosSettings_STATUS
----------------------------------------------------
+DdosSettings_STATUS{#DdosSettings_STATUS}
+-----------------------------------------
 
 Contains the DDoS protection settings of the public IP.
 
@@ -1524,8 +1524,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | protectedIP        | Enables DDoS protection on the public IP.                                                                                   | bool<br/><small>Optional</small>                                                                              |
 | protectionCoverage | The DDoS protection policy customizability of the public IP. Only standard coverage will have the ability to be customized. | [DdosSettings_ProtectionCoverage_STATUS](#DdosSettings_ProtectionCoverage_STATUS)<br/><small>Optional</small> |
 
-<a id="Delegation"></a>Delegation
----------------------------------
+Delegation{#Delegation}
+-----------------------
 
 Details the service to which the subnet is delegated.
 
@@ -1536,8 +1536,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | name        | The name of the resource that is unique within a subnet. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | serviceName | The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).           | string<br/><small>Optional</small> |
 
-<a id="Delegation_STATUS"></a>Delegation_STATUS
------------------------------------------------
+Delegation_STATUS{#Delegation_STATUS}
+-------------------------------------
 
 Details the service to which the subnet is delegated.
 
@@ -1553,8 +1553,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | serviceName       | The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).           | string<br/><small>Optional</small>                                                |
 | type              | Resource type.                                                                                         | string<br/><small>Optional</small>                                                |
 
-<a id="DhcpOptions"></a>DhcpOptions
------------------------------------
+DhcpOptions{#DhcpOptions}
+-------------------------
 
 DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.
 
@@ -1564,8 +1564,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 |------------|---------------------------------------|--------------------------------------|
 | dnsServers | The list of DNS servers IP addresses. | string[]<br/><small>Optional</small> |
 
-<a id="DhcpOptions_STATUS"></a>DhcpOptions_STATUS
--------------------------------------------------
+DhcpOptions_STATUS{#DhcpOptions_STATUS}
+---------------------------------------
 
 DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.
 
@@ -1575,8 +1575,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS).
 |------------|---------------------------------------|--------------------------------------|
 | dnsServers | The list of DNS servers IP addresses. | string[]<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 ExtendedLocation complex type.
 
@@ -1587,8 +1587,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec), [NetworkInterface_Spec](#Netwo
 | name     | The name of the extended location. | string<br/><small>Required</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Required</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 ExtendedLocation complex type.
 
@@ -1599,8 +1599,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS), [NetworkInterface_STATUS_N
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="FlowLog_STATUS"></a>FlowLog_STATUS
------------------------------------------
+FlowLog_STATUS{#FlowLog_STATUS}
+-------------------------------
 
 A flow log resource.
 
@@ -1610,8 +1610,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded"></a>FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded{#FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -1628,8 +1628,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | subnet                    | The reference to the subnet resource.                                                                                                                         | [Subnet_LoadBalancer_SubResourceEmbedded](#Subnet_LoadBalancer_SubResourceEmbedded)<br/><small>Optional</small>                           |
 | zones                     | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                   | string[]<br/><small>Optional</small>                                                                                                      |
 
-<a id="FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded"></a>FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded{#FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -1654,8 +1654,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | type                      | Type of the resource.                                                                                                                                         | string<br/><small>Optional</small>                                                                                                              |
 | zones                     | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                   | string[]<br/><small>Optional</small>                                                                                                            |
 
-<a id="InboundNatPool"></a>InboundNatPool
------------------------------------------
+InboundNatPool{#InboundNatPool}
+-------------------------------
 
 Inbound NAT pool of the load balancer.
 
@@ -1673,8 +1673,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                    | The name of the resource that is unique within the set of inbound NAT pools used by the load balancer. This name can be used to access the resource.                                                                                                                                 | string<br/><small>Optional</small>                                  |
 | protocol                | The reference to the transport protocol used by the inbound NAT pool.                                                                                                                                                                                                                | [TransportProtocol](#TransportProtocol)<br/><small>Required</small> |
 
-<a id="InboundNatPool_STATUS"></a>InboundNatPool_STATUS
--------------------------------------------------------
+InboundNatPool_STATUS{#InboundNatPool_STATUS}
+---------------------------------------------
 
 Inbound NAT pool of the load balancer.
 
@@ -1696,8 +1696,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the inbound NAT pool resource.                                                                                                                                                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                |
 
-<a id="InboundNatRule_LoadBalancer_SubResourceEmbedded"></a>InboundNatRule_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------
+InboundNatRule_LoadBalancer_SubResourceEmbedded{#InboundNatRule_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -1714,8 +1714,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                    | The name of the resource that is unique within the set of inbound NAT rules used by the load balancer. This name can be used to access the resource.                                                                                                                                 | string<br/><small>Optional</small>                                  |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                             | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small> |
 
-<a id="InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded"></a>InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------
+InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded{#InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -1737,8 +1737,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                              |
 
-<a id="IPAllocationMethod"></a>IPAllocationMethod
--------------------------------------------------
+IPAllocationMethod{#IPAllocationMethod}
+---------------------------------------
 
 IP address allocation method.
 
@@ -1749,8 +1749,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IPAllocationMethod_STATUS"></a>IPAllocationMethod_STATUS
----------------------------------------------------------------
+IPAllocationMethod_STATUS{#IPAllocationMethod_STATUS}
+-----------------------------------------------------
 
 IP address allocation method.
 
@@ -1761,8 +1761,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded"></a>IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded{#IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 IP configuration.
 
@@ -1772,8 +1772,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration.
 
@@ -1783,8 +1783,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfigurationProfile_STATUS"></a>IPConfigurationProfile_STATUS
------------------------------------------------------------------------
+IPConfigurationProfile_STATUS{#IPConfigurationProfile_STATUS}
+-------------------------------------------------------------
 
 IP configuration profile child resource.
 
@@ -1794,8 +1794,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IpTag"></a>IpTag
------------------------
+IpTag{#IpTag}
+-------------
 
 Contains the IpTag associated with the object.
 
@@ -1806,8 +1806,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IpTag_STATUS"></a>IpTag_STATUS
--------------------------------------
+IpTag_STATUS{#IpTag_STATUS}
+---------------------------
 
 Contains the IpTag associated with the object.
 
@@ -1818,8 +1818,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IPVersion"></a>IPVersion
--------------------------------
+IPVersion{#IPVersion}
+---------------------
 
 IP address version.
 
@@ -1830,8 +1830,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IPVersion_STATUS"></a>IPVersion_STATUS
----------------------------------------------
+IPVersion_STATUS{#IPVersion_STATUS}
+-----------------------------------
 
 IP address version.
 
@@ -1842,8 +1842,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="LoadBalancerOperatorSpec"></a>LoadBalancerOperatorSpec
--------------------------------------------------------------
+LoadBalancerOperatorSpec{#LoadBalancerOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1854,8 +1854,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LoadBalancersInboundNatRuleOperatorSpec"></a>LoadBalancersInboundNatRuleOperatorSpec
--------------------------------------------------------------------------------------------
+LoadBalancersInboundNatRuleOperatorSpec{#LoadBalancersInboundNatRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1866,8 +1866,8 @@ Used by: [LoadBalancersInboundNatRule_Spec](#LoadBalancersInboundNatRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LoadBalancerSku"></a>LoadBalancerSku
--------------------------------------------
+LoadBalancerSku{#LoadBalancerSku}
+---------------------------------
 
 SKU of a load balancer.
 
@@ -1878,8 +1878,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name     | Name of a load balancer SKU. | [LoadBalancerSku_Name](#LoadBalancerSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a load balancer SKU. | [LoadBalancerSku_Tier](#LoadBalancerSku_Tier)<br/><small>Optional</small> |
 
-<a id="LoadBalancerSku_STATUS"></a>LoadBalancerSku_STATUS
----------------------------------------------------------
+LoadBalancerSku_STATUS{#LoadBalancerSku_STATUS}
+-----------------------------------------------
 
 SKU of a load balancer.
 
@@ -1890,8 +1890,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | name     | Name of a load balancer SKU. | [LoadBalancerSku_Name_STATUS](#LoadBalancerSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a load balancer SKU. | [LoadBalancerSku_Tier_STATUS](#LoadBalancerSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="LoadBalancingRule"></a>LoadBalancingRule
------------------------------------------------
+LoadBalancingRule{#LoadBalancingRule}
+-------------------------------------
 
 A load balancing rule for a load balancer.
 
@@ -1912,8 +1912,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | probe                   | The reference to the load balancer probe used by the load balancing rule.                                                                                                                                                                                                            | [SubResource](#SubResource)<br/><small>Optional</small>                                                                               |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                             | [TransportProtocol](#TransportProtocol)<br/><small>Required</small>                                                                   |
 
-<a id="LoadBalancingRule_STATUS"></a>LoadBalancingRule_STATUS
--------------------------------------------------------------
+LoadBalancingRule_STATUS{#LoadBalancingRule_STATUS}
+---------------------------------------------------
 
 A load balancing rule for a load balancer.
 
@@ -1938,8 +1938,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the load balancing rule resource.                                                                                                                                                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                   |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                  |
 
-<a id="NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded"></a>NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------
+NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded{#NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -1949,8 +1949,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NatGatewaySpec_PublicIPAddress_SubResourceEmbedded"></a>NatGatewaySpec_PublicIPAddress_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------
+NatGatewaySpec_PublicIPAddress_SubResourceEmbedded{#NatGatewaySpec_PublicIPAddress_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -1960,8 +1960,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -1971,8 +1971,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceDnsSettings"></a>NetworkInterfaceDnsSettings
--------------------------------------------------------------------
+NetworkInterfaceDnsSettings{#NetworkInterfaceDnsSettings}
+---------------------------------------------------------
 
 DNS settings of a network interface.
 
@@ -1983,8 +1983,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | dnsServers           | List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with other IPs, it must be the only value in dnsServers collection. | string[]<br/><small>Optional</small> |
 | internalDnsNameLabel | Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.                                                                                                             | string<br/><small>Optional</small>   |
 
-<a id="NetworkInterfaceDnsSettings_STATUS"></a>NetworkInterfaceDnsSettings_STATUS
----------------------------------------------------------------------------------
+NetworkInterfaceDnsSettings_STATUS{#NetworkInterfaceDnsSettings_STATUS}
+-----------------------------------------------------------------------
 
 DNS settings of a network interface.
 
@@ -1998,8 +1998,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | internalDomainNameSuffix | Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of internalDomainNameSuffix.                    | string<br/><small>Optional</small>   |
 | internalFqdn             | Fully qualified DNS name supporting internal communications between VMs in the same virtual network.                                                                                                                              | string<br/><small>Optional</small>   |
 
-<a id="NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -2020,8 +2020,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | subnet                                | Subnet bound to the IP configuration.                                                                          | [Subnet_NetworkInterface_SubResourceEmbedded](#Subnet_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                                                               |
 | virtualNetworkTaps                    | The reference to Virtual Network Taps.                                                                         | [VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded[]](#VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                               |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -2031,8 +2031,8 @@ Used by: [LoadBalancersInboundNatRule_STATUS](#LoadBalancersInboundNatRule_STATU
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -2058,8 +2058,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | type                                  | Resource type.                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                  |
 | virtualNetworkTaps                    | The reference to Virtual Network Taps.                                                                         | [VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded[]](#VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                                       |
 
-<a id="NetworkInterfaceOperatorSpec"></a>NetworkInterfaceOperatorSpec
----------------------------------------------------------------------
+NetworkInterfaceOperatorSpec{#NetworkInterfaceOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2070,8 +2070,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkInterfacePropertiesFormat_MigrationPhase_STATUS"></a>NetworkInterfacePropertiesFormat_MigrationPhase_STATUS
--------------------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_MigrationPhase_STATUS{#NetworkInterfacePropertiesFormat_MigrationPhase_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -2083,8 +2083,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "None"      |             |
 | "Prepare"   |             |
 
-<a id="NetworkInterfacePropertiesFormat_NicType"></a>NetworkInterfacePropertiesFormat_NicType
----------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_NicType{#NetworkInterfacePropertiesFormat_NicType}
+-----------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 
@@ -2093,8 +2093,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | "Elastic"  |             |
 | "Standard" |             |
 
-<a id="NetworkInterfacePropertiesFormat_NicType_STATUS"></a>NetworkInterfacePropertiesFormat_NicType_STATUS
------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_NicType_STATUS{#NetworkInterfacePropertiesFormat_NicType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -2103,8 +2103,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "Elastic"  |             |
 | "Standard" |             |
 
-<a id="NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Tap configuration in a Network Interface.
 
@@ -2114,8 +2114,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -2125,8 +2125,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -2136,8 +2136,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupOperatorSpec"></a>NetworkSecurityGroupOperatorSpec
------------------------------------------------------------------------------
+NetworkSecurityGroupOperatorSpec{#NetworkSecurityGroupOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2148,8 +2148,8 @@ Used by: [NetworkSecurityGroup_Spec](#NetworkSecurityGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded"></a>NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded{#NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -2159,8 +2159,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded{#NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -2170,8 +2170,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupsSecurityRuleOperatorSpec"></a>NetworkSecurityGroupsSecurityRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRuleOperatorSpec{#NetworkSecurityGroupsSecurityRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2182,8 +2182,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="OutboundRule"></a>OutboundRule
--------------------------------------
+OutboundRule{#OutboundRule}
+---------------------------
 
 Outbound rule of the load balancer.
 
@@ -2199,8 +2199,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                     | The name of the resource that is unique within the set of outbound rules used by the load balancer. This name can be used to access the resource.         | string<br/><small>Optional</small>                                                                          |
 | protocol                 | The protocol for the outbound rule in load balancer.                                                                                                      | [OutboundRulePropertiesFormat_Protocol](#OutboundRulePropertiesFormat_Protocol)<br/><small>Required</small> |
 
-<a id="OutboundRule_STATUS"></a>OutboundRule_STATUS
----------------------------------------------------
+OutboundRule_STATUS{#OutboundRule_STATUS}
+-----------------------------------------
 
 Outbound rule of the load balancer.
 
@@ -2220,8 +2220,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState        | The provisioning state of the outbound rule resource.                                                                                                     | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                         |
 | type                     | Type of the resource.                                                                                                                                     | string<br/><small>Optional</small>                                                                                        |
 
-<a id="PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded{#PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -2231,8 +2231,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -2242,8 +2242,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded"></a>PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded{#PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Private link service resource.
 
@@ -2253,8 +2253,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceSpec"></a>PrivateLinkServiceSpec
----------------------------------------------------------
+PrivateLinkServiceSpec{#PrivateLinkServiceSpec}
+-----------------------------------------------
 
 Private link service resource.
 
@@ -2264,8 +2264,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Probe"></a>Probe
------------------------
+Probe{#Probe}
+-------------
 
 A load balancer probe.
 
@@ -2280,8 +2280,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | protocol          | The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.                                                                     | [ProbePropertiesFormat_Protocol](#ProbePropertiesFormat_Protocol)<br/><small>Required</small> |
 | requestPath       | The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value.                                                                                                                                               | string<br/><small>Optional</small>                                                            |
 
-<a id="Probe_STATUS"></a>Probe_STATUS
--------------------------------------
+Probe_STATUS{#Probe_STATUS}
+---------------------------
 
 A load balancer probe.
 
@@ -2301,8 +2301,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | requestPath        | The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value.                                                                                                                                               | string<br/><small>Optional</small>                                                                          |
 | type               | Type of the resource.                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                          |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 The current provisioning state.
 
@@ -2315,8 +2315,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="PublicIPAddressDnsSettings"></a>PublicIPAddressDnsSettings
------------------------------------------------------------------
+PublicIPAddressDnsSettings{#PublicIPAddressDnsSettings}
+-------------------------------------------------------
 
 Contains FQDN of the DNS record associated with the public IP address.
 
@@ -2328,8 +2328,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | fqdn            | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.                                                                                                                                  | string<br/><small>Optional</small> |
 | reverseFqdn     | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.                                               | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddressDnsSettings_STATUS"></a>PublicIPAddressDnsSettings_STATUS
--------------------------------------------------------------------------------
+PublicIPAddressDnsSettings_STATUS{#PublicIPAddressDnsSettings_STATUS}
+---------------------------------------------------------------------
 
 Contains FQDN of the DNS record associated with the public IP address.
 
@@ -2341,8 +2341,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | fqdn            | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.                                                                                                                                  | string<br/><small>Optional</small> |
 | reverseFqdn     | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.                                               | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddressOperatorSpec"></a>PublicIPAddressOperatorSpec
--------------------------------------------------------------------
+PublicIPAddressOperatorSpec{#PublicIPAddressOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2353,8 +2353,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressPropertiesFormat_MigrationPhase_STATUS"></a>PublicIPAddressPropertiesFormat_MigrationPhase_STATUS
------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressPropertiesFormat_MigrationPhase_STATUS{#PublicIPAddressPropertiesFormat_MigrationPhase_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 
@@ -2366,8 +2366,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | "None"      |             |
 | "Prepare"   |             |
 
-<a id="PublicIPAddressSku"></a>PublicIPAddressSku
--------------------------------------------------
+PublicIPAddressSku{#PublicIPAddressSku}
+---------------------------------------
 
 SKU of a public IP address.
 
@@ -2378,8 +2378,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | name     | Name of a public IP address SKU. | [PublicIPAddressSku_Name](#PublicIPAddressSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a public IP address SKU. | [PublicIPAddressSku_Tier](#PublicIPAddressSku_Tier)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSku_STATUS"></a>PublicIPAddressSku_STATUS
----------------------------------------------------------------
+PublicIPAddressSku_STATUS{#PublicIPAddressSku_STATUS}
+-----------------------------------------------------
 
 SKU of a public IP address.
 
@@ -2390,8 +2390,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | name     | Name of a public IP address SKU. | [PublicIPAddressSku_Name_STATUS](#PublicIPAddressSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a public IP address SKU. | [PublicIPAddressSku_Tier_STATUS](#PublicIPAddressSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded"></a>PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded{#PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -2401,8 +2401,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec), and [PublicIPAddress_Spe
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceNavigationLink_STATUS"></a>ResourceNavigationLink_STATUS
------------------------------------------------------------------------
+ResourceNavigationLink_STATUS{#ResourceNavigationLink_STATUS}
+-------------------------------------------------------------
 
 ResourceNavigationLink resource.
 
@@ -2412,8 +2412,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------------------------------|------------------------------------|
 | id       | Resource navigation link identifier. | string<br/><small>Optional</small> |
 
-<a id="RouteNextHopType"></a>RouteNextHopType
----------------------------------------------
+RouteNextHopType{#RouteNextHopType}
+-----------------------------------
 
 The type of Azure hop the packet should be sent to.
 
@@ -2427,8 +2427,8 @@ Used by: [RouteTablesRoute_Spec](#RouteTablesRoute_Spec).
 | "VirtualNetworkGateway" |             |
 | "VnetLocal"             |             |
 
-<a id="RouteNextHopType_STATUS"></a>RouteNextHopType_STATUS
------------------------------------------------------------
+RouteNextHopType_STATUS{#RouteNextHopType_STATUS}
+-------------------------------------------------
 
 The type of Azure hop the packet should be sent to.
 
@@ -2442,8 +2442,8 @@ Used by: [RouteTablesRoute_STATUS](#RouteTablesRoute_STATUS).
 | "VirtualNetworkGateway" |             |
 | "VnetLocal"             |             |
 
-<a id="RouteTable_STATUS_SubResourceEmbedded"></a>RouteTable_STATUS_SubResourceEmbedded
----------------------------------------------------------------------------------------
+RouteTable_STATUS_SubResourceEmbedded{#RouteTable_STATUS_SubResourceEmbedded}
+-----------------------------------------------------------------------------
 
 Route table resource.
 
@@ -2453,8 +2453,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="RouteTableOperatorSpec"></a>RouteTableOperatorSpec
----------------------------------------------------------
+RouteTableOperatorSpec{#RouteTableOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2465,8 +2465,8 @@ Used by: [RouteTable_Spec](#RouteTable_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------
+RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded{#RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------
 
 Route table resource.
 
@@ -2476,8 +2476,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="RouteTablesRouteOperatorSpec"></a>RouteTablesRouteOperatorSpec
----------------------------------------------------------------------
+RouteTablesRouteOperatorSpec{#RouteTablesRouteOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2488,8 +2488,8 @@ Used by: [RouteTablesRoute_Spec](#RouteTablesRoute_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SecurityRule_STATUS"></a>SecurityRule_STATUS
----------------------------------------------------
+SecurityRule_STATUS{#SecurityRule_STATUS}
+-----------------------------------------
 
 Network security rule.
 
@@ -2499,8 +2499,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SecurityRuleAccess"></a>SecurityRuleAccess
--------------------------------------------------
+SecurityRuleAccess{#SecurityRuleAccess}
+---------------------------------------
 
 Whether network traffic is allowed or denied.
 
@@ -2511,8 +2511,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="SecurityRuleAccess_STATUS"></a>SecurityRuleAccess_STATUS
----------------------------------------------------------------
+SecurityRuleAccess_STATUS{#SecurityRuleAccess_STATUS}
+-----------------------------------------------------
 
 Whether network traffic is allowed or denied.
 
@@ -2523,8 +2523,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="SecurityRuleDirection"></a>SecurityRuleDirection
--------------------------------------------------------
+SecurityRuleDirection{#SecurityRuleDirection}
+---------------------------------------------
 
 The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 
@@ -2535,8 +2535,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Inbound"  |             |
 | "Outbound" |             |
 
-<a id="SecurityRuleDirection_STATUS"></a>SecurityRuleDirection_STATUS
----------------------------------------------------------------------
+SecurityRuleDirection_STATUS{#SecurityRuleDirection_STATUS}
+-----------------------------------------------------------
 
 The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 
@@ -2547,8 +2547,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Inbound"  |             |
 | "Outbound" |             |
 
-<a id="SecurityRulePropertiesFormat_Protocol"></a>SecurityRulePropertiesFormat_Protocol
----------------------------------------------------------------------------------------
+SecurityRulePropertiesFormat_Protocol{#SecurityRulePropertiesFormat_Protocol}
+-----------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurityRule_Spec).
 
@@ -2561,8 +2561,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Tcp"  |             |
 | "Udp"  |             |
 
-<a id="SecurityRulePropertiesFormat_Protocol_STATUS"></a>SecurityRulePropertiesFormat_Protocol_STATUS
------------------------------------------------------------------------------------------------------
+SecurityRulePropertiesFormat_Protocol_STATUS{#SecurityRulePropertiesFormat_Protocol_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecurityRule_STATUS).
 
@@ -2575,8 +2575,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Tcp"  |             |
 | "Udp"  |             |
 
-<a id="ServiceAssociationLink_STATUS"></a>ServiceAssociationLink_STATUS
------------------------------------------------------------------------
+ServiceAssociationLink_STATUS{#ServiceAssociationLink_STATUS}
+-------------------------------------------------------------
 
 ServiceAssociationLink resource.
 
@@ -2586,8 +2586,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------
+ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Service End point policy resource.
 
@@ -2597,8 +2597,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded{#ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Service End point policy resource.
 
@@ -2608,8 +2608,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPropertiesFormat"></a>ServiceEndpointPropertiesFormat
----------------------------------------------------------------------------
+ServiceEndpointPropertiesFormat{#ServiceEndpointPropertiesFormat}
+-----------------------------------------------------------------
 
 The service endpoint properties.
 
@@ -2620,8 +2620,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | locations | A list of locations.              | string[]<br/><small>Optional</small> |
 | service   | The type of the endpoint service. | string<br/><small>Optional</small>   |
 
-<a id="ServiceEndpointPropertiesFormat_STATUS"></a>ServiceEndpointPropertiesFormat_STATUS
------------------------------------------------------------------------------------------
+ServiceEndpointPropertiesFormat_STATUS{#ServiceEndpointPropertiesFormat_STATUS}
+-------------------------------------------------------------------------------
 
 The service endpoint properties.
 
@@ -2633,8 +2633,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | provisioningState | The provisioning state of the service endpoint resource. | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | service           | The type of the endpoint service.                        | string<br/><small>Optional</small>                                                |
 
-<a id="Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -2644,8 +2644,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SubnetPropertiesFormat_PrivateEndpointNetworkPolicies"></a>SubnetPropertiesFormat_PrivateEndpointNetworkPolicies
------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateEndpointNetworkPolicies{#SubnetPropertiesFormat_PrivateEndpointNetworkPolicies}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 
@@ -2654,8 +2654,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS"></a>SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS{#SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 
@@ -2664,8 +2664,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies"></a>SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies
------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies{#SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 
@@ -2674,8 +2674,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS"></a>SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS{#SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 
@@ -2684,8 +2684,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Reference to another subresource.
 
@@ -2695,8 +2695,8 @@ Used by: [DdosSettings](#DdosSettings), [FrontendIPConfiguration_LoadBalancer_Su
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another subresource.
 
@@ -2706,8 +2706,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="TransportProtocol"></a>TransportProtocol
------------------------------------------------
+TransportProtocol{#TransportProtocol}
+-------------------------------------
 
 The transport protocol for the endpoint.
 
@@ -2719,8 +2719,8 @@ Used by: [InboundNatPool](#InboundNatPool), [InboundNatRule_LoadBalancer_SubReso
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="TransportProtocol_STATUS"></a>TransportProtocol_STATUS
--------------------------------------------------------------
+TransportProtocol_STATUS{#TransportProtocol_STATUS}
+---------------------------------------------------
 
 The transport protocol for the endpoint.
 
@@ -2732,8 +2732,8 @@ Used by: [InboundNatPool_STATUS](#InboundNatPool_STATUS), [InboundNatRule_STATUS
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="VirtualNetworkBgpCommunities"></a>VirtualNetworkBgpCommunities
----------------------------------------------------------------------
+VirtualNetworkBgpCommunities{#VirtualNetworkBgpCommunities}
+-----------------------------------------------------------
 
 Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
 
@@ -2743,8 +2743,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec), and [VirtualNetworksVirtua
 |-------------------------|--------------------------------------------------------|------------------------------------|
 | virtualNetworkCommunity | The BGP community associated with the virtual network. | string<br/><small>Required</small> |
 
-<a id="VirtualNetworkBgpCommunities_STATUS"></a>VirtualNetworkBgpCommunities_STATUS
------------------------------------------------------------------------------------
+VirtualNetworkBgpCommunities_STATUS{#VirtualNetworkBgpCommunities_STATUS}
+-------------------------------------------------------------------------
 
 Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
 
@@ -2755,8 +2755,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS), and [VirtualNetworksVi
 | regionalCommunity       | The BGP community associated with the region of the virtual network. | string<br/><small>Optional</small> |
 | virtualNetworkCommunity | The BGP community associated with the virtual network.               | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayIPConfiguration"></a>VirtualNetworkGatewayIPConfiguration
--------------------------------------------------------------------------------------
+VirtualNetworkGatewayIPConfiguration{#VirtualNetworkGatewayIPConfiguration}
+---------------------------------------------------------------------------
 
 IP configuration for virtual network gateway.
 
@@ -2769,8 +2769,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | publicIPAddress           | The reference to the public IP resource.                                                                       | [SubResource](#SubResource)<br/><small>Optional</small>               |
 | subnet                    | The reference to the subnet resource.                                                                          | [SubResource](#SubResource)<br/><small>Optional</small>               |
 
-<a id="VirtualNetworkGatewayIPConfiguration_STATUS"></a>VirtualNetworkGatewayIPConfiguration_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayIPConfiguration_STATUS{#VirtualNetworkGatewayIPConfiguration_STATUS}
+-----------------------------------------------------------------------------------------
 
 IP configuration for virtual network gateway.
 
@@ -2787,8 +2787,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | publicIPAddress           | The reference to the public IP resource.                                                                       | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>               |
 | subnet                    | The reference to the subnet resource.                                                                          | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>               |
 
-<a id="VirtualNetworkGatewayOperatorSpec"></a>VirtualNetworkGatewayOperatorSpec
--------------------------------------------------------------------------------
+VirtualNetworkGatewayOperatorSpec{#VirtualNetworkGatewayOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2799,8 +2799,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_GatewayType"></a>VirtualNetworkGatewayPropertiesFormat_GatewayType
----------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_GatewayType{#VirtualNetworkGatewayPropertiesFormat_GatewayType}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
@@ -2810,8 +2810,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | "LocalGateway" |             |
 | "Vpn"          |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS
------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS{#VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 
@@ -2821,8 +2821,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | "LocalGateway" |             |
 | "Vpn"          |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration"></a>VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration
----------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration{#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
@@ -2832,8 +2832,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | "Generation2" |             |
 | "None"        |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS{#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 
@@ -2843,8 +2843,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | "Generation2" |             |
 | "None"        |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnType"></a>VirtualNetworkGatewayPropertiesFormat_VpnType
--------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnType{#VirtualNetworkGatewayPropertiesFormat_VpnType}
+---------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
@@ -2853,8 +2853,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | "PolicyBased" |             |
 | "RouteBased"  |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS{#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 
@@ -2863,8 +2863,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | "PolicyBased" |             |
 | "RouteBased"  |             |
 
-<a id="VirtualNetworkGatewaySku"></a>VirtualNetworkGatewaySku
--------------------------------------------------------------
+VirtualNetworkGatewaySku{#VirtualNetworkGatewaySku}
+---------------------------------------------------
 
 VirtualNetworkGatewaySku details.
 
@@ -2875,8 +2875,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | name     | Gateway SKU name. | [VirtualNetworkGatewaySku_Name](#VirtualNetworkGatewaySku_Name)<br/><small>Optional</small> |
 | tier     | Gateway SKU tier. | [VirtualNetworkGatewaySku_Tier](#VirtualNetworkGatewaySku_Tier)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewaySku_STATUS"></a>VirtualNetworkGatewaySku_STATUS
----------------------------------------------------------------------------
+VirtualNetworkGatewaySku_STATUS{#VirtualNetworkGatewaySku_STATUS}
+-----------------------------------------------------------------
 
 VirtualNetworkGatewaySku details.
 
@@ -2888,8 +2888,8 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | name     | Gateway SKU name. | [VirtualNetworkGatewaySku_Name_STATUS](#VirtualNetworkGatewaySku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Gateway SKU tier. | [VirtualNetworkGatewaySku_Tier_STATUS](#VirtualNetworkGatewaySku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkOperatorSpec"></a>VirtualNetworkOperatorSpec
------------------------------------------------------------------
+VirtualNetworkOperatorSpec{#VirtualNetworkOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2900,8 +2900,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringState"></a>VirtualNetworkPeeringPropertiesFormat_PeeringState
------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringState{#VirtualNetworkPeeringPropertiesFormat_PeeringState}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetworkPeering_Spec).
 
@@ -2911,8 +2911,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetw
 | "Disconnected" |             |
 | "Initiated"    |             |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS"></a>VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS{#VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNetworkPeering_STATUS).
 
@@ -2922,8 +2922,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNe
 | "Disconnected" |             |
 | "Initiated"    |             |
 
-<a id="VirtualNetworksSubnetOperatorSpec"></a>VirtualNetworksSubnetOperatorSpec
--------------------------------------------------------------------------------
+VirtualNetworksSubnetOperatorSpec{#VirtualNetworksSubnetOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2934,8 +2934,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksVirtualNetworkPeeringOperatorSpec"></a>VirtualNetworksVirtualNetworkPeeringOperatorSpec
--------------------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeeringOperatorSpec{#VirtualNetworksVirtualNetworkPeeringOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2946,8 +2946,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetw
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VpnClientConfiguration"></a>VpnClientConfiguration
----------------------------------------------------------
+VpnClientConfiguration{#VpnClientConfiguration}
+-----------------------------------------------
 
 VpnClientConfiguration for P2S client.
 
@@ -2968,8 +2968,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | vpnClientRevokedCertificates | VpnClientRevokedCertificate for Virtual network gateway.                                                              | [VpnClientRevokedCertificate[]](#VpnClientRevokedCertificate)<br/><small>Optional</small>                                     |
 | vpnClientRootCertificates    | VpnClientRootCertificate for virtual network gateway.                                                                 | [VpnClientRootCertificate[]](#VpnClientRootCertificate)<br/><small>Optional</small>                                           |
 
-<a id="VpnClientConfiguration_STATUS"></a>VpnClientConfiguration_STATUS
------------------------------------------------------------------------
+VpnClientConfiguration_STATUS{#VpnClientConfiguration_STATUS}
+-------------------------------------------------------------
 
 VpnClientConfiguration for P2S client.
 
@@ -2990,31 +2990,31 @@ Used by: [VirtualNetworkGateway_STATUS](#VirtualNetworkGateway_STATUS).
 | vpnClientRevokedCertificates | VpnClientRevokedCertificate for Virtual network gateway.                                                              | [VpnClientRevokedCertificate_STATUS[]](#VpnClientRevokedCertificate_STATUS)<br/><small>Optional</small>                                     |
 | vpnClientRootCertificates    | VpnClientRootCertificate for virtual network gateway.                                                                 | [VpnClientRootCertificate_STATUS[]](#VpnClientRootCertificate_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded"></a>ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Backend Address Pool of an application gateway.
-
-Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded).
-
-| Property  | Description  | Type                                                                                                                                                       |
-|-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
-
-<a id="ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded"></a>ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Backend Address Pool of an application gateway.
-
-Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
-
-| Property | Description  | Type                               |
-|----------|--------------|------------------------------------|
-| id       | Resource ID. | string<br/><small>Optional</small> |
-
-<a id="ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
+ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded{#ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded}
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 
+Backend Address Pool of an application gateway.
+
+Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded).
+
+| Property  | Description  | Type                                                                                                                                                       |
+|-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
+
+ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded{#ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Backend Address Pool of an application gateway.
+
+Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
+
+| Property | Description  | Type                               |
+|----------|--------------|------------------------------------|
+| id       | Resource ID. | string<br/><small>Optional</small> |
+
+ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
+
 An application security group in a resource group.
 
 Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
@@ -3023,8 +3023,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded{#ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -3034,8 +3034,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_NetworkInterface_SubResourceEmbedded"></a>BackendAddressPool_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_NetworkInterface_SubResourceEmbedded{#BackendAddressPool_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -3045,8 +3045,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded"></a>BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded{#BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -3056,8 +3056,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="DdosSettings_ProtectionCoverage"></a>DdosSettings_ProtectionCoverage
----------------------------------------------------------------------------
+DdosSettings_ProtectionCoverage{#DdosSettings_ProtectionCoverage}
+-----------------------------------------------------------------
 
 Used by: [DdosSettings](#DdosSettings).
 
@@ -3066,8 +3066,8 @@ Used by: [DdosSettings](#DdosSettings).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="DdosSettings_ProtectionCoverage_STATUS"></a>DdosSettings_ProtectionCoverage_STATUS
------------------------------------------------------------------------------------------
+DdosSettings_ProtectionCoverage_STATUS{#DdosSettings_ProtectionCoverage_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [DdosSettings_STATUS](#DdosSettings_STATUS).
 
@@ -3076,8 +3076,8 @@ Used by: [DdosSettings_STATUS](#DdosSettings_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -3087,8 +3087,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -3098,8 +3098,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="InboundNatRule_NetworkInterface_SubResourceEmbedded"></a>InboundNatRule_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------
+InboundNatRule_NetworkInterface_SubResourceEmbedded{#InboundNatRule_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -3109,8 +3109,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded"></a>InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded{#InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -3120,8 +3120,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfigurationBgpPeeringAddress"></a>IPConfigurationBgpPeeringAddress
------------------------------------------------------------------------------
+IPConfigurationBgpPeeringAddress{#IPConfigurationBgpPeeringAddress}
+-------------------------------------------------------------------
 
 Properties of IPConfigurationBgpPeeringAddress.
 
@@ -3132,8 +3132,8 @@ Used by: [BgpSettings](#BgpSettings).
 | customBgpIpAddresses | The list of custom BGP peering addresses which belong to IP configuration. | string[]<br/><small>Optional</small> |
 | ipconfigurationId    | The ID of IP configuration which belongs to gateway.                       | string<br/><small>Optional</small>   |
 
-<a id="IPConfigurationBgpPeeringAddress_STATUS"></a>IPConfigurationBgpPeeringAddress_STATUS
--------------------------------------------------------------------------------------------
+IPConfigurationBgpPeeringAddress_STATUS{#IPConfigurationBgpPeeringAddress_STATUS}
+---------------------------------------------------------------------------------
 
 Properties of IPConfigurationBgpPeeringAddress.
 
@@ -3146,8 +3146,8 @@ Used by: [BgpSettings_STATUS](#BgpSettings_STATUS).
 | ipconfigurationId     | The ID of IP configuration which belongs to gateway.                        | string<br/><small>Optional</small>   |
 | tunnelIpAddresses     | The list of tunnel public IP addresses which belong to IP configuration.    | string[]<br/><small>Optional</small> |
 
-<a id="IpsecPolicy"></a>IpsecPolicy
------------------------------------
+IpsecPolicy{#IpsecPolicy}
+-------------------------
 
 An IPSec Policy configuration for a virtual network gateway connection.
 
@@ -3164,8 +3164,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | saDataSizeKilobytes | The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel.  | int<br/><small>Required</small>                                 |
 | saLifeTimeSeconds   | The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel. | int<br/><small>Required</small>                                 |
 
-<a id="IpsecPolicy_STATUS"></a>IpsecPolicy_STATUS
--------------------------------------------------
+IpsecPolicy_STATUS{#IpsecPolicy_STATUS}
+---------------------------------------
 
 An IPSec Policy configuration for a virtual network gateway connection.
 
@@ -3182,8 +3182,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | saDataSizeKilobytes | The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel.  | int<br/><small>Optional</small>                                               |
 | saLifeTimeSeconds   | The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel. | int<br/><small>Optional</small>                                               |
 
-<a id="LoadBalancerBackendAddress"></a>LoadBalancerBackendAddress
------------------------------------------------------------------
+LoadBalancerBackendAddress{#LoadBalancerBackendAddress}
+-------------------------------------------------------
 
 Load balancer backend addresses.
 
@@ -3197,8 +3197,8 @@ Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPo
 | subnet                              | Reference to an existing subnet.                                                     | [SubResource](#SubResource)<br/><small>Optional</small> |
 | virtualNetwork                      | Reference to an existing virtual network.                                            | [SubResource](#SubResource)<br/><small>Optional</small> |
 
-<a id="LoadBalancerBackendAddress_STATUS"></a>LoadBalancerBackendAddress_STATUS
--------------------------------------------------------------------------------
+LoadBalancerBackendAddress_STATUS{#LoadBalancerBackendAddress_STATUS}
+---------------------------------------------------------------------
 
 Load balancer backend addresses.
 
@@ -3213,8 +3213,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | subnet                              | Reference to an existing subnet.                                                     | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 | virtualNetwork                      | Reference to an existing virtual network.                                            | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small> |
 
-<a id="LoadBalancerSku_Name"></a>LoadBalancerSku_Name
------------------------------------------------------
+LoadBalancerSku_Name{#LoadBalancerSku_Name}
+-------------------------------------------
 
 Used by: [LoadBalancerSku](#LoadBalancerSku).
 
@@ -3223,8 +3223,8 @@ Used by: [LoadBalancerSku](#LoadBalancerSku).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="LoadBalancerSku_Name_STATUS"></a>LoadBalancerSku_Name_STATUS
--------------------------------------------------------------------
+LoadBalancerSku_Name_STATUS{#LoadBalancerSku_Name_STATUS}
+---------------------------------------------------------
 
 Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 
@@ -3233,8 +3233,8 @@ Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="LoadBalancerSku_Tier"></a>LoadBalancerSku_Tier
------------------------------------------------------
+LoadBalancerSku_Tier{#LoadBalancerSku_Tier}
+-------------------------------------------
 
 Used by: [LoadBalancerSku](#LoadBalancerSku).
 
@@ -3243,8 +3243,8 @@ Used by: [LoadBalancerSku](#LoadBalancerSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="LoadBalancerSku_Tier_STATUS"></a>LoadBalancerSku_Tier_STATUS
--------------------------------------------------------------------
+LoadBalancerSku_Tier_STATUS{#LoadBalancerSku_Tier_STATUS}
+---------------------------------------------------------
 
 Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 
@@ -3253,8 +3253,8 @@ Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="LoadBalancingRulePropertiesFormat_LoadDistribution"></a>LoadBalancingRulePropertiesFormat_LoadDistribution
------------------------------------------------------------------------------------------------------------------
+LoadBalancingRulePropertiesFormat_LoadDistribution{#LoadBalancingRulePropertiesFormat_LoadDistribution}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancingRule](#LoadBalancingRule).
 
@@ -3264,8 +3264,8 @@ Used by: [LoadBalancingRule](#LoadBalancingRule).
 | "SourceIP"         |             |
 | "SourceIPProtocol" |             |
 
-<a id="LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS"></a>LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS{#LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancingRule_STATUS](#LoadBalancingRule_STATUS).
 
@@ -3275,8 +3275,8 @@ Used by: [LoadBalancingRule_STATUS](#LoadBalancingRule_STATUS).
 | "SourceIP"         |             |
 | "SourceIPProtocol" |             |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -3286,8 +3286,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS"></a>NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS{#NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 PrivateLinkConnection properties for the network interface.
 
@@ -3299,8 +3299,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 | groupId            | The group ID for current private link connection.             | string<br/><small>Optional</small>   |
 | requiredMemberName | The required member name for current private link connection. | string<br/><small>Optional</small>   |
 
-<a id="OutboundRulePropertiesFormat_Protocol"></a>OutboundRulePropertiesFormat_Protocol
----------------------------------------------------------------------------------------
+OutboundRulePropertiesFormat_Protocol{#OutboundRulePropertiesFormat_Protocol}
+-----------------------------------------------------------------------------
 
 Used by: [OutboundRule](#OutboundRule).
 
@@ -3310,8 +3310,8 @@ Used by: [OutboundRule](#OutboundRule).
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="OutboundRulePropertiesFormat_Protocol_STATUS"></a>OutboundRulePropertiesFormat_Protocol_STATUS
------------------------------------------------------------------------------------------------------
+OutboundRulePropertiesFormat_Protocol_STATUS{#OutboundRulePropertiesFormat_Protocol_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 
@@ -3321,8 +3321,8 @@ Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="ProbePropertiesFormat_Protocol"></a>ProbePropertiesFormat_Protocol
--------------------------------------------------------------------------
+ProbePropertiesFormat_Protocol{#ProbePropertiesFormat_Protocol}
+---------------------------------------------------------------
 
 Used by: [Probe](#Probe).
 
@@ -3332,8 +3332,8 @@ Used by: [Probe](#Probe).
 | "Https" |             |
 | "Tcp"   |             |
 
-<a id="ProbePropertiesFormat_Protocol_STATUS"></a>ProbePropertiesFormat_Protocol_STATUS
----------------------------------------------------------------------------------------
+ProbePropertiesFormat_Protocol_STATUS{#ProbePropertiesFormat_Protocol_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [Probe_STATUS](#Probe_STATUS).
 
@@ -3343,8 +3343,8 @@ Used by: [Probe_STATUS](#Probe_STATUS).
 | "Https" |             |
 | "Tcp"   |             |
 
-<a id="PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded"></a>PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded{#PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -3354,8 +3354,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded"></a>PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded{#PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -3365,8 +3365,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSku_Name"></a>PublicIPAddressSku_Name
------------------------------------------------------------
+PublicIPAddressSku_Name{#PublicIPAddressSku_Name}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -3375,8 +3375,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Name_STATUS"></a>PublicIPAddressSku_Name_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Name_STATUS{#PublicIPAddressSku_Name_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -3385,8 +3385,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Tier"></a>PublicIPAddressSku_Tier
------------------------------------------------------------
+PublicIPAddressSku_Tier{#PublicIPAddressSku_Tier}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -3395,8 +3395,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPAddressSku_Tier_STATUS"></a>PublicIPAddressSku_Tier_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Tier_STATUS{#PublicIPAddressSku_Tier_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -3405,8 +3405,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded"></a>PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded{#PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -3416,8 +3416,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded"></a>PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded{#PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -3427,8 +3427,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="RadiusServer"></a>RadiusServer
--------------------------------------
+RadiusServer{#RadiusServer}
+---------------------------
 
 Radius Server Settings.
 
@@ -3440,8 +3440,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | radiusServerScore   | The initial score assigned to this radius server. | int<br/><small>Optional</small>    |
 | radiusServerSecret  | The secret used for this radius server.           | string<br/><small>Optional</small> |
 
-<a id="RadiusServer_STATUS"></a>RadiusServer_STATUS
----------------------------------------------------
+RadiusServer_STATUS{#RadiusServer_STATUS}
+-----------------------------------------
 
 Radius Server Settings.
 
@@ -3453,8 +3453,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | radiusServerScore   | The initial score assigned to this radius server. | int<br/><small>Optional</small>    |
 | radiusServerSecret  | The secret used for this radius server.           | string<br/><small>Optional</small> |
 
-<a id="Subnet_LoadBalancer_SubResourceEmbedded"></a>Subnet_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------
+Subnet_LoadBalancer_SubResourceEmbedded{#Subnet_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3464,8 +3464,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_NetworkInterface_SubResourceEmbedded"></a>Subnet_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------
+Subnet_NetworkInterface_SubResourceEmbedded{#Subnet_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3475,8 +3475,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_LoadBalancer_SubResourceEmbedded"></a>Subnet_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------
+Subnet_STATUS_LoadBalancer_SubResourceEmbedded{#Subnet_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3486,8 +3486,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_NetworkInterface_SubResourceEmbedded"></a>Subnet_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_NetworkInterface_SubResourceEmbedded{#Subnet_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3497,8 +3497,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewaySku_Name"></a>VirtualNetworkGatewaySku_Name
------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Name{#VirtualNetworkGatewaySku_Name}
+-------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 
@@ -3522,8 +3522,8 @@ Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Name_STATUS"></a>VirtualNetworkGatewaySku_Name_STATUS
--------------------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Name_STATUS{#VirtualNetworkGatewaySku_Name_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 
@@ -3547,8 +3547,8 @@ Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Tier"></a>VirtualNetworkGatewaySku_Tier
------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Tier{#VirtualNetworkGatewaySku_Tier}
+-------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 
@@ -3572,8 +3572,8 @@ Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Tier_STATUS"></a>VirtualNetworkGatewaySku_Tier_STATUS
--------------------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Tier_STATUS{#VirtualNetworkGatewaySku_Tier_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 
@@ -3597,8 +3597,8 @@ Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded"></a>VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded{#VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Virtual Network Tap resource.
 
@@ -3608,8 +3608,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded"></a>VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded{#VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Virtual Network Tap resource.
 
@@ -3619,8 +3619,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VpnClientConfiguration_VpnAuthenticationTypes"></a>VpnClientConfiguration_VpnAuthenticationTypes
--------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnAuthenticationTypes{#VpnClientConfiguration_VpnAuthenticationTypes}
+---------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 
@@ -3630,8 +3630,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | "Certificate" |             |
 | "Radius"      |             |
 
-<a id="VpnClientConfiguration_VpnAuthenticationTypes_STATUS"></a>VpnClientConfiguration_VpnAuthenticationTypes_STATUS
----------------------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnAuthenticationTypes_STATUS{#VpnClientConfiguration_VpnAuthenticationTypes_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 
@@ -3641,8 +3641,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | "Certificate" |             |
 | "Radius"      |             |
 
-<a id="VpnClientConfiguration_VpnClientProtocols"></a>VpnClientConfiguration_VpnClientProtocols
------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnClientProtocols{#VpnClientConfiguration_VpnClientProtocols}
+-------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 
@@ -3652,8 +3652,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | "OpenVPN" |             |
 | "SSTP"    |             |
 
-<a id="VpnClientConfiguration_VpnClientProtocols_STATUS"></a>VpnClientConfiguration_VpnClientProtocols_STATUS
--------------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnClientProtocols_STATUS{#VpnClientConfiguration_VpnClientProtocols_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 
@@ -3663,8 +3663,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | "OpenVPN" |             |
 | "SSTP"    |             |
 
-<a id="VpnClientRevokedCertificate"></a>VpnClientRevokedCertificate
--------------------------------------------------------------------
+VpnClientRevokedCertificate{#VpnClientRevokedCertificate}
+---------------------------------------------------------
 
 VPN client revoked certificate of virtual network gateway.
 
@@ -3675,8 +3675,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | name       | The name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | thumbprint | The revoked VPN client certificate thumbprint.                                                                 | string<br/><small>Optional</small> |
 
-<a id="VpnClientRevokedCertificate_STATUS"></a>VpnClientRevokedCertificate_STATUS
----------------------------------------------------------------------------------
+VpnClientRevokedCertificate_STATUS{#VpnClientRevokedCertificate_STATUS}
+-----------------------------------------------------------------------
 
 VPN client revoked certificate of virtual network gateway.
 
@@ -3690,8 +3690,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | provisioningState | The provisioning state of the VPN client revoked certificate resource.                                         | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | thumbprint        | The revoked VPN client certificate thumbprint.                                                                 | string<br/><small>Optional</small>                                                |
 
-<a id="VpnClientRootCertificate"></a>VpnClientRootCertificate
--------------------------------------------------------------
+VpnClientRootCertificate{#VpnClientRootCertificate}
+---------------------------------------------------
 
 VPN client root certificate of virtual network gateway.
 
@@ -3702,8 +3702,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | name           | The name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | publicCertData | The certificate public data.                                                                                   | string<br/><small>Required</small> |
 
-<a id="VpnClientRootCertificate_STATUS"></a>VpnClientRootCertificate_STATUS
----------------------------------------------------------------------------
+VpnClientRootCertificate_STATUS{#VpnClientRootCertificate_STATUS}
+-----------------------------------------------------------------
 
 VPN client root certificate of virtual network gateway.
 
@@ -3717,8 +3717,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | provisioningState | The provisioning state of the VPN client root certificate resource.                                            | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | publicCertData    | The certificate public data.                                                                                   | string<br/><small>Optional</small>                                                |
 
-<a id="DhGroup"></a>DhGroup
----------------------------
+DhGroup{#DhGroup}
+-----------------
 
 The DH Groups used in IKE Phase 1 for initial SA.
 
@@ -3735,8 +3735,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "ECP384"      |             |
 | "None"        |             |
 
-<a id="DhGroup_STATUS"></a>DhGroup_STATUS
------------------------------------------
+DhGroup_STATUS{#DhGroup_STATUS}
+-------------------------------
 
 The DH Groups used in IKE Phase 1 for initial SA.
 
@@ -3753,8 +3753,8 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "ECP384"      |             |
 | "None"        |             |
 
-<a id="IkeEncryption"></a>IkeEncryption
----------------------------------------
+IkeEncryption{#IkeEncryption}
+-----------------------------
 
 The IKE encryption algorithm (IKE phase 2).
 
@@ -3770,78 +3770,10 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "GCMAES128" |             |
 | "GCMAES256" |             |
 
-<a id="IkeEncryption_STATUS"></a>IkeEncryption_STATUS
------------------------------------------------------
-
-The IKE encryption algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "AES128"    |             |
-| "AES192"    |             |
-| "AES256"    |             |
-| "DES"       |             |
-| "DES3"      |             |
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-
-<a id="IkeIntegrity"></a>IkeIntegrity
--------------------------------------
-
-The IKE integrity algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy](#IpsecPolicy).
-
-| Value       | Description |
-|-------------|-------------|
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-| "MD5"       |             |
-| "SHA1"      |             |
-| "SHA256"    |             |
-| "SHA384"    |             |
-
-<a id="IkeIntegrity_STATUS"></a>IkeIntegrity_STATUS
----------------------------------------------------
-
-The IKE integrity algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-| "MD5"       |             |
-| "SHA1"      |             |
-| "SHA256"    |             |
-| "SHA384"    |             |
-
-<a id="IpsecEncryption"></a>IpsecEncryption
+IkeEncryption_STATUS{#IkeEncryption_STATUS}
 -------------------------------------------
 
-The IPSec encryption algorithm (IKE phase 1).
-
-Used by: [IpsecPolicy](#IpsecPolicy).
-
-| Value       | Description |
-|-------------|-------------|
-| "AES128"    |             |
-| "AES192"    |             |
-| "AES256"    |             |
-| "DES"       |             |
-| "DES3"      |             |
-| "GCMAES128" |             |
-| "GCMAES192" |             |
-| "GCMAES256" |             |
-| "None"      |             |
-
-<a id="IpsecEncryption_STATUS"></a>IpsecEncryption_STATUS
----------------------------------------------------------
-
-The IPSec encryption algorithm (IKE phase 1).
+The IKE encryption algorithm (IKE phase 2).
 
 Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 
@@ -3853,13 +3785,81 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "DES"       |             |
 | "DES3"      |             |
 | "GCMAES128" |             |
-| "GCMAES192" |             |
 | "GCMAES256" |             |
-| "None"      |             |
 
-<a id="IpsecIntegrity"></a>IpsecIntegrity
+IkeIntegrity{#IkeIntegrity}
+---------------------------
+
+The IKE integrity algorithm (IKE phase 2).
+
+Used by: [IpsecPolicy](#IpsecPolicy).
+
+| Value       | Description |
+|-------------|-------------|
+| "GCMAES128" |             |
+| "GCMAES256" |             |
+| "MD5"       |             |
+| "SHA1"      |             |
+| "SHA256"    |             |
+| "SHA384"    |             |
+
+IkeIntegrity_STATUS{#IkeIntegrity_STATUS}
 -----------------------------------------
 
+The IKE integrity algorithm (IKE phase 2).
+
+Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "GCMAES128" |             |
+| "GCMAES256" |             |
+| "MD5"       |             |
+| "SHA1"      |             |
+| "SHA256"    |             |
+| "SHA384"    |             |
+
+IpsecEncryption{#IpsecEncryption}
+---------------------------------
+
+The IPSec encryption algorithm (IKE phase 1).
+
+Used by: [IpsecPolicy](#IpsecPolicy).
+
+| Value       | Description |
+|-------------|-------------|
+| "AES128"    |             |
+| "AES192"    |             |
+| "AES256"    |             |
+| "DES"       |             |
+| "DES3"      |             |
+| "GCMAES128" |             |
+| "GCMAES192" |             |
+| "GCMAES256" |             |
+| "None"      |             |
+
+IpsecEncryption_STATUS{#IpsecEncryption_STATUS}
+-----------------------------------------------
+
+The IPSec encryption algorithm (IKE phase 1).
+
+Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "AES128"    |             |
+| "AES192"    |             |
+| "AES256"    |             |
+| "DES"       |             |
+| "DES3"      |             |
+| "GCMAES128" |             |
+| "GCMAES192" |             |
+| "GCMAES256" |             |
+| "None"      |             |
+
+IpsecIntegrity{#IpsecIntegrity}
+-------------------------------
+
 The IPSec integrity algorithm (IKE phase 1).
 
 Used by: [IpsecPolicy](#IpsecPolicy).
@@ -3873,8 +3873,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "SHA1"      |             |
 | "SHA256"    |             |
 
-<a id="IpsecIntegrity_STATUS"></a>IpsecIntegrity_STATUS
--------------------------------------------------------
+IpsecIntegrity_STATUS{#IpsecIntegrity_STATUS}
+---------------------------------------------
 
 The IPSec integrity algorithm (IKE phase 1).
 
@@ -3889,8 +3889,8 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "SHA1"      |             |
 | "SHA256"    |             |
 
-<a id="PfsGroup"></a>PfsGroup
------------------------------
+PfsGroup{#PfsGroup}
+-------------------
 
 The Pfs Groups used in IKE Phase 2 for new child SA.
 
@@ -3908,8 +3908,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "PFS24"   |             |
 | "PFSMM"   |             |
 
-<a id="PfsGroup_STATUS"></a>PfsGroup_STATUS
--------------------------------------------
+PfsGroup_STATUS{#PfsGroup_STATUS}
+---------------------------------
 
 The Pfs Groups used in IKE Phase 2 for new child SA.
 

--- a/docs/hugo/content/reference/network/v1api20220401.md
+++ b/docs/hugo/content/reference/network/v1api20220401.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20220401
 linktitle: v1api20220401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-04-01" |             |
 
-<a id="TrafficManagerProfile"></a>TrafficManagerProfile
--------------------------------------------------------
+TrafficManagerProfile{#TrafficManagerProfile}
+---------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}
 
@@ -26,7 +26,7 @@ Used by: [TrafficManagerProfileList](#TrafficManagerProfileList).
 | spec                                                                                    |             | [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrafficManagerProfile_Spec"></a>TrafficManagerProfile_Spec
+### TrafficManagerProfile_Spec {#TrafficManagerProfile_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -44,7 +44,7 @@ Used by: [TrafficManagerProfileList](#TrafficManagerProfileList).
 | trafficViewEnrollmentStatus | Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile.                                                                                           | [ProfileProperties_TrafficViewEnrollmentStatus](#ProfileProperties_TrafficViewEnrollmentStatus)<br/><small>Optional</small>                                          |
 | type                        | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="TrafficManagerProfile_STATUS"></a>TrafficManagerProfile_STATUS
+### TrafficManagerProfile_STATUS{#TrafficManagerProfile_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,8 +63,8 @@ Used by: [TrafficManagerProfileList](#TrafficManagerProfileList).
 | trafficViewEnrollmentStatus | Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile.                                                                                      | [ProfileProperties_TrafficViewEnrollmentStatus_STATUS](#ProfileProperties_TrafficViewEnrollmentStatus_STATUS)<br/><small>Optional</small>               |
 | type                        | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TrafficManagerProfileList"></a>TrafficManagerProfileList
----------------------------------------------------------------
+TrafficManagerProfileList{#TrafficManagerProfileList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}
 
@@ -74,8 +74,8 @@ Generator information: - Generated from: /trafficmanager/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [TrafficManagerProfile[]](#TrafficManagerProfile)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesAzureEndpoint"></a>TrafficManagerProfilesAzureEndpoint
------------------------------------------------------------------------------------
+TrafficManagerProfilesAzureEndpoint{#TrafficManagerProfilesAzureEndpoint}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/AzureEndpoints/{endpointName}
 
@@ -88,7 +88,7 @@ Used by: [TrafficManagerProfilesAzureEndpointList](#TrafficManagerProfilesAzureE
 | spec                                                                                    |             | [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrafficManagerProfilesAzureEndpoint_Spec"></a>TrafficManagerProfilesAzureEndpoint_Spec
+### TrafficManagerProfilesAzureEndpoint_Spec {#TrafficManagerProfilesAzureEndpoint_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [TrafficManagerProfilesAzureEndpointList](#TrafficManagerProfilesAzureE
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="TrafficManagerProfilesAzureEndpoint_STATUS"></a>TrafficManagerProfilesAzureEndpoint_STATUS
+### TrafficManagerProfilesAzureEndpoint_STATUS{#TrafficManagerProfilesAzureEndpoint_STATUS}
 
 | Property              | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -134,8 +134,8 @@ Used by: [TrafficManagerProfilesAzureEndpointList](#TrafficManagerProfilesAzureE
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="TrafficManagerProfilesAzureEndpointList"></a>TrafficManagerProfilesAzureEndpointList
--------------------------------------------------------------------------------------------
+TrafficManagerProfilesAzureEndpointList{#TrafficManagerProfilesAzureEndpointList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/AzureEndpoints/{endpointName}
 
@@ -145,8 +145,8 @@ Generator information: - Generated from: /trafficmanager/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [TrafficManagerProfilesAzureEndpoint[]](#TrafficManagerProfilesAzureEndpoint)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesExternalEndpoint"></a>TrafficManagerProfilesExternalEndpoint
------------------------------------------------------------------------------------------
+TrafficManagerProfilesExternalEndpoint{#TrafficManagerProfilesExternalEndpoint}
+-------------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/ExternalEndpoints/{endpointName}
 
@@ -159,7 +159,7 @@ Used by: [TrafficManagerProfilesExternalEndpointList](#TrafficManagerProfilesExt
 | spec                                                                                    |             | [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrafficManagerProfilesExternalEndpoint_Spec"></a>TrafficManagerProfilesExternalEndpoint_Spec
+### TrafficManagerProfilesExternalEndpoint_Spec {#TrafficManagerProfilesExternalEndpoint_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -182,7 +182,7 @@ Used by: [TrafficManagerProfilesExternalEndpointList](#TrafficManagerProfilesExt
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="TrafficManagerProfilesExternalEndpoint_STATUS"></a>TrafficManagerProfilesExternalEndpoint_STATUS
+### TrafficManagerProfilesExternalEndpoint_STATUS{#TrafficManagerProfilesExternalEndpoint_STATUS}
 
 | Property              | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -205,8 +205,8 @@ Used by: [TrafficManagerProfilesExternalEndpointList](#TrafficManagerProfilesExt
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="TrafficManagerProfilesExternalEndpointList"></a>TrafficManagerProfilesExternalEndpointList
--------------------------------------------------------------------------------------------------
+TrafficManagerProfilesExternalEndpointList{#TrafficManagerProfilesExternalEndpointList}
+---------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/ExternalEndpoints/{endpointName}
 
@@ -216,8 +216,8 @@ Generator information: - Generated from: /trafficmanager/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                 |
 | items                                                                               |             | [TrafficManagerProfilesExternalEndpoint[]](#TrafficManagerProfilesExternalEndpoint)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesNestedEndpoint"></a>TrafficManagerProfilesNestedEndpoint
--------------------------------------------------------------------------------------
+TrafficManagerProfilesNestedEndpoint{#TrafficManagerProfilesNestedEndpoint}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/NestedEndpoints/{endpointName}
 
@@ -230,7 +230,7 @@ Used by: [TrafficManagerProfilesNestedEndpointList](#TrafficManagerProfilesNeste
 | spec                                                                                    |             | [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="TrafficManagerProfilesNestedEndpoint_Spec"></a>TrafficManagerProfilesNestedEndpoint_Spec
+### TrafficManagerProfilesNestedEndpoint_Spec {#TrafficManagerProfilesNestedEndpoint_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -253,7 +253,7 @@ Used by: [TrafficManagerProfilesNestedEndpointList](#TrafficManagerProfilesNeste
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-### <a id="TrafficManagerProfilesNestedEndpoint_STATUS"></a>TrafficManagerProfilesNestedEndpoint_STATUS
+### TrafficManagerProfilesNestedEndpoint_STATUS{#TrafficManagerProfilesNestedEndpoint_STATUS}
 
 | Property              | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                    |
 |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -276,8 +276,8 @@ Used by: [TrafficManagerProfilesNestedEndpointList](#TrafficManagerProfilesNeste
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="TrafficManagerProfilesNestedEndpointList"></a>TrafficManagerProfilesNestedEndpointList
----------------------------------------------------------------------------------------------
+TrafficManagerProfilesNestedEndpointList{#TrafficManagerProfilesNestedEndpointList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /trafficmanager/resource-manager/Microsoft.Network/stable/2022-04-01/trafficmanager.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficmanagerprofiles/{profileName}/NestedEndpoints/{endpointName}
 
@@ -287,8 +287,8 @@ Generator information: - Generated from: /trafficmanager/resource-manager/Micros
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [TrafficManagerProfilesNestedEndpoint[]](#TrafficManagerProfilesNestedEndpoint)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfile_Spec"></a>TrafficManagerProfile_Spec
------------------------------------------------------------------
+TrafficManagerProfile_Spec{#TrafficManagerProfile_Spec}
+-------------------------------------------------------
 
 Used by: [TrafficManagerProfile](#TrafficManagerProfile).
 
@@ -308,8 +308,8 @@ Used by: [TrafficManagerProfile](#TrafficManagerProfile).
 | trafficViewEnrollmentStatus | Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile.                                                                                           | [ProfileProperties_TrafficViewEnrollmentStatus](#ProfileProperties_TrafficViewEnrollmentStatus)<br/><small>Optional</small>                                          |
 | type                        | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="TrafficManagerProfile_STATUS"></a>TrafficManagerProfile_STATUS
----------------------------------------------------------------------
+TrafficManagerProfile_STATUS{#TrafficManagerProfile_STATUS}
+-----------------------------------------------------------
 
 Used by: [TrafficManagerProfile](#TrafficManagerProfile).
 
@@ -330,8 +330,8 @@ Used by: [TrafficManagerProfile](#TrafficManagerProfile).
 | trafficViewEnrollmentStatus | Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile.                                                                                      | [ProfileProperties_TrafficViewEnrollmentStatus_STATUS](#ProfileProperties_TrafficViewEnrollmentStatus_STATUS)<br/><small>Optional</small>               |
 | type                        | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="TrafficManagerProfilesAzureEndpoint_Spec"></a>TrafficManagerProfilesAzureEndpoint_Spec
----------------------------------------------------------------------------------------------
+TrafficManagerProfilesAzureEndpoint_Spec{#TrafficManagerProfilesAzureEndpoint_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint](#TrafficManagerProfilesAzureEndpoint).
 
@@ -356,8 +356,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint](#TrafficManagerProfilesAzureEndpo
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="TrafficManagerProfilesAzureEndpoint_STATUS"></a>TrafficManagerProfilesAzureEndpoint_STATUS
--------------------------------------------------------------------------------------------------
+TrafficManagerProfilesAzureEndpoint_STATUS{#TrafficManagerProfilesAzureEndpoint_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint](#TrafficManagerProfilesAzureEndpoint).
 
@@ -382,8 +382,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint](#TrafficManagerProfilesAzureEndpo
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="TrafficManagerProfilesExternalEndpoint_Spec"></a>TrafficManagerProfilesExternalEndpoint_Spec
----------------------------------------------------------------------------------------------------
+TrafficManagerProfilesExternalEndpoint_Spec{#TrafficManagerProfilesExternalEndpoint_Spec}
+-----------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesExternalEndpoint](#TrafficManagerProfilesExternalEndpoint).
 
@@ -408,8 +408,8 @@ Used by: [TrafficManagerProfilesExternalEndpoint](#TrafficManagerProfilesExterna
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="TrafficManagerProfilesExternalEndpoint_STATUS"></a>TrafficManagerProfilesExternalEndpoint_STATUS
--------------------------------------------------------------------------------------------------------
+TrafficManagerProfilesExternalEndpoint_STATUS{#TrafficManagerProfilesExternalEndpoint_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesExternalEndpoint](#TrafficManagerProfilesExternalEndpoint).
 
@@ -434,8 +434,8 @@ Used by: [TrafficManagerProfilesExternalEndpoint](#TrafficManagerProfilesExterna
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="TrafficManagerProfilesNestedEndpoint_Spec"></a>TrafficManagerProfilesNestedEndpoint_Spec
------------------------------------------------------------------------------------------------
+TrafficManagerProfilesNestedEndpoint_Spec{#TrafficManagerProfilesNestedEndpoint_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesNestedEndpoint](#TrafficManagerProfilesNestedEndpoint).
 
@@ -460,8 +460,8 @@ Used by: [TrafficManagerProfilesNestedEndpoint](#TrafficManagerProfilesNestedEnd
 | type                    | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | weight                  | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                                      |
 
-<a id="TrafficManagerProfilesNestedEndpoint_STATUS"></a>TrafficManagerProfilesNestedEndpoint_STATUS
----------------------------------------------------------------------------------------------------
+TrafficManagerProfilesNestedEndpoint_STATUS{#TrafficManagerProfilesNestedEndpoint_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesNestedEndpoint](#TrafficManagerProfilesNestedEndpoint).
 
@@ -486,8 +486,8 @@ Used by: [TrafficManagerProfilesNestedEndpoint](#TrafficManagerProfilesNestedEnd
 | type                  | The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles.                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | weight                | The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.                                                                                                                                                                                       | int<br/><small>Optional</small>                                                                                                                         |
 
-<a id="AllowedEndpointRecordType"></a>AllowedEndpointRecordType
----------------------------------------------------------------
+AllowedEndpointRecordType{#AllowedEndpointRecordType}
+-----------------------------------------------------
 
 The allowed type DNS record types for this profile.
 
@@ -500,8 +500,8 @@ Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 | "IPv4Address" |             |
 | "IPv6Address" |             |
 
-<a id="AllowedEndpointRecordType_STATUS"></a>AllowedEndpointRecordType_STATUS
------------------------------------------------------------------------------
+AllowedEndpointRecordType_STATUS{#AllowedEndpointRecordType_STATUS}
+-------------------------------------------------------------------
 
 The allowed type DNS record types for this profile.
 
@@ -514,8 +514,8 @@ Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
 | "IPv4Address" |             |
 | "IPv6Address" |             |
 
-<a id="DnsConfig"></a>DnsConfig
--------------------------------
+DnsConfig{#DnsConfig}
+---------------------
 
 Class containing DNS settings in a Traffic Manager profile.
 
@@ -526,8 +526,8 @@ Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 | relativeName | The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile. | string<br/><small>Optional</small> |
 | ttl          | The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile.                                       | int<br/><small>Optional</small>    |
 
-<a id="DnsConfig_STATUS"></a>DnsConfig_STATUS
----------------------------------------------
+DnsConfig_STATUS{#DnsConfig_STATUS}
+-----------------------------------
 
 Class containing DNS settings in a Traffic Manager profile.
 
@@ -539,8 +539,8 @@ Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
 | relativeName | The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile. | string<br/><small>Optional</small> |
 | ttl          | The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile.                                       | int<br/><small>Optional</small>    |
 
-<a id="Endpoint_STATUS"></a>Endpoint_STATUS
--------------------------------------------
+Endpoint_STATUS{#Endpoint_STATUS}
+---------------------------------
 
 Class representing a Traffic Manager endpoint.
 
@@ -550,8 +550,8 @@ Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource Id for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficManagerProfiles/{resourceName} | string<br/><small>Optional</small> |
 
-<a id="EndpointProperties_AlwaysServe"></a>EndpointProperties_AlwaysServe
--------------------------------------------------------------------------
+EndpointProperties_AlwaysServe{#EndpointProperties_AlwaysServe}
+---------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec), [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec), and [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec).
 
@@ -560,19 +560,19 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EndpointProperties_AlwaysServe_STATUS"></a>EndpointProperties_AlwaysServe_STATUS
----------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="EndpointProperties_CustomHeaders"></a>EndpointProperties_CustomHeaders
+EndpointProperties_AlwaysServe_STATUS{#EndpointProperties_AlwaysServe_STATUS}
 -----------------------------------------------------------------------------
 
+Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+EndpointProperties_CustomHeaders{#EndpointProperties_CustomHeaders}
+-------------------------------------------------------------------
+
 Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec), [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec), and [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec).
 
 | Property | Description   | Type                               |
@@ -580,8 +580,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | name     | Header name.  | string<br/><small>Optional</small> |
 | value    | Header value. | string<br/><small>Optional</small> |
 
-<a id="EndpointProperties_CustomHeaders_STATUS"></a>EndpointProperties_CustomHeaders_STATUS
--------------------------------------------------------------------------------------------
+EndpointProperties_CustomHeaders_STATUS{#EndpointProperties_CustomHeaders_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
 
@@ -590,8 +590,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzu
 | name     | Header name.  | string<br/><small>Optional</small> |
 | value    | Header value. | string<br/><small>Optional</small> |
 
-<a id="EndpointProperties_EndpointMonitorStatus"></a>EndpointProperties_EndpointMonitorStatus
----------------------------------------------------------------------------------------------
+EndpointProperties_EndpointMonitorStatus{#EndpointProperties_EndpointMonitorStatus}
+-----------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec), [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec), and [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec).
 
@@ -605,8 +605,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | "Stopped"          |             |
 | "Unmonitored"      |             |
 
-<a id="EndpointProperties_EndpointMonitorStatus_STATUS"></a>EndpointProperties_EndpointMonitorStatus_STATUS
------------------------------------------------------------------------------------------------------------
+EndpointProperties_EndpointMonitorStatus_STATUS{#EndpointProperties_EndpointMonitorStatus_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
 
@@ -620,8 +620,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzu
 | "Stopped"          |             |
 | "Unmonitored"      |             |
 
-<a id="EndpointProperties_EndpointStatus"></a>EndpointProperties_EndpointStatus
--------------------------------------------------------------------------------
+EndpointProperties_EndpointStatus{#EndpointProperties_EndpointStatus}
+---------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec), [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec), and [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec).
 
@@ -630,8 +630,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EndpointProperties_EndpointStatus_STATUS"></a>EndpointProperties_EndpointStatus_STATUS
----------------------------------------------------------------------------------------------
+EndpointProperties_EndpointStatus_STATUS{#EndpointProperties_EndpointStatus_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
 
@@ -640,8 +640,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzu
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EndpointProperties_Subnets"></a>EndpointProperties_Subnets
------------------------------------------------------------------
+EndpointProperties_Subnets{#EndpointProperties_Subnets}
+-------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzureEndpoint_Spec), [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesExternalEndpoint_Spec), and [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNestedEndpoint_Spec).
 
@@ -651,8 +651,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | last     | Last address in the subnet.                             | string<br/><small>Optional</small> |
 | scope    | Block size (number of leading bits in the subnet mask). | int<br/><small>Optional</small>    |
 
-<a id="EndpointProperties_Subnets_STATUS"></a>EndpointProperties_Subnets_STATUS
--------------------------------------------------------------------------------
+EndpointProperties_Subnets_STATUS{#EndpointProperties_Subnets_STATUS}
+---------------------------------------------------------------------
 
 Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzureEndpoint_STATUS), [TrafficManagerProfilesExternalEndpoint_STATUS](#TrafficManagerProfilesExternalEndpoint_STATUS), and [TrafficManagerProfilesNestedEndpoint_STATUS](#TrafficManagerProfilesNestedEndpoint_STATUS).
 
@@ -662,8 +662,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_STATUS](#TrafficManagerProfilesAzu
 | last     | Last address in the subnet.                             | string<br/><small>Optional</small> |
 | scope    | Block size (number of leading bits in the subnet mask). | int<br/><small>Optional</small>    |
 
-<a id="MonitorConfig"></a>MonitorConfig
----------------------------------------
+MonitorConfig{#MonitorConfig}
+-----------------------------
 
 Class containing endpoint monitoring settings in a Traffic Manager profile.
 
@@ -681,8 +681,8 @@ Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 | timeoutInSeconds          | The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check.             | int<br/><small>Optional</small>                                                                                 |
 | toleratedNumberOfFailures | The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check. | int<br/><small>Optional</small>                                                                                 |
 
-<a id="MonitorConfig_STATUS"></a>MonitorConfig_STATUS
------------------------------------------------------
+MonitorConfig_STATUS{#MonitorConfig_STATUS}
+-------------------------------------------
 
 Class containing endpoint monitoring settings in a Traffic Manager profile.
 
@@ -700,8 +700,8 @@ Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
 | timeoutInSeconds          | The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check.             | int<br/><small>Optional</small>                                                                                               |
 | toleratedNumberOfFailures | The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check. | int<br/><small>Optional</small>                                                                                               |
 
-<a id="ProfileProperties_ProfileStatus"></a>ProfileProperties_ProfileStatus
----------------------------------------------------------------------------
+ProfileProperties_ProfileStatus{#ProfileProperties_ProfileStatus}
+-----------------------------------------------------------------
 
 Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 
@@ -710,66 +710,66 @@ Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ProfileProperties_ProfileStatus_STATUS"></a>ProfileProperties_ProfileStatus_STATUS
------------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="ProfileProperties_TrafficRoutingMethod"></a>ProfileProperties_TrafficRoutingMethod
------------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
-
-| Value         | Description |
-|---------------|-------------|
-| "Geographic"  |             |
-| "MultiValue"  |             |
-| "Performance" |             |
-| "Priority"    |             |
-| "Subnet"      |             |
-| "Weighted"    |             |
-
-<a id="ProfileProperties_TrafficRoutingMethod_STATUS"></a>ProfileProperties_TrafficRoutingMethod_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "Geographic"  |             |
-| "MultiValue"  |             |
-| "Performance" |             |
-| "Priority"    |             |
-| "Subnet"      |             |
-| "Weighted"    |             |
-
-<a id="ProfileProperties_TrafficViewEnrollmentStatus"></a>ProfileProperties_TrafficViewEnrollmentStatus
--------------------------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="ProfileProperties_TrafficViewEnrollmentStatus_STATUS"></a>ProfileProperties_TrafficViewEnrollmentStatus_STATUS
----------------------------------------------------------------------------------------------------------------------
-
-Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="TrafficManagerProfileOperatorSpec"></a>TrafficManagerProfileOperatorSpec
+ProfileProperties_ProfileStatus_STATUS{#ProfileProperties_ProfileStatus_STATUS}
 -------------------------------------------------------------------------------
+
+Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+ProfileProperties_TrafficRoutingMethod{#ProfileProperties_TrafficRoutingMethod}
+-------------------------------------------------------------------------------
+
+Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
+
+| Value         | Description |
+|---------------|-------------|
+| "Geographic"  |             |
+| "MultiValue"  |             |
+| "Performance" |             |
+| "Priority"    |             |
+| "Subnet"      |             |
+| "Weighted"    |             |
+
+ProfileProperties_TrafficRoutingMethod_STATUS{#ProfileProperties_TrafficRoutingMethod_STATUS}
+---------------------------------------------------------------------------------------------
+
+Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "Geographic"  |             |
+| "MultiValue"  |             |
+| "Performance" |             |
+| "Priority"    |             |
+| "Subnet"      |             |
+| "Weighted"    |             |
+
+ProfileProperties_TrafficViewEnrollmentStatus{#ProfileProperties_TrafficViewEnrollmentStatus}
+---------------------------------------------------------------------------------------------
+
+Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+ProfileProperties_TrafficViewEnrollmentStatus_STATUS{#ProfileProperties_TrafficViewEnrollmentStatus_STATUS}
+-----------------------------------------------------------------------------------------------------------
+
+Used by: [TrafficManagerProfile_STATUS](#TrafficManagerProfile_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+TrafficManagerProfileOperatorSpec{#TrafficManagerProfileOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -781,8 +781,8 @@ Used by: [TrafficManagerProfile_Spec](#TrafficManagerProfile_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [TrafficManagerProfileOperatorConfigMaps](#TrafficManagerProfileOperatorConfigMaps)<br/><small>Optional</small>                                                     |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesAzureEndpointOperatorSpec"></a>TrafficManagerProfilesAzureEndpointOperatorSpec
------------------------------------------------------------------------------------------------------------
+TrafficManagerProfilesAzureEndpointOperatorSpec{#TrafficManagerProfilesAzureEndpointOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -793,8 +793,8 @@ Used by: [TrafficManagerProfilesAzureEndpoint_Spec](#TrafficManagerProfilesAzure
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesExternalEndpointOperatorSpec"></a>TrafficManagerProfilesExternalEndpointOperatorSpec
------------------------------------------------------------------------------------------------------------------
+TrafficManagerProfilesExternalEndpointOperatorSpec{#TrafficManagerProfilesExternalEndpointOperatorSpec}
+-------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -805,8 +805,8 @@ Used by: [TrafficManagerProfilesExternalEndpoint_Spec](#TrafficManagerProfilesEx
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TrafficManagerProfilesNestedEndpointOperatorSpec"></a>TrafficManagerProfilesNestedEndpointOperatorSpec
--------------------------------------------------------------------------------------------------------------
+TrafficManagerProfilesNestedEndpointOperatorSpec{#TrafficManagerProfilesNestedEndpointOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -817,85 +817,85 @@ Used by: [TrafficManagerProfilesNestedEndpoint_Spec](#TrafficManagerProfilesNest
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="MonitorConfig_CustomHeaders"></a>MonitorConfig_CustomHeaders
--------------------------------------------------------------------
-
-Used by: [MonitorConfig](#MonitorConfig).
-
-| Property | Description   | Type                               |
-|----------|---------------|------------------------------------|
-| name     | Header name.  | string<br/><small>Optional</small> |
-| value    | Header value. | string<br/><small>Optional</small> |
-
-<a id="MonitorConfig_CustomHeaders_STATUS"></a>MonitorConfig_CustomHeaders_STATUS
----------------------------------------------------------------------------------
-
-Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
-
-| Property | Description   | Type                               |
-|----------|---------------|------------------------------------|
-| name     | Header name.  | string<br/><small>Optional</small> |
-| value    | Header value. | string<br/><small>Optional</small> |
-
-<a id="MonitorConfig_ExpectedStatusCodeRanges"></a>MonitorConfig_ExpectedStatusCodeRanges
------------------------------------------------------------------------------------------
-
-Used by: [MonitorConfig](#MonitorConfig).
-
-| Property | Description      | Type                            |
-|----------|------------------|---------------------------------|
-| max      | Max status code. | int<br/><small>Optional</small> |
-| min      | Min status code. | int<br/><small>Optional</small> |
-
-<a id="MonitorConfig_ExpectedStatusCodeRanges_STATUS"></a>MonitorConfig_ExpectedStatusCodeRanges_STATUS
--------------------------------------------------------------------------------------------------------
-
-Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
-
-| Property | Description      | Type                            |
-|----------|------------------|---------------------------------|
-| max      | Max status code. | int<br/><small>Optional</small> |
-| min      | Min status code. | int<br/><small>Optional</small> |
-
-<a id="MonitorConfig_ProfileMonitorStatus"></a>MonitorConfig_ProfileMonitorStatus
----------------------------------------------------------------------------------
-
-Used by: [MonitorConfig](#MonitorConfig).
-
-| Value               | Description |
-|---------------------|-------------|
-| "CheckingEndpoints" |             |
-| "Degraded"          |             |
-| "Disabled"          |             |
-| "Inactive"          |             |
-| "Online"            |             |
-
-<a id="MonitorConfig_ProfileMonitorStatus_STATUS"></a>MonitorConfig_ProfileMonitorStatus_STATUS
------------------------------------------------------------------------------------------------
-
-Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
-
-| Value               | Description |
-|---------------------|-------------|
-| "CheckingEndpoints" |             |
-| "Degraded"          |             |
-| "Disabled"          |             |
-| "Inactive"          |             |
-| "Online"            |             |
-
-<a id="MonitorConfig_Protocol"></a>MonitorConfig_Protocol
+MonitorConfig_CustomHeaders{#MonitorConfig_CustomHeaders}
 ---------------------------------------------------------
 
 Used by: [MonitorConfig](#MonitorConfig).
 
+| Property | Description   | Type                               |
+|----------|---------------|------------------------------------|
+| name     | Header name.  | string<br/><small>Optional</small> |
+| value    | Header value. | string<br/><small>Optional</small> |
+
+MonitorConfig_CustomHeaders_STATUS{#MonitorConfig_CustomHeaders_STATUS}
+-----------------------------------------------------------------------
+
+Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
+
+| Property | Description   | Type                               |
+|----------|---------------|------------------------------------|
+| name     | Header name.  | string<br/><small>Optional</small> |
+| value    | Header value. | string<br/><small>Optional</small> |
+
+MonitorConfig_ExpectedStatusCodeRanges{#MonitorConfig_ExpectedStatusCodeRanges}
+-------------------------------------------------------------------------------
+
+Used by: [MonitorConfig](#MonitorConfig).
+
+| Property | Description      | Type                            |
+|----------|------------------|---------------------------------|
+| max      | Max status code. | int<br/><small>Optional</small> |
+| min      | Min status code. | int<br/><small>Optional</small> |
+
+MonitorConfig_ExpectedStatusCodeRanges_STATUS{#MonitorConfig_ExpectedStatusCodeRanges_STATUS}
+---------------------------------------------------------------------------------------------
+
+Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
+
+| Property | Description      | Type                            |
+|----------|------------------|---------------------------------|
+| max      | Max status code. | int<br/><small>Optional</small> |
+| min      | Min status code. | int<br/><small>Optional</small> |
+
+MonitorConfig_ProfileMonitorStatus{#MonitorConfig_ProfileMonitorStatus}
+-----------------------------------------------------------------------
+
+Used by: [MonitorConfig](#MonitorConfig).
+
+| Value               | Description |
+|---------------------|-------------|
+| "CheckingEndpoints" |             |
+| "Degraded"          |             |
+| "Disabled"          |             |
+| "Inactive"          |             |
+| "Online"            |             |
+
+MonitorConfig_ProfileMonitorStatus_STATUS{#MonitorConfig_ProfileMonitorStatus_STATUS}
+-------------------------------------------------------------------------------------
+
+Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
+
+| Value               | Description |
+|---------------------|-------------|
+| "CheckingEndpoints" |             |
+| "Degraded"          |             |
+| "Disabled"          |             |
+| "Inactive"          |             |
+| "Online"            |             |
+
+MonitorConfig_Protocol{#MonitorConfig_Protocol}
+-----------------------------------------------
+
+Used by: [MonitorConfig](#MonitorConfig).
+
 | Value   | Description |
 |---------|-------------|
 | "HTTP"  |             |
 | "HTTPS" |             |
 | "TCP"   |             |
 
-<a id="MonitorConfig_Protocol_STATUS"></a>MonitorConfig_Protocol_STATUS
------------------------------------------------------------------------
+MonitorConfig_Protocol_STATUS{#MonitorConfig_Protocol_STATUS}
+-------------------------------------------------------------
 
 Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
 
@@ -905,8 +905,8 @@ Used by: [MonitorConfig_STATUS](#MonitorConfig_STATUS).
 | "HTTPS" |             |
 | "TCP"   |             |
 
-<a id="TrafficManagerProfileOperatorConfigMaps"></a>TrafficManagerProfileOperatorConfigMaps
--------------------------------------------------------------------------------------------
+TrafficManagerProfileOperatorConfigMaps{#TrafficManagerProfileOperatorConfigMaps}
+---------------------------------------------------------------------------------
 
 Used by: [TrafficManagerProfileOperatorSpec](#TrafficManagerProfileOperatorSpec).
 

--- a/docs/hugo/content/reference/network/v1api20220701.md
+++ b/docs/hugo/content/reference/network/v1api20220701.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20220701
 linktitle: v1api20220701
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-07-01" |             |
 
-<a id="ApplicationGateway"></a>ApplicationGateway
--------------------------------------------------
+ApplicationGateway{#ApplicationGateway}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/applicationGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/applicationGateways/{applicationGatewayName}
 
@@ -26,7 +26,7 @@ Used by: [ApplicationGatewayList](#ApplicationGatewayList).
 | spec                                                                                    |             | [ApplicationGateway_Spec](#ApplicationGateway_Spec)<br/><small>Optional</small>                                                                                   |
 | status                                                                                  |             | [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="ApplicationGateway_Spec"></a>ApplicationGateway_Spec
+### ApplicationGateway_Spec {#ApplicationGateway_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                                |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,7 +69,7 @@ Used by: [ApplicationGatewayList](#ApplicationGatewayList).
 | webApplicationFirewallConfiguration | Web application firewall configuration.                                                                                                                                                                                                                                                      | [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGatewayWebApplicationFirewallConfiguration)<br/><small>Optional</small>                                         |
 | zones                               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                 | string[]<br/><small>Optional</small>                                                                                                                                                |
 
-### <a id="ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded"></a>ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded
+### ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded{#ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded}
 
 | Property                            | Description                                                                                                                                                                                                           | Type                                                                                                                                                                                              |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -118,8 +118,8 @@ Used by: [ApplicationGatewayList](#ApplicationGatewayList).
 | webApplicationFirewallConfiguration | Web application firewall configuration.                                                                                                                                                                               | [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#ApplicationGatewayWebApplicationFirewallConfiguration_STATUS)<br/><small>Optional</small>                                         |
 | zones                               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                                              |
 
-<a id="ApplicationGatewayList"></a>ApplicationGatewayList
----------------------------------------------------------
+ApplicationGatewayList{#ApplicationGatewayList}
+-----------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/applicationGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/applicationGateways/{applicationGatewayName}
 
@@ -129,8 +129,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ApplicationGateway[]](#ApplicationGateway)<br/><small>Optional</small> |
 
-<a id="BastionHost"></a>BastionHost
------------------------------------
+BastionHost{#BastionHost}
+-------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/bastionHost.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/bastionHosts/{bastionHostName}
 
@@ -143,7 +143,7 @@ Used by: [BastionHostList](#BastionHostList).
 | spec                                                                                    |             | [BastionHost_Spec](#BastionHost_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BastionHost_STATUS](#BastionHost_STATUS)<br/><small>Optional</small> |
 
-### <a id="BastionHost_Spec"></a>BastionHost_Spec
+### BastionHost_Spec {#BastionHost_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -162,7 +162,7 @@ Used by: [BastionHostList](#BastionHostList).
 | sku                 | The sku of this Bastion Host.                                                                                                                                                                                                                                                                | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="BastionHost_STATUS"></a>BastionHost_STATUS
+### BastionHost_STATUS{#BastionHost_STATUS}
 
 | Property            | Description                                                              | Type                                                                                                                                                    |
 |---------------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -184,8 +184,8 @@ Used by: [BastionHostList](#BastionHostList).
 | tags                | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="BastionHostList"></a>BastionHostList
--------------------------------------------
+BastionHostList{#BastionHostList}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/bastionHost.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/bastionHosts/{bastionHostName}
 
@@ -195,8 +195,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [BastionHost[]](#BastionHost)<br/><small>Optional</small> |
 
-<a id="DnsForwardingRuleset"></a>DnsForwardingRuleset
------------------------------------------------------
+DnsForwardingRuleset{#DnsForwardingRuleset}
+-------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}
 
@@ -209,7 +209,7 @@ Used by: [DnsForwardingRulesetList](#DnsForwardingRulesetList).
 | spec                                                                                    |             | [DnsForwardingRuleset_Spec](#DnsForwardingRuleset_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsForwardingRuleset_STATUS](#DnsForwardingRuleset_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsForwardingRuleset_Spec"></a>DnsForwardingRuleset_Spec
+### DnsForwardingRuleset_Spec {#DnsForwardingRuleset_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -220,7 +220,7 @@ Used by: [DnsForwardingRulesetList](#DnsForwardingRulesetList).
 | owner                        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DnsForwardingRuleset_STATUS"></a>DnsForwardingRuleset_STATUS
+### DnsForwardingRuleset_STATUS{#DnsForwardingRuleset_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -236,8 +236,8 @@ Used by: [DnsForwardingRulesetList](#DnsForwardingRulesetList).
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsForwardingRulesetList"></a>DnsForwardingRulesetList
--------------------------------------------------------------
+DnsForwardingRulesetList{#DnsForwardingRulesetList}
+---------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}
 
@@ -247,8 +247,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [DnsForwardingRuleset[]](#DnsForwardingRuleset)<br/><small>Optional</small> |
 
-<a id="DnsForwardingRuleSetsForwardingRule"></a>DnsForwardingRuleSetsForwardingRule
------------------------------------------------------------------------------------
+DnsForwardingRuleSetsForwardingRule{#DnsForwardingRuleSetsForwardingRule}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/forwardingRules/{forwardingRuleName}
 
@@ -261,7 +261,7 @@ Used by: [DnsForwardingRuleSetsForwardingRuleList](#DnsForwardingRuleSetsForward
 | spec                                                                                    |             | [DnsForwardingRuleSetsForwardingRule_Spec](#DnsForwardingRuleSetsForwardingRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsForwardingRuleSetsForwardingRule_STATUS](#DnsForwardingRuleSetsForwardingRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsForwardingRuleSetsForwardingRule_Spec"></a>DnsForwardingRuleSetsForwardingRule_Spec
+### DnsForwardingRuleSetsForwardingRule_Spec {#DnsForwardingRuleSetsForwardingRule_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -273,7 +273,7 @@ Used by: [DnsForwardingRuleSetsForwardingRuleList](#DnsForwardingRuleSetsForward
 | owner               | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsForwardingRuleset resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | targetDnsServers    | DNS servers to forward the DNS query to.                                                                                                                                                                                                                                                          | [TargetDnsServer[]](#TargetDnsServer)<br/><small>Required</small>                                                                                                    |
 
-### <a id="DnsForwardingRuleSetsForwardingRule_STATUS"></a>DnsForwardingRuleSetsForwardingRule_STATUS
+### DnsForwardingRuleSetsForwardingRule_STATUS{#DnsForwardingRuleSetsForwardingRule_STATUS}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -289,8 +289,8 @@ Used by: [DnsForwardingRuleSetsForwardingRuleList](#DnsForwardingRuleSetsForward
 | targetDnsServers    | DNS servers to forward the DNS query to.                                                                                                                                                                                                                                                                                  | [TargetDnsServer_STATUS[]](#TargetDnsServer_STATUS)<br/><small>Optional</small>                                                                         |
 | type                | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsForwardingRuleSetsForwardingRuleList"></a>DnsForwardingRuleSetsForwardingRuleList
--------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsForwardingRuleList{#DnsForwardingRuleSetsForwardingRuleList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/forwardingRules/{forwardingRuleName}
 
@@ -300,8 +300,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [DnsForwardingRuleSetsForwardingRule[]](#DnsForwardingRuleSetsForwardingRule)<br/><small>Optional</small> |
 
-<a id="DnsForwardingRuleSetsVirtualNetworkLink"></a>DnsForwardingRuleSetsVirtualNetworkLink
--------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsVirtualNetworkLink{#DnsForwardingRuleSetsVirtualNetworkLink}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -314,7 +314,7 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLinkList](#DnsForwardingRuleSetsVir
 | spec                                                                                    |             | [DnsForwardingRuleSetsVirtualNetworkLink_Spec](#DnsForwardingRuleSetsVirtualNetworkLink_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsForwardingRuleSetsVirtualNetworkLink_STATUS](#DnsForwardingRuleSetsVirtualNetworkLink_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsForwardingRuleSetsVirtualNetworkLink_Spec"></a>DnsForwardingRuleSetsVirtualNetworkLink_Spec
+### DnsForwardingRuleSetsVirtualNetworkLink_Spec {#DnsForwardingRuleSetsVirtualNetworkLink_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                 |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -324,7 +324,7 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLinkList](#DnsForwardingRuleSetsVir
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsForwardingRuleset resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | virtualNetwork | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                      | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 
-### <a id="DnsForwardingRuleSetsVirtualNetworkLink_STATUS"></a>DnsForwardingRuleSetsVirtualNetworkLink_STATUS
+### DnsForwardingRuleSetsVirtualNetworkLink_STATUS{#DnsForwardingRuleSetsVirtualNetworkLink_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -338,8 +338,8 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLinkList](#DnsForwardingRuleSetsVir
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetwork    | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                                              | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 
-<a id="DnsForwardingRuleSetsVirtualNetworkLinkList"></a>DnsForwardingRuleSetsVirtualNetworkLinkList
----------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsVirtualNetworkLinkList{#DnsForwardingRuleSetsVirtualNetworkLinkList}
+-----------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -349,8 +349,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                   |
 | items                                                                               |             | [DnsForwardingRuleSetsVirtualNetworkLink[]](#DnsForwardingRuleSetsVirtualNetworkLink)<br/><small>Optional</small> |
 
-<a id="DnsResolver"></a>DnsResolver
------------------------------------
+DnsResolver{#DnsResolver}
+-------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}
 
@@ -363,7 +363,7 @@ Used by: [DnsResolverList](#DnsResolverList).
 | spec                                                                                    |             | [DnsResolver_Spec](#DnsResolver_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsResolver_STATUS](#DnsResolver_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsResolver_Spec"></a>DnsResolver_Spec
+### DnsResolver_Spec {#DnsResolver_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -374,7 +374,7 @@ Used by: [DnsResolverList](#DnsResolverList).
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                 | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 
-### <a id="DnsResolver_STATUS"></a>DnsResolver_STATUS
+### DnsResolver_STATUS{#DnsResolver_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -391,8 +391,8 @@ Used by: [DnsResolverList](#DnsResolverList).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetwork    | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                                              | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 
-<a id="DnsResolverList"></a>DnsResolverList
--------------------------------------------
+DnsResolverList{#DnsResolverList}
+---------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}
 
@@ -402,8 +402,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [DnsResolver[]](#DnsResolver)<br/><small>Optional</small> |
 
-<a id="DnsResolversInboundEndpoint"></a>DnsResolversInboundEndpoint
--------------------------------------------------------------------
+DnsResolversInboundEndpoint{#DnsResolversInboundEndpoint}
+---------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}/inboundEndpoints/{inboundEndpointName}
 
@@ -416,7 +416,7 @@ Used by: [DnsResolversInboundEndpointList](#DnsResolversInboundEndpointList).
 | spec                                                                                    |             | [DnsResolversInboundEndpoint_Spec](#DnsResolversInboundEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsResolversInboundEndpoint_STATUS](#DnsResolversInboundEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsResolversInboundEndpoint_Spec"></a>DnsResolversInboundEndpoint_Spec
+### DnsResolversInboundEndpoint_Spec {#DnsResolversInboundEndpoint_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -427,7 +427,7 @@ Used by: [DnsResolversInboundEndpointList](#DnsResolversInboundEndpointList).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsResolver resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags             | Resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DnsResolversInboundEndpoint_STATUS"></a>DnsResolversInboundEndpoint_STATUS
+### DnsResolversInboundEndpoint_STATUS{#DnsResolversInboundEndpoint_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -443,8 +443,8 @@ Used by: [DnsResolversInboundEndpointList](#DnsResolversInboundEndpointList).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsResolversInboundEndpointList"></a>DnsResolversInboundEndpointList
----------------------------------------------------------------------------
+DnsResolversInboundEndpointList{#DnsResolversInboundEndpointList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}/inboundEndpoints/{inboundEndpointName}
 
@@ -454,8 +454,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [DnsResolversInboundEndpoint[]](#DnsResolversInboundEndpoint)<br/><small>Optional</small> |
 
-<a id="DnsResolversOutboundEndpoint"></a>DnsResolversOutboundEndpoint
----------------------------------------------------------------------
+DnsResolversOutboundEndpoint{#DnsResolversOutboundEndpoint}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}/outboundEndpoints/{outboundEndpointName}
 
@@ -468,7 +468,7 @@ Used by: [DnsResolversOutboundEndpointList](#DnsResolversOutboundEndpointList).
 | spec                                                                                    |             | [DnsResolversOutboundEndpoint_Spec](#DnsResolversOutboundEndpoint_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [DnsResolversOutboundEndpoint_STATUS](#DnsResolversOutboundEndpoint_STATUS)<br/><small>Optional</small> |
 
-### <a id="DnsResolversOutboundEndpoint_Spec"></a>DnsResolversOutboundEndpoint_Spec
+### DnsResolversOutboundEndpoint_Spec {#DnsResolversOutboundEndpoint_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -479,7 +479,7 @@ Used by: [DnsResolversOutboundEndpointList](#DnsResolversOutboundEndpointList).
 | subnet       | The reference to the subnet used for the outbound endpoint.                                                                                                                                                                                                                              | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="DnsResolversOutboundEndpoint_STATUS"></a>DnsResolversOutboundEndpoint_STATUS
+### DnsResolversOutboundEndpoint_STATUS{#DnsResolversOutboundEndpoint_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -495,8 +495,8 @@ Used by: [DnsResolversOutboundEndpointList](#DnsResolversOutboundEndpointList).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsResolversOutboundEndpointList"></a>DnsResolversOutboundEndpointList
------------------------------------------------------------------------------
+DnsResolversOutboundEndpointList{#DnsResolversOutboundEndpointList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft.Network/stable/2022-07-01/dnsresolver.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/dnsResolvers/{dnsResolverName}/outboundEndpoints/{outboundEndpointName}
 
@@ -506,8 +506,8 @@ Generator information: - Generated from: /dnsresolver/resource-manager/Microsoft
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [DnsResolversOutboundEndpoint[]](#DnsResolversOutboundEndpoint)<br/><small>Optional</small> |
 
-<a id="NatGateway"></a>NatGateway
----------------------------------
+NatGateway{#NatGateway}
+-----------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/natGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/natGateways/{natGatewayName}
 
@@ -520,7 +520,7 @@ Used by: [NatGatewayList](#NatGatewayList).
 | spec                                                                                    |             | [NatGateway_Spec](#NatGateway_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NatGateway_STATUS](#NatGateway_STATUS)<br/><small>Optional</small> |
 
-### <a id="NatGateway_Spec"></a>NatGateway_Spec
+### NatGateway_Spec {#NatGateway_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -535,7 +535,7 @@ Used by: [NatGatewayList](#NatGatewayList).
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed.                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="NatGateway_STATUS"></a>NatGateway_STATUS
+### NatGateway_STATUS{#NatGateway_STATUS}
 
 | Property             | Description                                                                             | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -555,8 +555,8 @@ Used by: [NatGatewayList](#NatGatewayList).
 | type                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="NatGatewayList"></a>NatGatewayList
------------------------------------------
+NatGatewayList{#NatGatewayList}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/natGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/natGateways/{natGatewayName}
 
@@ -566,8 +566,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [NatGateway[]](#NatGateway)<br/><small>Optional</small> |
 
-<a id="PrivateEndpoint"></a>PrivateEndpoint
--------------------------------------------
+PrivateEndpoint{#PrivateEndpoint}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}
 
@@ -580,7 +580,7 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | spec                                                                                    |             | [PrivateEndpoint_Spec](#PrivateEndpoint_Spec)<br/><small>Optional</small>                                                                             |
 | status                                                                                  |             | [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="PrivateEndpoint_Spec"></a>PrivateEndpoint_Spec
+### PrivateEndpoint_Spec {#PrivateEndpoint_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -597,7 +597,7 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | subnet                              | The ID of the subnet from which the private IP will be allocated.                                                                                                                                                                                                                            | [Subnet_PrivateEndpoint_SubResourceEmbedded](#Subnet_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small>                                                |
 | tags                                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded
+### PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded{#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded}
 
 | Property                            | Description                                                                                                                                                            | Type                                                                                                                                                                      |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -619,8 +619,8 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | tags                                | Resource tags.                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                             |
 | type                                | Resource type.                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                        |
 
-<a id="PrivateEndpointList"></a>PrivateEndpointList
----------------------------------------------------
+PrivateEndpointList{#PrivateEndpointList}
+-----------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}
 
@@ -630,8 +630,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [PrivateEndpoint[]](#PrivateEndpoint)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup"></a>PrivateEndpointsPrivateDnsZoneGroup
------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup{#PrivateEndpointsPrivateDnsZoneGroup}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}
 
@@ -644,7 +644,7 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | spec                                                                                    |             | [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZoneGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateEndpointsPrivateDnsZoneGroup_STATUS](#PrivateEndpointsPrivateDnsZoneGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateEndpointsPrivateDnsZoneGroup_Spec"></a>PrivateEndpointsPrivateDnsZoneGroup_Spec
+### PrivateEndpointsPrivateDnsZoneGroup_Spec {#PrivateEndpointsPrivateDnsZoneGroup_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -653,7 +653,7 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/PrivateEndpoint resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                                                                                                                                                                                                               | [PrivateDnsZoneConfig[]](#PrivateDnsZoneConfig)<br/><small>Optional</small>                                                                                          |
 
-### <a id="PrivateEndpointsPrivateDnsZoneGroup_STATUS"></a>PrivateEndpointsPrivateDnsZoneGroup_STATUS
+### PrivateEndpointsPrivateDnsZoneGroup_STATUS{#PrivateEndpointsPrivateDnsZoneGroup_STATUS}
 
 | Property              | Description                                                                                                | Type                                                                                                                                                    |
 |-----------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -664,8 +664,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                             | [PrivateDnsZoneConfig_STATUS[]](#PrivateDnsZoneConfig_STATUS)<br/><small>Optional</small>                                                               |
 | provisioningState     | The provisioning state of the private dns zone group resource.                                             | [PrivateEndpointProvisioningState_STATUS](#PrivateEndpointProvisioningState_STATUS)<br/><small>Optional</small>                                         |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroupList"></a>PrivateEndpointsPrivateDnsZoneGroupList
--------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroupList{#PrivateEndpointsPrivateDnsZoneGroupList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}
 
@@ -675,8 +675,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [PrivateEndpointsPrivateDnsZoneGroup[]](#PrivateEndpointsPrivateDnsZoneGroup)<br/><small>Optional</small> |
 
-<a id="PrivateLinkService"></a>PrivateLinkService
--------------------------------------------------
+PrivateLinkService{#PrivateLinkService}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateLinkService.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateLinkServices/{serviceName}
 
@@ -689,7 +689,7 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | spec                                                                                    |             | [PrivateLinkService_Spec](#PrivateLinkService_Spec)<br/><small>Optional</small>                                                                                   |
 | status                                                                                  |             | [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="PrivateLinkService_Spec"></a>PrivateLinkService_Spec
+### PrivateLinkService_Spec {#PrivateLinkService_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -706,7 +706,7 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | visibility                           | The visibility list of the private link service.                                                                                                                                                                                                                                             | [ResourceSet](#ResourceSet)<br/><small>Optional</small>                                                                                                              |
 
-### <a id="PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded"></a>PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
+### PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded{#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded}
 
 | Property                             | Description                                                                             | Type                                                                                                                                                                          |
 |--------------------------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -729,8 +729,8 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | type                                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                                            |
 | visibility                           | The visibility list of the private link service.                                        | [ResourceSet_STATUS](#ResourceSet_STATUS)<br/><small>Optional</small>                                                                                                         |
 
-<a id="PrivateLinkServiceList"></a>PrivateLinkServiceList
----------------------------------------------------------
+PrivateLinkServiceList{#PrivateLinkServiceList}
+-----------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/privateLinkService.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateLinkServices/{serviceName}
 
@@ -740,8 +740,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [PrivateLinkService[]](#PrivateLinkService)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefix"></a>PublicIPPrefix
------------------------------------------
+PublicIPPrefix{#PublicIPPrefix}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpPrefix.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}
 
@@ -754,7 +754,7 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | spec                                                                                    |             | [PublicIPPrefix_Spec](#PublicIPPrefix_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS)<br/><small>Optional</small> |
 
-### <a id="PublicIPPrefix_Spec"></a>PublicIPPrefix_Spec
+### PublicIPPrefix_Spec {#PublicIPPrefix_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -772,7 +772,7 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                  | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="PublicIPPrefix_STATUS"></a>PublicIPPrefix_STATUS
+### PublicIPPrefix_STATUS{#PublicIPPrefix_STATUS}
 
 | Property                            | Description                                                                                    | Type                                                                                                                                                    |
 |-------------------------------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -797,8 +797,8 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | type                                | Resource type.                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                               | A list of availability zones denoting the IP allocated for the resource needs to come from.    | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PublicIPPrefixList"></a>PublicIPPrefixList
--------------------------------------------------
+PublicIPPrefixList{#PublicIPPrefixList}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpPrefix.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}
 
@@ -808,8 +808,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PublicIPPrefix[]](#PublicIPPrefix)<br/><small>Optional</small> |
 
-<a id="ApplicationGateway_Spec"></a>ApplicationGateway_Spec
------------------------------------------------------------
+ApplicationGateway_Spec{#ApplicationGateway_Spec}
+-------------------------------------------------
 
 Used by: [ApplicationGateway](#ApplicationGateway).
 
@@ -854,8 +854,8 @@ Used by: [ApplicationGateway](#ApplicationGateway).
 | webApplicationFirewallConfiguration | Web application firewall configuration.                                                                                                                                                                                                                                                      | [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGatewayWebApplicationFirewallConfiguration)<br/><small>Optional</small>                                         |
 | zones                               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                 | string[]<br/><small>Optional</small>                                                                                                                                                |
 
-<a id="ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded"></a>ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded{#ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Application gateway resource.
 
@@ -908,8 +908,8 @@ Used by: [ApplicationGateway](#ApplicationGateway).
 | webApplicationFirewallConfiguration | Web application firewall configuration.                                                                                                                                                                               | [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#ApplicationGatewayWebApplicationFirewallConfiguration_STATUS)<br/><small>Optional</small>                                         |
 | zones                               | A list of availability zones denoting where the resource needs to come from.                                                                                                                                          | string[]<br/><small>Optional</small>                                                                                                                                                              |
 
-<a id="BastionHost_Spec"></a>BastionHost_Spec
----------------------------------------------
+BastionHost_Spec{#BastionHost_Spec}
+-----------------------------------
 
 Used by: [BastionHost](#BastionHost).
 
@@ -930,8 +930,8 @@ Used by: [BastionHost](#BastionHost).
 | sku                 | The sku of this Bastion Host.                                                                                                                                                                                                                                                                | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="BastionHost_STATUS"></a>BastionHost_STATUS
--------------------------------------------------
+BastionHost_STATUS{#BastionHost_STATUS}
+---------------------------------------
 
 Bastion Host resource.
 
@@ -957,8 +957,8 @@ Used by: [BastionHost](#BastionHost).
 | tags                | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsForwardingRuleset_Spec"></a>DnsForwardingRuleset_Spec
----------------------------------------------------------------
+DnsForwardingRuleset_Spec{#DnsForwardingRuleset_Spec}
+-----------------------------------------------------
 
 Used by: [DnsForwardingRuleset](#DnsForwardingRuleset).
 
@@ -971,8 +971,8 @@ Used by: [DnsForwardingRuleset](#DnsForwardingRuleset).
 | owner                        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DnsForwardingRuleset_STATUS"></a>DnsForwardingRuleset_STATUS
--------------------------------------------------------------------
+DnsForwardingRuleset_STATUS{#DnsForwardingRuleset_STATUS}
+---------------------------------------------------------
 
 Describes a DNS forwarding ruleset.
 
@@ -992,8 +992,8 @@ Used by: [DnsForwardingRuleset](#DnsForwardingRuleset).
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                         | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsForwardingRuleSetsForwardingRule_Spec"></a>DnsForwardingRuleSetsForwardingRule_Spec
----------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsForwardingRule_Spec{#DnsForwardingRuleSetsForwardingRule_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsForwardingRule](#DnsForwardingRuleSetsForwardingRule).
 
@@ -1007,8 +1007,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule](#DnsForwardingRuleSetsForwardingR
 | owner               | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsForwardingRuleset resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | targetDnsServers    | DNS servers to forward the DNS query to.                                                                                                                                                                                                                                                          | [TargetDnsServer[]](#TargetDnsServer)<br/><small>Required</small>                                                                                                    |
 
-<a id="DnsForwardingRuleSetsForwardingRule_STATUS"></a>DnsForwardingRuleSetsForwardingRule_STATUS
--------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsForwardingRule_STATUS{#DnsForwardingRuleSetsForwardingRule_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsForwardingRule](#DnsForwardingRuleSetsForwardingRule).
 
@@ -1026,8 +1026,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule](#DnsForwardingRuleSetsForwardingR
 | targetDnsServers    | DNS servers to forward the DNS query to.                                                                                                                                                                                                                                                                                  | [TargetDnsServer_STATUS[]](#TargetDnsServer_STATUS)<br/><small>Optional</small>                                                                         |
 | type                | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsForwardingRuleSetsVirtualNetworkLink_Spec"></a>DnsForwardingRuleSetsVirtualNetworkLink_Spec
------------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsVirtualNetworkLink_Spec{#DnsForwardingRuleSetsVirtualNetworkLink_Spec}
+-------------------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsVirtualNetworkLink](#DnsForwardingRuleSetsVirtualNetworkLink).
 
@@ -1039,8 +1039,8 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLink](#DnsForwardingRuleSetsVirtual
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsForwardingRuleset resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | virtualNetwork | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                      | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 
-<a id="DnsForwardingRuleSetsVirtualNetworkLink_STATUS"></a>DnsForwardingRuleSetsVirtualNetworkLink_STATUS
----------------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsVirtualNetworkLink_STATUS{#DnsForwardingRuleSetsVirtualNetworkLink_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsVirtualNetworkLink](#DnsForwardingRuleSetsVirtualNetworkLink).
 
@@ -1056,8 +1056,8 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLink](#DnsForwardingRuleSetsVirtual
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetwork    | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                                              | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 
-<a id="DnsResolver_Spec"></a>DnsResolver_Spec
----------------------------------------------
+DnsResolver_Spec{#DnsResolver_Spec}
+-----------------------------------
 
 Used by: [DnsResolver](#DnsResolver).
 
@@ -1070,8 +1070,8 @@ Used by: [DnsResolver](#DnsResolver).
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                 | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 
-<a id="DnsResolver_STATUS"></a>DnsResolver_STATUS
--------------------------------------------------
+DnsResolver_STATUS{#DnsResolver_STATUS}
+---------------------------------------
 
 Describes a DNS resolver.
 
@@ -1092,8 +1092,8 @@ Used by: [DnsResolver](#DnsResolver).
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetwork    | The reference to the virtual network. This cannot be changed after creation.                                                                                                                                                                                                                                              | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 
-<a id="DnsResolversInboundEndpoint_Spec"></a>DnsResolversInboundEndpoint_Spec
------------------------------------------------------------------------------
+DnsResolversInboundEndpoint_Spec{#DnsResolversInboundEndpoint_Spec}
+-------------------------------------------------------------------
 
 Used by: [DnsResolversInboundEndpoint](#DnsResolversInboundEndpoint).
 
@@ -1106,8 +1106,8 @@ Used by: [DnsResolversInboundEndpoint](#DnsResolversInboundEndpoint).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/DnsResolver resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags             | Resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DnsResolversInboundEndpoint_STATUS"></a>DnsResolversInboundEndpoint_STATUS
----------------------------------------------------------------------------------
+DnsResolversInboundEndpoint_STATUS{#DnsResolversInboundEndpoint_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [DnsResolversInboundEndpoint](#DnsResolversInboundEndpoint).
 
@@ -1125,8 +1125,8 @@ Used by: [DnsResolversInboundEndpoint](#DnsResolversInboundEndpoint).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DnsResolversOutboundEndpoint_Spec"></a>DnsResolversOutboundEndpoint_Spec
--------------------------------------------------------------------------------
+DnsResolversOutboundEndpoint_Spec{#DnsResolversOutboundEndpoint_Spec}
+---------------------------------------------------------------------
 
 Used by: [DnsResolversOutboundEndpoint](#DnsResolversOutboundEndpoint).
 
@@ -1139,8 +1139,8 @@ Used by: [DnsResolversOutboundEndpoint](#DnsResolversOutboundEndpoint).
 | subnet       | The reference to the subnet used for the outbound endpoint.                                                                                                                                                                                                                              | [SubResource](#SubResource)<br/><small>Required</small>                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                           | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="DnsResolversOutboundEndpoint_STATUS"></a>DnsResolversOutboundEndpoint_STATUS
------------------------------------------------------------------------------------
+DnsResolversOutboundEndpoint_STATUS{#DnsResolversOutboundEndpoint_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [DnsResolversOutboundEndpoint](#DnsResolversOutboundEndpoint).
 
@@ -1158,8 +1158,8 @@ Used by: [DnsResolversOutboundEndpoint](#DnsResolversOutboundEndpoint).
 | tags              | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NatGateway_Spec"></a>NatGateway_Spec
--------------------------------------------
+NatGateway_Spec{#NatGateway_Spec}
+---------------------------------
 
 Used by: [NatGateway](#NatGateway).
 
@@ -1176,8 +1176,8 @@ Used by: [NatGateway](#NatGateway).
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed.                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="NatGateway_STATUS"></a>NatGateway_STATUS
------------------------------------------------
+NatGateway_STATUS{#NatGateway_STATUS}
+-------------------------------------
 
 Nat Gateway resource.
 
@@ -1201,8 +1201,8 @@ Used by: [NatGateway](#NatGateway).
 | type                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PrivateEndpoint_Spec"></a>PrivateEndpoint_Spec
------------------------------------------------------
+PrivateEndpoint_Spec{#PrivateEndpoint_Spec}
+-------------------------------------------
 
 Used by: [PrivateEndpoint](#PrivateEndpoint).
 
@@ -1221,8 +1221,8 @@ Used by: [PrivateEndpoint](#PrivateEndpoint).
 | subnet                              | The ID of the subnet from which the private IP will be allocated.                                                                                                                                                                                                                            | [Subnet_PrivateEndpoint_SubResourceEmbedded](#Subnet_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small>                                                |
 | tags                                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded{#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -1248,8 +1248,8 @@ Used by: [PrivateEndpoint](#PrivateEndpoint).
 | tags                                | Resource tags.                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                             |
 | type                                | Resource type.                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                        |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup_Spec"></a>PrivateEndpointsPrivateDnsZoneGroup_Spec
----------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup_Spec{#PrivateEndpointsPrivateDnsZoneGroup_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGroup).
 
@@ -1260,8 +1260,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGr
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/PrivateEndpoint resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                                                                                                                                                                                                               | [PrivateDnsZoneConfig[]](#PrivateDnsZoneConfig)<br/><small>Optional</small>                                                                                          |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup_STATUS"></a>PrivateEndpointsPrivateDnsZoneGroup_STATUS
--------------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup_STATUS{#PrivateEndpointsPrivateDnsZoneGroup_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGroup).
 
@@ -1274,8 +1274,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGr
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                             | [PrivateDnsZoneConfig_STATUS[]](#PrivateDnsZoneConfig_STATUS)<br/><small>Optional</small>                                                               |
 | provisioningState     | The provisioning state of the private dns zone group resource.                                             | [PrivateEndpointProvisioningState_STATUS](#PrivateEndpointProvisioningState_STATUS)<br/><small>Optional</small>                                         |
 
-<a id="PrivateLinkService_Spec"></a>PrivateLinkService_Spec
------------------------------------------------------------
+PrivateLinkService_Spec{#PrivateLinkService_Spec}
+-------------------------------------------------
 
 Used by: [PrivateLinkService](#PrivateLinkService).
 
@@ -1294,8 +1294,8 @@ Used by: [PrivateLinkService](#PrivateLinkService).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | visibility                           | The visibility list of the private link service.                                                                                                                                                                                                                                             | [ResourceSet](#ResourceSet)<br/><small>Optional</small>                                                                                                              |
 
-<a id="PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded"></a>PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded{#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Private link service resource.
 
@@ -1322,8 +1322,8 @@ Used by: [PrivateLinkService](#PrivateLinkService).
 | type                                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                                            |
 | visibility                           | The visibility list of the private link service.                                        | [ResourceSet_STATUS](#ResourceSet_STATUS)<br/><small>Optional</small>                                                                                                         |
 
-<a id="PublicIPPrefix_Spec"></a>PublicIPPrefix_Spec
----------------------------------------------------
+PublicIPPrefix_Spec{#PublicIPPrefix_Spec}
+-----------------------------------------
 
 Used by: [PublicIPPrefix](#PublicIPPrefix).
 
@@ -1343,8 +1343,8 @@ Used by: [PublicIPPrefix](#PublicIPPrefix).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                  | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="PublicIPPrefix_STATUS"></a>PublicIPPrefix_STATUS
--------------------------------------------------------
+PublicIPPrefix_STATUS{#PublicIPPrefix_STATUS}
+---------------------------------------------
 
 Public IP prefix resource.
 
@@ -1373,8 +1373,8 @@ Used by: [PublicIPPrefix](#PublicIPPrefix).
 | type                                | Resource type.                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                               | A list of availability zones denoting the IP allocated for the resource needs to come from.    | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="ApplicationGatewayAuthenticationCertificate"></a>ApplicationGatewayAuthenticationCertificate
----------------------------------------------------------------------------------------------------
+ApplicationGatewayAuthenticationCertificate{#ApplicationGatewayAuthenticationCertificate}
+-----------------------------------------------------------------------------------------
 
 Authentication certificates of an application gateway.
 
@@ -1385,8 +1385,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | data     | Certificate public data.                                                             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | name     | Name of the authentication certificate that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ApplicationGatewayAuthenticationCertificate_STATUS"></a>ApplicationGatewayAuthenticationCertificate_STATUS
------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayAuthenticationCertificate_STATUS{#ApplicationGatewayAuthenticationCertificate_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Authentication certificates of an application gateway.
 
@@ -1396,8 +1396,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayAutoscaleConfiguration"></a>ApplicationGatewayAutoscaleConfiguration
----------------------------------------------------------------------------------------------
+ApplicationGatewayAutoscaleConfiguration{#ApplicationGatewayAutoscaleConfiguration}
+-----------------------------------------------------------------------------------
 
 Application Gateway autoscale configuration.
 
@@ -1408,8 +1408,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | maxCapacity | Upper bound on number of Application Gateway capacity. | int<br/><small>Optional</small> |
 | minCapacity | Lower bound on number of Application Gateway capacity. | int<br/><small>Required</small> |
 
-<a id="ApplicationGatewayAutoscaleConfiguration_STATUS"></a>ApplicationGatewayAutoscaleConfiguration_STATUS
------------------------------------------------------------------------------------------------------------
+ApplicationGatewayAutoscaleConfiguration_STATUS{#ApplicationGatewayAutoscaleConfiguration_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Application Gateway autoscale configuration.
 
@@ -1420,8 +1420,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | maxCapacity | Upper bound on number of Application Gateway capacity. | int<br/><small>Optional</small> |
 | minCapacity | Lower bound on number of Application Gateway capacity. | int<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayBackendAddressPool"></a>ApplicationGatewayBackendAddressPool
--------------------------------------------------------------------------------------
+ApplicationGatewayBackendAddressPool{#ApplicationGatewayBackendAddressPool}
+---------------------------------------------------------------------------
 
 Backend Address Pool of an application gateway.
 
@@ -1432,8 +1432,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | backendAddresses | Backend addresses.                                                             | [ApplicationGatewayBackendAddress[]](#ApplicationGatewayBackendAddress)<br/><small>Optional</small> |
 | name             | Name of the backend address pool that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                                  |
 
-<a id="ApplicationGatewayBackendAddressPool_STATUS"></a>ApplicationGatewayBackendAddressPool_STATUS
----------------------------------------------------------------------------------------------------
+ApplicationGatewayBackendAddressPool_STATUS{#ApplicationGatewayBackendAddressPool_STATUS}
+-----------------------------------------------------------------------------------------
 
 Backend Address Pool of an application gateway.
 
@@ -1443,8 +1443,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayBackendHttpSettings"></a>ApplicationGatewayBackendHttpSettings
----------------------------------------------------------------------------------------
+ApplicationGatewayBackendHttpSettings{#ApplicationGatewayBackendHttpSettings}
+-----------------------------------------------------------------------------
 
 Backend address pool settings of an application gateway.
 
@@ -1467,8 +1467,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | requestTimeout                 | Request timeout in seconds. Application Gateway will fail the request if response is not received within RequestTimeout. Acceptable values are from 1 second to 86400 seconds. | int<br/><small>Optional</small>                                                                                                                                                     |
 | trustedRootCertificates        | Array of references to application gateway trusted root certificates.                                                                                                          | [SubResource[]](#SubResource)<br/><small>Optional</small>                                                                                                                           |
 
-<a id="ApplicationGatewayBackendHttpSettings_STATUS"></a>ApplicationGatewayBackendHttpSettings_STATUS
------------------------------------------------------------------------------------------------------
+ApplicationGatewayBackendHttpSettings_STATUS{#ApplicationGatewayBackendHttpSettings_STATUS}
+-------------------------------------------------------------------------------------------
 
 Backend address pool settings of an application gateway.
 
@@ -1478,8 +1478,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayBackendSettings"></a>ApplicationGatewayBackendSettings
--------------------------------------------------------------------------------
+ApplicationGatewayBackendSettings{#ApplicationGatewayBackendSettings}
+---------------------------------------------------------------------
 
 Backend address pool settings of an application gateway.
 
@@ -1496,8 +1496,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | timeout                        | Connection timeout in seconds. Application Gateway will fail the request if response is not received within ConnectionTimeout. Acceptable values are from 1 second to 86400 seconds. | int<br/><small>Optional</small>                                                       |
 | trustedRootCertificates        | Array of references to application gateway trusted root certificates.                                                                                                                | [SubResource[]](#SubResource)<br/><small>Optional</small>                             |
 
-<a id="ApplicationGatewayBackendSettings_STATUS"></a>ApplicationGatewayBackendSettings_STATUS
----------------------------------------------------------------------------------------------
+ApplicationGatewayBackendSettings_STATUS{#ApplicationGatewayBackendSettings_STATUS}
+-----------------------------------------------------------------------------------
 
 Backend address pool settings of an application gateway.
 
@@ -1507,8 +1507,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayCustomError"></a>ApplicationGatewayCustomError
------------------------------------------------------------------------
+ApplicationGatewayCustomError{#ApplicationGatewayCustomError}
+-------------------------------------------------------------
 
 Customer error of an application gateway.
 
@@ -1519,8 +1519,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec), and [ApplicationGa
 | customErrorPageUrl | Error page URL of the application gateway customer error. | string<br/><small>Optional</small>                                                                                |
 | statusCode         | Status code of the application gateway customer error.    | [ApplicationGatewayCustomError_StatusCode](#ApplicationGatewayCustomError_StatusCode)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayCustomError_STATUS"></a>ApplicationGatewayCustomError_STATUS
--------------------------------------------------------------------------------------
+ApplicationGatewayCustomError_STATUS{#ApplicationGatewayCustomError_STATUS}
+---------------------------------------------------------------------------
 
 Customer error of an application gateway.
 
@@ -1531,8 +1531,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | customErrorPageUrl | Error page URL of the application gateway customer error. | string<br/><small>Optional</small>                                                                                              |
 | statusCode         | Status code of the application gateway customer error.    | [ApplicationGatewayCustomError_StatusCode_STATUS](#ApplicationGatewayCustomError_StatusCode_STATUS)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayFrontendIPConfiguration"></a>ApplicationGatewayFrontendIPConfiguration
------------------------------------------------------------------------------------------------
+ApplicationGatewayFrontendIPConfiguration{#ApplicationGatewayFrontendIPConfiguration}
+-------------------------------------------------------------------------------------
 
 Frontend IP configuration of an application gateway.
 
@@ -1547,8 +1547,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | publicIPAddress           | Reference to the PublicIP resource.                                                 | [SubResource](#SubResource)<br/><small>Optional</small>               |
 | subnet                    | Reference to the subnet resource.                                                   | [SubResource](#SubResource)<br/><small>Optional</small>               |
 
-<a id="ApplicationGatewayFrontendIPConfiguration_STATUS"></a>ApplicationGatewayFrontendIPConfiguration_STATUS
--------------------------------------------------------------------------------------------------------------
+ApplicationGatewayFrontendIPConfiguration_STATUS{#ApplicationGatewayFrontendIPConfiguration_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Frontend IP configuration of an application gateway.
 
@@ -1558,8 +1558,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayFrontendPort"></a>ApplicationGatewayFrontendPort
--------------------------------------------------------------------------
+ApplicationGatewayFrontendPort{#ApplicationGatewayFrontendPort}
+---------------------------------------------------------------
 
 Frontend port of an application gateway.
 
@@ -1570,8 +1570,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name     | Name of the frontend port that is unique within an Application Gateway. | string<br/><small>Optional</small> |
 | port     | Frontend port.                                                          | int<br/><small>Optional</small>    |
 
-<a id="ApplicationGatewayFrontendPort_STATUS"></a>ApplicationGatewayFrontendPort_STATUS
----------------------------------------------------------------------------------------
+ApplicationGatewayFrontendPort_STATUS{#ApplicationGatewayFrontendPort_STATUS}
+-----------------------------------------------------------------------------
 
 Frontend port of an application gateway.
 
@@ -1581,8 +1581,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayGlobalConfiguration"></a>ApplicationGatewayGlobalConfiguration
----------------------------------------------------------------------------------------
+ApplicationGatewayGlobalConfiguration{#ApplicationGatewayGlobalConfiguration}
+-----------------------------------------------------------------------------
 
 Application Gateway global configuration.
 
@@ -1593,8 +1593,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | enableRequestBuffering  | Enable request buffering.  | bool<br/><small>Optional</small> |
 | enableResponseBuffering | Enable response buffering. | bool<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayGlobalConfiguration_STATUS"></a>ApplicationGatewayGlobalConfiguration_STATUS
------------------------------------------------------------------------------------------------------
+ApplicationGatewayGlobalConfiguration_STATUS{#ApplicationGatewayGlobalConfiguration_STATUS}
+-------------------------------------------------------------------------------------------
 
 Application Gateway global configuration.
 
@@ -1605,8 +1605,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | enableRequestBuffering  | Enable request buffering.  | bool<br/><small>Optional</small> |
 | enableResponseBuffering | Enable response buffering. | bool<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayHttpListener"></a>ApplicationGatewayHttpListener
--------------------------------------------------------------------------
+ApplicationGatewayHttpListener{#ApplicationGatewayHttpListener}
+---------------------------------------------------------------
 
 Http listener of an application gateway.
 
@@ -1626,8 +1626,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | sslCertificate              | SSL certificate resource of an application gateway.                                   | [SubResource](#SubResource)<br/><small>Optional</small>                                       |
 | sslProfile                  | SSL profile resource of the application gateway.                                      | [SubResource](#SubResource)<br/><small>Optional</small>                                       |
 
-<a id="ApplicationGatewayHttpListener_STATUS"></a>ApplicationGatewayHttpListener_STATUS
----------------------------------------------------------------------------------------
+ApplicationGatewayHttpListener_STATUS{#ApplicationGatewayHttpListener_STATUS}
+-----------------------------------------------------------------------------
 
 Http listener of an application gateway.
 
@@ -1637,8 +1637,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_ApplicationGateway_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_ApplicationGateway_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_ApplicationGateway_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_ApplicationGateway_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -1649,8 +1649,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name     | Name of the IP configuration that is unique within an Application Gateway.                          | string<br/><small>Optional</small>                      |
 | subnet   | Reference to the subnet resource. A subnet from where application gateway gets its private address. | [SubResource](#SubResource)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_STATUS_ApplicationGateway_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_STATUS_ApplicationGateway_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_STATUS_ApplicationGateway_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_STATUS_ApplicationGateway_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -1660,8 +1660,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayListener"></a>ApplicationGatewayListener
------------------------------------------------------------------
+ApplicationGatewayListener{#ApplicationGatewayListener}
+-------------------------------------------------------
 
 Listener of an application gateway.
 
@@ -1676,8 +1676,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | sslCertificate          | SSL certificate resource of an application gateway.                | [SubResource](#SubResource)<br/><small>Optional</small>                               |
 | sslProfile              | SSL profile resource of the application gateway.                   | [SubResource](#SubResource)<br/><small>Optional</small>                               |
 
-<a id="ApplicationGatewayListener_STATUS"></a>ApplicationGatewayListener_STATUS
--------------------------------------------------------------------------------
+ApplicationGatewayListener_STATUS{#ApplicationGatewayListener_STATUS}
+---------------------------------------------------------------------
 
 Listener of an application gateway.
 
@@ -1687,8 +1687,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayLoadDistributionPolicy"></a>ApplicationGatewayLoadDistributionPolicy
----------------------------------------------------------------------------------------------
+ApplicationGatewayLoadDistributionPolicy{#ApplicationGatewayLoadDistributionPolicy}
+-----------------------------------------------------------------------------------
 
 Load Distribution Policy of an application gateway.
 
@@ -1700,8 +1700,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | loadDistributionTargets   | Load Distribution Targets resource of an application gateway.                      | [ApplicationGatewayLoadDistributionTarget[]](#ApplicationGatewayLoadDistributionTarget)<br/><small>Optional</small>             |
 | name                      | Name of the load distribution policy that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                                                              |
 
-<a id="ApplicationGatewayLoadDistributionPolicy_STATUS"></a>ApplicationGatewayLoadDistributionPolicy_STATUS
------------------------------------------------------------------------------------------------------------
+ApplicationGatewayLoadDistributionPolicy_STATUS{#ApplicationGatewayLoadDistributionPolicy_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Load Distribution Policy of an application gateway.
 
@@ -1711,8 +1711,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayOperatorSpec"></a>ApplicationGatewayOperatorSpec
--------------------------------------------------------------------------
+ApplicationGatewayOperatorSpec{#ApplicationGatewayOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1723,8 +1723,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayPrivateEndpointConnection_STATUS"></a>ApplicationGatewayPrivateEndpointConnection_STATUS
------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayPrivateEndpointConnection_STATUS{#ApplicationGatewayPrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Private Endpoint connection on an application gateway.
 
@@ -1734,8 +1734,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayPrivateLinkConfiguration"></a>ApplicationGatewayPrivateLinkConfiguration
--------------------------------------------------------------------------------------------------
+ApplicationGatewayPrivateLinkConfiguration{#ApplicationGatewayPrivateLinkConfiguration}
+---------------------------------------------------------------------------------------
 
 Private Link Configuration on an application gateway.
 
@@ -1746,8 +1746,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | ipConfigurations | An array of application gateway private link ip configurations.                      | [ApplicationGatewayPrivateLinkIpConfiguration[]](#ApplicationGatewayPrivateLinkIpConfiguration)<br/><small>Optional</small> |
 | name             | Name of the private link configuration that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ApplicationGatewayPrivateLinkConfiguration_STATUS"></a>ApplicationGatewayPrivateLinkConfiguration_STATUS
----------------------------------------------------------------------------------------------------------------
+ApplicationGatewayPrivateLinkConfiguration_STATUS{#ApplicationGatewayPrivateLinkConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Private Link Configuration on an application gateway.
 
@@ -1757,8 +1757,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayProbe"></a>ApplicationGatewayProbe
------------------------------------------------------------
+ApplicationGatewayProbe{#ApplicationGatewayProbe}
+-------------------------------------------------
 
 Probe of the application gateway.
 
@@ -1779,8 +1779,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | timeout                             | The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable values are from 1 second to 86400 seconds.                                                 | int<br/><small>Optional</small>                                                                                       |
 | unhealthyThreshold                  | The probe retry count. Backend server is marked down after consecutive probe failure count reaches UnhealthyThreshold. Acceptable values are from 1 second to 20.                                                      | int<br/><small>Optional</small>                                                                                       |
 
-<a id="ApplicationGatewayProbe_STATUS"></a>ApplicationGatewayProbe_STATUS
--------------------------------------------------------------------------
+ApplicationGatewayProbe_STATUS{#ApplicationGatewayProbe_STATUS}
+---------------------------------------------------------------
 
 Probe of the application gateway.
 
@@ -1790,8 +1790,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayPropertiesFormat_OperationalState_STATUS"></a>ApplicationGatewayPropertiesFormat_OperationalState_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayPropertiesFormat_OperationalState_STATUS{#ApplicationGatewayPropertiesFormat_OperationalState_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded).
 
@@ -1802,8 +1802,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | "Stopped"  |             |
 | "Stopping" |             |
 
-<a id="ApplicationGatewayProvisioningState_STATUS"></a>ApplicationGatewayProvisioningState_STATUS
--------------------------------------------------------------------------------------------------
+ApplicationGatewayProvisioningState_STATUS{#ApplicationGatewayProvisioningState_STATUS}
+---------------------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -1816,8 +1816,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="ApplicationGatewayRedirectConfiguration"></a>ApplicationGatewayRedirectConfiguration
--------------------------------------------------------------------------------------------
+ApplicationGatewayRedirectConfiguration{#ApplicationGatewayRedirectConfiguration}
+---------------------------------------------------------------------------------
 
 Redirect configuration of an application gateway.
 
@@ -1835,8 +1835,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | targetUrl           | Url to redirect the request to.                                                  | string<br/><small>Optional</small>                                |
 | urlPathMaps         | Url path maps specifying default redirect configuration.                         | [SubResource[]](#SubResource)<br/><small>Optional</small>         |
 
-<a id="ApplicationGatewayRedirectConfiguration_STATUS"></a>ApplicationGatewayRedirectConfiguration_STATUS
----------------------------------------------------------------------------------------------------------
+ApplicationGatewayRedirectConfiguration_STATUS{#ApplicationGatewayRedirectConfiguration_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Redirect configuration of an application gateway.
 
@@ -1846,8 +1846,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayRequestRoutingRule"></a>ApplicationGatewayRequestRoutingRule
--------------------------------------------------------------------------------------
+ApplicationGatewayRequestRoutingRule{#ApplicationGatewayRequestRoutingRule}
+---------------------------------------------------------------------------
 
 Request routing rule of an application gateway.
 
@@ -1866,8 +1866,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | ruleType               | Rule type.                                                                     | [ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType](#ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType)<br/><small>Optional</small> |
 | urlPathMap             | URL path map resource of the application gateway.                              | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                     |
 
-<a id="ApplicationGatewayRequestRoutingRule_STATUS"></a>ApplicationGatewayRequestRoutingRule_STATUS
----------------------------------------------------------------------------------------------------
+ApplicationGatewayRequestRoutingRule_STATUS{#ApplicationGatewayRequestRoutingRule_STATUS}
+-----------------------------------------------------------------------------------------
 
 Request routing rule of an application gateway.
 
@@ -1877,8 +1877,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayRewriteRuleSet"></a>ApplicationGatewayRewriteRuleSet
------------------------------------------------------------------------------
+ApplicationGatewayRewriteRuleSet{#ApplicationGatewayRewriteRuleSet}
+-------------------------------------------------------------------
 
 Rewrite rule set of an application gateway.
 
@@ -1889,8 +1889,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name         | Name of the rewrite rule set that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                            |
 | rewriteRules | Rewrite rules in the rewrite rule set.                                     | [ApplicationGatewayRewriteRule[]](#ApplicationGatewayRewriteRule)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayRewriteRuleSet_STATUS"></a>ApplicationGatewayRewriteRuleSet_STATUS
--------------------------------------------------------------------------------------------
+ApplicationGatewayRewriteRuleSet_STATUS{#ApplicationGatewayRewriteRuleSet_STATUS}
+---------------------------------------------------------------------------------
 
 Rewrite rule set of an application gateway.
 
@@ -1900,8 +1900,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayRoutingRule"></a>ApplicationGatewayRoutingRule
------------------------------------------------------------------------
+ApplicationGatewayRoutingRule{#ApplicationGatewayRoutingRule}
+-------------------------------------------------------------
 
 Routing rule of an application gateway.
 
@@ -1916,8 +1916,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | priority           | Priority of the routing rule.                                          | int<br/><small>Required</small>                                                                                                               |
 | ruleType           | Rule type.                                                             | [ApplicationGatewayRoutingRulePropertiesFormat_RuleType](#ApplicationGatewayRoutingRulePropertiesFormat_RuleType)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayRoutingRule_STATUS"></a>ApplicationGatewayRoutingRule_STATUS
--------------------------------------------------------------------------------------
+ApplicationGatewayRoutingRule_STATUS{#ApplicationGatewayRoutingRule_STATUS}
+---------------------------------------------------------------------------
 
 Routing rule of an application gateway.
 
@@ -1927,8 +1927,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySku"></a>ApplicationGatewaySku
--------------------------------------------------------
+ApplicationGatewaySku{#ApplicationGatewaySku}
+---------------------------------------------
 
 SKU of an application gateway.
 
@@ -1940,8 +1940,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name     | Name of an application gateway SKU.                  | [ApplicationGatewaySku_Name](#ApplicationGatewaySku_Name)<br/><small>Optional</small> |
 | tier     | Tier of an application gateway.                      | [ApplicationGatewaySku_Tier](#ApplicationGatewaySku_Tier)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySku_STATUS"></a>ApplicationGatewaySku_STATUS
----------------------------------------------------------------------
+ApplicationGatewaySku_STATUS{#ApplicationGatewaySku_STATUS}
+-----------------------------------------------------------
 
 SKU of an application gateway.
 
@@ -1953,8 +1953,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | name     | Name of an application gateway SKU.                  | [ApplicationGatewaySku_Name_STATUS](#ApplicationGatewaySku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of an application gateway.                      | [ApplicationGatewaySku_Tier_STATUS](#ApplicationGatewaySku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySslCertificate"></a>ApplicationGatewaySslCertificate
------------------------------------------------------------------------------
+ApplicationGatewaySslCertificate{#ApplicationGatewaySslCertificate}
+-------------------------------------------------------------------
 
 SSL certificates of an application gateway.
 
@@ -1967,8 +1967,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name             | Name of the SSL certificate that is unique within an Application Gateway.                           | string<br/><small>Optional</small>                                                                                                                     |
 | password         | Password for the pfx file specified in data. Only applicable in PUT request.                        | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySslCertificate_STATUS"></a>ApplicationGatewaySslCertificate_STATUS
--------------------------------------------------------------------------------------------
+ApplicationGatewaySslCertificate_STATUS{#ApplicationGatewaySslCertificate_STATUS}
+---------------------------------------------------------------------------------
 
 SSL certificates of an application gateway.
 
@@ -1978,8 +1978,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySslPolicy"></a>ApplicationGatewaySslPolicy
--------------------------------------------------------------------
+ApplicationGatewaySslPolicy{#ApplicationGatewaySslPolicy}
+---------------------------------------------------------
 
 Application Gateway Ssl policy.
 
@@ -1993,8 +1993,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec), and [ApplicationGa
 | policyName           | Name of Ssl predefined policy.                                                 | [PolicyNameEnum](#PolicyNameEnum)<br/><small>Optional</small>                                                 |
 | policyType           | Type of Ssl Policy.                                                            | [ApplicationGatewaySslPolicy_PolicyType](#ApplicationGatewaySslPolicy_PolicyType)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySslPolicy_STATUS"></a>ApplicationGatewaySslPolicy_STATUS
----------------------------------------------------------------------------------
+ApplicationGatewaySslPolicy_STATUS{#ApplicationGatewaySslPolicy_STATUS}
+-----------------------------------------------------------------------
 
 Application Gateway Ssl policy.
 
@@ -2008,8 +2008,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | policyName           | Name of Ssl predefined policy.                                                 | [PolicyNameEnum_STATUS](#PolicyNameEnum_STATUS)<br/><small>Optional</small>                                                 |
 | policyType           | Type of Ssl Policy.                                                            | [ApplicationGatewaySslPolicy_PolicyType_STATUS](#ApplicationGatewaySslPolicy_PolicyType_STATUS)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewaySslProfile"></a>ApplicationGatewaySslProfile
----------------------------------------------------------------------
+ApplicationGatewaySslProfile{#ApplicationGatewaySslProfile}
+-----------------------------------------------------------
 
 SSL profile of an application gateway.
 
@@ -2022,8 +2022,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | sslPolicy                 | SSL policy of the application gateway resource.                          | [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy)<br/><small>Optional</small>                             |
 | trustedClientCertificates | Array of references to application gateway trusted client certificates.  | [SubResource[]](#SubResource)<br/><small>Optional</small>                                                           |
 
-<a id="ApplicationGatewaySslProfile_STATUS"></a>ApplicationGatewaySslProfile_STATUS
------------------------------------------------------------------------------------
+ApplicationGatewaySslProfile_STATUS{#ApplicationGatewaySslProfile_STATUS}
+-------------------------------------------------------------------------
 
 SSL profile of an application gateway.
 
@@ -2033,8 +2033,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayTrustedClientCertificate"></a>ApplicationGatewayTrustedClientCertificate
--------------------------------------------------------------------------------------------------
+ApplicationGatewayTrustedClientCertificate{#ApplicationGatewayTrustedClientCertificate}
+---------------------------------------------------------------------------------------
 
 Trusted client certificates of an application gateway.
 
@@ -2045,8 +2045,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | data     | Certificate public data.                                                             | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | name     | Name of the trusted client certificate that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ApplicationGatewayTrustedClientCertificate_STATUS"></a>ApplicationGatewayTrustedClientCertificate_STATUS
----------------------------------------------------------------------------------------------------------------
+ApplicationGatewayTrustedClientCertificate_STATUS{#ApplicationGatewayTrustedClientCertificate_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Trusted client certificates of an application gateway.
 
@@ -2056,8 +2056,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayTrustedRootCertificate"></a>ApplicationGatewayTrustedRootCertificate
----------------------------------------------------------------------------------------------
+ApplicationGatewayTrustedRootCertificate{#ApplicationGatewayTrustedRootCertificate}
+-----------------------------------------------------------------------------------
 
 Trusted Root certificates of an application gateway.
 
@@ -2069,8 +2069,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | keyVaultSecretId | Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault. | string<br/><small>Optional</small>                                                                                                                     |
 | name             | Name of the trusted root certificate that is unique within an Application Gateway.                  | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ApplicationGatewayTrustedRootCertificate_STATUS"></a>ApplicationGatewayTrustedRootCertificate_STATUS
------------------------------------------------------------------------------------------------------------
+ApplicationGatewayTrustedRootCertificate_STATUS{#ApplicationGatewayTrustedRootCertificate_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Trusted Root certificates of an application gateway.
 
@@ -2080,8 +2080,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayUrlPathMap"></a>ApplicationGatewayUrlPathMap
----------------------------------------------------------------------
+ApplicationGatewayUrlPathMap{#ApplicationGatewayUrlPathMap}
+-----------------------------------------------------------
 
 UrlPathMaps give a url path to the backend mapping information for PathBasedRouting.
 
@@ -2097,8 +2097,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | name                          | Name of the URL path map that is unique within an Application Gateway. | string<br/><small>Optional</small>                                                      |
 | pathRules                     | Path rule of URL path map resource.                                    | [ApplicationGatewayPathRule[]](#ApplicationGatewayPathRule)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayUrlPathMap_STATUS"></a>ApplicationGatewayUrlPathMap_STATUS
------------------------------------------------------------------------------------
+ApplicationGatewayUrlPathMap_STATUS{#ApplicationGatewayUrlPathMap_STATUS}
+-------------------------------------------------------------------------
 
 UrlPathMaps give a url path to the backend mapping information for PathBasedRouting.
 
@@ -2108,8 +2108,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayWebApplicationFirewallConfiguration"></a>ApplicationGatewayWebApplicationFirewallConfiguration
------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayWebApplicationFirewallConfiguration{#ApplicationGatewayWebApplicationFirewallConfiguration}
+-------------------------------------------------------------------------------------------------------------
 
 Application gateway web application firewall configuration.
 
@@ -2128,8 +2128,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | ruleSetType            | The type of the web application firewall rule set. Possible values are: 'OWASP'. | string<br/><small>Required</small>                                                                                                                                    |
 | ruleSetVersion         | The version of the rule set type.                                                | string<br/><small>Required</small>                                                                                                                                    |
 
-<a id="ApplicationGatewayWebApplicationFirewallConfiguration_STATUS"></a>ApplicationGatewayWebApplicationFirewallConfiguration_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayWebApplicationFirewallConfiguration_STATUS{#ApplicationGatewayWebApplicationFirewallConfiguration_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Application gateway web application firewall configuration.
 
@@ -2148,8 +2148,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | ruleSetType            | The type of the web application firewall rule set. Possible values are: 'OWASP'. | string<br/><small>Optional</small>                                                                                                                                                  |
 | ruleSetVersion         | The version of the rule set type.                                                | string<br/><small>Optional</small>                                                                                                                                                  |
 
-<a id="ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2159,8 +2159,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded{#ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2170,8 +2170,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BastionHostIPConfiguration"></a>BastionHostIPConfiguration
------------------------------------------------------------------
+BastionHostIPConfiguration{#BastionHostIPConfiguration}
+-------------------------------------------------------
 
 IP configuration of an Bastion Host.
 
@@ -2184,8 +2184,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 | publicIPAddress           | Reference of the PublicIP resource.                                                                        | [SubResource](#SubResource)<br/><small>Required</small>               |
 | subnet                    | Reference of the subnet resource.                                                                          | [SubResource](#SubResource)<br/><small>Required</small>               |
 
-<a id="BastionHostIPConfiguration_STATUS"></a>BastionHostIPConfiguration_STATUS
--------------------------------------------------------------------------------
+BastionHostIPConfiguration_STATUS{#BastionHostIPConfiguration_STATUS}
+---------------------------------------------------------------------
 
 IP configuration of an Bastion Host.
 
@@ -2195,8 +2195,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="BastionHostOperatorSpec"></a>BastionHostOperatorSpec
------------------------------------------------------------
+BastionHostOperatorSpec{#BastionHostOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2207,8 +2207,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BastionHostProvisioningState_STATUS"></a>BastionHostProvisioningState_STATUS
------------------------------------------------------------------------------------
+BastionHostProvisioningState_STATUS{#BastionHostProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -2221,8 +2221,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="CustomDnsConfigPropertiesFormat_STATUS"></a>CustomDnsConfigPropertiesFormat_STATUS
------------------------------------------------------------------------------------------
+CustomDnsConfigPropertiesFormat_STATUS{#CustomDnsConfigPropertiesFormat_STATUS}
+-------------------------------------------------------------------------------
 
 Contains custom Dns resolution configuration from customer.
 
@@ -2233,8 +2233,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | fqdn        | Fqdn that resolves to private endpoint ip address.      | string<br/><small>Optional</small>   |
 | ipAddresses | A list of private ip addresses of the private endpoint. | string[]<br/><small>Optional</small> |
 
-<a id="DnsForwardingRulesetOperatorSpec"></a>DnsForwardingRulesetOperatorSpec
------------------------------------------------------------------------------
+DnsForwardingRulesetOperatorSpec{#DnsForwardingRulesetOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2245,8 +2245,8 @@ Used by: [DnsForwardingRuleset_Spec](#DnsForwardingRuleset_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsForwardingRuleSetsForwardingRuleOperatorSpec"></a>DnsForwardingRuleSetsForwardingRuleOperatorSpec
------------------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsForwardingRuleOperatorSpec{#DnsForwardingRuleSetsForwardingRuleOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2257,8 +2257,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule_Spec](#DnsForwardingRuleSetsForwar
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsForwardingRuleSetsVirtualNetworkLinkOperatorSpec"></a>DnsForwardingRuleSetsVirtualNetworkLinkOperatorSpec
--------------------------------------------------------------------------------------------------------------------
+DnsForwardingRuleSetsVirtualNetworkLinkOperatorSpec{#DnsForwardingRuleSetsVirtualNetworkLinkOperatorSpec}
+---------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2269,8 +2269,8 @@ Used by: [DnsForwardingRuleSetsVirtualNetworkLink_Spec](#DnsForwardingRuleSetsVi
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsResolverOperatorSpec"></a>DnsResolverOperatorSpec
------------------------------------------------------------
+DnsResolverOperatorSpec{#DnsResolverOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2281,8 +2281,8 @@ Used by: [DnsResolver_Spec](#DnsResolver_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsResolverProperties_DnsResolverState_STATUS"></a>DnsResolverProperties_DnsResolverState_STATUS
--------------------------------------------------------------------------------------------------------
+DnsResolverProperties_DnsResolverState_STATUS{#DnsResolverProperties_DnsResolverState_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [DnsResolver_STATUS](#DnsResolver_STATUS).
 
@@ -2291,8 +2291,8 @@ Used by: [DnsResolver_STATUS](#DnsResolver_STATUS).
 | "Connected"    |             |
 | "Disconnected" |             |
 
-<a id="DnsresolverProvisioningState_STATUS"></a>DnsresolverProvisioningState_STATUS
------------------------------------------------------------------------------------
+DnsresolverProvisioningState_STATUS{#DnsresolverProvisioningState_STATUS}
+-------------------------------------------------------------------------
 
 The current provisioning state of the resource.
 
@@ -2307,8 +2307,8 @@ Used by: [DnsForwardingRuleset_STATUS](#DnsForwardingRuleset_STATUS), [DnsForwar
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="DnsResolversInboundEndpointOperatorSpec"></a>DnsResolversInboundEndpointOperatorSpec
--------------------------------------------------------------------------------------------
+DnsResolversInboundEndpointOperatorSpec{#DnsResolversInboundEndpointOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2319,8 +2319,8 @@ Used by: [DnsResolversInboundEndpoint_Spec](#DnsResolversInboundEndpoint_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="DnsResolversOutboundEndpointOperatorSpec"></a>DnsResolversOutboundEndpointOperatorSpec
----------------------------------------------------------------------------------------------
+DnsResolversOutboundEndpointOperatorSpec{#DnsResolversOutboundEndpointOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2331,8 +2331,8 @@ Used by: [DnsResolversOutboundEndpoint_Spec](#DnsResolversOutboundEndpoint_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 ExtendedLocation complex type.
 
@@ -2343,8 +2343,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec), [PrivateLinkService_Spec
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 ExtendedLocation complex type.
 
@@ -2355,8 +2355,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="ForwardingRuleProperties_ForwardingRuleState"></a>ForwardingRuleProperties_ForwardingRuleState
------------------------------------------------------------------------------------------------------
+ForwardingRuleProperties_ForwardingRuleState{#ForwardingRuleProperties_ForwardingRuleState}
+-------------------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsForwardingRule_Spec](#DnsForwardingRuleSetsForwardingRule_Spec).
 
@@ -2365,8 +2365,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule_Spec](#DnsForwardingRuleSetsForwar
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ForwardingRuleProperties_ForwardingRuleState_STATUS"></a>ForwardingRuleProperties_ForwardingRuleState_STATUS
--------------------------------------------------------------------------------------------------------------------
+ForwardingRuleProperties_ForwardingRuleState_STATUS{#ForwardingRuleProperties_ForwardingRuleState_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [DnsForwardingRuleSetsForwardingRule_STATUS](#DnsForwardingRuleSetsForwardingRule_STATUS).
 
@@ -2375,8 +2375,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule_STATUS](#DnsForwardingRuleSetsForw
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded"></a>FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded{#FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2386,8 +2386,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded"></a>FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded{#FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2397,8 +2397,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IpConfiguration"></a>IpConfiguration
--------------------------------------------
+IpConfiguration{#IpConfiguration}
+---------------------------------
 
 IP configuration.
 
@@ -2410,8 +2410,8 @@ Used by: [DnsResolversInboundEndpoint_Spec](#DnsResolversInboundEndpoint_Spec).
 | privateIpAllocationMethod | Private IP address allocation method.                      | [IpConfiguration_PrivateIpAllocationMethod](#IpConfiguration_PrivateIpAllocationMethod)<br/><small>Optional</small> |
 | subnet                    | The reference to the subnet bound to the IP configuration. | [SubResource](#SubResource)<br/><small>Required</small>                                                             |
 
-<a id="IpConfiguration_STATUS"></a>IpConfiguration_STATUS
----------------------------------------------------------
+IpConfiguration_STATUS{#IpConfiguration_STATUS}
+-----------------------------------------------
 
 IP configuration.
 
@@ -2423,8 +2423,8 @@ Used by: [DnsResolversInboundEndpoint_STATUS](#DnsResolversInboundEndpoint_STATU
 | privateIpAllocationMethod | Private IP address allocation method.                      | [IpConfiguration_PrivateIpAllocationMethod_STATUS](#IpConfiguration_PrivateIpAllocationMethod_STATUS)<br/><small>Optional</small> |
 | subnet                    | The reference to the subnet bound to the IP configuration. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                             |
 
-<a id="IpTag"></a>IpTag
------------------------
+IpTag{#IpTag}
+-------------
 
 Contains the IpTag associated with the object.
 
@@ -2435,8 +2435,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IpTag_STATUS"></a>IpTag_STATUS
--------------------------------------
+IpTag_STATUS{#IpTag_STATUS}
+---------------------------
 
 Contains the IpTag associated with the object.
 
@@ -2447,8 +2447,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IPVersion"></a>IPVersion
--------------------------------
+IPVersion{#IPVersion}
+---------------------
 
 IP address version.
 
@@ -2459,8 +2459,8 @@ Used by: [PrivateLinkServiceIpConfiguration](#PrivateLinkServiceIpConfiguration)
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IPVersion_STATUS"></a>IPVersion_STATUS
----------------------------------------------
+IPVersion_STATUS{#IPVersion_STATUS}
+-----------------------------------
 
 IP address version.
 
@@ -2471,8 +2471,8 @@ Used by: [PrivateLinkServiceIpConfiguration_STATUS](#PrivateLinkServiceIpConfigu
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Identity for the resource.
 
@@ -2483,8 +2483,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                            | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the resource.
 
@@ -2497,8 +2497,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                            | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS](#ManagedServiceIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded"></a>NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded{#NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2508,8 +2508,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NatGatewayOperatorSpec"></a>NatGatewayOperatorSpec
----------------------------------------------------------
+NatGatewayOperatorSpec{#NatGatewayOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2520,8 +2520,8 @@ Used by: [NatGateway_Spec](#NatGateway_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NatGatewaySku"></a>NatGatewaySku
----------------------------------------
+NatGatewaySku{#NatGatewaySku}
+-----------------------------
 
 SKU of nat gateway.
 
@@ -2531,8 +2531,8 @@ Used by: [NatGateway_Spec](#NatGateway_Spec).
 |----------|--------------------------|-----------------------------------------------------------------------|
 | name     | Name of Nat Gateway SKU. | [NatGatewaySku_Name](#NatGatewaySku_Name)<br/><small>Optional</small> |
 
-<a id="NatGatewaySku_STATUS"></a>NatGatewaySku_STATUS
------------------------------------------------------
+NatGatewaySku_STATUS{#NatGatewaySku_STATUS}
+-------------------------------------------
 
 SKU of nat gateway.
 
@@ -2542,8 +2542,8 @@ Used by: [NatGateway_STATUS](#NatGateway_STATUS).
 |----------|--------------------------|-------------------------------------------------------------------------------------|
 | name     | Name of Nat Gateway SKU. | [NatGatewaySku_Name_STATUS](#NatGatewaySku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded"></a>NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------
+NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded{#NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2553,8 +2553,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded{#NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -2564,8 +2564,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded"></a>NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded{#NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -2575,8 +2575,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateDnsZoneConfig"></a>PrivateDnsZoneConfig
------------------------------------------------------
+PrivateDnsZoneConfig{#PrivateDnsZoneConfig}
+-------------------------------------------
 
 PrivateDnsZoneConfig resource.
 
@@ -2587,8 +2587,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZ
 | name                    | Name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small>                                                                                                                         |
 | privateDnsZoneReference | The resource id of the private dns zone.                                                                   | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZoneConfig_STATUS"></a>PrivateDnsZoneConfig_STATUS
--------------------------------------------------------------------
+PrivateDnsZoneConfig_STATUS{#PrivateDnsZoneConfig_STATUS}
+---------------------------------------------------------
 
 PrivateDnsZoneConfig resource.
 
@@ -2600,8 +2600,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_STATUS](#PrivateEndpointsPrivateDn
 | privateDnsZoneId | The resource id of the private dns zone.                                                                   | string<br/><small>Optional</small>                                  |
 | recordSets       | A collection of information regarding a recordSet, holding information to identify private resources.      | [RecordSet_STATUS[]](#RecordSet_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 PrivateEndpointConnection resource.
 
@@ -2611,8 +2611,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointIPConfiguration"></a>PrivateEndpointIPConfiguration
--------------------------------------------------------------------------
+PrivateEndpointIPConfiguration{#PrivateEndpointIPConfiguration}
+---------------------------------------------------------------
 
 An IP Configuration of the private endpoint.
 
@@ -2625,8 +2625,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 | name             | The name of the resource that is unique within a resource group.                                           | string<br/><small>Optional</small> |
 | privateIPAddress | A private ip address obtained from the private endpoint's subnet.                                          | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointIPConfiguration_STATUS"></a>PrivateEndpointIPConfiguration_STATUS
----------------------------------------------------------------------------------------
+PrivateEndpointIPConfiguration_STATUS{#PrivateEndpointIPConfiguration_STATUS}
+-----------------------------------------------------------------------------
 
 An IP Configuration of the private endpoint.
 
@@ -2641,8 +2641,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | privateIPAddress | A private ip address obtained from the private endpoint's subnet.                                          | string<br/><small>Optional</small> |
 | type             | The resource type.                                                                                         | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointOperatorSpec"></a>PrivateEndpointOperatorSpec
--------------------------------------------------------------------
+PrivateEndpointOperatorSpec{#PrivateEndpointOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2654,8 +2654,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [PrivateEndpointOperatorConfigMaps](#PrivateEndpointOperatorConfigMaps)<br/><small>Optional</small>                                                                 |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointProvisioningState_STATUS"></a>PrivateEndpointProvisioningState_STATUS
--------------------------------------------------------------------------------------------
+PrivateEndpointProvisioningState_STATUS{#PrivateEndpointProvisioningState_STATUS}
+---------------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -2668,8 +2668,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_STATUS](#PrivateEndpointsPrivateDn
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroupOperatorSpec"></a>PrivateEndpointsPrivateDnsZoneGroupOperatorSpec
------------------------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroupOperatorSpec{#PrivateEndpointsPrivateDnsZoneGroupOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2680,8 +2680,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZ
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnection"></a>PrivateLinkServiceConnection
----------------------------------------------------------------------
+PrivateLinkServiceConnection{#PrivateLinkServiceConnection}
+-----------------------------------------------------------
 
 PrivateLinkServiceConnection resource.
 
@@ -2695,8 +2695,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec), and [PrivateEndpoint_Spe
 | privateLinkServiceReference       | The resource id of private link service.                                                                       | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | requestMessage                    | A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.    | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkServiceConnection_STATUS"></a>PrivateLinkServiceConnection_STATUS
------------------------------------------------------------------------------------
+PrivateLinkServiceConnection_STATUS{#PrivateLinkServiceConnection_STATUS}
+-------------------------------------------------------------------------
 
 PrivateLinkServiceConnection resource.
 
@@ -2714,8 +2714,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | requestMessage                    | A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.    | string<br/><small>Optional</small>                                                                                    |
 | type                              | The resource type.                                                                                             | string<br/><small>Optional</small>                                                                                    |
 
-<a id="PrivateLinkServiceIpConfiguration"></a>PrivateLinkServiceIpConfiguration
--------------------------------------------------------------------------------
+PrivateLinkServiceIpConfiguration{#PrivateLinkServiceIpConfiguration}
+---------------------------------------------------------------------
 
 The private link service ip configuration.
 
@@ -2730,8 +2730,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 | privateIPAllocationMethod | The private IP address allocation method.                               | [IPAllocationMethod](#IPAllocationMethod)<br/><small>Optional</small>                                                       |
 | subnet                    | The reference to the subnet resource.                                   | [Subnet_PrivateLinkService_SubResourceEmbedded](#Subnet_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceIpConfiguration_STATUS"></a>PrivateLinkServiceIpConfiguration_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceIpConfiguration_STATUS{#PrivateLinkServiceIpConfiguration_STATUS}
+-----------------------------------------------------------------------------------
 
 The private link service ip configuration.
 
@@ -2750,8 +2750,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 | subnet                    | The reference to the subnet resource.                                         | [Subnet_STATUS_PrivateLinkService_SubResourceEmbedded](#Subnet_STATUS_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 | type                      | The resource type.                                                            | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="PrivateLinkServiceOperatorSpec"></a>PrivateLinkServiceOperatorSpec
--------------------------------------------------------------------------
+PrivateLinkServiceOperatorSpec{#PrivateLinkServiceOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2763,8 +2763,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [PrivateLinkServiceOperatorConfigMaps](#PrivateLinkServiceOperatorConfigMaps)<br/><small>Optional</small>                                                           |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixOperatorSpec"></a>PublicIPPrefixOperatorSpec
------------------------------------------------------------------
+PublicIPPrefixOperatorSpec{#PublicIPPrefixOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2775,8 +2775,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PublicIpPrefixProvisioningState_STATUS"></a>PublicIpPrefixProvisioningState_STATUS
------------------------------------------------------------------------------------------
+PublicIpPrefixProvisioningState_STATUS{#PublicIpPrefixProvisioningState_STATUS}
+-------------------------------------------------------------------------------
 
 The current provisioning state.
 
@@ -2789,8 +2789,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="PublicIPPrefixSku"></a>PublicIPPrefixSku
------------------------------------------------
+PublicIPPrefixSku{#PublicIPPrefixSku}
+-------------------------------------
 
 SKU of a public IP prefix.
 
@@ -2801,8 +2801,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 | name     | Name of a public IP prefix SKU. | [PublicIPPrefixSku_Name](#PublicIPPrefixSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a public IP prefix SKU. | [PublicIPPrefixSku_Tier](#PublicIPPrefixSku_Tier)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixSku_STATUS"></a>PublicIPPrefixSku_STATUS
--------------------------------------------------------------
+PublicIPPrefixSku_STATUS{#PublicIPPrefixSku_STATUS}
+---------------------------------------------------
 
 SKU of a public IP prefix.
 
@@ -2813,8 +2813,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 | name     | Name of a public IP prefix SKU. | [PublicIPPrefixSku_Name_STATUS](#PublicIPPrefixSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a public IP prefix SKU. | [PublicIPPrefixSku_Tier_STATUS](#PublicIPPrefixSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ReferencedPublicIpAddress_STATUS"></a>ReferencedPublicIpAddress_STATUS
------------------------------------------------------------------------------
+ReferencedPublicIpAddress_STATUS{#ReferencedPublicIpAddress_STATUS}
+-------------------------------------------------------------------
 
 Reference to a public IP address.
 
@@ -2824,8 +2824,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 |----------|--------------------------------|------------------------------------|
 | id       | The PublicIPAddress Reference. | string<br/><small>Optional</small> |
 
-<a id="ResourceSet"></a>ResourceSet
------------------------------------
+ResourceSet{#ResourceSet}
+-------------------------
 
 The base resource set for visibility and auto-approval.
 
@@ -2835,8 +2835,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec), and [PrivateLinkSe
 |---------------|----------------------------|--------------------------------------|
 | subscriptions | The list of subscriptions. | string[]<br/><small>Optional</small> |
 
-<a id="ResourceSet_STATUS"></a>ResourceSet_STATUS
--------------------------------------------------
+ResourceSet_STATUS{#ResourceSet_STATUS}
+---------------------------------------
 
 The base resource set for visibility and auto-approval.
 
@@ -2846,8 +2846,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |---------------|----------------------------|--------------------------------------|
 | subscriptions | The list of subscriptions. | string[]<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The sku of this Bastion Host.
 
@@ -2857,8 +2857,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 |----------|--------------------------------|---------------------------------------------------|
 | name     | The name of this Bastion Host. | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The sku of this Bastion Host.
 
@@ -2868,8 +2868,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 |----------|--------------------------------|-----------------------------------------------------------------|
 | name     | The name of this Bastion Host. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="Subnet_PrivateEndpoint_SubResourceEmbedded"></a>Subnet_PrivateEndpoint_SubResourceEmbedded
--------------------------------------------------------------------------------------------------
+Subnet_PrivateEndpoint_SubResourceEmbedded{#Subnet_PrivateEndpoint_SubResourceEmbedded}
+---------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -2879,8 +2879,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded{#Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -2890,8 +2890,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Reference to another ARM resource.
 
@@ -2901,8 +2901,8 @@ Used by: [ApplicationGateway_Spec](#ApplicationGateway_Spec), [ApplicationGatewa
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another ARM resource.
 
@@ -2912,8 +2912,8 @@ Used by: [ApplicationGateway_STATUS_ApplicationGateway_SubResourceEmbedded](#App
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2928,8 +2928,8 @@ Used by: [DnsForwardingRuleset_STATUS](#DnsForwardingRuleset_STATUS), [DnsForwar
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TargetDnsServer"></a>TargetDnsServer
--------------------------------------------
+TargetDnsServer{#TargetDnsServer}
+---------------------------------
 
 Describes a server to forward the DNS queries to.
 
@@ -2941,8 +2941,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule_Spec](#DnsForwardingRuleSetsForwar
 | ipAddressFromConfig | DNS server IP address. | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | port                | DNS server port.       | int<br/><small>Optional</small>                                                                                                                              |
 
-<a id="TargetDnsServer_STATUS"></a>TargetDnsServer_STATUS
----------------------------------------------------------
+TargetDnsServer_STATUS{#TargetDnsServer_STATUS}
+-----------------------------------------------
 
 Describes a server to forward the DNS queries to.
 
@@ -2953,8 +2953,8 @@ Used by: [DnsForwardingRuleSetsForwardingRule_STATUS](#DnsForwardingRuleSetsForw
 | ipAddress | DNS server IP address. | string<br/><small>Optional</small> |
 | port      | DNS server port.       | int<br/><small>Optional</small>    |
 
-<a id="ApplicationGatewayBackendAddress"></a>ApplicationGatewayBackendAddress
------------------------------------------------------------------------------
+ApplicationGatewayBackendAddress{#ApplicationGatewayBackendAddress}
+-------------------------------------------------------------------
 
 Backend address of an application gateway.
 
@@ -2965,8 +2965,8 @@ Used by: [ApplicationGatewayBackendAddressPool](#ApplicationGatewayBackendAddres
 | fqdn      | Fully qualified domain name (FQDN). | string<br/><small>Optional</small> |
 | ipAddress | IP address.                         | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayBackendHttpSettingsPropertiesFormat_CookieBasedAffinity"></a>ApplicationGatewayBackendHttpSettingsPropertiesFormat_CookieBasedAffinity
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayBackendHttpSettingsPropertiesFormat_CookieBasedAffinity{#ApplicationGatewayBackendHttpSettingsPropertiesFormat_CookieBasedAffinity}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayBackendHttpSettings](#ApplicationGatewayBackendHttpSettings).
 
@@ -2975,8 +2975,8 @@ Used by: [ApplicationGatewayBackendHttpSettings](#ApplicationGatewayBackendHttpS
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ApplicationGatewayClientAuthConfiguration"></a>ApplicationGatewayClientAuthConfiguration
------------------------------------------------------------------------------------------------
+ApplicationGatewayClientAuthConfiguration{#ApplicationGatewayClientAuthConfiguration}
+-------------------------------------------------------------------------------------
 
 Application gateway client authentication configuration.
 
@@ -2987,8 +2987,8 @@ Used by: [ApplicationGatewaySslProfile](#ApplicationGatewaySslProfile).
 | verifyClientCertIssuerDN | Verify client certificate issuer name on the application gateway. | bool<br/><small>Optional</small>                                                                                                                                  |
 | verifyClientRevocation   | Verify client certificate revocation status.                      | [ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation](#ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayConnectionDraining"></a>ApplicationGatewayConnectionDraining
--------------------------------------------------------------------------------------
+ApplicationGatewayConnectionDraining{#ApplicationGatewayConnectionDraining}
+---------------------------------------------------------------------------
 
 Connection draining allows open connections to a backend server to be active for a specified time after the backend server got removed from the configuration.
 
@@ -2999,8 +2999,8 @@ Used by: [ApplicationGatewayBackendHttpSettings](#ApplicationGatewayBackendHttpS
 | drainTimeoutInSec | The number of seconds connection draining is active. Acceptable values are from 1 second to 3600 seconds. | int<br/><small>Required</small>  |
 | enabled           | Whether connection draining is enabled or not.                                                            | bool<br/><small>Required</small> |
 
-<a id="ApplicationGatewayCustomError_StatusCode"></a>ApplicationGatewayCustomError_StatusCode
----------------------------------------------------------------------------------------------
+ApplicationGatewayCustomError_StatusCode{#ApplicationGatewayCustomError_StatusCode}
+-----------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayCustomError](#ApplicationGatewayCustomError).
 
@@ -3009,8 +3009,8 @@ Used by: [ApplicationGatewayCustomError](#ApplicationGatewayCustomError).
 | "HttpStatus403" |             |
 | "HttpStatus502" |             |
 
-<a id="ApplicationGatewayCustomError_StatusCode_STATUS"></a>ApplicationGatewayCustomError_StatusCode_STATUS
------------------------------------------------------------------------------------------------------------
+ApplicationGatewayCustomError_StatusCode_STATUS{#ApplicationGatewayCustomError_StatusCode_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayCustomError_STATUS](#ApplicationGatewayCustomError_STATUS).
 
@@ -3019,8 +3019,8 @@ Used by: [ApplicationGatewayCustomError_STATUS](#ApplicationGatewayCustomError_S
 | "HttpStatus403" |             |
 | "HttpStatus502" |             |
 
-<a id="ApplicationGatewayFirewallDisabledRuleGroup"></a>ApplicationGatewayFirewallDisabledRuleGroup
----------------------------------------------------------------------------------------------------
+ApplicationGatewayFirewallDisabledRuleGroup{#ApplicationGatewayFirewallDisabledRuleGroup}
+-----------------------------------------------------------------------------------------
 
 Allows to disable rules within a rule group or an entire rule group.
 
@@ -3031,8 +3031,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGat
 | ruleGroupName | The name of the rule group that will be disabled.                                               | string<br/><small>Required</small> |
 | rules         | The list of rules that will be disabled. If null, all rules of the rule group will be disabled. | int[]<br/><small>Optional</small>  |
 
-<a id="ApplicationGatewayFirewallDisabledRuleGroup_STATUS"></a>ApplicationGatewayFirewallDisabledRuleGroup_STATUS
------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayFirewallDisabledRuleGroup_STATUS{#ApplicationGatewayFirewallDisabledRuleGroup_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Allows to disable rules within a rule group or an entire rule group.
 
@@ -3043,8 +3043,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#Applica
 | ruleGroupName | The name of the rule group that will be disabled.                                               | string<br/><small>Optional</small> |
 | rules         | The list of rules that will be disabled. If null, all rules of the rule group will be disabled. | int[]<br/><small>Optional</small>  |
 
-<a id="ApplicationGatewayFirewallExclusion"></a>ApplicationGatewayFirewallExclusion
------------------------------------------------------------------------------------
+ApplicationGatewayFirewallExclusion{#ApplicationGatewayFirewallExclusion}
+-------------------------------------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -3056,8 +3056,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGat
 | selector              | When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to.           | string<br/><small>Required</small> |
 | selectorMatchOperator | When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to. | string<br/><small>Required</small> |
 
-<a id="ApplicationGatewayFirewallExclusion_STATUS"></a>ApplicationGatewayFirewallExclusion_STATUS
--------------------------------------------------------------------------------------------------
+ApplicationGatewayFirewallExclusion_STATUS{#ApplicationGatewayFirewallExclusion_STATUS}
+---------------------------------------------------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -3069,8 +3069,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#Applica
 | selector              | When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to.           | string<br/><small>Optional</small> |
 | selectorMatchOperator | When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayLoadDistributionAlgorithmEnum"></a>ApplicationGatewayLoadDistributionAlgorithmEnum
------------------------------------------------------------------------------------------------------------
+ApplicationGatewayLoadDistributionAlgorithmEnum{#ApplicationGatewayLoadDistributionAlgorithmEnum}
+-------------------------------------------------------------------------------------------------
 
 Load Distribution Algorithm enums.
 
@@ -3082,8 +3082,8 @@ Used by: [ApplicationGatewayLoadDistributionPolicy](#ApplicationGatewayLoadDistr
 | "LeastConnections" |             |
 | "RoundRobin"       |             |
 
-<a id="ApplicationGatewayLoadDistributionTarget"></a>ApplicationGatewayLoadDistributionTarget
----------------------------------------------------------------------------------------------
+ApplicationGatewayLoadDistributionTarget{#ApplicationGatewayLoadDistributionTarget}
+-----------------------------------------------------------------------------------
 
 Load Distribution Target of an application gateway.
 
@@ -3093,8 +3093,8 @@ Used by: [ApplicationGatewayLoadDistributionPolicy](#ApplicationGatewayLoadDistr
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayPathRule"></a>ApplicationGatewayPathRule
------------------------------------------------------------------
+ApplicationGatewayPathRule{#ApplicationGatewayPathRule}
+-------------------------------------------------------
 
 Path rule of URL path map of an application gateway.
 
@@ -3104,8 +3104,8 @@ Used by: [ApplicationGatewayUrlPathMap](#ApplicationGatewayUrlPathMap).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayPrivateLinkIpConfiguration"></a>ApplicationGatewayPrivateLinkIpConfiguration
------------------------------------------------------------------------------------------------------
+ApplicationGatewayPrivateLinkIpConfiguration{#ApplicationGatewayPrivateLinkIpConfiguration}
+-------------------------------------------------------------------------------------------
 
 The application gateway private link ip configuration.
 
@@ -3115,8 +3115,8 @@ Used by: [ApplicationGatewayPrivateLinkConfiguration](#ApplicationGatewayPrivate
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayProbeHealthResponseMatch"></a>ApplicationGatewayProbeHealthResponseMatch
--------------------------------------------------------------------------------------------------
+ApplicationGatewayProbeHealthResponseMatch{#ApplicationGatewayProbeHealthResponseMatch}
+---------------------------------------------------------------------------------------
 
 Application gateway probe health response match.
 
@@ -3127,8 +3127,8 @@ Used by: [ApplicationGatewayProbe](#ApplicationGatewayProbe).
 | body        | Body that must be contained in the health response. Default value is empty.               | string<br/><small>Optional</small>   |
 | statusCodes | Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399. | string[]<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayProtocol"></a>ApplicationGatewayProtocol
------------------------------------------------------------------
+ApplicationGatewayProtocol{#ApplicationGatewayProtocol}
+-------------------------------------------------------
 
 Application Gateway protocol.
 
@@ -3141,8 +3141,8 @@ Used by: [ApplicationGatewayBackendHttpSettings](#ApplicationGatewayBackendHttpS
 | "Tcp"   |             |
 | "Tls"   |             |
 
-<a id="ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType"></a>ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType
----------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType{#ApplicationGatewayRequestRoutingRulePropertiesFormat_RuleType}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayRequestRoutingRule](#ApplicationGatewayRequestRoutingRule).
 
@@ -3151,8 +3151,8 @@ Used by: [ApplicationGatewayRequestRoutingRule](#ApplicationGatewayRequestRoutin
 | "Basic"            |             |
 | "PathBasedRouting" |             |
 
-<a id="ApplicationGatewayRewriteRule"></a>ApplicationGatewayRewriteRule
------------------------------------------------------------------------
+ApplicationGatewayRewriteRule{#ApplicationGatewayRewriteRule}
+-------------------------------------------------------------
 
 Rewrite rule of an application gateway.
 
@@ -3165,8 +3165,8 @@ Used by: [ApplicationGatewayRewriteRuleSet](#ApplicationGatewayRewriteRuleSet).
 | name         | Name of the rewrite rule that is unique within an Application Gateway.                                             | string<br/><small>Optional</small>                                                                              |
 | ruleSequence | Rule Sequence of the rewrite rule that determines the order of execution of a particular rule in a RewriteRuleSet. | int<br/><small>Optional</small>                                                                                 |
 
-<a id="ApplicationGatewayRoutingRulePropertiesFormat_RuleType"></a>ApplicationGatewayRoutingRulePropertiesFormat_RuleType
--------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayRoutingRulePropertiesFormat_RuleType{#ApplicationGatewayRoutingRulePropertiesFormat_RuleType}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayRoutingRule](#ApplicationGatewayRoutingRule).
 
@@ -3175,8 +3175,8 @@ Used by: [ApplicationGatewayRoutingRule](#ApplicationGatewayRoutingRule).
 | "Basic"            |             |
 | "PathBasedRouting" |             |
 
-<a id="ApplicationGatewaySku_Name"></a>ApplicationGatewaySku_Name
------------------------------------------------------------------
+ApplicationGatewaySku_Name{#ApplicationGatewaySku_Name}
+-------------------------------------------------------
 
 Used by: [ApplicationGatewaySku](#ApplicationGatewaySku).
 
@@ -3190,8 +3190,8 @@ Used by: [ApplicationGatewaySku](#ApplicationGatewaySku).
 | "WAF_Medium"      |             |
 | "WAF_v2"          |             |
 
-<a id="ApplicationGatewaySku_Name_STATUS"></a>ApplicationGatewaySku_Name_STATUS
--------------------------------------------------------------------------------
+ApplicationGatewaySku_Name_STATUS{#ApplicationGatewaySku_Name_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ApplicationGatewaySku_STATUS](#ApplicationGatewaySku_STATUS).
 
@@ -3205,8 +3205,8 @@ Used by: [ApplicationGatewaySku_STATUS](#ApplicationGatewaySku_STATUS).
 | "WAF_Medium"      |             |
 | "WAF_v2"          |             |
 
-<a id="ApplicationGatewaySku_Tier"></a>ApplicationGatewaySku_Tier
------------------------------------------------------------------
+ApplicationGatewaySku_Tier{#ApplicationGatewaySku_Tier}
+-------------------------------------------------------
 
 Used by: [ApplicationGatewaySku](#ApplicationGatewaySku).
 
@@ -3217,8 +3217,8 @@ Used by: [ApplicationGatewaySku](#ApplicationGatewaySku).
 | "WAF"         |             |
 | "WAF_v2"      |             |
 
-<a id="ApplicationGatewaySku_Tier_STATUS"></a>ApplicationGatewaySku_Tier_STATUS
--------------------------------------------------------------------------------
+ApplicationGatewaySku_Tier_STATUS{#ApplicationGatewaySku_Tier_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ApplicationGatewaySku_STATUS](#ApplicationGatewaySku_STATUS).
 
@@ -3229,8 +3229,8 @@ Used by: [ApplicationGatewaySku_STATUS](#ApplicationGatewaySku_STATUS).
 | "WAF"         |             |
 | "WAF_v2"      |             |
 
-<a id="ApplicationGatewaySslPolicy_PolicyType"></a>ApplicationGatewaySslPolicy_PolicyType
------------------------------------------------------------------------------------------
+ApplicationGatewaySslPolicy_PolicyType{#ApplicationGatewaySslPolicy_PolicyType}
+-------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy).
 
@@ -3240,8 +3240,8 @@ Used by: [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy).
 | "CustomV2"   |             |
 | "Predefined" |             |
 
-<a id="ApplicationGatewaySslPolicy_PolicyType_STATUS"></a>ApplicationGatewaySslPolicy_PolicyType_STATUS
--------------------------------------------------------------------------------------------------------
+ApplicationGatewaySslPolicy_PolicyType_STATUS{#ApplicationGatewaySslPolicy_PolicyType_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewaySslPolicy_STATUS](#ApplicationGatewaySslPolicy_STATUS).
 
@@ -3251,8 +3251,8 @@ Used by: [ApplicationGatewaySslPolicy_STATUS](#ApplicationGatewaySslPolicy_STATU
 | "CustomV2"   |             |
 | "Predefined" |             |
 
-<a id="ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode"></a>ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode
--------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode{#ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGatewayWebApplicationFirewallConfiguration).
 
@@ -3261,8 +3261,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration](#ApplicationGat
 | "Detection"  |             |
 | "Prevention" |             |
 
-<a id="ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode_STATUS"></a>ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode_STATUS{#ApplicationGatewayWebApplicationFirewallConfiguration_FirewallMode_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#ApplicationGatewayWebApplicationFirewallConfiguration_STATUS).
 
@@ -3271,8 +3271,8 @@ Used by: [ApplicationGatewayWebApplicationFirewallConfiguration_STATUS](#Applica
 | "Detection"  |             |
 | "Prevention" |             |
 
-<a id="CipherSuitesEnum"></a>CipherSuitesEnum
----------------------------------------------
+CipherSuitesEnum{#CipherSuitesEnum}
+-----------------------------------
 
 Ssl cipher suites enums.
 
@@ -3309,8 +3309,8 @@ Used by: [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy).
 | "TLS_RSA_WITH_AES_256_CBC_SHA256"         |             |
 | "TLS_RSA_WITH_AES_256_GCM_SHA384"         |             |
 
-<a id="CipherSuitesEnum_STATUS"></a>CipherSuitesEnum_STATUS
------------------------------------------------------------
+CipherSuitesEnum_STATUS{#CipherSuitesEnum_STATUS}
+-------------------------------------------------
 
 Ssl cipher suites enums.
 
@@ -3347,8 +3347,8 @@ Used by: [ApplicationGatewaySslPolicy_STATUS](#ApplicationGatewaySslPolicy_STATU
 | "TLS_RSA_WITH_AES_256_CBC_SHA256"         |             |
 | "TLS_RSA_WITH_AES_256_GCM_SHA384"         |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -3358,8 +3358,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -3369,8 +3369,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="IPAllocationMethod"></a>IPAllocationMethod
--------------------------------------------------
+IPAllocationMethod{#IPAllocationMethod}
+---------------------------------------
 
 IP address allocation method.
 
@@ -3381,8 +3381,8 @@ Used by: [ApplicationGatewayFrontendIPConfiguration](#ApplicationGatewayFrontend
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IPAllocationMethod_STATUS"></a>IPAllocationMethod_STATUS
----------------------------------------------------------------
+IPAllocationMethod_STATUS{#IPAllocationMethod_STATUS}
+-----------------------------------------------------
 
 IP address allocation method.
 
@@ -3393,8 +3393,8 @@ Used by: [PrivateLinkServiceIpConfiguration_STATUS](#PrivateLinkServiceIpConfigu
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IpConfiguration_PrivateIpAllocationMethod"></a>IpConfiguration_PrivateIpAllocationMethod
------------------------------------------------------------------------------------------------
+IpConfiguration_PrivateIpAllocationMethod{#IpConfiguration_PrivateIpAllocationMethod}
+-------------------------------------------------------------------------------------
 
 Used by: [IpConfiguration](#IpConfiguration).
 
@@ -3403,8 +3403,8 @@ Used by: [IpConfiguration](#IpConfiguration).
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IpConfiguration_PrivateIpAllocationMethod_STATUS"></a>IpConfiguration_PrivateIpAllocationMethod_STATUS
--------------------------------------------------------------------------------------------------------------
+IpConfiguration_PrivateIpAllocationMethod_STATUS{#IpConfiguration_PrivateIpAllocationMethod_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [IpConfiguration_STATUS](#IpConfiguration_STATUS).
 
@@ -3413,8 +3413,8 @@ Used by: [IpConfiguration_STATUS](#IpConfiguration_STATUS).
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -3425,8 +3425,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -3437,8 +3437,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentity_UserAssignedIdentities_STATUS"></a>ManagedServiceIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedServiceIdentity_UserAssignedIdentities_STATUS{#ManagedServiceIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -3447,8 +3447,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="NatGatewaySku_Name"></a>NatGatewaySku_Name
--------------------------------------------------
+NatGatewaySku_Name{#NatGatewaySku_Name}
+---------------------------------------
 
 Used by: [NatGatewaySku](#NatGatewaySku).
 
@@ -3456,8 +3456,8 @@ Used by: [NatGatewaySku](#NatGatewaySku).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="NatGatewaySku_Name_STATUS"></a>NatGatewaySku_Name_STATUS
----------------------------------------------------------------
+NatGatewaySku_Name_STATUS{#NatGatewaySku_Name_STATUS}
+-----------------------------------------------------
 
 Used by: [NatGatewaySku_STATUS](#NatGatewaySku_STATUS).
 
@@ -3465,8 +3465,8 @@ Used by: [NatGatewaySku_STATUS](#NatGatewaySku_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="PolicyNameEnum"></a>PolicyNameEnum
------------------------------------------
+PolicyNameEnum{#PolicyNameEnum}
+-------------------------------
 
 Ssl predefined policy name enums.
 
@@ -3480,8 +3480,8 @@ Used by: [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy).
 | "AppGwSslPolicy20220101"  |             |
 | "AppGwSslPolicy20220101S" |             |
 
-<a id="PolicyNameEnum_STATUS"></a>PolicyNameEnum_STATUS
--------------------------------------------------------
+PolicyNameEnum_STATUS{#PolicyNameEnum_STATUS}
+---------------------------------------------
 
 Ssl predefined policy name enums.
 
@@ -3495,8 +3495,8 @@ Used by: [ApplicationGatewaySslPolicy_STATUS](#ApplicationGatewaySslPolicy_STATU
 | "AppGwSslPolicy20220101"  |             |
 | "AppGwSslPolicy20220101S" |             |
 
-<a id="PrivateEndpointOperatorConfigMaps"></a>PrivateEndpointOperatorConfigMaps
--------------------------------------------------------------------------------
+PrivateEndpointOperatorConfigMaps{#PrivateEndpointOperatorConfigMaps}
+---------------------------------------------------------------------
 
 Used by: [PrivateEndpointOperatorSpec](#PrivateEndpointOperatorSpec).
 
@@ -3504,8 +3504,8 @@ Used by: [PrivateEndpointOperatorSpec](#PrivateEndpointOperatorSpec).
 |----------------------------|------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | primaryNicPrivateIpAddress | indicates where the PrimaryNicPrivateIpAddress config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnectionState"></a>PrivateLinkServiceConnectionState
--------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState{#PrivateLinkServiceConnectionState}
+---------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -3517,8 +3517,8 @@ Used by: [PrivateLinkServiceConnection](#PrivateLinkServiceConnection).
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small> |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -3530,8 +3530,8 @@ Used by: [PrivateLinkServiceConnection_STATUS](#PrivateLinkServiceConnection_STA
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small> |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceOperatorConfigMaps"></a>PrivateLinkServiceOperatorConfigMaps
--------------------------------------------------------------------------------------
+PrivateLinkServiceOperatorConfigMaps{#PrivateLinkServiceOperatorConfigMaps}
+---------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceOperatorSpec](#PrivateLinkServiceOperatorSpec).
 
@@ -3539,8 +3539,8 @@ Used by: [PrivateLinkServiceOperatorSpec](#PrivateLinkServiceOperatorSpec).
 |----------|---------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | alias    | indicates where the Alias config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ProtocolsEnum"></a>ProtocolsEnum
----------------------------------------
+ProtocolsEnum{#ProtocolsEnum}
+-----------------------------
 
 Ssl protocol enums.
 
@@ -3553,8 +3553,8 @@ Used by: [ApplicationGatewaySslPolicy](#ApplicationGatewaySslPolicy), and [Appli
 | "TLSv1_2" |             |
 | "TLSv1_3" |             |
 
-<a id="ProtocolsEnum_STATUS"></a>ProtocolsEnum_STATUS
------------------------------------------------------
+ProtocolsEnum_STATUS{#ProtocolsEnum_STATUS}
+-------------------------------------------
 
 Ssl protocol enums.
 
@@ -3567,8 +3567,8 @@ Used by: [ApplicationGatewaySslPolicy_STATUS](#ApplicationGatewaySslPolicy_STATU
 | "TLSv1_2" |             |
 | "TLSv1_3" |             |
 
-<a id="PublicIPPrefixSku_Name"></a>PublicIPPrefixSku_Name
----------------------------------------------------------
+PublicIPPrefixSku_Name{#PublicIPPrefixSku_Name}
+-----------------------------------------------
 
 Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 
@@ -3576,8 +3576,8 @@ Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="PublicIPPrefixSku_Name_STATUS"></a>PublicIPPrefixSku_Name_STATUS
------------------------------------------------------------------------
+PublicIPPrefixSku_Name_STATUS{#PublicIPPrefixSku_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 
@@ -3585,8 +3585,8 @@ Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="PublicIPPrefixSku_Tier"></a>PublicIPPrefixSku_Tier
----------------------------------------------------------
+PublicIPPrefixSku_Tier{#PublicIPPrefixSku_Tier}
+-----------------------------------------------
 
 Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 
@@ -3595,8 +3595,8 @@ Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPPrefixSku_Tier_STATUS"></a>PublicIPPrefixSku_Tier_STATUS
------------------------------------------------------------------------
+PublicIPPrefixSku_Tier_STATUS{#PublicIPPrefixSku_Tier_STATUS}
+-------------------------------------------------------------
 
 Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 
@@ -3605,8 +3605,8 @@ Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="RecordSet_STATUS"></a>RecordSet_STATUS
----------------------------------------------
+RecordSet_STATUS{#RecordSet_STATUS}
+-----------------------------------
 
 A collective group of information about the record set information.
 
@@ -3621,8 +3621,8 @@ Used by: [PrivateDnsZoneConfig_STATUS](#PrivateDnsZoneConfig_STATUS).
 | recordType        | Resource record type.                              | string<br/><small>Optional</small>                                                                              |
 | ttl               | Recordset time to live.                            | int<br/><small>Optional</small>                                                                                 |
 
-<a id="RedirectTypeEnum"></a>RedirectTypeEnum
----------------------------------------------
+RedirectTypeEnum{#RedirectTypeEnum}
+-----------------------------------
 
 Redirect type enum.
 
@@ -3635,8 +3635,8 @@ Used by: [ApplicationGatewayRedirectConfiguration](#ApplicationGatewayRedirectCo
 | "SeeOther"  |             |
 | "Temporary" |             |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -3645,8 +3645,8 @@ Used by: [Sku](#Sku).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -3655,8 +3655,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="Subnet_PrivateLinkService_SubResourceEmbedded"></a>Subnet_PrivateLinkService_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------
+Subnet_PrivateLinkService_SubResourceEmbedded{#Subnet_PrivateLinkService_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3666,8 +3666,8 @@ Used by: [PrivateLinkServiceIpConfiguration](#PrivateLinkServiceIpConfiguration)
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_PrivateLinkService_SubResourceEmbedded"></a>Subnet_STATUS_PrivateLinkService_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_PrivateLinkService_SubResourceEmbedded{#Subnet_STATUS_PrivateLinkService_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -3677,7 +3677,19 @@ Used by: [PrivateLinkServiceIpConfiguration_STATUS](#PrivateLinkServiceIpConfigu
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3689,20 +3701,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -3712,8 +3712,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation"></a>ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation
----------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation{#ApplicationGatewayClientAuthConfiguration_VerifyClientRevocation}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ApplicationGatewayClientAuthConfiguration](#ApplicationGatewayClientAuthConfiguration).
 
@@ -3722,8 +3722,8 @@ Used by: [ApplicationGatewayClientAuthConfiguration](#ApplicationGatewayClientAu
 | "None" |             |
 | "OCSP" |             |
 
-<a id="ApplicationGatewayRewriteRuleActionSet"></a>ApplicationGatewayRewriteRuleActionSet
------------------------------------------------------------------------------------------
+ApplicationGatewayRewriteRuleActionSet{#ApplicationGatewayRewriteRuleActionSet}
+-------------------------------------------------------------------------------
 
 Set of actions in the Rewrite Rule in Application Gateway.
 
@@ -3735,8 +3735,8 @@ Used by: [ApplicationGatewayRewriteRule](#ApplicationGatewayRewriteRule).
 | responseHeaderConfigurations | Response Header Actions in the Action Set.  | [ApplicationGatewayHeaderConfiguration[]](#ApplicationGatewayHeaderConfiguration)<br/><small>Optional</small> |
 | urlConfiguration             | Url Configuration Action in the Action Set. | [ApplicationGatewayUrlConfiguration](#ApplicationGatewayUrlConfiguration)<br/><small>Optional</small>         |
 
-<a id="ApplicationGatewayRewriteRuleCondition"></a>ApplicationGatewayRewriteRuleCondition
------------------------------------------------------------------------------------------
+ApplicationGatewayRewriteRuleCondition{#ApplicationGatewayRewriteRuleCondition}
+-------------------------------------------------------------------------------
 
 Set of conditions in the Rewrite Rule in Application Gateway.
 
@@ -3749,8 +3749,8 @@ Used by: [ApplicationGatewayRewriteRule](#ApplicationGatewayRewriteRule).
 | pattern    | The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition. | string<br/><small>Optional</small> |
 | variable   | The condition parameter of the RewriteRuleCondition.                                                      | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayHeaderConfiguration"></a>ApplicationGatewayHeaderConfiguration
----------------------------------------------------------------------------------------
+ApplicationGatewayHeaderConfiguration{#ApplicationGatewayHeaderConfiguration}
+-----------------------------------------------------------------------------
 
 Header configuration of the Actions set in Application Gateway.
 
@@ -3761,8 +3761,8 @@ Used by: [ApplicationGatewayRewriteRuleActionSet](#ApplicationGatewayRewriteRule
 | headerName  | Header name of the header configuration.  | string<br/><small>Optional</small> |
 | headerValue | Header value of the header configuration. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayUrlConfiguration"></a>ApplicationGatewayUrlConfiguration
----------------------------------------------------------------------------------
+ApplicationGatewayUrlConfiguration{#ApplicationGatewayUrlConfiguration}
+-----------------------------------------------------------------------
 
 Url configuration of the Actions set in Application Gateway.
 

--- a/docs/hugo/content/reference/network/v1api20240101.md
+++ b/docs/hugo/content/reference/network/v1api20240101.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20240101
 linktitle: v1api20240101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-01-01" |             |
 
-<a id="ApplicationSecurityGroup"></a>ApplicationSecurityGroup
--------------------------------------------------------------
+ApplicationSecurityGroup{#ApplicationSecurityGroup}
+---------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-01-01/applicationSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}
 
@@ -26,7 +26,7 @@ Used by: [ApplicationSecurityGroupList](#ApplicationSecurityGroupList).
 | spec                                                                                    |             | [ApplicationSecurityGroup_Spec](#ApplicationSecurityGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ApplicationSecurityGroup_STATUS](#ApplicationSecurityGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="ApplicationSecurityGroup_Spec"></a>ApplicationSecurityGroup_Spec
+### ApplicationSecurityGroup_Spec {#ApplicationSecurityGroup_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -36,7 +36,7 @@ Used by: [ApplicationSecurityGroupList](#ApplicationSecurityGroupList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="ApplicationSecurityGroup_STATUS"></a>ApplicationSecurityGroup_STATUS
+### ApplicationSecurityGroup_STATUS{#ApplicationSecurityGroup_STATUS}
 
 | Property          | Description                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,8 +50,8 @@ Used by: [ApplicationSecurityGroupList](#ApplicationSecurityGroupList).
 | tags              | Resource tags.                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | Resource type.                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ApplicationSecurityGroupList"></a>ApplicationSecurityGroupList
----------------------------------------------------------------------
+ApplicationSecurityGroupList{#ApplicationSecurityGroupList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-01-01/applicationSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}
 
@@ -61,8 +61,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [ApplicationSecurityGroup[]](#ApplicationSecurityGroup)<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallPolicy"></a>WebApplicationFirewallPolicy
----------------------------------------------------------------------
+WebApplicationFirewallPolicy{#WebApplicationFirewallPolicy}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-01-01/webapplicationfirewall.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}
 
@@ -75,7 +75,7 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | spec                                                                                    |             | [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="WebApplicationFirewallPolicy_Spec"></a>WebApplicationFirewallPolicy_Spec
+### WebApplicationFirewallPolicy_Spec {#WebApplicationFirewallPolicy_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -88,7 +88,7 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | policySettings | The PolicySettings for policy.                                                                                                                                                                                                                                                               | [PolicySettings](#PolicySettings)<br/><small>Optional</small>                                                                                                        |
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="WebApplicationFirewallPolicy_STATUS"></a>WebApplicationFirewallPolicy_STATUS
+### WebApplicationFirewallPolicy_STATUS{#WebApplicationFirewallPolicy_STATUS}
 
 | Property            | Description                                                              | Type                                                                                                                                                                                                                        |
 |---------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -108,8 +108,8 @@ Used by: [WebApplicationFirewallPolicyList](#WebApplicationFirewallPolicyList).
 | tags                | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                                                                                               |
 | type                | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                                                                                          |
 
-<a id="WebApplicationFirewallPolicyList"></a>WebApplicationFirewallPolicyList
------------------------------------------------------------------------------
+WebApplicationFirewallPolicyList{#WebApplicationFirewallPolicyList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-01-01/webapplicationfirewall.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}
 
@@ -119,8 +119,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [WebApplicationFirewallPolicy[]](#WebApplicationFirewallPolicy)<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroup_Spec"></a>ApplicationSecurityGroup_Spec
------------------------------------------------------------------------
+ApplicationSecurityGroup_Spec{#ApplicationSecurityGroup_Spec}
+-------------------------------------------------------------
 
 Used by: [ApplicationSecurityGroup](#ApplicationSecurityGroup).
 
@@ -132,8 +132,8 @@ Used by: [ApplicationSecurityGroup](#ApplicationSecurityGroup).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ApplicationSecurityGroup_STATUS"></a>ApplicationSecurityGroup_STATUS
----------------------------------------------------------------------------
+ApplicationSecurityGroup_STATUS{#ApplicationSecurityGroup_STATUS}
+-----------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -151,8 +151,8 @@ Used by: [ApplicationSecurityGroup](#ApplicationSecurityGroup).
 | tags              | Resource tags.                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | Resource type.                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WebApplicationFirewallPolicy_Spec"></a>WebApplicationFirewallPolicy_Spec
--------------------------------------------------------------------------------
+WebApplicationFirewallPolicy_Spec{#WebApplicationFirewallPolicy_Spec}
+---------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 
@@ -167,8 +167,8 @@ Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 | policySettings | The PolicySettings for policy.                                                                                                                                                                                                                                                               | [PolicySettings](#PolicySettings)<br/><small>Optional</small>                                                                                                        |
 | tags           | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WebApplicationFirewallPolicy_STATUS"></a>WebApplicationFirewallPolicy_STATUS
------------------------------------------------------------------------------------
+WebApplicationFirewallPolicy_STATUS{#WebApplicationFirewallPolicy_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 
@@ -190,8 +190,8 @@ Used by: [WebApplicationFirewallPolicy](#WebApplicationFirewallPolicy).
 | tags                | Resource tags.                                                           | map[string]string<br/><small>Optional</small>                                                                                                                                                                               |
 | type                | Resource type.                                                           | string<br/><small>Optional</small>                                                                                                                                                                                          |
 
-<a id="ApplicationGateway_STATUS_ApplicationGatewayWebApplicationFirewallPolicy_SubResourceEmbedded"></a>ApplicationGateway_STATUS_ApplicationGatewayWebApplicationFirewallPolicy_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGateway_STATUS_ApplicationGatewayWebApplicationFirewallPolicy_SubResourceEmbedded{#ApplicationGateway_STATUS_ApplicationGatewayWebApplicationFirewallPolicy_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Application gateway resource.
 
@@ -201,8 +201,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupOperatorSpec"></a>ApplicationSecurityGroupOperatorSpec
--------------------------------------------------------------------------------------
+ApplicationSecurityGroupOperatorSpec{#ApplicationSecurityGroupOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -213,8 +213,8 @@ Used by: [ApplicationSecurityGroup_Spec](#ApplicationSecurityGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ManagedRulesDefinition"></a>ManagedRulesDefinition
----------------------------------------------------------
+ManagedRulesDefinition{#ManagedRulesDefinition}
+-----------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -225,8 +225,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | exclusions      | The Exclusions that are applied on the policy.             | [OwaspCrsExclusionEntry[]](#OwaspCrsExclusionEntry)<br/><small>Optional</small> |
 | managedRuleSets | The managed rule sets that are associated with the policy. | [ManagedRuleSet[]](#ManagedRuleSet)<br/><small>Required</small>                 |
 
-<a id="ManagedRulesDefinition_STATUS"></a>ManagedRulesDefinition_STATUS
------------------------------------------------------------------------
+ManagedRulesDefinition_STATUS{#ManagedRulesDefinition_STATUS}
+-------------------------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -237,8 +237,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | exclusions      | The Exclusions that are applied on the policy.             | [OwaspCrsExclusionEntry_STATUS[]](#OwaspCrsExclusionEntry_STATUS)<br/><small>Optional</small> |
 | managedRuleSets | The managed rule sets that are associated with the policy. | [ManagedRuleSet_STATUS[]](#ManagedRuleSet_STATUS)<br/><small>Optional</small>                 |
 
-<a id="PolicySettings"></a>PolicySettings
------------------------------------------
+PolicySettings{#PolicySettings}
+-------------------------------
 
 Defines contents of a web application firewall global configuration.
 
@@ -259,8 +259,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | requestBodyInspectLimitInKB       | Max inspection limit in KB for request body inspection for WAF.                                                      | int<br/><small>Optional</small>                                                         |
 | state                             | The state of the policy.                                                                                             | [PolicySettings_State](#PolicySettings_State)<br/><small>Optional</small>               |
 
-<a id="PolicySettings_STATUS"></a>PolicySettings_STATUS
--------------------------------------------------------
+PolicySettings_STATUS{#PolicySettings_STATUS}
+---------------------------------------------
 
 Defines contents of a web application firewall global configuration.
 
@@ -281,8 +281,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | requestBodyInspectLimitInKB       | Max inspection limit in KB for request body inspection for WAF.                                                      | int<br/><small>Optional</small>                                                                       |
 | state                             | The state of the policy.                                                                                             | [PolicySettings_State_STATUS](#PolicySettings_State_STATUS)<br/><small>Optional</small>               |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 The current provisioning state.
 
@@ -295,8 +295,8 @@ Used by: [ApplicationSecurityGroup_STATUS](#ApplicationSecurityGroup_STATUS), an
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another subresource.
 
@@ -306,8 +306,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallCustomRule"></a>WebApplicationFirewallCustomRule
------------------------------------------------------------------------------
+WebApplicationFirewallCustomRule{#WebApplicationFirewallCustomRule}
+-------------------------------------------------------------------
 
 Defines contents of a web application rule.
 
@@ -325,8 +325,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | ruleType           | The rule type.                                                                                         | [WebApplicationFirewallCustomRule_RuleType](#WebApplicationFirewallCustomRule_RuleType)<br/><small>Required</small>                   |
 | state              | Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified.    | [WebApplicationFirewallCustomRule_State](#WebApplicationFirewallCustomRule_State)<br/><small>Optional</small>                         |
 
-<a id="WebApplicationFirewallCustomRule_STATUS"></a>WebApplicationFirewallCustomRule_STATUS
--------------------------------------------------------------------------------------------
+WebApplicationFirewallCustomRule_STATUS{#WebApplicationFirewallCustomRule_STATUS}
+---------------------------------------------------------------------------------
 
 Defines contents of a web application rule.
 
@@ -345,8 +345,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | ruleType           | The rule type.                                                                                         | [WebApplicationFirewallCustomRule_RuleType_STATUS](#WebApplicationFirewallCustomRule_RuleType_STATUS)<br/><small>Optional</small>                   |
 | state              | Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified.    | [WebApplicationFirewallCustomRule_State_STATUS](#WebApplicationFirewallCustomRule_State_STATUS)<br/><small>Optional</small>                         |
 
-<a id="WebApplicationFirewallPolicyOperatorSpec"></a>WebApplicationFirewallPolicyOperatorSpec
----------------------------------------------------------------------------------------------
+WebApplicationFirewallPolicyOperatorSpec{#WebApplicationFirewallPolicyOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -357,8 +357,8 @@ Used by: [WebApplicationFirewallPolicy_Spec](#WebApplicationFirewallPolicy_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WebApplicationFirewallPolicyPropertiesFormat_ResourceState_STATUS"></a>WebApplicationFirewallPolicyPropertiesFormat_ResourceState_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallPolicyPropertiesFormat_ResourceState_STATUS{#WebApplicationFirewallPolicyPropertiesFormat_ResourceState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STATUS).
 
@@ -371,8 +371,8 @@ Used by: [WebApplicationFirewallPolicy_STATUS](#WebApplicationFirewallPolicy_STA
 | "Enabled"   |             |
 | "Enabling"  |             |
 
-<a id="GroupByUserSession"></a>GroupByUserSession
--------------------------------------------------
+GroupByUserSession{#GroupByUserSession}
+---------------------------------------
 
 Define user session identifier group by clauses.
 
@@ -382,8 +382,8 @@ Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
 |------------------|------------------------------------|-------------------------------------------------------------------|
 | groupByVariables | List of group by clause variables. | [GroupByVariable[]](#GroupByVariable)<br/><small>Required</small> |
 
-<a id="GroupByUserSession_STATUS"></a>GroupByUserSession_STATUS
----------------------------------------------------------------
+GroupByUserSession_STATUS{#GroupByUserSession_STATUS}
+-----------------------------------------------------
 
 Define user session identifier group by clauses.
 
@@ -393,8 +393,8 @@ Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustom
 |------------------|------------------------------------|---------------------------------------------------------------------------------|
 | groupByVariables | List of group by clause variables. | [GroupByVariable_STATUS[]](#GroupByVariable_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedRuleSet"></a>ManagedRuleSet
------------------------------------------
+ManagedRuleSet{#ManagedRuleSet}
+-------------------------------
 
 Defines a managed rule set.
 
@@ -406,8 +406,8 @@ Used by: [ManagedRulesDefinition](#ManagedRulesDefinition).
 | ruleSetType        | Defines the rule set type to use.                          | string<br/><small>Required</small>                                                  |
 | ruleSetVersion     | Defines the version of the rule set to use.                | string<br/><small>Required</small>                                                  |
 
-<a id="ManagedRuleSet_STATUS"></a>ManagedRuleSet_STATUS
--------------------------------------------------------
+ManagedRuleSet_STATUS{#ManagedRuleSet_STATUS}
+---------------------------------------------
 
 Defines a managed rule set.
 
@@ -419,8 +419,8 @@ Used by: [ManagedRulesDefinition_STATUS](#ManagedRulesDefinition_STATUS).
 | ruleSetType        | Defines the rule set type to use.                          | string<br/><small>Optional</small>                                                                |
 | ruleSetVersion     | Defines the version of the rule set to use.                | string<br/><small>Optional</small>                                                                |
 
-<a id="MatchCondition"></a>MatchCondition
------------------------------------------
+MatchCondition{#MatchCondition}
+-------------------------------
 
 Define match conditions.
 
@@ -434,8 +434,8 @@ Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
 | operator         | The operator to be matched.              | [MatchCondition_Operator](#MatchCondition_Operator)<br/><small>Required</small> |
 | transforms       | List of transforms.                      | [Transform[]](#Transform)<br/><small>Optional</small>                           |
 
-<a id="MatchCondition_STATUS"></a>MatchCondition_STATUS
--------------------------------------------------------
+MatchCondition_STATUS{#MatchCondition_STATUS}
+---------------------------------------------
 
 Define match conditions.
 
@@ -449,8 +449,8 @@ Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustom
 | operator         | The operator to be matched.              | [MatchCondition_Operator_STATUS](#MatchCondition_Operator_STATUS)<br/><small>Optional</small> |
 | transforms       | List of transforms.                      | [Transform_STATUS[]](#Transform_STATUS)<br/><small>Optional</small>                           |
 
-<a id="OwaspCrsExclusionEntry"></a>OwaspCrsExclusionEntry
----------------------------------------------------------
+OwaspCrsExclusionEntry{#OwaspCrsExclusionEntry}
+-----------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -463,8 +463,8 @@ Used by: [ManagedRulesDefinition](#ManagedRulesDefinition).
 | selector                 | When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to.           | string<br/><small>Required</small>                                                                                        |
 | selectorMatchOperator    | When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to. | [OwaspCrsExclusionEntry_SelectorMatchOperator](#OwaspCrsExclusionEntry_SelectorMatchOperator)<br/><small>Required</small> |
 
-<a id="OwaspCrsExclusionEntry_STATUS"></a>OwaspCrsExclusionEntry_STATUS
------------------------------------------------------------------------
+OwaspCrsExclusionEntry_STATUS{#OwaspCrsExclusionEntry_STATUS}
+-------------------------------------------------------------
 
 Allow to exclude some variable satisfy the condition for the WAF check.
 
@@ -477,8 +477,8 @@ Used by: [ManagedRulesDefinition_STATUS](#ManagedRulesDefinition_STATUS).
 | selector                 | When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to.           | string<br/><small>Optional</small>                                                                                                      |
 | selectorMatchOperator    | When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to. | [OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS](#OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS)<br/><small>Optional</small> |
 
-<a id="PolicySettings_LogScrubbing"></a>PolicySettings_LogScrubbing
--------------------------------------------------------------------
+PolicySettings_LogScrubbing{#PolicySettings_LogScrubbing}
+---------------------------------------------------------
 
 Used by: [PolicySettings](#PolicySettings).
 
@@ -487,8 +487,8 @@ Used by: [PolicySettings](#PolicySettings).
 | scrubbingRules | The rules that are applied to the logs for scrubbing.        | [WebApplicationFirewallScrubbingRules[]](#WebApplicationFirewallScrubbingRules)<br/><small>Optional</small> |
 | state          | State of the log scrubbing config. Default value is Enabled. | [PolicySettings_LogScrubbing_State](#PolicySettings_LogScrubbing_State)<br/><small>Optional</small>         |
 
-<a id="PolicySettings_LogScrubbing_STATUS"></a>PolicySettings_LogScrubbing_STATUS
----------------------------------------------------------------------------------
+PolicySettings_LogScrubbing_STATUS{#PolicySettings_LogScrubbing_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 
@@ -497,8 +497,8 @@ Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 | scrubbingRules | The rules that are applied to the logs for scrubbing.        | [WebApplicationFirewallScrubbingRules_STATUS[]](#WebApplicationFirewallScrubbingRules_STATUS)<br/><small>Optional</small> |
 | state          | State of the log scrubbing config. Default value is Enabled. | [PolicySettings_LogScrubbing_State_STATUS](#PolicySettings_LogScrubbing_State_STATUS)<br/><small>Optional</small>         |
 
-<a id="PolicySettings_Mode"></a>PolicySettings_Mode
----------------------------------------------------
+PolicySettings_Mode{#PolicySettings_Mode}
+-----------------------------------------
 
 Used by: [PolicySettings](#PolicySettings).
 
@@ -507,8 +507,8 @@ Used by: [PolicySettings](#PolicySettings).
 | "Detection"  |             |
 | "Prevention" |             |
 
-<a id="PolicySettings_Mode_STATUS"></a>PolicySettings_Mode_STATUS
------------------------------------------------------------------
+PolicySettings_Mode_STATUS{#PolicySettings_Mode_STATUS}
+-------------------------------------------------------
 
 Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 
@@ -517,8 +517,8 @@ Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 | "Detection"  |             |
 | "Prevention" |             |
 
-<a id="PolicySettings_State"></a>PolicySettings_State
------------------------------------------------------
+PolicySettings_State{#PolicySettings_State}
+-------------------------------------------
 
 Used by: [PolicySettings](#PolicySettings).
 
@@ -527,8 +527,8 @@ Used by: [PolicySettings](#PolicySettings).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PolicySettings_State_STATUS"></a>PolicySettings_State_STATUS
--------------------------------------------------------------------
+PolicySettings_State_STATUS{#PolicySettings_State_STATUS}
+---------------------------------------------------------
 
 Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 
@@ -537,8 +537,8 @@ Used by: [PolicySettings_STATUS](#PolicySettings_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WebApplicationFirewallCustomRule_Action"></a>WebApplicationFirewallCustomRule_Action
--------------------------------------------------------------------------------------------
+WebApplicationFirewallCustomRule_Action{#WebApplicationFirewallCustomRule_Action}
+---------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
 
@@ -549,73 +549,73 @@ Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
 | "JSChallenge" |             |
 | "Log"         |             |
 
-<a id="WebApplicationFirewallCustomRule_Action_STATUS"></a>WebApplicationFirewallCustomRule_Action_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "Allow"       |             |
-| "Block"       |             |
-| "JSChallenge" |             |
-| "Log"         |             |
-
-<a id="WebApplicationFirewallCustomRule_RateLimitDuration"></a>WebApplicationFirewallCustomRule_RateLimitDuration
------------------------------------------------------------------------------------------------------------------
-
-Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
-
-| Value      | Description |
-|------------|-------------|
-| "FiveMins" |             |
-| "OneMin"   |             |
-
-<a id="WebApplicationFirewallCustomRule_RateLimitDuration_STATUS"></a>WebApplicationFirewallCustomRule_RateLimitDuration_STATUS
--------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "FiveMins" |             |
-| "OneMin"   |             |
-
-<a id="WebApplicationFirewallCustomRule_RuleType"></a>WebApplicationFirewallCustomRule_RuleType
+WebApplicationFirewallCustomRule_Action_STATUS{#WebApplicationFirewallCustomRule_Action_STATUS}
 -----------------------------------------------------------------------------------------------
 
-Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
-
-| Value           | Description |
-|-----------------|-------------|
-| "Invalid"       |             |
-| "MatchRule"     |             |
-| "RateLimitRule" |             |
-
-<a id="WebApplicationFirewallCustomRule_RuleType_STATUS"></a>WebApplicationFirewallCustomRule_RuleType_STATUS
--------------------------------------------------------------------------------------------------------------
-
 Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
 
-| Value           | Description |
-|-----------------|-------------|
-| "Invalid"       |             |
-| "MatchRule"     |             |
-| "RateLimitRule" |             |
+| Value         | Description |
+|---------------|-------------|
+| "Allow"       |             |
+| "Block"       |             |
+| "JSChallenge" |             |
+| "Log"         |             |
 
-<a id="WebApplicationFirewallCustomRule_State"></a>WebApplicationFirewallCustomRule_State
------------------------------------------------------------------------------------------
-
-Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="WebApplicationFirewallCustomRule_State_STATUS"></a>WebApplicationFirewallCustomRule_State_STATUS
+WebApplicationFirewallCustomRule_RateLimitDuration{#WebApplicationFirewallCustomRule_RateLimitDuration}
 -------------------------------------------------------------------------------------------------------
 
+Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
+
+| Value      | Description |
+|------------|-------------|
+| "FiveMins" |             |
+| "OneMin"   |             |
+
+WebApplicationFirewallCustomRule_RateLimitDuration_STATUS{#WebApplicationFirewallCustomRule_RateLimitDuration_STATUS}
+---------------------------------------------------------------------------------------------------------------------
+
+Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "FiveMins" |             |
+| "OneMin"   |             |
+
+WebApplicationFirewallCustomRule_RuleType{#WebApplicationFirewallCustomRule_RuleType}
+-------------------------------------------------------------------------------------
+
+Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
+
+| Value           | Description |
+|-----------------|-------------|
+| "Invalid"       |             |
+| "MatchRule"     |             |
+| "RateLimitRule" |             |
+
+WebApplicationFirewallCustomRule_RuleType_STATUS{#WebApplicationFirewallCustomRule_RuleType_STATUS}
+---------------------------------------------------------------------------------------------------
+
+Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
+
+| Value           | Description |
+|-----------------|-------------|
+| "Invalid"       |             |
+| "MatchRule"     |             |
+| "RateLimitRule" |             |
+
+WebApplicationFirewallCustomRule_State{#WebApplicationFirewallCustomRule_State}
+-------------------------------------------------------------------------------
+
+Used by: [WebApplicationFirewallCustomRule](#WebApplicationFirewallCustomRule).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+WebApplicationFirewallCustomRule_State_STATUS{#WebApplicationFirewallCustomRule_State_STATUS}
+---------------------------------------------------------------------------------------------
+
 Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustomRule_STATUS).
 
 | Value      | Description |
@@ -623,8 +623,8 @@ Used by: [WebApplicationFirewallCustomRule_STATUS](#WebApplicationFirewallCustom
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ExclusionManagedRuleSet"></a>ExclusionManagedRuleSet
------------------------------------------------------------
+ExclusionManagedRuleSet{#ExclusionManagedRuleSet}
+-------------------------------------------------
 
 Defines a managed rule set for Exclusions.
 
@@ -636,8 +636,8 @@ Used by: [OwaspCrsExclusionEntry](#OwaspCrsExclusionEntry).
 | ruleSetType    | Defines the rule set type to use.                 | string<br/><small>Required</small>                                                    |
 | ruleSetVersion | Defines the version of the rule set to use.       | string<br/><small>Required</small>                                                    |
 
-<a id="ExclusionManagedRuleSet_STATUS"></a>ExclusionManagedRuleSet_STATUS
--------------------------------------------------------------------------
+ExclusionManagedRuleSet_STATUS{#ExclusionManagedRuleSet_STATUS}
+---------------------------------------------------------------
 
 Defines a managed rule set for Exclusions.
 
@@ -649,8 +649,8 @@ Used by: [OwaspCrsExclusionEntry_STATUS](#OwaspCrsExclusionEntry_STATUS).
 | ruleSetType    | Defines the rule set type to use.                 | string<br/><small>Optional</small>                                                                  |
 | ruleSetVersion | Defines the version of the rule set to use.       | string<br/><small>Optional</small>                                                                  |
 
-<a id="GroupByVariable"></a>GroupByVariable
--------------------------------------------
+GroupByVariable{#GroupByVariable}
+---------------------------------
 
 Define user session group by clause variables.
 
@@ -660,8 +660,8 @@ Used by: [GroupByUserSession](#GroupByUserSession).
 |--------------|-------------------------------|-------------------------------------------------------------------------------------------|
 | variableName | User Session clause variable. | [GroupByVariable_VariableName](#GroupByVariable_VariableName)<br/><small>Required</small> |
 
-<a id="GroupByVariable_STATUS"></a>GroupByVariable_STATUS
----------------------------------------------------------
+GroupByVariable_STATUS{#GroupByVariable_STATUS}
+-----------------------------------------------
 
 Define user session group by clause variables.
 
@@ -671,8 +671,8 @@ Used by: [GroupByUserSession_STATUS](#GroupByUserSession_STATUS).
 |--------------|-------------------------------|---------------------------------------------------------------------------------------------------------|
 | variableName | User Session clause variable. | [GroupByVariable_VariableName_STATUS](#GroupByVariable_VariableName_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedRuleGroupOverride"></a>ManagedRuleGroupOverride
--------------------------------------------------------------
+ManagedRuleGroupOverride{#ManagedRuleGroupOverride}
+---------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -683,8 +683,8 @@ Used by: [ManagedRuleSet](#ManagedRuleSet).
 | ruleGroupName | The managed rule group to override.                                                              | string<br/><small>Required</small>                                        |
 | rules         | List of rules that will be disabled. If none specified, all rules in the group will be disabled. | [ManagedRuleOverride[]](#ManagedRuleOverride)<br/><small>Optional</small> |
 
-<a id="ManagedRuleGroupOverride_STATUS"></a>ManagedRuleGroupOverride_STATUS
----------------------------------------------------------------------------
+ManagedRuleGroupOverride_STATUS{#ManagedRuleGroupOverride_STATUS}
+-----------------------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -695,8 +695,8 @@ Used by: [ManagedRuleSet_STATUS](#ManagedRuleSet_STATUS).
 | ruleGroupName | The managed rule group to override.                                                              | string<br/><small>Optional</small>                                                      |
 | rules         | List of rules that will be disabled. If none specified, all rules in the group will be disabled. | [ManagedRuleOverride_STATUS[]](#ManagedRuleOverride_STATUS)<br/><small>Optional</small> |
 
-<a id="MatchCondition_Operator"></a>MatchCondition_Operator
------------------------------------------------------------
+MatchCondition_Operator{#MatchCondition_Operator}
+-------------------------------------------------
 
 Used by: [MatchCondition](#MatchCondition).
 
@@ -715,8 +715,8 @@ Used by: [MatchCondition](#MatchCondition).
 | "LessThanOrEqual"    |             |
 | "Regex"              |             |
 
-<a id="MatchCondition_Operator_STATUS"></a>MatchCondition_Operator_STATUS
--------------------------------------------------------------------------
+MatchCondition_Operator_STATUS{#MatchCondition_Operator_STATUS}
+---------------------------------------------------------------
 
 Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 
@@ -735,8 +735,8 @@ Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 | "LessThanOrEqual"    |             |
 | "Regex"              |             |
 
-<a id="MatchVariable"></a>MatchVariable
----------------------------------------
+MatchVariable{#MatchVariable}
+-----------------------------
 
 Define match variables.
 
@@ -747,8 +747,8 @@ Used by: [MatchCondition](#MatchCondition).
 | selector     | The selector of match variable. | string<br/><small>Optional</small>                                                    |
 | variableName | Match Variable.                 | [MatchVariable_VariableName](#MatchVariable_VariableName)<br/><small>Required</small> |
 
-<a id="MatchVariable_STATUS"></a>MatchVariable_STATUS
------------------------------------------------------
+MatchVariable_STATUS{#MatchVariable_STATUS}
+-------------------------------------------
 
 Define match variables.
 
@@ -759,8 +759,8 @@ Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 | selector     | The selector of match variable. | string<br/><small>Optional</small>                                                                  |
 | variableName | Match Variable.                 | [MatchVariable_VariableName_STATUS](#MatchVariable_VariableName_STATUS)<br/><small>Optional</small> |
 
-<a id="OwaspCrsExclusionEntry_MatchVariable"></a>OwaspCrsExclusionEntry_MatchVariable
--------------------------------------------------------------------------------------
+OwaspCrsExclusionEntry_MatchVariable{#OwaspCrsExclusionEntry_MatchVariable}
+---------------------------------------------------------------------------
 
 Used by: [OwaspCrsExclusionEntry](#OwaspCrsExclusionEntry).
 
@@ -776,8 +776,8 @@ Used by: [OwaspCrsExclusionEntry](#OwaspCrsExclusionEntry).
 | "RequestHeaderNames"  |             |
 | "RequestHeaderValues" |             |
 
-<a id="OwaspCrsExclusionEntry_MatchVariable_STATUS"></a>OwaspCrsExclusionEntry_MatchVariable_STATUS
----------------------------------------------------------------------------------------------------
+OwaspCrsExclusionEntry_MatchVariable_STATUS{#OwaspCrsExclusionEntry_MatchVariable_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [OwaspCrsExclusionEntry_STATUS](#OwaspCrsExclusionEntry_STATUS).
 
@@ -793,8 +793,8 @@ Used by: [OwaspCrsExclusionEntry_STATUS](#OwaspCrsExclusionEntry_STATUS).
 | "RequestHeaderNames"  |             |
 | "RequestHeaderValues" |             |
 
-<a id="OwaspCrsExclusionEntry_SelectorMatchOperator"></a>OwaspCrsExclusionEntry_SelectorMatchOperator
------------------------------------------------------------------------------------------------------
+OwaspCrsExclusionEntry_SelectorMatchOperator{#OwaspCrsExclusionEntry_SelectorMatchOperator}
+-------------------------------------------------------------------------------------------
 
 Used by: [OwaspCrsExclusionEntry](#OwaspCrsExclusionEntry).
 
@@ -806,8 +806,8 @@ Used by: [OwaspCrsExclusionEntry](#OwaspCrsExclusionEntry).
 | "EqualsAny"  |             |
 | "StartsWith" |             |
 
-<a id="OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS"></a>OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS
--------------------------------------------------------------------------------------------------------------------
+OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS{#OwaspCrsExclusionEntry_SelectorMatchOperator_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [OwaspCrsExclusionEntry_STATUS](#OwaspCrsExclusionEntry_STATUS).
 
@@ -819,8 +819,8 @@ Used by: [OwaspCrsExclusionEntry_STATUS](#OwaspCrsExclusionEntry_STATUS).
 | "EqualsAny"  |             |
 | "StartsWith" |             |
 
-<a id="PolicySettings_LogScrubbing_State"></a>PolicySettings_LogScrubbing_State
--------------------------------------------------------------------------------
+PolicySettings_LogScrubbing_State{#PolicySettings_LogScrubbing_State}
+---------------------------------------------------------------------
 
 Used by: [PolicySettings_LogScrubbing](#PolicySettings_LogScrubbing).
 
@@ -829,8 +829,8 @@ Used by: [PolicySettings_LogScrubbing](#PolicySettings_LogScrubbing).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PolicySettings_LogScrubbing_State_STATUS"></a>PolicySettings_LogScrubbing_State_STATUS
----------------------------------------------------------------------------------------------
+PolicySettings_LogScrubbing_State_STATUS{#PolicySettings_LogScrubbing_State_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [PolicySettings_LogScrubbing_STATUS](#PolicySettings_LogScrubbing_STATUS).
 
@@ -839,8 +839,8 @@ Used by: [PolicySettings_LogScrubbing_STATUS](#PolicySettings_LogScrubbing_STATU
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="Transform"></a>Transform
--------------------------------
+Transform{#Transform}
+---------------------
 
 Transforms applied before matching.
 
@@ -856,8 +856,8 @@ Used by: [MatchCondition](#MatchCondition).
 | "UrlDecode"        |             |
 | "UrlEncode"        |             |
 
-<a id="Transform_STATUS"></a>Transform_STATUS
----------------------------------------------
+Transform_STATUS{#Transform_STATUS}
+-----------------------------------
 
 Transforms applied before matching.
 
@@ -873,8 +873,8 @@ Used by: [MatchCondition_STATUS](#MatchCondition_STATUS).
 | "UrlDecode"        |             |
 | "UrlEncode"        |             |
 
-<a id="WebApplicationFirewallScrubbingRules"></a>WebApplicationFirewallScrubbingRules
--------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules{#WebApplicationFirewallScrubbingRules}
+---------------------------------------------------------------------------
 
 Allow certain variables to be scrubbed on WAF logs
 
@@ -887,8 +887,8 @@ Used by: [PolicySettings_LogScrubbing](#PolicySettings_LogScrubbing).
 | selectorMatchOperator | When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to. | [WebApplicationFirewallScrubbingRules_SelectorMatchOperator](#WebApplicationFirewallScrubbingRules_SelectorMatchOperator)<br/><small>Required</small> |
 | state                 | Defines the state of log scrubbing rule. Default value is Enabled.                                                            | [WebApplicationFirewallScrubbingRules_State](#WebApplicationFirewallScrubbingRules_State)<br/><small>Optional</small>                                 |
 
-<a id="WebApplicationFirewallScrubbingRules_STATUS"></a>WebApplicationFirewallScrubbingRules_STATUS
----------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_STATUS{#WebApplicationFirewallScrubbingRules_STATUS}
+-----------------------------------------------------------------------------------------
 
 Allow certain variables to be scrubbed on WAF logs
 
@@ -901,8 +901,8 @@ Used by: [PolicySettings_LogScrubbing_STATUS](#PolicySettings_LogScrubbing_STATU
 | selectorMatchOperator | When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to. | [WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS](#WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS)<br/><small>Optional</small> |
 | state                 | Defines the state of log scrubbing rule. Default value is Enabled.                                                            | [WebApplicationFirewallScrubbingRules_State_STATUS](#WebApplicationFirewallScrubbingRules_State_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="ExclusionManagedRuleGroup"></a>ExclusionManagedRuleGroup
----------------------------------------------------------------
+ExclusionManagedRuleGroup{#ExclusionManagedRuleGroup}
+-----------------------------------------------------
 
 Defines a managed rule group to use for exclusion.
 
@@ -913,8 +913,8 @@ Used by: [ExclusionManagedRuleSet](#ExclusionManagedRuleSet).
 | ruleGroupName | The managed rule group for exclusion.                                                            | string<br/><small>Required</small>                                          |
 | rules         | List of rules that will be excluded. If none specified, all rules in the group will be excluded. | [ExclusionManagedRule[]](#ExclusionManagedRule)<br/><small>Optional</small> |
 
-<a id="ExclusionManagedRuleGroup_STATUS"></a>ExclusionManagedRuleGroup_STATUS
------------------------------------------------------------------------------
+ExclusionManagedRuleGroup_STATUS{#ExclusionManagedRuleGroup_STATUS}
+-------------------------------------------------------------------
 
 Defines a managed rule group to use for exclusion.
 
@@ -925,8 +925,8 @@ Used by: [ExclusionManagedRuleSet_STATUS](#ExclusionManagedRuleSet_STATUS).
 | ruleGroupName | The managed rule group for exclusion.                                                            | string<br/><small>Optional</small>                                                        |
 | rules         | List of rules that will be excluded. If none specified, all rules in the group will be excluded. | [ExclusionManagedRule_STATUS[]](#ExclusionManagedRule_STATUS)<br/><small>Optional</small> |
 
-<a id="GroupByVariable_VariableName"></a>GroupByVariable_VariableName
----------------------------------------------------------------------
+GroupByVariable_VariableName{#GroupByVariable_VariableName}
+-----------------------------------------------------------
 
 Used by: [GroupByVariable](#GroupByVariable).
 
@@ -936,8 +936,8 @@ Used by: [GroupByVariable](#GroupByVariable).
 | "GeoLocation" |             |
 | "None"        |             |
 
-<a id="GroupByVariable_VariableName_STATUS"></a>GroupByVariable_VariableName_STATUS
------------------------------------------------------------------------------------
+GroupByVariable_VariableName_STATUS{#GroupByVariable_VariableName_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [GroupByVariable_STATUS](#GroupByVariable_STATUS).
 
@@ -947,8 +947,8 @@ Used by: [GroupByVariable_STATUS](#GroupByVariable_STATUS).
 | "GeoLocation" |             |
 | "None"        |             |
 
-<a id="ManagedRuleOverride"></a>ManagedRuleOverride
----------------------------------------------------
+ManagedRuleOverride{#ManagedRuleOverride}
+-----------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -960,8 +960,8 @@ Used by: [ManagedRuleGroupOverride](#ManagedRuleGroupOverride).
 | ruleId   | Identifier for the managed rule.                                      | string<br/><small>Required</small>                                                  |
 | state    | The state of the managed rule. Defaults to Disabled if not specified. | [ManagedRuleOverride_State](#ManagedRuleOverride_State)<br/><small>Optional</small> |
 
-<a id="ManagedRuleOverride_STATUS"></a>ManagedRuleOverride_STATUS
------------------------------------------------------------------
+ManagedRuleOverride_STATUS{#ManagedRuleOverride_STATUS}
+-------------------------------------------------------
 
 Defines a managed rule group override setting.
 
@@ -973,8 +973,8 @@ Used by: [ManagedRuleGroupOverride_STATUS](#ManagedRuleGroupOverride_STATUS).
 | ruleId   | Identifier for the managed rule.                                      | string<br/><small>Optional</small>                                                                |
 | state    | The state of the managed rule. Defaults to Disabled if not specified. | [ManagedRuleOverride_State_STATUS](#ManagedRuleOverride_State_STATUS)<br/><small>Optional</small> |
 
-<a id="MatchVariable_VariableName"></a>MatchVariable_VariableName
------------------------------------------------------------------
+MatchVariable_VariableName{#MatchVariable_VariableName}
+-------------------------------------------------------
 
 Used by: [MatchVariable](#MatchVariable).
 
@@ -989,8 +989,8 @@ Used by: [MatchVariable](#MatchVariable).
 | "RequestMethod"  |             |
 | "RequestUri"     |             |
 
-<a id="MatchVariable_VariableName_STATUS"></a>MatchVariable_VariableName_STATUS
--------------------------------------------------------------------------------
+MatchVariable_VariableName_STATUS{#MatchVariable_VariableName_STATUS}
+---------------------------------------------------------------------
 
 Used by: [MatchVariable_STATUS](#MatchVariable_STATUS).
 
@@ -1005,8 +1005,8 @@ Used by: [MatchVariable_STATUS](#MatchVariable_STATUS).
 | "RequestMethod"  |             |
 | "RequestUri"     |             |
 
-<a id="WebApplicationFirewallScrubbingRules_MatchVariable"></a>WebApplicationFirewallScrubbingRules_MatchVariable
------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_MatchVariable{#WebApplicationFirewallScrubbingRules_MatchVariable}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbingRules).
 
@@ -1019,8 +1019,8 @@ Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbing
 | "RequestJSONArgNames" |             |
 | "RequestPostArgNames" |             |
 
-<a id="WebApplicationFirewallScrubbingRules_MatchVariable_STATUS"></a>WebApplicationFirewallScrubbingRules_MatchVariable_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_MatchVariable_STATUS{#WebApplicationFirewallScrubbingRules_MatchVariable_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallScrubbingRules_STATUS).
 
@@ -1033,8 +1033,8 @@ Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallSc
 | "RequestJSONArgNames" |             |
 | "RequestPostArgNames" |             |
 
-<a id="WebApplicationFirewallScrubbingRules_SelectorMatchOperator"></a>WebApplicationFirewallScrubbingRules_SelectorMatchOperator
----------------------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_SelectorMatchOperator{#WebApplicationFirewallScrubbingRules_SelectorMatchOperator}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbingRules).
 
@@ -1043,8 +1043,8 @@ Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbing
 | "Equals"    |             |
 | "EqualsAny" |             |
 
-<a id="WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS"></a>WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS{#WebApplicationFirewallScrubbingRules_SelectorMatchOperator_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallScrubbingRules_STATUS).
 
@@ -1053,8 +1053,8 @@ Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallSc
 | "Equals"    |             |
 | "EqualsAny" |             |
 
-<a id="WebApplicationFirewallScrubbingRules_State"></a>WebApplicationFirewallScrubbingRules_State
--------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_State{#WebApplicationFirewallScrubbingRules_State}
+---------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbingRules).
 
@@ -1063,8 +1063,8 @@ Used by: [WebApplicationFirewallScrubbingRules](#WebApplicationFirewallScrubbing
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WebApplicationFirewallScrubbingRules_State_STATUS"></a>WebApplicationFirewallScrubbingRules_State_STATUS
----------------------------------------------------------------------------------------------------------------
+WebApplicationFirewallScrubbingRules_State_STATUS{#WebApplicationFirewallScrubbingRules_State_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallScrubbingRules_STATUS).
 
@@ -1073,8 +1073,8 @@ Used by: [WebApplicationFirewallScrubbingRules_STATUS](#WebApplicationFirewallSc
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ActionType"></a>ActionType
----------------------------------
+ActionType{#ActionType}
+-----------------------
 
 Defines the action to take on rule match.
 
@@ -1088,8 +1088,8 @@ Used by: [ManagedRuleOverride](#ManagedRuleOverride).
 | "JSChallenge"    |             |
 | "Log"            |             |
 
-<a id="ActionType_STATUS"></a>ActionType_STATUS
------------------------------------------------
+ActionType_STATUS{#ActionType_STATUS}
+-------------------------------------
 
 Defines the action to take on rule match.
 
@@ -1103,8 +1103,8 @@ Used by: [ManagedRuleOverride_STATUS](#ManagedRuleOverride_STATUS).
 | "JSChallenge"    |             |
 | "Log"            |             |
 
-<a id="ExclusionManagedRule"></a>ExclusionManagedRule
------------------------------------------------------
+ExclusionManagedRule{#ExclusionManagedRule}
+-------------------------------------------
 
 Defines a managed rule to use for exclusion.
 
@@ -1114,8 +1114,8 @@ Used by: [ExclusionManagedRuleGroup](#ExclusionManagedRuleGroup).
 |----------|----------------------------------|------------------------------------|
 | ruleId   | Identifier for the managed rule. | string<br/><small>Required</small> |
 
-<a id="ExclusionManagedRule_STATUS"></a>ExclusionManagedRule_STATUS
--------------------------------------------------------------------
+ExclusionManagedRule_STATUS{#ExclusionManagedRule_STATUS}
+---------------------------------------------------------
 
 Defines a managed rule to use for exclusion.
 
@@ -1125,8 +1125,8 @@ Used by: [ExclusionManagedRuleGroup_STATUS](#ExclusionManagedRuleGroup_STATUS).
 |----------|----------------------------------|------------------------------------|
 | ruleId   | Identifier for the managed rule. | string<br/><small>Optional</small> |
 
-<a id="ManagedRuleOverride_State"></a>ManagedRuleOverride_State
----------------------------------------------------------------
+ManagedRuleOverride_State{#ManagedRuleOverride_State}
+-----------------------------------------------------
 
 Used by: [ManagedRuleOverride](#ManagedRuleOverride).
 
@@ -1135,8 +1135,8 @@ Used by: [ManagedRuleOverride](#ManagedRuleOverride).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ManagedRuleOverride_State_STATUS"></a>ManagedRuleOverride_State_STATUS
------------------------------------------------------------------------------
+ManagedRuleOverride_State_STATUS{#ManagedRuleOverride_State_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagedRuleOverride_STATUS](#ManagedRuleOverride_STATUS).
 

--- a/docs/hugo/content/reference/network/v1api20240301.md
+++ b/docs/hugo/content/reference/network/v1api20240301.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20240301
 linktitle: v1api20240301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-03-01" |             |
 
-<a id="BastionHost"></a>BastionHost
------------------------------------
+BastionHost{#BastionHost}
+-------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/bastionHost.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/bastionHosts/{bastionHostName}
 
@@ -26,7 +26,7 @@ Used by: [BastionHostList](#BastionHostList).
 | spec                                                                                    |             | [BastionHost_Spec](#BastionHost_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [BastionHost_STATUS](#BastionHost_STATUS)<br/><small>Optional</small> |
 
-### <a id="BastionHost_Spec"></a>BastionHost_Spec
+### BastionHost_Spec {#BastionHost_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -50,7 +50,7 @@ Used by: [BastionHostList](#BastionHostList).
 | virtualNetwork         | Reference to an existing virtual network required for Developer Bastion Host only.                                                                                                                                                                                                           | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                  | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                 | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="BastionHost_STATUS"></a>BastionHost_STATUS
+### BastionHost_STATUS{#BastionHost_STATUS}
 
 | Property               | Description                                                                        | Type                                                                                                                                                    |
 |------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -77,8 +77,8 @@ Used by: [BastionHostList](#BastionHostList).
 | virtualNetwork         | Reference to an existing virtual network required for Developer Bastion Host only. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | zones                  | A list of availability zones denoting where the resource needs to come from.       | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="BastionHostList"></a>BastionHostList
--------------------------------------------
+BastionHostList{#BastionHostList}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/bastionHost.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/bastionHosts/{bastionHostName}
 
@@ -88,8 +88,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                           |
 | items                                                                               |             | [BastionHost[]](#BastionHost)<br/><small>Optional</small> |
 
-<a id="LoadBalancer"></a>LoadBalancer
--------------------------------------
+LoadBalancer{#LoadBalancer}
+---------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}
 
@@ -102,7 +102,7 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | spec                                                                                    |             | [LoadBalancer_Spec](#LoadBalancer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [LoadBalancer_STATUS](#LoadBalancer_STATUS)<br/><small>Optional</small> |
 
-### <a id="LoadBalancer_Spec"></a>LoadBalancer_Spec
+### LoadBalancer_Spec {#LoadBalancer_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                                 |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -121,7 +121,7 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | sku                      | The load balancer SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [LoadBalancerSku](#LoadBalancerSku)<br/><small>Optional</small>                                                                                                      |
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="LoadBalancer_STATUS"></a>LoadBalancer_STATUS
+### LoadBalancer_STATUS{#LoadBalancer_STATUS}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Type                                                                                                                                                              |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -144,8 +144,8 @@ Used by: [LoadBalancerList](#LoadBalancerList).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                     |
 | type                     | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="LoadBalancerList"></a>LoadBalancerList
----------------------------------------------
+LoadBalancerList{#LoadBalancerList}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}
 
@@ -155,8 +155,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [LoadBalancer[]](#LoadBalancer)<br/><small>Optional</small> |
 
-<a id="LoadBalancersInboundNatRule"></a>LoadBalancersInboundNatRule
--------------------------------------------------------------------
+LoadBalancersInboundNatRule{#LoadBalancersInboundNatRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}
 
@@ -169,7 +169,7 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | spec                                                                                    |             | [LoadBalancersInboundNatRule_Spec](#LoadBalancersInboundNatRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [LoadBalancersInboundNatRule_STATUS](#LoadBalancersInboundNatRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="LoadBalancersInboundNatRule_Spec"></a>LoadBalancersInboundNatRule_Spec
+### LoadBalancersInboundNatRule_Spec {#LoadBalancersInboundNatRule_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -187,7 +187,7 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/LoadBalancer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                                  | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small>                                                                                                  |
 
-### <a id="LoadBalancersInboundNatRule_STATUS"></a>LoadBalancersInboundNatRule_STATUS
+### LoadBalancersInboundNatRule_STATUS{#LoadBalancersInboundNatRule_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                                                            |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -209,8 +209,8 @@ Used by: [LoadBalancersInboundNatRuleList](#LoadBalancersInboundNatRuleList).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                              | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="LoadBalancersInboundNatRuleList"></a>LoadBalancersInboundNatRuleList
----------------------------------------------------------------------------
+LoadBalancersInboundNatRuleList{#LoadBalancersInboundNatRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/loadBalancer.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}
 
@@ -220,8 +220,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [LoadBalancersInboundNatRule[]](#LoadBalancersInboundNatRule)<br/><small>Optional</small> |
 
-<a id="NatGateway"></a>NatGateway
----------------------------------
+NatGateway{#NatGateway}
+-----------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/natGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/natGateways/{natGatewayName}
 
@@ -234,7 +234,7 @@ Used by: [NatGatewayList](#NatGatewayList).
 | spec                                                                                    |             | [NatGateway_Spec](#NatGateway_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NatGateway_STATUS](#NatGateway_STATUS)<br/><small>Optional</small> |
 
-### <a id="NatGateway_Spec"></a>NatGateway_Spec
+### NatGateway_Spec {#NatGateway_Spec}
 
 | Property             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -249,7 +249,7 @@ Used by: [NatGatewayList](#NatGatewayList).
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed.                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="NatGateway_STATUS"></a>NatGateway_STATUS
+### NatGateway_STATUS{#NatGateway_STATUS}
 
 | Property             | Description                                                                             | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -269,8 +269,8 @@ Used by: [NatGatewayList](#NatGatewayList).
 | type                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="NatGatewayList"></a>NatGatewayList
------------------------------------------
+NatGatewayList{#NatGatewayList}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/natGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/natGateways/{natGatewayName}
 
@@ -280,8 +280,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [NatGateway[]](#NatGateway)<br/><small>Optional</small> |
 
-<a id="NetworkInterface"></a>NetworkInterface
----------------------------------------------
+NetworkInterface{#NetworkInterface}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkInterface.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkInterfaces/{networkInterfaceName}
 
@@ -294,7 +294,7 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | spec                                                                                    |             | [NetworkInterface_Spec](#NetworkInterface_Spec)<br/><small>Optional</small>                                                                               |
 | status                                                                                  |             | [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="NetworkInterface_Spec"></a>NetworkInterface_Spec
+### NetworkInterface_Spec {#NetworkInterface_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                        |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -316,7 +316,7 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                               |
 | workloadType                | WorkloadType of the NetworkInterface for BareMetal resources                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                          |
 
-### <a id="NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded
+### NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded}
 
 | Property                    | Description                                                                                                                         | Type                                                                                                                                                                                        |
 |-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -351,8 +351,8 @@ Used by: [NetworkInterfaceList](#NetworkInterfaceList).
 | vnetEncryptionSupported     | Whether the virtual machine this nic is attached to supports encryption.                                                            | bool<br/><small>Optional</small>                                                                                                                                                            |
 | workloadType                | WorkloadType of the NetworkInterface for BareMetal resources                                                                        | string<br/><small>Optional</small>                                                                                                                                                          |
 
-<a id="NetworkInterfaceList"></a>NetworkInterfaceList
------------------------------------------------------
+NetworkInterfaceList{#NetworkInterfaceList}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkInterface.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkInterfaces/{networkInterfaceName}
 
@@ -362,8 +362,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [NetworkInterface[]](#NetworkInterface)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup"></a>NetworkSecurityGroup
------------------------------------------------------
+NetworkSecurityGroup{#NetworkSecurityGroup}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}
 
@@ -376,7 +376,7 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | spec                                                                                    |             | [NetworkSecurityGroup_Spec](#NetworkSecurityGroup_Spec)<br/><small>Optional</small>                                                                                       |
 | status                                                                                  |             | [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="NetworkSecurityGroup_Spec"></a>NetworkSecurityGroup_Spec
+### NetworkSecurityGroup_Spec {#NetworkSecurityGroup_Spec}
 
 | Property        | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -387,7 +387,7 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags            | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded
+### NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
 
 | Property             | Description                                                                                                                                                     | Type                                                                                                                                                                |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -405,8 +405,8 @@ Used by: [NetworkSecurityGroupList](#NetworkSecurityGroupList).
 | tags                 | Resource tags.                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                       |
 | type                 | Resource type.                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="NetworkSecurityGroupList"></a>NetworkSecurityGroupList
--------------------------------------------------------------
+NetworkSecurityGroupList{#NetworkSecurityGroupList}
+---------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}
 
@@ -416,8 +416,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [NetworkSecurityGroup[]](#NetworkSecurityGroup)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupsSecurityRule"></a>NetworkSecurityGroupsSecurityRule
--------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule{#NetworkSecurityGroupsSecurityRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}
 
@@ -430,7 +430,7 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | spec                                                                                    |             | [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurityRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecurityRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NetworkSecurityGroupsSecurityRule_Spec"></a>NetworkSecurityGroupsSecurityRule_Spec
+### NetworkSecurityGroupsSecurityRule_Spec {#NetworkSecurityGroupsSecurityRule_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                       | Type                                                                                                                                                                                                      |
 |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -453,7 +453,7 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | sourcePortRange                      | The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                        |
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                                                      |
 
-### <a id="NetworkSecurityGroupsSecurityRule_STATUS"></a>NetworkSecurityGroupsSecurityRule_STATUS
+### NetworkSecurityGroupsSecurityRule_STATUS{#NetworkSecurityGroupsSecurityRule_STATUS}
 
 | Property                             | Description                                                                                                                                                                                                                                                  | Type                                                                                                                                                                                                            |
 |--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -479,8 +479,8 @@ Used by: [NetworkSecurityGroupsSecurityRuleList](#NetworkSecurityGroupsSecurityR
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                                                            |
 | type                                 | The type of the resource.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="NetworkSecurityGroupsSecurityRuleList"></a>NetworkSecurityGroupsSecurityRuleList
----------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRuleList{#NetworkSecurityGroupsSecurityRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/networkSecurityGroup.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}
 
@@ -490,8 +490,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NetworkSecurityGroupsSecurityRule[]](#NetworkSecurityGroupsSecurityRule)<br/><small>Optional</small> |
 
-<a id="PrivateEndpoint"></a>PrivateEndpoint
--------------------------------------------
+PrivateEndpoint{#PrivateEndpoint}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}
 
@@ -504,7 +504,7 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | spec                                                                                    |             | [PrivateEndpoint_Spec](#PrivateEndpoint_Spec)<br/><small>Optional</small>                                                                             |
 | status                                                                                  |             | [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="PrivateEndpoint_Spec"></a>PrivateEndpoint_Spec
+### PrivateEndpoint_Spec {#PrivateEndpoint_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -521,7 +521,7 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | subnet                              | The ID of the subnet from which the private IP will be allocated.                                                                                                                                                                                                                            | [Subnet_PrivateEndpoint_SubResourceEmbedded](#Subnet_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small>                                                |
 | tags                                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded
+### PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded{#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded}
 
 | Property                            | Description                                                                                                                                                            | Type                                                                                                                                                                      |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -543,8 +543,8 @@ Used by: [PrivateEndpointList](#PrivateEndpointList).
 | tags                                | Resource tags.                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                             |
 | type                                | Resource type.                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                        |
 
-<a id="PrivateEndpointList"></a>PrivateEndpointList
----------------------------------------------------
+PrivateEndpointList{#PrivateEndpointList}
+-----------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}
 
@@ -554,8 +554,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [PrivateEndpoint[]](#PrivateEndpoint)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup"></a>PrivateEndpointsPrivateDnsZoneGroup
------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup{#PrivateEndpointsPrivateDnsZoneGroup}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}
 
@@ -568,7 +568,7 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | spec                                                                                    |             | [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZoneGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateEndpointsPrivateDnsZoneGroup_STATUS](#PrivateEndpointsPrivateDnsZoneGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateEndpointsPrivateDnsZoneGroup_Spec"></a>PrivateEndpointsPrivateDnsZoneGroup_Spec
+### PrivateEndpointsPrivateDnsZoneGroup_Spec {#PrivateEndpointsPrivateDnsZoneGroup_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -577,7 +577,7 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/PrivateEndpoint resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                                                                                                                                                                                                               | [PrivateDnsZoneConfig[]](#PrivateDnsZoneConfig)<br/><small>Optional</small>                                                                                          |
 
-### <a id="PrivateEndpointsPrivateDnsZoneGroup_STATUS"></a>PrivateEndpointsPrivateDnsZoneGroup_STATUS
+### PrivateEndpointsPrivateDnsZoneGroup_STATUS{#PrivateEndpointsPrivateDnsZoneGroup_STATUS}
 
 | Property              | Description                                                                                                | Type                                                                                                                                                    |
 |-----------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -588,8 +588,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroupList](#PrivateEndpointsPrivateDnsZo
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                             | [PrivateDnsZoneConfig_STATUS[]](#PrivateDnsZoneConfig_STATUS)<br/><small>Optional</small>                                                               |
 | provisioningState     | The provisioning state of the private dns zone group resource.                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroupList"></a>PrivateEndpointsPrivateDnsZoneGroupList
--------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroupList{#PrivateEndpointsPrivateDnsZoneGroupList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateEndpoint.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}
 
@@ -599,8 +599,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [PrivateEndpointsPrivateDnsZoneGroup[]](#PrivateEndpointsPrivateDnsZoneGroup)<br/><small>Optional</small> |
 
-<a id="PrivateLinkService"></a>PrivateLinkService
--------------------------------------------------
+PrivateLinkService{#PrivateLinkService}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateLinkService.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateLinkServices/{serviceName}
 
@@ -613,7 +613,7 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | spec                                                                                    |             | [PrivateLinkService_Spec](#PrivateLinkService_Spec)<br/><small>Optional</small>                                                                                   |
 | status                                                                                  |             | [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="PrivateLinkService_Spec"></a>PrivateLinkService_Spec
+### PrivateLinkService_Spec {#PrivateLinkService_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -631,7 +631,7 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | visibility                           | The visibility list of the private link service.                                                                                                                                                                                                                                             | [ResourceSet](#ResourceSet)<br/><small>Optional</small>                                                                                                              |
 
-### <a id="PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded"></a>PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
+### PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded{#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded}
 
 | Property                             | Description                                                                             | Type                                                                                                                                                                          |
 |--------------------------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -655,8 +655,8 @@ Used by: [PrivateLinkServiceList](#PrivateLinkServiceList).
 | type                                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                                            |
 | visibility                           | The visibility list of the private link service.                                        | [ResourceSet_STATUS](#ResourceSet_STATUS)<br/><small>Optional</small>                                                                                                         |
 
-<a id="PrivateLinkServiceList"></a>PrivateLinkServiceList
----------------------------------------------------------
+PrivateLinkServiceList{#PrivateLinkServiceList}
+-----------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/privateLinkService.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateLinkServices/{serviceName}
 
@@ -666,8 +666,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [PrivateLinkService[]](#PrivateLinkService)<br/><small>Optional</small> |
 
-<a id="PublicIPAddress"></a>PublicIPAddress
--------------------------------------------
+PublicIPAddress{#PublicIPAddress}
+---------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/publicIpAddress.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPAddresses/{publicIpAddressName}
 
@@ -680,7 +680,7 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | spec                                                                                    |             | [PublicIPAddress_Spec](#PublicIPAddress_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PublicIPAddress_STATUS](#PublicIPAddress_STATUS)<br/><small>Optional</small> |
 
-### <a id="PublicIPAddress_Spec"></a>PublicIPAddress_Spec
+### PublicIPAddress_Spec {#PublicIPAddress_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -705,7 +705,7 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="PublicIPAddress_STATUS"></a>PublicIPAddress_STATUS
+### PublicIPAddress_STATUS{#PublicIPAddress_STATUS}
 
 | Property                 | Description                                                                                 | Type                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -734,8 +734,8 @@ Used by: [PublicIPAddressList](#PublicIPAddressList).
 | type                     | Resource type.                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PublicIPAddressList"></a>PublicIPAddressList
----------------------------------------------------
+PublicIPAddressList{#PublicIPAddressList}
+-----------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/publicIpAddress.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPAddresses/{publicIpAddressName}
 
@@ -745,8 +745,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [PublicIPAddress[]](#PublicIPAddress)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefix"></a>PublicIPPrefix
------------------------------------------
+PublicIPPrefix{#PublicIPPrefix}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/publicIpPrefix.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}
 
@@ -759,7 +759,7 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | spec                                                                                    |             | [PublicIPPrefix_Spec](#PublicIPPrefix_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS)<br/><small>Optional</small> |
 
-### <a id="PublicIPPrefix_Spec"></a>PublicIPPrefix_Spec
+### PublicIPPrefix_Spec {#PublicIPPrefix_Spec}
 
 | Property               | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -777,7 +777,7 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                  | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="PublicIPPrefix_STATUS"></a>PublicIPPrefix_STATUS
+### PublicIPPrefix_STATUS{#PublicIPPrefix_STATUS}
 
 | Property                            | Description                                                                                    | Type                                                                                                                                                    |
 |-------------------------------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -802,8 +802,8 @@ Used by: [PublicIPPrefixList](#PublicIPPrefixList).
 | type                                | Resource type.                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                               | A list of availability zones denoting the IP allocated for the resource needs to come from.    | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PublicIPPrefixList"></a>PublicIPPrefixList
--------------------------------------------------
+PublicIPPrefixList{#PublicIPPrefixList}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/publicIpPrefix.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}
 
@@ -813,8 +813,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PublicIPPrefix[]](#PublicIPPrefix)<br/><small>Optional</small> |
 
-<a id="RouteTable"></a>RouteTable
----------------------------------
+RouteTable{#RouteTable}
+-----------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}
 
@@ -827,7 +827,7 @@ Used by: [RouteTableList](#RouteTableList).
 | spec                                                                                    |             | [RouteTable_Spec](#RouteTable_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RouteTable_STATUS](#RouteTable_STATUS)<br/><small>Optional</small> |
 
-### <a id="RouteTable_Spec"></a>RouteTable_Spec
+### RouteTable_Spec {#RouteTable_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -838,7 +838,7 @@ Used by: [RouteTableList](#RouteTableList).
 | owner                      | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="RouteTable_STATUS"></a>RouteTable_STATUS
+### RouteTable_STATUS{#RouteTable_STATUS}
 
 | Property                   | Description                                                                           | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -853,8 +853,8 @@ Used by: [RouteTableList](#RouteTableList).
 | tags                       | Resource tags.                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Resource type.                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTableList"></a>RouteTableList
------------------------------------------
+RouteTableList{#RouteTableList}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}
 
@@ -864,8 +864,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [RouteTable[]](#RouteTable)<br/><small>Optional</small> |
 
-<a id="RouteTablesRoute"></a>RouteTablesRoute
----------------------------------------------
+RouteTablesRoute{#RouteTablesRoute}
+-----------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}
 
@@ -878,7 +878,7 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | spec                                                                                    |             | [RouteTablesRoute_Spec](#RouteTablesRoute_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [RouteTablesRoute_STATUS](#RouteTablesRoute_STATUS)<br/><small>Optional</small> |
 
-### <a id="RouteTablesRoute_Spec"></a>RouteTablesRoute_Spec
+### RouteTablesRoute_Spec {#RouteTablesRoute_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -889,7 +889,7 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                         | [RouteTablesRouteOperatorSpec](#RouteTablesRouteOperatorSpec)<br/><small>Optional</small>                                                                            |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/RouteTable resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="RouteTablesRoute_STATUS"></a>RouteTablesRoute_STATUS
+### RouteTablesRoute_STATUS{#RouteTablesRoute_STATUS}
 
 | Property          | Description                                                                                                                            | Type                                                                                                                                                    |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -904,8 +904,8 @@ Used by: [RouteTablesRouteList](#RouteTablesRouteList).
 | provisioningState | The provisioning state of the route resource.                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 | type              | The type of the resource.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTablesRouteList"></a>RouteTablesRouteList
------------------------------------------------------
+RouteTablesRouteList{#RouteTablesRouteList}
+-------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/routeTable.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}
 
@@ -915,8 +915,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [RouteTablesRoute[]](#RouteTablesRoute)<br/><small>Optional</small> |
 
-<a id="VirtualNetwork"></a>VirtualNetwork
------------------------------------------
+VirtualNetwork{#VirtualNetwork}
+-------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}
 
@@ -929,7 +929,7 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | spec                                                                                    |             | [VirtualNetwork_Spec](#VirtualNetwork_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetwork_STATUS](#VirtualNetwork_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetwork_Spec"></a>VirtualNetwork_Spec
+### VirtualNetwork_Spec {#VirtualNetwork_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -950,7 +950,7 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | privateEndpointVNetPolicies | Private Endpoint VNet Policies.                                                                                                                                                                                                                                                              | [PrivateEndpointVNetPolicies](#PrivateEndpointVNetPolicies)<br/><small>Optional</small>                                                                              |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="VirtualNetwork_STATUS"></a>VirtualNetwork_STATUS
+### VirtualNetwork_STATUS{#VirtualNetwork_STATUS}
 
 | Property                    | Description                                                                                                                                                      | Type                                                                                                                                                    |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -976,8 +976,8 @@ Used by: [VirtualNetworkList](#VirtualNetworkList).
 | tags                        | Resource tags.                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                        | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetworkGateway"></a>VirtualNetworkGateway
--------------------------------------------------------
+VirtualNetworkGateway{#VirtualNetworkGateway}
+---------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetworkGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}
 
@@ -990,7 +990,7 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | spec                                                                                    |             | [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec)<br/><small>Optional</small>                                                                                         |
 | status                                                                                  |             | [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworkGateway_Spec"></a>VirtualNetworkGateway_Spec
+### VirtualNetworkGateway_Spec {#VirtualNetworkGateway_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1025,7 +1025,7 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | vpnGatewayGeneration                  | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                                                                                                                                       | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration)<br/><small>Optional</small>                |
 | vpnType                               | The type of this virtual network gateway.                                                                                                                                                                                                                                                    | [VirtualNetworkGatewayPropertiesFormat_VpnType](#VirtualNetworkGatewayPropertiesFormat_VpnType)<br/><small>Optional</small>                                          |
 
-### <a id="VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded"></a>VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
+### VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded{#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded}
 
 | Property                          | Description                                                                                                                                                                       | Type                                                                                                                                                                |
 |-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1065,8 +1065,8 @@ Used by: [VirtualNetworkGatewayList](#VirtualNetworkGatewayList).
 | vpnGatewayGeneration              | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                            | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS)<br/><small>Optional</small> |
 | vpnType                           | The type of this virtual network gateway.                                                                                                                                         | [VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS)<br/><small>Optional</small>                           |
 
-<a id="VirtualNetworkGatewayList"></a>VirtualNetworkGatewayList
----------------------------------------------------------------
+VirtualNetworkGatewayList{#VirtualNetworkGatewayList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetworkGateway.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}
 
@@ -1076,8 +1076,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [VirtualNetworkGateway[]](#VirtualNetworkGateway)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkList"></a>VirtualNetworkList
--------------------------------------------------
+VirtualNetworkList{#VirtualNetworkList}
+---------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}
 
@@ -1087,8 +1087,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [VirtualNetwork[]](#VirtualNetwork)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksSubnet"></a>VirtualNetworksSubnet
--------------------------------------------------------
+VirtualNetworksSubnet{#VirtualNetworksSubnet}
+---------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 
@@ -1101,7 +1101,7 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | spec                                                                                    |             | [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworksSubnet_Spec"></a>VirtualNetworksSubnet_Spec
+### VirtualNetworksSubnet_Spec {#VirtualNetworksSubnet_Spec}
 
 | Property                           | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                                        |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1123,7 +1123,7 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                                                                                                                                                              | [ServiceEndpointPropertiesFormat[]](#ServiceEndpointPropertiesFormat)<br/><small>Optional</small>                                                                                           |
 | sharingScope                       | Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty.                                                                | [SubnetPropertiesFormat_SharingScope](#SubnetPropertiesFormat_SharingScope)<br/><small>Optional</small>                                                                                     |
 
-### <a id="VirtualNetworksSubnet_STATUS"></a>VirtualNetworksSubnet_STATUS
+### VirtualNetworksSubnet_STATUS{#VirtualNetworksSubnet_STATUS}
 
 | Property                           | Description                                                                                                                                                                                                                  | Type                                                                                                                                                                                                      |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1154,8 +1154,8 @@ Used by: [VirtualNetworksSubnetList](#VirtualNetworksSubnetList).
 | sharingScope                       | Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty. | [SubnetPropertiesFormat_SharingScope_STATUS](#SubnetPropertiesFormat_SharingScope_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                               | Resource type.                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                                                        |
 
-<a id="VirtualNetworksSubnetList"></a>VirtualNetworksSubnetList
----------------------------------------------------------------
+VirtualNetworksSubnetList{#VirtualNetworksSubnetList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 
@@ -1165,8 +1165,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [VirtualNetworksSubnet[]](#VirtualNetworksSubnet)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksVirtualNetworkPeering"></a>VirtualNetworksVirtualNetworkPeering
--------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering{#VirtualNetworksVirtualNetworkPeering}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}
 
@@ -1179,7 +1179,7 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | spec                                                                                    |             | [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetworkPeering_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNetworkPeering_STATUS)<br/><small>Optional</small> |
 
-### <a id="VirtualNetworksVirtualNetworkPeering_Spec"></a>VirtualNetworksVirtualNetworkPeering_Spec
+### VirtualNetworksVirtualNetworkPeering_Spec {#VirtualNetworksVirtualNetworkPeering_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1204,7 +1204,7 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | remoteVirtualNetworkAddressSpace | The reference to the current address space of the remote virtual network.                                                                                                                                                                                                                                                               | [AddressSpace](#AddressSpace)<br/><small>Optional</small>                                                                                                            |
 | useRemoteGateways                | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="VirtualNetworksVirtualNetworkPeering_STATUS"></a>VirtualNetworksVirtualNetworkPeering_STATUS
+### VirtualNetworksVirtualNetworkPeering_STATUS{#VirtualNetworksVirtualNetworkPeering_STATUS}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                        |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1234,8 +1234,8 @@ Used by: [VirtualNetworksVirtualNetworkPeeringList](#VirtualNetworksVirtualNetwo
 | type                             | Resource type.                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                          |
 | useRemoteGateways                | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                            |
 
-<a id="VirtualNetworksVirtualNetworkPeeringList"></a>VirtualNetworksVirtualNetworkPeeringList
----------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeeringList{#VirtualNetworksVirtualNetworkPeeringList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /network/resource-manager/Microsoft.Network/stable/2024-03-01/virtualNetwork.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}
 
@@ -1245,8 +1245,8 @@ Generator information: - Generated from: /network/resource-manager/Microsoft.Net
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [VirtualNetworksVirtualNetworkPeering[]](#VirtualNetworksVirtualNetworkPeering)<br/><small>Optional</small> |
 
-<a id="BastionHost_Spec"></a>BastionHost_Spec
----------------------------------------------
+BastionHost_Spec{#BastionHost_Spec}
+-----------------------------------
 
 Used by: [BastionHost](#BastionHost).
 
@@ -1272,8 +1272,8 @@ Used by: [BastionHost](#BastionHost).
 | virtualNetwork         | Reference to an existing virtual network required for Developer Bastion Host only.                                                                                                                                                                                                           | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 | zones                  | A list of availability zones denoting where the resource needs to come from.                                                                                                                                                                                                                 | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="BastionHost_STATUS"></a>BastionHost_STATUS
--------------------------------------------------
+BastionHost_STATUS{#BastionHost_STATUS}
+---------------------------------------
 
 Bastion Host resource.
 
@@ -1304,8 +1304,8 @@ Used by: [BastionHost](#BastionHost).
 | virtualNetwork         | Reference to an existing virtual network required for Developer Bastion Host only. | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | zones                  | A list of availability zones denoting where the resource needs to come from.       | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="LoadBalancer_Spec"></a>LoadBalancer_Spec
------------------------------------------------
+LoadBalancer_Spec{#LoadBalancer_Spec}
+-------------------------------------
 
 Used by: [LoadBalancer](#LoadBalancer).
 
@@ -1326,8 +1326,8 @@ Used by: [LoadBalancer](#LoadBalancer).
 | sku                      | The load balancer SKU.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [LoadBalancerSku](#LoadBalancerSku)<br/><small>Optional</small>                                                                                                      |
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="LoadBalancer_STATUS"></a>LoadBalancer_STATUS
----------------------------------------------------
+LoadBalancer_STATUS{#LoadBalancer_STATUS}
+-----------------------------------------
 
 LoadBalancer resource.
 
@@ -1354,8 +1354,8 @@ Used by: [LoadBalancer](#LoadBalancer).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | map[string]string<br/><small>Optional</small>                                                                                                                     |
 | type                     | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                                |
 
-<a id="LoadBalancersInboundNatRule_Spec"></a>LoadBalancersInboundNatRule_Spec
------------------------------------------------------------------------------
+LoadBalancersInboundNatRule_Spec{#LoadBalancersInboundNatRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 
@@ -1375,8 +1375,8 @@ Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 | owner                   | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/LoadBalancer resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                                  | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small>                                                                                                  |
 
-<a id="LoadBalancersInboundNatRule_STATUS"></a>LoadBalancersInboundNatRule_STATUS
----------------------------------------------------------------------------------
+LoadBalancersInboundNatRule_STATUS{#LoadBalancersInboundNatRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 
@@ -1400,8 +1400,8 @@ Used by: [LoadBalancersInboundNatRule](#LoadBalancersInboundNatRule).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                              | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="NatGateway_Spec"></a>NatGateway_Spec
--------------------------------------------
+NatGateway_Spec{#NatGateway_Spec}
+---------------------------------
 
 Used by: [NatGateway](#NatGateway).
 
@@ -1418,8 +1418,8 @@ Used by: [NatGateway](#NatGateway).
 | tags                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed.                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="NatGateway_STATUS"></a>NatGateway_STATUS
------------------------------------------------
+NatGateway_STATUS{#NatGateway_STATUS}
+-------------------------------------
 
 Nat Gateway resource.
 
@@ -1443,8 +1443,8 @@ Used by: [NatGateway](#NatGateway).
 | type                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 | zones                | A list of availability zones denoting the zone in which Nat Gateway should be deployed. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="NetworkInterface_Spec"></a>NetworkInterface_Spec
--------------------------------------------------------
+NetworkInterface_Spec{#NetworkInterface_Spec}
+---------------------------------------------
 
 Used by: [NetworkInterface](#NetworkInterface).
 
@@ -1468,8 +1468,8 @@ Used by: [NetworkInterface](#NetworkInterface).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                               |
 | workloadType                | WorkloadType of the NetworkInterface for BareMetal resources                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                          |
 
-<a id="NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -1508,8 +1508,8 @@ Used by: [NetworkInterface](#NetworkInterface).
 | vnetEncryptionSupported     | Whether the virtual machine this nic is attached to supports encryption.                                                            | bool<br/><small>Optional</small>                                                                                                                                                            |
 | workloadType                | WorkloadType of the NetworkInterface for BareMetal resources                                                                        | string<br/><small>Optional</small>                                                                                                                                                          |
 
-<a id="NetworkSecurityGroup_Spec"></a>NetworkSecurityGroup_Spec
----------------------------------------------------------------
+NetworkSecurityGroup_Spec{#NetworkSecurityGroup_Spec}
+-----------------------------------------------------
 
 Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 
@@ -1522,8 +1522,8 @@ Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 | owner           | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags            | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -1545,8 +1545,8 @@ Used by: [NetworkSecurityGroup](#NetworkSecurityGroup).
 | tags                 | Resource tags.                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                       |
 | type                 | Resource type.                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                  |
 
-<a id="NetworkSecurityGroupsSecurityRule_Spec"></a>NetworkSecurityGroupsSecurityRule_Spec
------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule_Spec{#NetworkSecurityGroupsSecurityRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule).
 
@@ -1571,8 +1571,8 @@ Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule)
 | sourcePortRange                      | The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                                                        |
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                                                           | string[]<br/><small>Optional</small>                                                                                                                                                                      |
 
-<a id="NetworkSecurityGroupsSecurityRule_STATUS"></a>NetworkSecurityGroupsSecurityRule_STATUS
----------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRule_STATUS{#NetworkSecurityGroupsSecurityRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule).
 
@@ -1600,8 +1600,8 @@ Used by: [NetworkSecurityGroupsSecurityRule](#NetworkSecurityGroupsSecurityRule)
 | sourcePortRanges                     | The source port ranges.                                                                                                                                                                                                                                      | string[]<br/><small>Optional</small>                                                                                                                                                                            |
 | type                                 | The type of the resource.                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                                              |
 
-<a id="PrivateEndpoint_Spec"></a>PrivateEndpoint_Spec
------------------------------------------------------
+PrivateEndpoint_Spec{#PrivateEndpoint_Spec}
+-------------------------------------------
 
 Used by: [PrivateEndpoint](#PrivateEndpoint).
 
@@ -1620,8 +1620,8 @@ Used by: [PrivateEndpoint](#PrivateEndpoint).
 | subnet                              | The ID of the subnet from which the private IP will be allocated.                                                                                                                                                                                                                            | [Subnet_PrivateEndpoint_SubResourceEmbedded](#Subnet_PrivateEndpoint_SubResourceEmbedded)<br/><small>Optional</small>                                                |
 | tags                                | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded{#PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -1647,8 +1647,8 @@ Used by: [PrivateEndpoint](#PrivateEndpoint).
 | tags                                | Resource tags.                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                             |
 | type                                | Resource type.                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                        |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup_Spec"></a>PrivateEndpointsPrivateDnsZoneGroup_Spec
----------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup_Spec{#PrivateEndpointsPrivateDnsZoneGroup_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGroup).
 
@@ -1659,8 +1659,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGr
 | owner                 | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/PrivateEndpoint resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                                                                                                                                                                                                               | [PrivateDnsZoneConfig[]](#PrivateDnsZoneConfig)<br/><small>Optional</small>                                                                                          |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroup_STATUS"></a>PrivateEndpointsPrivateDnsZoneGroup_STATUS
--------------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroup_STATUS{#PrivateEndpointsPrivateDnsZoneGroup_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGroup).
 
@@ -1673,8 +1673,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup](#PrivateEndpointsPrivateDnsZoneGr
 | privateDnsZoneConfigs | A collection of private dns zone configurations of the private dns zone group.                             | [PrivateDnsZoneConfig_STATUS[]](#PrivateDnsZoneConfig_STATUS)<br/><small>Optional</small>                                                               |
 | provisioningState     | The provisioning state of the private dns zone group resource.                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 
-<a id="PrivateLinkService_Spec"></a>PrivateLinkService_Spec
------------------------------------------------------------
+PrivateLinkService_Spec{#PrivateLinkService_Spec}
+-------------------------------------------------
 
 Used by: [PrivateLinkService](#PrivateLinkService).
 
@@ -1694,8 +1694,8 @@ Used by: [PrivateLinkService](#PrivateLinkService).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | visibility                           | The visibility list of the private link service.                                                                                                                                                                                                                                             | [ResourceSet](#ResourceSet)<br/><small>Optional</small>                                                                                                              |
 
-<a id="PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded"></a>PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded{#PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Private link service resource.
 
@@ -1723,8 +1723,8 @@ Used by: [PrivateLinkService](#PrivateLinkService).
 | type                                 | Resource type.                                                                          | string<br/><small>Optional</small>                                                                                                                                            |
 | visibility                           | The visibility list of the private link service.                                        | [ResourceSet_STATUS](#ResourceSet_STATUS)<br/><small>Optional</small>                                                                                                         |
 
-<a id="PublicIPAddress_Spec"></a>PublicIPAddress_Spec
------------------------------------------------------
+PublicIPAddress_Spec{#PublicIPAddress_Spec}
+-------------------------------------------
 
 Used by: [PublicIPAddress](#PublicIPAddress).
 
@@ -1751,8 +1751,8 @@ Used by: [PublicIPAddress](#PublicIPAddress).
 | tags                     | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="PublicIPAddress_STATUS"></a>PublicIPAddress_STATUS
----------------------------------------------------------
+PublicIPAddress_STATUS{#PublicIPAddress_STATUS}
+-----------------------------------------------
 
 Public IP address resource.
 
@@ -1785,8 +1785,8 @@ Used by: [PublicIPAddress](#PublicIPAddress).
 | type                     | Resource type.                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | zones                    | A list of availability zones denoting the IP allocated for the resource needs to come from. | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="PublicIPPrefix_Spec"></a>PublicIPPrefix_Spec
----------------------------------------------------
+PublicIPPrefix_Spec{#PublicIPPrefix_Spec}
+-----------------------------------------
 
 Used by: [PublicIPPrefix](#PublicIPPrefix).
 
@@ -1806,8 +1806,8 @@ Used by: [PublicIPPrefix](#PublicIPPrefix).
 | tags                   | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zones                  | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                                                                                                                                                  | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="PublicIPPrefix_STATUS"></a>PublicIPPrefix_STATUS
--------------------------------------------------------
+PublicIPPrefix_STATUS{#PublicIPPrefix_STATUS}
+---------------------------------------------
 
 Public IP prefix resource.
 
@@ -1836,8 +1836,8 @@ Used by: [PublicIPPrefix](#PublicIPPrefix).
 | type                                | Resource type.                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | zones                               | A list of availability zones denoting the IP allocated for the resource needs to come from.    | string[]<br/><small>Optional</small>                                                                                                                    |
 
-<a id="RouteTable_Spec"></a>RouteTable_Spec
--------------------------------------------
+RouteTable_Spec{#RouteTable_Spec}
+---------------------------------
 
 Used by: [RouteTable](#RouteTable).
 
@@ -1850,8 +1850,8 @@ Used by: [RouteTable](#RouteTable).
 | owner                      | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="RouteTable_STATUS"></a>RouteTable_STATUS
------------------------------------------------
+RouteTable_STATUS{#RouteTable_STATUS}
+-------------------------------------
 
 Route table resource.
 
@@ -1870,8 +1870,8 @@ Used by: [RouteTable](#RouteTable).
 | tags                       | Resource tags.                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | Resource type.                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="RouteTablesRoute_Spec"></a>RouteTablesRoute_Spec
--------------------------------------------------------
+RouteTablesRoute_Spec{#RouteTablesRoute_Spec}
+---------------------------------------------
 
 Used by: [RouteTablesRoute](#RouteTablesRoute).
 
@@ -1884,8 +1884,8 @@ Used by: [RouteTablesRoute](#RouteTablesRoute).
 | operatorSpec     | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                         | [RouteTablesRouteOperatorSpec](#RouteTablesRouteOperatorSpec)<br/><small>Optional</small>                                                                            |
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a network.azure.com/RouteTable resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="RouteTablesRoute_STATUS"></a>RouteTablesRoute_STATUS
------------------------------------------------------------
+RouteTablesRoute_STATUS{#RouteTablesRoute_STATUS}
+-------------------------------------------------
 
 Used by: [RouteTablesRoute](#RouteTablesRoute).
 
@@ -1902,8 +1902,8 @@ Used by: [RouteTablesRoute](#RouteTablesRoute).
 | provisioningState | The provisioning state of the route resource.                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                       |
 | type              | The type of the resource.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetwork_Spec"></a>VirtualNetwork_Spec
----------------------------------------------------
+VirtualNetwork_Spec{#VirtualNetwork_Spec}
+-----------------------------------------
 
 Used by: [VirtualNetwork](#VirtualNetwork).
 
@@ -1926,8 +1926,8 @@ Used by: [VirtualNetwork](#VirtualNetwork).
 | privateEndpointVNetPolicies | Private Endpoint VNet Policies.                                                                                                                                                                                                                                                              | [PrivateEndpointVNetPolicies](#PrivateEndpointVNetPolicies)<br/><small>Optional</small>                                                                              |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="VirtualNetwork_STATUS"></a>VirtualNetwork_STATUS
--------------------------------------------------------
+VirtualNetwork_STATUS{#VirtualNetwork_STATUS}
+---------------------------------------------
 
 Virtual Network resource.
 
@@ -1957,8 +1957,8 @@ Used by: [VirtualNetwork](#VirtualNetwork).
 | tags                        | Resource tags.                                                                                                                                                   | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                        | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetworkGateway_Spec"></a>VirtualNetworkGateway_Spec
------------------------------------------------------------------
+VirtualNetworkGateway_Spec{#VirtualNetworkGateway_Spec}
+-------------------------------------------------------
 
 Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 
@@ -1995,8 +1995,8 @@ Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 | vpnGatewayGeneration                  | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                                                                                                                                       | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration)<br/><small>Optional</small>                |
 | vpnType                               | The type of this virtual network gateway.                                                                                                                                                                                                                                                    | [VirtualNetworkGatewayPropertiesFormat_VpnType](#VirtualNetworkGatewayPropertiesFormat_VpnType)<br/><small>Optional</small>                                          |
 
-<a id="VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded"></a>VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded{#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 A common class for general resource information.
 
@@ -2040,8 +2040,8 @@ Used by: [VirtualNetworkGateway](#VirtualNetworkGateway).
 | vpnGatewayGeneration              | The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.                                                                                            | [VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS)<br/><small>Optional</small> |
 | vpnType                           | The type of this virtual network gateway.                                                                                                                                         | [VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS](#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS)<br/><small>Optional</small>                           |
 
-<a id="VirtualNetworksSubnet_Spec"></a>VirtualNetworksSubnet_Spec
------------------------------------------------------------------
+VirtualNetworksSubnet_Spec{#VirtualNetworksSubnet_Spec}
+-------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 
@@ -2065,8 +2065,8 @@ Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 | serviceEndpoints                   | An array of service endpoints.                                                                                                                                                                                                                                                              | [ServiceEndpointPropertiesFormat[]](#ServiceEndpointPropertiesFormat)<br/><small>Optional</small>                                                                                           |
 | sharingScope                       | Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty.                                                                | [SubnetPropertiesFormat_SharingScope](#SubnetPropertiesFormat_SharingScope)<br/><small>Optional</small>                                                                                     |
 
-<a id="VirtualNetworksSubnet_STATUS"></a>VirtualNetworksSubnet_STATUS
----------------------------------------------------------------------
+VirtualNetworksSubnet_STATUS{#VirtualNetworksSubnet_STATUS}
+-----------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 
@@ -2099,8 +2099,8 @@ Used by: [VirtualNetworksSubnet](#VirtualNetworksSubnet).
 | sharingScope                       | Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty. | [SubnetPropertiesFormat_SharingScope_STATUS](#SubnetPropertiesFormat_SharingScope_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                               | Resource type.                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                                                                        |
 
-<a id="VirtualNetworksVirtualNetworkPeering_Spec"></a>VirtualNetworksVirtualNetworkPeering_Spec
------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering_Spec{#VirtualNetworksVirtualNetworkPeering_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPeering).
 
@@ -2127,8 +2127,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPe
 | remoteVirtualNetworkAddressSpace | The reference to the current address space of the remote virtual network.                                                                                                                                                                                                                                                               | [AddressSpace](#AddressSpace)<br/><small>Optional</small>                                                                                                            |
 | useRemoteGateways                | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="VirtualNetworksVirtualNetworkPeering_STATUS"></a>VirtualNetworksVirtualNetworkPeering_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeering_STATUS{#VirtualNetworksVirtualNetworkPeering_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPeering).
 
@@ -2160,8 +2160,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering](#VirtualNetworksVirtualNetworkPe
 | type                             | Resource type.                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                          |
 | useRemoteGateways                | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. | bool<br/><small>Optional</small>                                                                                                                            |
 
-<a id="AddressSpace"></a>AddressSpace
--------------------------------------
+AddressSpace{#AddressSpace}
+---------------------------
 
 AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 
@@ -2171,8 +2171,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec), [VirtualNetworkGateway_Spe
 |-----------------|------------------------------------------------------------------------------|--------------------------------------|
 | addressPrefixes | A list of address blocks reserved for this virtual network in CIDR notation. | string[]<br/><small>Optional</small> |
 
-<a id="AddressSpace_STATUS"></a>AddressSpace_STATUS
----------------------------------------------------
+AddressSpace_STATUS{#AddressSpace_STATUS}
+-----------------------------------------
 
 AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 
@@ -2182,8 +2182,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS), [VirtualNetworkGateway
 |-----------------|------------------------------------------------------------------------------|--------------------------------------|
 | addressPrefixes | A list of address blocks reserved for this virtual network in CIDR notation. | string[]<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -2193,8 +2193,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded{#ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 
@@ -2204,8 +2204,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2215,8 +2215,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2226,8 +2226,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded{#ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2237,8 +2237,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded{#ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -2248,8 +2248,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_LoadBalancer_SubResourceEmbedded"></a>BackendAddressPool_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_LoadBalancer_SubResourceEmbedded{#BackendAddressPool_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -2265,8 +2265,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | tunnelInterfaces             | An array of gateway load balancer tunnel interfaces.                                                                                                     | [GatewayLoadBalancerTunnelInterface[]](#GatewayLoadBalancerTunnelInterface)<br/><small>Optional</small>                 |
 | virtualNetwork               | A reference to a virtual network.                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                 |
 
-<a id="BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded"></a>BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded{#BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -2291,8 +2291,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | type                         | Type of the resource.                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                                                |
 | virtualNetwork               | A reference to a virtual network.                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                                             |
 
-<a id="BastionHostIPConfiguration"></a>BastionHostIPConfiguration
------------------------------------------------------------------
+BastionHostIPConfiguration{#BastionHostIPConfiguration}
+-------------------------------------------------------
 
 IP configuration of an Bastion Host.
 
@@ -2305,8 +2305,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 | publicIPAddress           | Reference of the PublicIP resource.                                                                        | [SubResource](#SubResource)<br/><small>Required</small>               |
 | subnet                    | Reference of the subnet resource.                                                                          | [SubResource](#SubResource)<br/><small>Required</small>               |
 
-<a id="BastionHostIPConfiguration_STATUS"></a>BastionHostIPConfiguration_STATUS
--------------------------------------------------------------------------------
+BastionHostIPConfiguration_STATUS{#BastionHostIPConfiguration_STATUS}
+---------------------------------------------------------------------
 
 IP configuration of an Bastion Host.
 
@@ -2316,8 +2316,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="BastionHostOperatorSpec"></a>BastionHostOperatorSpec
------------------------------------------------------------
+BastionHostOperatorSpec{#BastionHostOperatorSpec}
+-------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2328,8 +2328,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="BastionHostPropertiesFormat_NetworkAcls"></a>BastionHostPropertiesFormat_NetworkAcls
--------------------------------------------------------------------------------------------
+BastionHostPropertiesFormat_NetworkAcls{#BastionHostPropertiesFormat_NetworkAcls}
+---------------------------------------------------------------------------------
 
 Used by: [BastionHost_Spec](#BastionHost_Spec).
 
@@ -2337,8 +2337,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 |----------|---------------------------------------------------|-------------------------------------------------|
 | ipRules  | Sets the IP ACL rules for Developer Bastion Host. | [IPRule[]](#IPRule)<br/><small>Optional</small> |
 
-<a id="BastionHostPropertiesFormat_NetworkAcls_STATUS"></a>BastionHostPropertiesFormat_NetworkAcls_STATUS
----------------------------------------------------------------------------------------------------------
+BastionHostPropertiesFormat_NetworkAcls_STATUS{#BastionHostPropertiesFormat_NetworkAcls_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 
@@ -2346,8 +2346,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 |----------|---------------------------------------------------|---------------------------------------------------------------|
 | ipRules  | Sets the IP ACL rules for Developer Bastion Host. | [IPRule_STATUS[]](#IPRule_STATUS)<br/><small>Optional</small> |
 
-<a id="BgpSettings"></a>BgpSettings
------------------------------------
+BgpSettings{#BgpSettings}
+-------------------------
 
 BGP settings details.
 
@@ -2360,8 +2360,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | bgpPeeringAddresses | BGP peering address with IP configuration ID for virtual network gateway. | [IPConfigurationBgpPeeringAddress[]](#IPConfigurationBgpPeeringAddress)<br/><small>Optional</small> |
 | peerWeight          | The weight added to routes learned from this BGP speaker.                 | int<br/><small>Optional</small>                                                                     |
 
-<a id="BgpSettings_STATUS"></a>BgpSettings_STATUS
--------------------------------------------------
+BgpSettings_STATUS{#BgpSettings_STATUS}
+---------------------------------------
 
 BGP settings details.
 
@@ -2374,8 +2374,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | bgpPeeringAddresses | BGP peering address with IP configuration ID for virtual network gateway. | [IPConfigurationBgpPeeringAddress_STATUS[]](#IPConfigurationBgpPeeringAddress_STATUS)<br/><small>Optional</small> |
 | peerWeight          | The weight added to routes learned from this BGP speaker.                 | int<br/><small>Optional</small>                                                                                   |
 
-<a id="CustomDnsConfigPropertiesFormat_STATUS"></a>CustomDnsConfigPropertiesFormat_STATUS
------------------------------------------------------------------------------------------
+CustomDnsConfigPropertiesFormat_STATUS{#CustomDnsConfigPropertiesFormat_STATUS}
+-------------------------------------------------------------------------------
 
 Contains custom Dns resolution configuration from customer.
 
@@ -2386,8 +2386,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | fqdn        | Fqdn that resolves to private endpoint ip address.      | string<br/><small>Optional</small>   |
 | ipAddresses | A list of private ip addresses of the private endpoint. | string[]<br/><small>Optional</small> |
 
-<a id="DdosSettings"></a>DdosSettings
--------------------------------------
+DdosSettings{#DdosSettings}
+---------------------------
 
 Contains the DDoS protection settings of the public IP.
 
@@ -2398,8 +2398,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | ddosProtectionPlan | The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled | [SubResource](#SubResource)<br/><small>Optional</small>                                 |
 | protectionMode     | The DDoS protection mode of the public IP                                                            | [DdosSettings_ProtectionMode](#DdosSettings_ProtectionMode)<br/><small>Optional</small> |
 
-<a id="DdosSettings_STATUS"></a>DdosSettings_STATUS
----------------------------------------------------
+DdosSettings_STATUS{#DdosSettings_STATUS}
+-----------------------------------------
 
 Contains the DDoS protection settings of the public IP.
 
@@ -2410,8 +2410,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | ddosProtectionPlan | The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                 |
 | protectionMode     | The DDoS protection mode of the public IP                                                            | [DdosSettings_ProtectionMode_STATUS](#DdosSettings_ProtectionMode_STATUS)<br/><small>Optional</small> |
 
-<a id="Delegation"></a>Delegation
----------------------------------
+Delegation{#Delegation}
+-----------------------
 
 Details the service to which the subnet is delegated.
 
@@ -2422,8 +2422,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | name        | The name of the resource that is unique within a subnet. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | serviceName | The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).           | string<br/><small>Optional</small> |
 
-<a id="Delegation_STATUS"></a>Delegation_STATUS
------------------------------------------------
+Delegation_STATUS{#Delegation_STATUS}
+-------------------------------------
 
 Details the service to which the subnet is delegated.
 
@@ -2439,8 +2439,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | serviceName       | The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).           | string<br/><small>Optional</small>                                                |
 | type              | Resource type.                                                                                         | string<br/><small>Optional</small>                                                |
 
-<a id="DhcpOptions"></a>DhcpOptions
------------------------------------
+DhcpOptions{#DhcpOptions}
+-------------------------
 
 DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.
 
@@ -2450,8 +2450,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 |------------|---------------------------------------|--------------------------------------|
 | dnsServers | The list of DNS servers IP addresses. | string[]<br/><small>Optional</small> |
 
-<a id="DhcpOptions_STATUS"></a>DhcpOptions_STATUS
--------------------------------------------------
+DhcpOptions_STATUS{#DhcpOptions_STATUS}
+---------------------------------------
 
 DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.
 
@@ -2461,8 +2461,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS).
 |------------|---------------------------------------|--------------------------------------|
 | dnsServers | The list of DNS servers IP addresses. | string[]<br/><small>Optional</small> |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 ExtendedLocation complex type.
 
@@ -2473,8 +2473,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec), [NetworkInterface_Spec](#Netwo
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 ExtendedLocation complex type.
 
@@ -2485,8 +2485,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS), [NetworkInterface_STATUS_N
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="FlowLog_STATUS_SubResourceEmbedded"></a>FlowLog_STATUS_SubResourceEmbedded
----------------------------------------------------------------------------------
+FlowLog_STATUS_SubResourceEmbedded{#FlowLog_STATUS_SubResourceEmbedded}
+-----------------------------------------------------------------------
 
 A flow log resource.
 
@@ -2496,8 +2496,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded"></a>FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded{#FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2515,8 +2515,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | subnet                    | The reference to the subnet resource.                                                                                                                         | [Subnet_LoadBalancer_SubResourceEmbedded](#Subnet_LoadBalancer_SubResourceEmbedded)<br/><small>Optional</small>                           |
 | zones                     | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                   | string[]<br/><small>Optional</small>                                                                                                      |
 
-<a id="FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded"></a>FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded{#FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2526,8 +2526,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded"></a>FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded{#FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2553,8 +2553,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | type                      | Type of the resource.                                                                                                                                         | string<br/><small>Optional</small>                                                                                                              |
 | zones                     | A list of availability zones denoting the IP allocated for the resource needs to come from.                                                                   | string[]<br/><small>Optional</small>                                                                                                            |
 
-<a id="FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded"></a>FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------
+FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded{#FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Frontend IP address of the load balancer.
 
@@ -2564,8 +2564,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="InboundNatPool"></a>InboundNatPool
------------------------------------------
+InboundNatPool{#InboundNatPool}
+-------------------------------
 
 Inbound NAT pool of the load balancer.
 
@@ -2583,8 +2583,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                    | The name of the resource that is unique within the set of inbound NAT pools used by the load balancer. This name can be used to access the resource.                                                                                                                                 | string<br/><small>Optional</small>                                  |
 | protocol                | The reference to the transport protocol used by the inbound NAT pool.                                                                                                                                                                                                                | [TransportProtocol](#TransportProtocol)<br/><small>Required</small> |
 
-<a id="InboundNatPool_STATUS"></a>InboundNatPool_STATUS
--------------------------------------------------------
+InboundNatPool_STATUS{#InboundNatPool_STATUS}
+---------------------------------------------
 
 Inbound NAT pool of the load balancer.
 
@@ -2606,8 +2606,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the inbound NAT pool resource.                                                                                                                                                                                                                             | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                |
 
-<a id="InboundNatRule_LoadBalancer_SubResourceEmbedded"></a>InboundNatRule_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------
+InboundNatRule_LoadBalancer_SubResourceEmbedded{#InboundNatRule_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -2627,8 +2627,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                    | The name of the resource that is unique within the set of inbound NAT rules used by the load balancer. This name can be used to access the resource.                                                                                                                                  | string<br/><small>Optional</small>                                  |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                              | [TransportProtocol](#TransportProtocol)<br/><small>Optional</small> |
 
-<a id="InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded"></a>InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------
+InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded{#InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -2653,8 +2653,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the inbound NAT rule resource.                                                                                                                                                                                                                              | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                                               |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                              |
 
-<a id="IPAllocationMethod"></a>IPAllocationMethod
--------------------------------------------------
+IPAllocationMethod{#IPAllocationMethod}
+---------------------------------------
 
 IP address allocation method.
 
@@ -2665,8 +2665,8 @@ Used by: [BastionHostIPConfiguration](#BastionHostIPConfiguration), [FrontendIPC
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IPAllocationMethod_STATUS"></a>IPAllocationMethod_STATUS
----------------------------------------------------------------
+IPAllocationMethod_STATUS{#IPAllocationMethod_STATUS}
+-----------------------------------------------------
 
 IP address allocation method.
 
@@ -2677,8 +2677,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 | "Dynamic" |             |
 | "Static"  |             |
 
-<a id="IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded"></a>IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded{#IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 IP configuration.
 
@@ -2688,8 +2688,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 IP configuration.
 
@@ -2699,8 +2699,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfigurationProfile_STATUS"></a>IPConfigurationProfile_STATUS
------------------------------------------------------------------------
+IPConfigurationProfile_STATUS{#IPConfigurationProfile_STATUS}
+-------------------------------------------------------------
 
 IP configuration profile child resource.
 
@@ -2710,8 +2710,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IpTag"></a>IpTag
------------------------
+IpTag{#IpTag}
+-------------
 
 Contains the IpTag associated with the object.
 
@@ -2722,8 +2722,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec), and [PublicIPPrefix_Spec
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IpTag_STATUS"></a>IpTag_STATUS
--------------------------------------
+IpTag_STATUS{#IpTag_STATUS}
+---------------------------
 
 Contains the IpTag associated with the object.
 
@@ -2734,8 +2734,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS), and [PublicIPPrefix_
 | ipTagType | The IP tag type. Example: FirstPartyUsage.                           | string<br/><small>Optional</small> |
 | tag       | The value of the IP tag associated with the public IP. Example: SQL. | string<br/><small>Optional</small> |
 
-<a id="IPVersion"></a>IPVersion
--------------------------------
+IPVersion{#IPVersion}
+---------------------
 
 IP address version.
 
@@ -2746,8 +2746,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="IPVersion_STATUS"></a>IPVersion_STATUS
----------------------------------------------
+IPVersion_STATUS{#IPVersion_STATUS}
+-----------------------------------
 
 IP address version.
 
@@ -2758,8 +2758,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 | "IPv4" |             |
 | "IPv6" |             |
 
-<a id="LoadBalancerOperatorSpec"></a>LoadBalancerOperatorSpec
--------------------------------------------------------------
+LoadBalancerOperatorSpec{#LoadBalancerOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2770,8 +2770,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LoadBalancersInboundNatRuleOperatorSpec"></a>LoadBalancersInboundNatRuleOperatorSpec
--------------------------------------------------------------------------------------------
+LoadBalancersInboundNatRuleOperatorSpec{#LoadBalancersInboundNatRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2782,8 +2782,8 @@ Used by: [LoadBalancersInboundNatRule_Spec](#LoadBalancersInboundNatRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LoadBalancerSku"></a>LoadBalancerSku
--------------------------------------------
+LoadBalancerSku{#LoadBalancerSku}
+---------------------------------
 
 SKU of a load balancer.
 
@@ -2794,8 +2794,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name     | Name of a load balancer SKU. | [LoadBalancerSku_Name](#LoadBalancerSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a load balancer SKU. | [LoadBalancerSku_Tier](#LoadBalancerSku_Tier)<br/><small>Optional</small> |
 
-<a id="LoadBalancerSku_STATUS"></a>LoadBalancerSku_STATUS
----------------------------------------------------------
+LoadBalancerSku_STATUS{#LoadBalancerSku_STATUS}
+-----------------------------------------------
 
 SKU of a load balancer.
 
@@ -2806,8 +2806,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | name     | Name of a load balancer SKU. | [LoadBalancerSku_Name_STATUS](#LoadBalancerSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a load balancer SKU. | [LoadBalancerSku_Tier_STATUS](#LoadBalancerSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="LoadBalancingRule"></a>LoadBalancingRule
------------------------------------------------
+LoadBalancingRule{#LoadBalancingRule}
+-------------------------------------
 
 A load balancing rule for a load balancer.
 
@@ -2829,8 +2829,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | probe                   | The reference to the load balancer probe used by the load balancing rule.                                                                                                                                                                                                            | [SubResource](#SubResource)<br/><small>Optional</small>                                                                               |
 | protocol                | The reference to the transport protocol used by the load balancing rule.                                                                                                                                                                                                             | [TransportProtocol](#TransportProtocol)<br/><small>Required</small>                                                                   |
 
-<a id="LoadBalancingRule_STATUS"></a>LoadBalancingRule_STATUS
--------------------------------------------------------------
+LoadBalancingRule_STATUS{#LoadBalancingRule_STATUS}
+---------------------------------------------------
 
 A load balancing rule for a load balancer.
 
@@ -2856,8 +2856,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState       | The provisioning state of the load balancing rule resource.                                                                                                                                                                                                                          | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                                   |
 | type                    | Type of the resource.                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                  |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Identity for the resource.
 
@@ -2868,8 +2868,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                            | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Identity for the resource.
 
@@ -2882,8 +2882,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | type                   | The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.                                                                                                                                            | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small>                                                |
 | userAssignedIdentities | The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'. | [map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS](#ManagedServiceIdentity_UserAssignedIdentities_STATUS)<br/><small>Optional</small> |
 
-<a id="NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded"></a>NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------
+NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded{#NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2893,8 +2893,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded"></a>NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded{#NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2904,8 +2904,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NatGatewayOperatorSpec"></a>NatGatewayOperatorSpec
----------------------------------------------------------
+NatGatewayOperatorSpec{#NatGatewayOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2916,8 +2916,8 @@ Used by: [NatGateway_Spec](#NatGateway_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NatGatewaySku"></a>NatGatewaySku
----------------------------------------
+NatGatewaySku{#NatGatewaySku}
+-----------------------------
 
 SKU of nat gateway.
 
@@ -2927,8 +2927,8 @@ Used by: [NatGateway_Spec](#NatGateway_Spec).
 |----------|--------------------------|-----------------------------------------------------------------------|
 | name     | Name of Nat Gateway SKU. | [NatGatewaySku_Name](#NatGatewaySku_Name)<br/><small>Optional</small> |
 
-<a id="NatGatewaySku_STATUS"></a>NatGatewaySku_STATUS
------------------------------------------------------
+NatGatewaySku_STATUS{#NatGatewaySku_STATUS}
+-------------------------------------------
 
 SKU of nat gateway.
 
@@ -2938,8 +2938,8 @@ Used by: [NatGateway_STATUS](#NatGateway_STATUS).
 |----------|--------------------------|-------------------------------------------------------------------------------------|
 | name     | Name of Nat Gateway SKU. | [NatGatewaySku_Name_STATUS](#NatGatewaySku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="NatGatewaySpec_PublicIPAddress_SubResourceEmbedded"></a>NatGatewaySpec_PublicIPAddress_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------
+NatGatewaySpec_PublicIPAddress_SubResourceEmbedded{#NatGatewaySpec_PublicIPAddress_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2949,8 +2949,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded"></a>NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------
+NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded{#NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------
 
 Nat Gateway resource.
 
@@ -2960,8 +2960,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -2971,8 +2971,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded{#NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -2982,8 +2982,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded"></a>NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded{#NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 A network interface in a resource group.
 
@@ -2993,8 +2993,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceDnsSettings"></a>NetworkInterfaceDnsSettings
--------------------------------------------------------------------
+NetworkInterfaceDnsSettings{#NetworkInterfaceDnsSettings}
+---------------------------------------------------------
 
 DNS settings of a network interface.
 
@@ -3005,8 +3005,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | dnsServers           | List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with other IPs, it must be the only value in dnsServers collection. | string[]<br/><small>Optional</small> |
 | internalDnsNameLabel | Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.                                                                                                             | string<br/><small>Optional</small>   |
 
-<a id="NetworkInterfaceDnsSettings_STATUS"></a>NetworkInterfaceDnsSettings_STATUS
----------------------------------------------------------------------------------
+NetworkInterfaceDnsSettings_STATUS{#NetworkInterfaceDnsSettings_STATUS}
+-----------------------------------------------------------------------
 
 DNS settings of a network interface.
 
@@ -3020,8 +3020,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | internalDomainNameSuffix | Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of internalDomainNameSuffix.                    | string<br/><small>Optional</small>   |
 | internalFqdn             | Fully qualified DNS name supporting internal communications between VMs in the same virtual network.                                                                                                                              | string<br/><small>Optional</small>   |
 
-<a id="NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -3044,8 +3044,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | subnet                                | Subnet bound to the IP configuration.                                                                                                                           | [Subnet_NetworkInterface_SubResourceEmbedded](#Subnet_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                                                               |
 | virtualNetworkTaps                    | The reference to Virtual Network Taps.                                                                                                                          | [VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded[]](#VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                               |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -3055,8 +3055,8 @@ Used by: [LoadBalancersInboundNatRule_STATUS](#LoadBalancersInboundNatRule_STATU
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -3084,8 +3084,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | type                                  | Resource type.                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                                                                  |
 | virtualNetworkTaps                    | The reference to Virtual Network Taps.                                                                                                                          | [VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded[]](#VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded)<br/><small>Optional</small>                                       |
 
-<a id="NetworkInterfaceOperatorSpec"></a>NetworkInterfaceOperatorSpec
----------------------------------------------------------------------
+NetworkInterfaceOperatorSpec{#NetworkInterfaceOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3096,8 +3096,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkInterfacePropertiesFormat_AuxiliaryMode"></a>NetworkInterfacePropertiesFormat_AuxiliaryMode
----------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_AuxiliaryMode{#NetworkInterfacePropertiesFormat_AuxiliaryMode}
+-----------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 
@@ -3108,8 +3108,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | "MaxConnections"         |             |
 | "None"                   |             |
 
-<a id="NetworkInterfacePropertiesFormat_AuxiliaryMode_STATUS"></a>NetworkInterfacePropertiesFormat_AuxiliaryMode_STATUS
------------------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_AuxiliaryMode_STATUS{#NetworkInterfacePropertiesFormat_AuxiliaryMode_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -3120,8 +3120,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "MaxConnections"         |             |
 | "None"                   |             |
 
-<a id="NetworkInterfacePropertiesFormat_AuxiliarySku"></a>NetworkInterfacePropertiesFormat_AuxiliarySku
--------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_AuxiliarySku{#NetworkInterfacePropertiesFormat_AuxiliarySku}
+---------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 
@@ -3133,8 +3133,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | "A8"   |             |
 | "None" |             |
 
-<a id="NetworkInterfacePropertiesFormat_AuxiliarySku_STATUS"></a>NetworkInterfacePropertiesFormat_AuxiliarySku_STATUS
----------------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_AuxiliarySku_STATUS{#NetworkInterfacePropertiesFormat_AuxiliarySku_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -3146,8 +3146,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "A8"   |             |
 | "None" |             |
 
-<a id="NetworkInterfacePropertiesFormat_MigrationPhase_STATUS"></a>NetworkInterfacePropertiesFormat_MigrationPhase_STATUS
--------------------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_MigrationPhase_STATUS{#NetworkInterfacePropertiesFormat_MigrationPhase_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -3159,8 +3159,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "None"      |             |
 | "Prepare"   |             |
 
-<a id="NetworkInterfacePropertiesFormat_NicType"></a>NetworkInterfacePropertiesFormat_NicType
----------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_NicType{#NetworkInterfacePropertiesFormat_NicType}
+-----------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 
@@ -3169,8 +3169,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 | "Elastic"  |             |
 | "Standard" |             |
 
-<a id="NetworkInterfacePropertiesFormat_NicType_STATUS"></a>NetworkInterfacePropertiesFormat_NicType_STATUS
------------------------------------------------------------------------------------------------------------
+NetworkInterfacePropertiesFormat_NicType_STATUS{#NetworkInterfacePropertiesFormat_NicType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded).
 
@@ -3179,8 +3179,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 | "Elastic"  |             |
 | "Standard" |             |
 
-<a id="NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Tap configuration in a Network Interface.
 
@@ -3190,8 +3190,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -3201,8 +3201,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -3212,8 +3212,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupOperatorSpec"></a>NetworkSecurityGroupOperatorSpec
------------------------------------------------------------------------------
+NetworkSecurityGroupOperatorSpec{#NetworkSecurityGroupOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3224,8 +3224,8 @@ Used by: [NetworkSecurityGroup_Spec](#NetworkSecurityGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded"></a>NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded{#NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -3235,8 +3235,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded{#NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 NetworkSecurityGroup resource.
 
@@ -3246,8 +3246,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="NetworkSecurityGroupsSecurityRuleOperatorSpec"></a>NetworkSecurityGroupsSecurityRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NetworkSecurityGroupsSecurityRuleOperatorSpec{#NetworkSecurityGroupsSecurityRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3258,8 +3258,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="OutboundRule"></a>OutboundRule
--------------------------------------
+OutboundRule{#OutboundRule}
+---------------------------
 
 Outbound rule of the load balancer.
 
@@ -3275,8 +3275,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | name                     | The name of the resource that is unique within the set of outbound rules used by the load balancer. This name can be used to access the resource.         | string<br/><small>Optional</small>                                                                          |
 | protocol                 | The protocol for the outbound rule in load balancer.                                                                                                      | [OutboundRulePropertiesFormat_Protocol](#OutboundRulePropertiesFormat_Protocol)<br/><small>Required</small> |
 
-<a id="OutboundRule_STATUS"></a>OutboundRule_STATUS
----------------------------------------------------
+OutboundRule_STATUS{#OutboundRule_STATUS}
+-----------------------------------------
 
 Outbound rule of the load balancer.
 
@@ -3296,8 +3296,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | provisioningState        | The provisioning state of the outbound rule resource.                                                                                                     | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                         |
 | type                     | Type of the resource.                                                                                                                                     | string<br/><small>Optional</small>                                                                                        |
 
-<a id="PrivateDnsZoneConfig"></a>PrivateDnsZoneConfig
------------------------------------------------------
+PrivateDnsZoneConfig{#PrivateDnsZoneConfig}
+-------------------------------------------
 
 PrivateDnsZoneConfig resource.
 
@@ -3308,8 +3308,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZ
 | name                    | Name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small>                                                                                                                         |
 | privateDnsZoneReference | The resource id of the private dns zone.                                                                   | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZoneConfig_STATUS"></a>PrivateDnsZoneConfig_STATUS
--------------------------------------------------------------------
+PrivateDnsZoneConfig_STATUS{#PrivateDnsZoneConfig_STATUS}
+---------------------------------------------------------
 
 PrivateDnsZoneConfig resource.
 
@@ -3321,8 +3321,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_STATUS](#PrivateEndpointsPrivateDn
 | privateDnsZoneId | The resource id of the private dns zone.                                                                   | string<br/><small>Optional</small>                                  |
 | recordSets       | A collection of information regarding a recordSet, holding information to identify private resources.      | [RecordSet_STATUS[]](#RecordSet_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded{#PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -3332,8 +3332,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Private endpoint resource.
 
@@ -3343,8 +3343,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 PrivateEndpointConnection resource.
 
@@ -3354,8 +3354,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointIPConfiguration"></a>PrivateEndpointIPConfiguration
--------------------------------------------------------------------------
+PrivateEndpointIPConfiguration{#PrivateEndpointIPConfiguration}
+---------------------------------------------------------------
 
 An IP Configuration of the private endpoint.
 
@@ -3368,8 +3368,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 | name             | The name of the resource that is unique within a resource group.                                           | string<br/><small>Optional</small> |
 | privateIPAddress | A private ip address obtained from the private endpoint's subnet.                                          | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointIPConfiguration_STATUS"></a>PrivateEndpointIPConfiguration_STATUS
----------------------------------------------------------------------------------------
+PrivateEndpointIPConfiguration_STATUS{#PrivateEndpointIPConfiguration_STATUS}
+-----------------------------------------------------------------------------
 
 An IP Configuration of the private endpoint.
 
@@ -3384,8 +3384,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | privateIPAddress | A private ip address obtained from the private endpoint's subnet.                                          | string<br/><small>Optional</small> |
 | type             | The resource type.                                                                                         | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointOperatorSpec"></a>PrivateEndpointOperatorSpec
--------------------------------------------------------------------
+PrivateEndpointOperatorSpec{#PrivateEndpointOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3397,8 +3397,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [PrivateEndpointOperatorConfigMaps](#PrivateEndpointOperatorConfigMaps)<br/><small>Optional</small>                                                                 |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointsPrivateDnsZoneGroupOperatorSpec"></a>PrivateEndpointsPrivateDnsZoneGroupOperatorSpec
------------------------------------------------------------------------------------------------------------
+PrivateEndpointsPrivateDnsZoneGroupOperatorSpec{#PrivateEndpointsPrivateDnsZoneGroupOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3409,8 +3409,8 @@ Used by: [PrivateEndpointsPrivateDnsZoneGroup_Spec](#PrivateEndpointsPrivateDnsZ
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointVNetPolicies"></a>PrivateEndpointVNetPolicies
--------------------------------------------------------------------
+PrivateEndpointVNetPolicies{#PrivateEndpointVNetPolicies}
+---------------------------------------------------------
 
 Private Endpoint VNet Policies.
 
@@ -3421,8 +3421,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 | "Basic"    |             |
 | "Disabled" |             |
 
-<a id="PrivateEndpointVNetPolicies_STATUS"></a>PrivateEndpointVNetPolicies_STATUS
----------------------------------------------------------------------------------
+PrivateEndpointVNetPolicies_STATUS{#PrivateEndpointVNetPolicies_STATUS}
+-----------------------------------------------------------------------
 
 Private Endpoint VNet Policies.
 
@@ -3433,8 +3433,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS).
 | "Basic"    |             |
 | "Disabled" |             |
 
-<a id="PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded"></a>PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded{#PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Private link service resource.
 
@@ -3444,8 +3444,8 @@ Used by: [NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded](#Network
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnection"></a>PrivateLinkServiceConnection
----------------------------------------------------------------------
+PrivateLinkServiceConnection{#PrivateLinkServiceConnection}
+-----------------------------------------------------------
 
 PrivateLinkServiceConnection resource.
 
@@ -3459,8 +3459,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec), and [PrivateEndpoint_Spe
 | privateLinkServiceReference       | The resource id of private link service.                                                                       | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | requestMessage                    | A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.    | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="PrivateLinkServiceConnection_STATUS"></a>PrivateLinkServiceConnection_STATUS
------------------------------------------------------------------------------------
+PrivateLinkServiceConnection_STATUS{#PrivateLinkServiceConnection_STATUS}
+-------------------------------------------------------------------------
 
 PrivateLinkServiceConnection resource.
 
@@ -3478,8 +3478,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 | requestMessage                    | A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.    | string<br/><small>Optional</small>                                                                                |
 | type                              | The resource type.                                                                                             | string<br/><small>Optional</small>                                                                                |
 
-<a id="PrivateLinkServiceIpConfiguration"></a>PrivateLinkServiceIpConfiguration
--------------------------------------------------------------------------------
+PrivateLinkServiceIpConfiguration{#PrivateLinkServiceIpConfiguration}
+---------------------------------------------------------------------
 
 The private link service ip configuration.
 
@@ -3494,8 +3494,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 | privateIPAllocationMethod | The private IP address allocation method.                               | [IPAllocationMethod](#IPAllocationMethod)<br/><small>Optional</small>                                                       |
 | subnet                    | The reference to the subnet resource.                                   | [Subnet_PrivateLinkService_SubResourceEmbedded](#Subnet_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceIpConfiguration_STATUS"></a>PrivateLinkServiceIpConfiguration_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceIpConfiguration_STATUS{#PrivateLinkServiceIpConfiguration_STATUS}
+-----------------------------------------------------------------------------------
 
 The private link service ip configuration.
 
@@ -3514,8 +3514,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 | subnet                    | The reference to the subnet resource.                                         | [Subnet_STATUS_PrivateLinkService_SubResourceEmbedded](#Subnet_STATUS_PrivateLinkService_SubResourceEmbedded)<br/><small>Optional</small> |
 | type                      | The resource type.                                                            | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="PrivateLinkServiceOperatorSpec"></a>PrivateLinkServiceOperatorSpec
--------------------------------------------------------------------------
+PrivateLinkServiceOperatorSpec{#PrivateLinkServiceOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3527,8 +3527,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [PrivateLinkServiceOperatorConfigMaps](#PrivateLinkServiceOperatorConfigMaps)<br/><small>Optional</small>                                                           |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceSpec"></a>PrivateLinkServiceSpec
----------------------------------------------------------
+PrivateLinkServiceSpec{#PrivateLinkServiceSpec}
+-----------------------------------------------
 
 Private link service resource.
 
@@ -3538,8 +3538,8 @@ Used by: [NetworkInterface_Spec](#NetworkInterface_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Probe"></a>Probe
------------------------
+Probe{#Probe}
+-------------
 
 A load balancer probe.
 
@@ -3556,8 +3556,8 @@ Used by: [LoadBalancer_Spec](#LoadBalancer_Spec).
 | protocol                  | The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.                                                                                                  | [ProbePropertiesFormat_Protocol](#ProbePropertiesFormat_Protocol)<br/><small>Required</small>                                   |
 | requestPath               | The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value.                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                              |
 
-<a id="Probe_STATUS"></a>Probe_STATUS
--------------------------------------
+Probe_STATUS{#Probe_STATUS}
+---------------------------
 
 A load balancer probe.
 
@@ -3579,8 +3579,8 @@ Used by: [LoadBalancer_STATUS](#LoadBalancer_STATUS).
 | requestPath               | The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value.                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                            |
 | type                      | Type of the resource.                                                                                                                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                            |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 The current provisioning state.
 
@@ -3593,8 +3593,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="PublicIPAddressDnsSettings"></a>PublicIPAddressDnsSettings
------------------------------------------------------------------
+PublicIPAddressDnsSettings{#PublicIPAddressDnsSettings}
+-------------------------------------------------------
 
 Contains FQDN of the DNS record associated with the public IP address.
 
@@ -3607,8 +3607,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | fqdn                 | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.                                                                                                                                  | string<br/><small>Optional</small>                                                                                              |
 | reverseFqdn          | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.                                               | string<br/><small>Optional</small>                                                                                              |
 
-<a id="PublicIPAddressDnsSettings_STATUS"></a>PublicIPAddressDnsSettings_STATUS
--------------------------------------------------------------------------------
+PublicIPAddressDnsSettings_STATUS{#PublicIPAddressDnsSettings_STATUS}
+---------------------------------------------------------------------
 
 Contains FQDN of the DNS record associated with the public IP address.
 
@@ -3621,8 +3621,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | fqdn                 | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.                                                                                                                                  | string<br/><small>Optional</small>                                                                                                            |
 | reverseFqdn          | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.                                               | string<br/><small>Optional</small>                                                                                                            |
 
-<a id="PublicIPAddressOperatorSpec"></a>PublicIPAddressOperatorSpec
--------------------------------------------------------------------
+PublicIPAddressOperatorSpec{#PublicIPAddressOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3633,8 +3633,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressPropertiesFormat_DeleteOption"></a>PublicIPAddressPropertiesFormat_DeleteOption
------------------------------------------------------------------------------------------------------
+PublicIPAddressPropertiesFormat_DeleteOption{#PublicIPAddressPropertiesFormat_DeleteOption}
+-------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 
@@ -3643,8 +3643,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="PublicIPAddressPropertiesFormat_DeleteOption_STATUS"></a>PublicIPAddressPropertiesFormat_DeleteOption_STATUS
--------------------------------------------------------------------------------------------------------------------
+PublicIPAddressPropertiesFormat_DeleteOption_STATUS{#PublicIPAddressPropertiesFormat_DeleteOption_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 
@@ -3653,8 +3653,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | "Delete" |             |
 | "Detach" |             |
 
-<a id="PublicIPAddressPropertiesFormat_MigrationPhase_STATUS"></a>PublicIPAddressPropertiesFormat_MigrationPhase_STATUS
------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressPropertiesFormat_MigrationPhase_STATUS{#PublicIPAddressPropertiesFormat_MigrationPhase_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 
@@ -3666,8 +3666,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | "None"      |             |
 | "Prepare"   |             |
 
-<a id="PublicIPAddressSku"></a>PublicIPAddressSku
--------------------------------------------------
+PublicIPAddressSku{#PublicIPAddressSku}
+---------------------------------------
 
 SKU of a public IP address.
 
@@ -3678,8 +3678,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec).
 | name     | Name of a public IP address SKU. | [PublicIPAddressSku_Name](#PublicIPAddressSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a public IP address SKU. | [PublicIPAddressSku_Tier](#PublicIPAddressSku_Tier)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSku_STATUS"></a>PublicIPAddressSku_STATUS
----------------------------------------------------------------
+PublicIPAddressSku_STATUS{#PublicIPAddressSku_STATUS}
+-----------------------------------------------------
 
 SKU of a public IP address.
 
@@ -3690,8 +3690,8 @@ Used by: [PublicIPAddress_STATUS](#PublicIPAddress_STATUS).
 | name     | Name of a public IP address SKU. | [PublicIPAddressSku_Name_STATUS](#PublicIPAddressSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a public IP address SKU. | [PublicIPAddressSku_Tier_STATUS](#PublicIPAddressSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded"></a>PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded{#PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -3701,8 +3701,8 @@ Used by: [PublicIPAddress_Spec](#PublicIPAddress_Spec), and [PublicIPAddress_Spe
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixOperatorSpec"></a>PublicIPPrefixOperatorSpec
------------------------------------------------------------------
+PublicIPPrefixOperatorSpec{#PublicIPPrefixOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3713,8 +3713,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixSku"></a>PublicIPPrefixSku
------------------------------------------------
+PublicIPPrefixSku{#PublicIPPrefixSku}
+-------------------------------------
 
 SKU of a public IP prefix.
 
@@ -3725,8 +3725,8 @@ Used by: [PublicIPPrefix_Spec](#PublicIPPrefix_Spec).
 | name     | Name of a public IP prefix SKU. | [PublicIPPrefixSku_Name](#PublicIPPrefixSku_Name)<br/><small>Optional</small> |
 | tier     | Tier of a public IP prefix SKU. | [PublicIPPrefixSku_Tier](#PublicIPPrefixSku_Tier)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixSku_STATUS"></a>PublicIPPrefixSku_STATUS
--------------------------------------------------------------
+PublicIPPrefixSku_STATUS{#PublicIPPrefixSku_STATUS}
+---------------------------------------------------
 
 SKU of a public IP prefix.
 
@@ -3737,8 +3737,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 | name     | Name of a public IP prefix SKU. | [PublicIPPrefixSku_Name_STATUS](#PublicIPPrefixSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Tier of a public IP prefix SKU. | [PublicIPPrefixSku_Tier_STATUS](#PublicIPPrefixSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="ReferencedPublicIpAddress_STATUS"></a>ReferencedPublicIpAddress_STATUS
------------------------------------------------------------------------------
+ReferencedPublicIpAddress_STATUS{#ReferencedPublicIpAddress_STATUS}
+-------------------------------------------------------------------
 
 Reference to a public IP address.
 
@@ -3748,8 +3748,8 @@ Used by: [PublicIPPrefix_STATUS](#PublicIPPrefix_STATUS).
 |----------|--------------------------------|------------------------------------|
 | id       | The PublicIPAddress Reference. | string<br/><small>Optional</small> |
 
-<a id="ResourceNavigationLink_STATUS"></a>ResourceNavigationLink_STATUS
------------------------------------------------------------------------
+ResourceNavigationLink_STATUS{#ResourceNavigationLink_STATUS}
+-------------------------------------------------------------
 
 ResourceNavigationLink resource.
 
@@ -3759,8 +3759,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------------------------------|------------------------------------|
 | id       | Resource navigation link identifier. | string<br/><small>Optional</small> |
 
-<a id="ResourceSet"></a>ResourceSet
------------------------------------
+ResourceSet{#ResourceSet}
+-------------------------
 
 The base resource set for visibility and auto-approval.
 
@@ -3770,8 +3770,8 @@ Used by: [PrivateLinkService_Spec](#PrivateLinkService_Spec), and [PrivateLinkSe
 |---------------|----------------------------|--------------------------------------|
 | subscriptions | The list of subscriptions. | string[]<br/><small>Optional</small> |
 
-<a id="ResourceSet_STATUS"></a>ResourceSet_STATUS
--------------------------------------------------
+ResourceSet_STATUS{#ResourceSet_STATUS}
+---------------------------------------
 
 The base resource set for visibility and auto-approval.
 
@@ -3781,8 +3781,8 @@ Used by: [PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded](#Pri
 |---------------|----------------------------|--------------------------------------|
 | subscriptions | The list of subscriptions. | string[]<br/><small>Optional</small> |
 
-<a id="RouteNextHopType"></a>RouteNextHopType
----------------------------------------------
+RouteNextHopType{#RouteNextHopType}
+-----------------------------------
 
 The type of Azure hop the packet should be sent to.
 
@@ -3796,8 +3796,8 @@ Used by: [RouteTablesRoute_Spec](#RouteTablesRoute_Spec).
 | "VirtualNetworkGateway" |             |
 | "VnetLocal"             |             |
 
-<a id="RouteNextHopType_STATUS"></a>RouteNextHopType_STATUS
------------------------------------------------------------
+RouteNextHopType_STATUS{#RouteNextHopType_STATUS}
+-------------------------------------------------
 
 The type of Azure hop the packet should be sent to.
 
@@ -3811,8 +3811,8 @@ Used by: [RouteTablesRoute_STATUS](#RouteTablesRoute_STATUS).
 | "VirtualNetworkGateway" |             |
 | "VnetLocal"             |             |
 
-<a id="RouteTable_STATUS_SubResourceEmbedded"></a>RouteTable_STATUS_SubResourceEmbedded
----------------------------------------------------------------------------------------
+RouteTable_STATUS_SubResourceEmbedded{#RouteTable_STATUS_SubResourceEmbedded}
+-----------------------------------------------------------------------------
 
 Route table resource.
 
@@ -3822,8 +3822,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="RouteTableOperatorSpec"></a>RouteTableOperatorSpec
----------------------------------------------------------
+RouteTableOperatorSpec{#RouteTableOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3834,8 +3834,8 @@ Used by: [RouteTable_Spec](#RouteTable_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------
+RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded{#RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------
 
 Route table resource.
 
@@ -3845,8 +3845,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="RouteTablesRouteOperatorSpec"></a>RouteTablesRouteOperatorSpec
----------------------------------------------------------------------
+RouteTablesRouteOperatorSpec{#RouteTablesRouteOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -3857,8 +3857,8 @@ Used by: [RouteTablesRoute_Spec](#RouteTablesRoute_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SecurityRule_STATUS"></a>SecurityRule_STATUS
----------------------------------------------------
+SecurityRule_STATUS{#SecurityRule_STATUS}
+-----------------------------------------
 
 Network security rule.
 
@@ -3868,8 +3868,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SecurityRuleAccess"></a>SecurityRuleAccess
--------------------------------------------------
+SecurityRuleAccess{#SecurityRuleAccess}
+---------------------------------------
 
 Whether network traffic is allowed or denied.
 
@@ -3880,8 +3880,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="SecurityRuleAccess_STATUS"></a>SecurityRuleAccess_STATUS
----------------------------------------------------------------
+SecurityRuleAccess_STATUS{#SecurityRuleAccess_STATUS}
+-----------------------------------------------------
 
 Whether network traffic is allowed or denied.
 
@@ -3892,8 +3892,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="SecurityRuleDirection"></a>SecurityRuleDirection
--------------------------------------------------------
+SecurityRuleDirection{#SecurityRuleDirection}
+---------------------------------------------
 
 The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 
@@ -3904,8 +3904,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Inbound"  |             |
 | "Outbound" |             |
 
-<a id="SecurityRuleDirection_STATUS"></a>SecurityRuleDirection_STATUS
----------------------------------------------------------------------
+SecurityRuleDirection_STATUS{#SecurityRuleDirection_STATUS}
+-----------------------------------------------------------
 
 The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 
@@ -3916,8 +3916,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Inbound"  |             |
 | "Outbound" |             |
 
-<a id="SecurityRulePropertiesFormat_Protocol"></a>SecurityRulePropertiesFormat_Protocol
----------------------------------------------------------------------------------------
+SecurityRulePropertiesFormat_Protocol{#SecurityRulePropertiesFormat_Protocol}
+-----------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurityRule_Spec).
 
@@ -3930,8 +3930,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_Spec](#NetworkSecurityGroupsSecurity
 | "Tcp"  |             |
 | "Udp"  |             |
 
-<a id="SecurityRulePropertiesFormat_Protocol_STATUS"></a>SecurityRulePropertiesFormat_Protocol_STATUS
------------------------------------------------------------------------------------------------------
+SecurityRulePropertiesFormat_Protocol_STATUS{#SecurityRulePropertiesFormat_Protocol_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecurityRule_STATUS).
 
@@ -3944,8 +3944,8 @@ Used by: [NetworkSecurityGroupsSecurityRule_STATUS](#NetworkSecurityGroupsSecuri
 | "Tcp"  |             |
 | "Udp"  |             |
 
-<a id="ServiceAssociationLink_STATUS"></a>ServiceAssociationLink_STATUS
------------------------------------------------------------------------
+ServiceAssociationLink_STATUS{#ServiceAssociationLink_STATUS}
+-------------------------------------------------------------
 
 ServiceAssociationLink resource.
 
@@ -3955,8 +3955,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------
+ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded{#ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Service End point policy resource.
 
@@ -3966,8 +3966,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded"></a>ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------
+ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded{#ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Service End point policy resource.
 
@@ -3977,8 +3977,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ServiceEndpointPropertiesFormat"></a>ServiceEndpointPropertiesFormat
----------------------------------------------------------------------------
+ServiceEndpointPropertiesFormat{#ServiceEndpointPropertiesFormat}
+-----------------------------------------------------------------
 
 The service endpoint properties.
 
@@ -3990,8 +3990,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | networkIdentifier | SubResource as network identifier. | [SubResource](#SubResource)<br/><small>Optional</small> |
 | service           | The type of the endpoint service.  | string<br/><small>Optional</small>                      |
 
-<a id="ServiceEndpointPropertiesFormat_STATUS"></a>ServiceEndpointPropertiesFormat_STATUS
------------------------------------------------------------------------------------------
+ServiceEndpointPropertiesFormat_STATUS{#ServiceEndpointPropertiesFormat_STATUS}
+-------------------------------------------------------------------------------
 
 The service endpoint properties.
 
@@ -4004,8 +4004,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | provisioningState | The provisioning state of the service endpoint resource. | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | service           | The type of the endpoint service.                        | string<br/><small>Optional</small>                                                |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The sku of this Bastion Host.
 
@@ -4015,8 +4015,8 @@ Used by: [BastionHost_Spec](#BastionHost_Spec).
 |----------|-------------------------------------------|---------------------------------------------------|
 | name     | The name of the sku of this Bastion Host. | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The sku of this Bastion Host.
 
@@ -4026,8 +4026,8 @@ Used by: [BastionHost_STATUS](#BastionHost_STATUS).
 |----------|-------------------------------------------|-----------------------------------------------------------------|
 | name     | The name of the sku of this Bastion Host. | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="Subnet_PrivateEndpoint_SubResourceEmbedded"></a>Subnet_PrivateEndpoint_SubResourceEmbedded
--------------------------------------------------------------------------------------------------
+Subnet_PrivateEndpoint_SubResourceEmbedded{#Subnet_PrivateEndpoint_SubResourceEmbedded}
+---------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -4037,8 +4037,8 @@ Used by: [PrivateEndpoint_Spec](#PrivateEndpoint_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded"></a>Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded{#Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -4048,8 +4048,8 @@ Used by: [NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded](
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded"></a>Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded{#Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -4059,8 +4059,8 @@ Used by: [PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded](#PrivateEn
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="SubnetPropertiesFormat_PrivateEndpointNetworkPolicies"></a>SubnetPropertiesFormat_PrivateEndpointNetworkPolicies
------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateEndpointNetworkPolicies{#SubnetPropertiesFormat_PrivateEndpointNetworkPolicies}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 
@@ -4071,8 +4071,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | "NetworkSecurityGroupEnabled" |             |
 | "RouteTableEnabled"           |             |
 
-<a id="SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS"></a>SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS{#SubnetPropertiesFormat_PrivateEndpointNetworkPolicies_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 
@@ -4083,8 +4083,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | "NetworkSecurityGroupEnabled" |             |
 | "RouteTableEnabled"           |             |
 
-<a id="SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies"></a>SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies
------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies{#SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 
@@ -4093,8 +4093,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS"></a>SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS{#SubnetPropertiesFormat_PrivateLinkServiceNetworkPolicies_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 
@@ -4103,8 +4103,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SubnetPropertiesFormat_SharingScope"></a>SubnetPropertiesFormat_SharingScope
------------------------------------------------------------------------------------
+SubnetPropertiesFormat_SharingScope{#SubnetPropertiesFormat_SharingScope}
+-------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 
@@ -4113,8 +4113,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | "DelegatedServices" |             |
 | "Tenant"            |             |
 
-<a id="SubnetPropertiesFormat_SharingScope_STATUS"></a>SubnetPropertiesFormat_SharingScope_STATUS
--------------------------------------------------------------------------------------------------
+SubnetPropertiesFormat_SharingScope_STATUS{#SubnetPropertiesFormat_SharingScope_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 
@@ -4123,8 +4123,8 @@ Used by: [VirtualNetworksSubnet_STATUS](#VirtualNetworksSubnet_STATUS).
 | "DelegatedServices" |             |
 | "Tenant"            |             |
 
-<a id="SubResource"></a>SubResource
------------------------------------
+SubResource{#SubResource}
+-------------------------
 
 Reference to another subresource.
 
@@ -4134,8 +4134,8 @@ Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPo
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another subresource.
 
@@ -4145,8 +4145,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="TransportProtocol"></a>TransportProtocol
------------------------------------------------
+TransportProtocol{#TransportProtocol}
+-------------------------------------
 
 The transport protocol for the endpoint.
 
@@ -4158,8 +4158,8 @@ Used by: [InboundNatPool](#InboundNatPool), [InboundNatRule_LoadBalancer_SubReso
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="TransportProtocol_STATUS"></a>TransportProtocol_STATUS
--------------------------------------------------------------
+TransportProtocol_STATUS{#TransportProtocol_STATUS}
+---------------------------------------------------
 
 The transport protocol for the endpoint.
 
@@ -4171,8 +4171,8 @@ Used by: [InboundNatPool_STATUS](#InboundNatPool_STATUS), [InboundNatRule_STATUS
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="VirtualNetworkBgpCommunities"></a>VirtualNetworkBgpCommunities
----------------------------------------------------------------------
+VirtualNetworkBgpCommunities{#VirtualNetworkBgpCommunities}
+-----------------------------------------------------------
 
 Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
 
@@ -4182,8 +4182,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec), and [VirtualNetworksVirtua
 |-------------------------|--------------------------------------------------------|------------------------------------|
 | virtualNetworkCommunity | The BGP community associated with the virtual network. | string<br/><small>Required</small> |
 
-<a id="VirtualNetworkBgpCommunities_STATUS"></a>VirtualNetworkBgpCommunities_STATUS
------------------------------------------------------------------------------------
+VirtualNetworkBgpCommunities_STATUS{#VirtualNetworkBgpCommunities_STATUS}
+-------------------------------------------------------------------------
 
 Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
 
@@ -4194,8 +4194,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS), and [VirtualNetworksVi
 | regionalCommunity       | The BGP community associated with the region of the virtual network. | string<br/><small>Optional</small> |
 | virtualNetworkCommunity | The BGP community associated with the virtual network.               | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkEncryption"></a>VirtualNetworkEncryption
--------------------------------------------------------------
+VirtualNetworkEncryption{#VirtualNetworkEncryption}
+---------------------------------------------------
 
 Indicates if encryption is enabled on virtual network and if VM without encryption is allowed in encrypted VNet.
 
@@ -4206,8 +4206,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 | enabled     | Indicates if encryption is enabled on the virtual network.                                                                                                                | bool<br/><small>Required</small>                                                                          |
 | enforcement | If the encrypted VNet allows VM that does not support encryption. This field is for future support, AllowUnencrypted is the only supported value at general availability. | [VirtualNetworkEncryption_Enforcement](#VirtualNetworkEncryption_Enforcement)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkEncryption_STATUS"></a>VirtualNetworkEncryption_STATUS
----------------------------------------------------------------------------
+VirtualNetworkEncryption_STATUS{#VirtualNetworkEncryption_STATUS}
+-----------------------------------------------------------------
 
 Indicates if encryption is enabled on virtual network and if VM without encryption is allowed in encrypted VNet.
 
@@ -4218,8 +4218,8 @@ Used by: [VirtualNetwork_STATUS](#VirtualNetwork_STATUS), and [VirtualNetworksVi
 | enabled     | Indicates if encryption is enabled on the virtual network.                                                                                                                | bool<br/><small>Optional</small>                                                                                        |
 | enforcement | If the encrypted VNet allows VM that does not support encryption. This field is for future support, AllowUnencrypted is the only supported value at general availability. | [VirtualNetworkEncryption_Enforcement_STATUS](#VirtualNetworkEncryption_Enforcement_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayAutoScaleConfiguration"></a>VirtualNetworkGatewayAutoScaleConfiguration
----------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayAutoScaleConfiguration{#VirtualNetworkGatewayAutoScaleConfiguration}
+-----------------------------------------------------------------------------------------
 
 Virtual Network Gateway Autoscale Configuration details
 
@@ -4229,8 +4229,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 |----------|-------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | bounds   | The bounds of the autoscale configuration | [VirtualNetworkGatewayAutoScaleBounds](#VirtualNetworkGatewayAutoScaleBounds)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayAutoScaleConfiguration_STATUS"></a>VirtualNetworkGatewayAutoScaleConfiguration_STATUS
------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayAutoScaleConfiguration_STATUS{#VirtualNetworkGatewayAutoScaleConfiguration_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Virtual Network Gateway Autoscale Configuration details
 
@@ -4240,8 +4240,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 |----------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | bounds   | The bounds of the autoscale configuration | [VirtualNetworkGatewayAutoScaleBounds_STATUS](#VirtualNetworkGatewayAutoScaleBounds_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayIPConfiguration"></a>VirtualNetworkGatewayIPConfiguration
--------------------------------------------------------------------------------------
+VirtualNetworkGatewayIPConfiguration{#VirtualNetworkGatewayIPConfiguration}
+---------------------------------------------------------------------------
 
 IP configuration for virtual network gateway.
 
@@ -4254,8 +4254,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | publicIPAddress           | The reference to the public IP resource.                                                                       | [SubResource](#SubResource)<br/><small>Optional</small>               |
 | subnet                    | The reference to the subnet resource.                                                                          | [SubResource](#SubResource)<br/><small>Optional</small>               |
 
-<a id="VirtualNetworkGatewayIPConfiguration_STATUS"></a>VirtualNetworkGatewayIPConfiguration_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayIPConfiguration_STATUS{#VirtualNetworkGatewayIPConfiguration_STATUS}
+-----------------------------------------------------------------------------------------
 
 IP configuration for virtual network gateway.
 
@@ -4272,8 +4272,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | publicIPAddress           | The reference to the public IP resource.                                                                       | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>               |
 | subnet                    | The reference to the subnet resource.                                                                          | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>               |
 
-<a id="VirtualNetworkGatewayNatRule"></a>VirtualNetworkGatewayNatRule
----------------------------------------------------------------------
+VirtualNetworkGatewayNatRule{#VirtualNetworkGatewayNatRule}
+-----------------------------------------------------------
 
 VirtualNetworkGatewayNatRule Resource.
 
@@ -4288,8 +4288,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | name              | The name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small>                                                                                      |
 | type              | The type of NAT rule for VPN NAT.                                                                              | [VirtualNetworkGatewayNatRuleProperties_Type](#VirtualNetworkGatewayNatRuleProperties_Type)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayNatRule_STATUS"></a>VirtualNetworkGatewayNatRule_STATUS
------------------------------------------------------------------------------------
+VirtualNetworkGatewayNatRule_STATUS{#VirtualNetworkGatewayNatRule_STATUS}
+-------------------------------------------------------------------------
 
 VirtualNetworkGatewayNatRule Resource.
 
@@ -4308,8 +4308,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | provisioningState | The provisioning state of the NAT Rule resource.                                                               | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                                     |
 | type              | Resource type.                                                                                                 | string<br/><small>Optional</small>                                                                                                    |
 
-<a id="VirtualNetworkGatewayOperatorSpec"></a>VirtualNetworkGatewayOperatorSpec
--------------------------------------------------------------------------------
+VirtualNetworkGatewayOperatorSpec{#VirtualNetworkGatewayOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -4320,8 +4320,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayPolicyGroup"></a>VirtualNetworkGatewayPolicyGroup
------------------------------------------------------------------------------
+VirtualNetworkGatewayPolicyGroup{#VirtualNetworkGatewayPolicyGroup}
+-------------------------------------------------------------------
 
 Parameters for VirtualNetworkGatewayPolicyGroup.
 
@@ -4334,8 +4334,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | policyMembers | Multiple PolicyMembers for VirtualNetworkGatewayPolicyGroup.                                                   | [VirtualNetworkGatewayPolicyGroupMember[]](#VirtualNetworkGatewayPolicyGroupMember)<br/><small>Required</small> |
 | priority      | Priority for VirtualNetworkGatewayPolicyGroup.                                                                 | int<br/><small>Required</small>                                                                                 |
 
-<a id="VirtualNetworkGatewayPolicyGroup_STATUS"></a>VirtualNetworkGatewayPolicyGroup_STATUS
--------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPolicyGroup_STATUS{#VirtualNetworkGatewayPolicyGroup_STATUS}
+---------------------------------------------------------------------------------
 
 Parameters for VirtualNetworkGatewayPolicyGroup.
 
@@ -4352,92 +4352,92 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | provisioningState                 | The provisioning state of the VirtualNetworkGatewayPolicyGroup resource.                                       | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small>                                             |
 | vngClientConnectionConfigurations | List of references to vngClientConnectionConfigurations.                                                       | [SubResource_STATUS[]](#SubResource_STATUS)<br/><small>Optional</small>                                                       |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_AdminState"></a>VirtualNetworkGatewayPropertiesFormat_AdminState
+VirtualNetworkGatewayPropertiesFormat_AdminState{#VirtualNetworkGatewayPropertiesFormat_AdminState}
+---------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+VirtualNetworkGatewayPropertiesFormat_AdminState_STATUS{#VirtualNetworkGatewayPropertiesFormat_AdminState_STATUS}
+-----------------------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+VirtualNetworkGatewayPropertiesFormat_GatewayType{#VirtualNetworkGatewayPropertiesFormat_GatewayType}
+-----------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
+
+| Value          | Description |
+|----------------|-------------|
+| "ExpressRoute" |             |
+| "LocalGateway" |             |
+| "Vpn"          |             |
+
+VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS{#VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
+
+| Value          | Description |
+|----------------|-------------|
+| "ExpressRoute" |             |
+| "LocalGateway" |             |
+| "Vpn"          |             |
+
+VirtualNetworkGatewayPropertiesFormat_ResiliencyModel{#VirtualNetworkGatewayPropertiesFormat_ResiliencyModel}
 -------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
+| Value         | Description |
+|---------------|-------------|
+| "MultiHomed"  |             |
+| "SingleHomed" |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_AdminState_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_AdminState_STATUS
+VirtualNetworkGatewayPropertiesFormat_ResiliencyModel_STATUS{#VirtualNetworkGatewayPropertiesFormat_ResiliencyModel_STATUS}
 ---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
 
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
+| Value         | Description |
+|---------------|-------------|
+| "MultiHomed"  |             |
+| "SingleHomed" |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_GatewayType"></a>VirtualNetworkGatewayPropertiesFormat_GatewayType
----------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
-
-| Value          | Description |
-|----------------|-------------|
-| "ExpressRoute" |             |
-| "LocalGateway" |             |
-| "Vpn"          |             |
-
-<a id="VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_GatewayType_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
-
-| Value          | Description |
-|----------------|-------------|
-| "ExpressRoute" |             |
-| "LocalGateway" |             |
-| "Vpn"          |             |
-
-<a id="VirtualNetworkGatewayPropertiesFormat_ResiliencyModel"></a>VirtualNetworkGatewayPropertiesFormat_ResiliencyModel
+VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration{#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration}
 -----------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
 | Value         | Description |
 |---------------|-------------|
-| "MultiHomed"  |             |
-| "SingleHomed" |             |
+| "Generation1" |             |
+| "Generation2" |             |
+| "None"        |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_ResiliencyModel_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_ResiliencyModel_STATUS
+VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS{#VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS}
 -------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
 
 | Value         | Description |
 |---------------|-------------|
-| "MultiHomed"  |             |
-| "SingleHomed" |             |
-
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration"></a>VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration
----------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
-
-| Value         | Description |
-|---------------|-------------|
 | "Generation1" |             |
 | "Generation2" |             |
 | "None"        |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_VpnGatewayGeneration_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
-
-| Value         | Description |
-|---------------|-------------|
-| "Generation1" |             |
-| "Generation2" |             |
-| "None"        |             |
-
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnType"></a>VirtualNetworkGatewayPropertiesFormat_VpnType
--------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnType{#VirtualNetworkGatewayPropertiesFormat_VpnType}
+---------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 
@@ -4446,8 +4446,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | "PolicyBased" |             |
 | "RouteBased"  |             |
 
-<a id="VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS"></a>VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS{#VirtualNetworkGatewayPropertiesFormat_VpnType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded](#VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded).
 
@@ -4456,8 +4456,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | "PolicyBased" |             |
 | "RouteBased"  |             |
 
-<a id="VirtualNetworkGatewaySku"></a>VirtualNetworkGatewaySku
--------------------------------------------------------------
+VirtualNetworkGatewaySku{#VirtualNetworkGatewaySku}
+---------------------------------------------------
 
 VirtualNetworkGatewaySku details.
 
@@ -4468,8 +4468,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | name     | Gateway SKU name. | [VirtualNetworkGatewaySku_Name](#VirtualNetworkGatewaySku_Name)<br/><small>Optional</small> |
 | tier     | Gateway SKU tier. | [VirtualNetworkGatewaySku_Tier](#VirtualNetworkGatewaySku_Tier)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewaySku_STATUS"></a>VirtualNetworkGatewaySku_STATUS
----------------------------------------------------------------------------
+VirtualNetworkGatewaySku_STATUS{#VirtualNetworkGatewaySku_STATUS}
+-----------------------------------------------------------------
 
 VirtualNetworkGatewaySku details.
 
@@ -4481,8 +4481,8 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | name     | Gateway SKU name. | [VirtualNetworkGatewaySku_Name_STATUS](#VirtualNetworkGatewaySku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | Gateway SKU tier. | [VirtualNetworkGatewaySku_Tier_STATUS](#VirtualNetworkGatewaySku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkOperatorSpec"></a>VirtualNetworkOperatorSpec
------------------------------------------------------------------
+VirtualNetworkOperatorSpec{#VirtualNetworkOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -4493,8 +4493,8 @@ Used by: [VirtualNetwork_Spec](#VirtualNetwork_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringState"></a>VirtualNetworkPeeringPropertiesFormat_PeeringState
------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringState{#VirtualNetworkPeeringPropertiesFormat_PeeringState}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetworkPeering_Spec).
 
@@ -4504,8 +4504,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetw
 | "Disconnected" |             |
 | "Initiated"    |             |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS"></a>VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS{#VirtualNetworkPeeringPropertiesFormat_PeeringState_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNetworkPeering_STATUS).
 
@@ -4515,8 +4515,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNe
 | "Disconnected" |             |
 | "Initiated"    |             |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel"></a>VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel
--------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel{#VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetworkPeering_Spec).
 
@@ -4527,8 +4527,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetw
 | "LocalNotInSync"          |             |
 | "RemoteNotInSync"         |             |
 
-<a id="VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel_STATUS"></a>VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel_STATUS
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel_STATUS{#VirtualNetworkPeeringPropertiesFormat_PeeringSyncLevel_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNetworkPeering_STATUS).
 
@@ -4539,8 +4539,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_STATUS](#VirtualNetworksVirtualNe
 | "LocalNotInSync"          |             |
 | "RemoteNotInSync"         |             |
 
-<a id="VirtualNetworksSubnetOperatorSpec"></a>VirtualNetworksSubnetOperatorSpec
--------------------------------------------------------------------------------
+VirtualNetworksSubnetOperatorSpec{#VirtualNetworksSubnetOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -4551,8 +4551,8 @@ Used by: [VirtualNetworksSubnet_Spec](#VirtualNetworksSubnet_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VirtualNetworksVirtualNetworkPeeringOperatorSpec"></a>VirtualNetworksVirtualNetworkPeeringOperatorSpec
--------------------------------------------------------------------------------------------------------------
+VirtualNetworksVirtualNetworkPeeringOperatorSpec{#VirtualNetworksVirtualNetworkPeeringOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -4563,8 +4563,8 @@ Used by: [VirtualNetworksVirtualNetworkPeering_Spec](#VirtualNetworksVirtualNetw
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="VpnClientConfiguration"></a>VpnClientConfiguration
----------------------------------------------------------
+VpnClientConfiguration{#VpnClientConfiguration}
+-----------------------------------------------
 
 VpnClientConfiguration for P2S client.
 
@@ -4586,8 +4586,8 @@ Used by: [VirtualNetworkGateway_Spec](#VirtualNetworkGateway_Spec).
 | vpnClientRevokedCertificates      | VpnClientRevokedCertificate for Virtual network gateway.                                                              | [VpnClientRevokedCertificate[]](#VpnClientRevokedCertificate)<br/><small>Optional</small>                                     |
 | vpnClientRootCertificates         | VpnClientRootCertificate for virtual network gateway.                                                                 | [VpnClientRootCertificate[]](#VpnClientRootCertificate)<br/><small>Optional</small>                                           |
 
-<a id="VpnClientConfiguration_STATUS"></a>VpnClientConfiguration_STATUS
------------------------------------------------------------------------
+VpnClientConfiguration_STATUS{#VpnClientConfiguration_STATUS}
+-------------------------------------------------------------
 
 VpnClientConfiguration for P2S client.
 
@@ -4609,31 +4609,31 @@ Used by: [VirtualNetworkGateway_STATUS_VirtualNetworkGateway_SubResourceEmbedded
 | vpnClientRevokedCertificates      | VpnClientRevokedCertificate for Virtual network gateway.                                                              | [VpnClientRevokedCertificate_STATUS[]](#VpnClientRevokedCertificate_STATUS)<br/><small>Optional</small>                                     |
 | vpnClientRootCertificates         | VpnClientRootCertificate for virtual network gateway.                                                                 | [VpnClientRootCertificate_STATUS[]](#VpnClientRootCertificate_STATUS)<br/><small>Optional</small>                                           |
 
-<a id="ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded"></a>ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Backend Address Pool of an application gateway.
-
-Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded).
-
-| Property  | Description  | Type                                                                                                                                                       |
-|-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
-
-<a id="ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded"></a>ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Backend Address Pool of an application gateway.
-
-Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
-
-| Property | Description  | Type                               |
-|----------|--------------|------------------------------------|
-| id       | Resource ID. | string<br/><small>Optional</small> |
-
-<a id="ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded"></a>ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
+ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded{#ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded}
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 
+Backend Address Pool of an application gateway.
+
+Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded).
+
+| Property  | Description  | Type                                                                                                                                                       |
+|-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
+
+ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded{#ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Backend Address Pool of an application gateway.
+
+Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
+
+| Property | Description  | Type                               |
+|----------|--------------|------------------------------------|
+| id       | Resource ID. | string<br/><small>Optional</small> |
+
+ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded{#ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------
+
 An application security group in a resource group.
 
 Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded](#NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded).
@@ -4642,8 +4642,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded"></a>ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------
+ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded{#ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 An application security group in a resource group.
 
@@ -4653,8 +4653,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_NetworkInterface_SubResourceEmbedded"></a>BackendAddressPool_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_NetworkInterface_SubResourceEmbedded{#BackendAddressPool_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -4664,8 +4664,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded"></a>BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------
+BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded{#BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------
 
 Pool of backend IP addresses.
 
@@ -4675,8 +4675,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="BackendAddressPoolPropertiesFormat_SyncMode"></a>BackendAddressPoolPropertiesFormat_SyncMode
----------------------------------------------------------------------------------------------------
+BackendAddressPoolPropertiesFormat_SyncMode{#BackendAddressPoolPropertiesFormat_SyncMode}
+-----------------------------------------------------------------------------------------
 
 Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPool_LoadBalancer_SubResourceEmbedded).
 
@@ -4685,8 +4685,8 @@ Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPo
 | "Automatic" |             |
 | "Manual"    |             |
 
-<a id="BackendAddressPoolPropertiesFormat_SyncMode_STATUS"></a>BackendAddressPoolPropertiesFormat_SyncMode_STATUS
------------------------------------------------------------------------------------------------------------------
+BackendAddressPoolPropertiesFormat_SyncMode_STATUS{#BackendAddressPoolPropertiesFormat_SyncMode_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded).
 
@@ -4695,8 +4695,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | "Automatic" |             |
 | "Manual"    |             |
 
-<a id="DdosSettings_ProtectionMode"></a>DdosSettings_ProtectionMode
--------------------------------------------------------------------
+DdosSettings_ProtectionMode{#DdosSettings_ProtectionMode}
+---------------------------------------------------------
 
 Used by: [DdosSettings](#DdosSettings).
 
@@ -4706,8 +4706,8 @@ Used by: [DdosSettings](#DdosSettings).
 | "Enabled"                 |             |
 | "VirtualNetworkInherited" |             |
 
-<a id="DdosSettings_ProtectionMode_STATUS"></a>DdosSettings_ProtectionMode_STATUS
----------------------------------------------------------------------------------
+DdosSettings_ProtectionMode_STATUS{#DdosSettings_ProtectionMode_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [DdosSettings_STATUS](#DdosSettings_STATUS).
 
@@ -4717,8 +4717,8 @@ Used by: [DdosSettings_STATUS](#DdosSettings_STATUS).
 | "Enabled"                 |             |
 | "VirtualNetworkInherited" |             |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -4728,8 +4728,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.
 
@@ -4739,8 +4739,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="GatewayLoadBalancerTunnelInterface"></a>GatewayLoadBalancerTunnelInterface
----------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface{#GatewayLoadBalancerTunnelInterface}
+-----------------------------------------------------------------------
 
 Gateway load balancer tunnel interface of a load balancer backend address pool.
 
@@ -4753,8 +4753,8 @@ Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPo
 | protocol   | Protocol of gateway load balancer tunnel interface.     | [GatewayLoadBalancerTunnelInterface_Protocol](#GatewayLoadBalancerTunnelInterface_Protocol)<br/><small>Optional</small> |
 | type       | Traffic type of gateway load balancer tunnel interface. | [GatewayLoadBalancerTunnelInterface_Type](#GatewayLoadBalancerTunnelInterface_Type)<br/><small>Optional</small>         |
 
-<a id="GatewayLoadBalancerTunnelInterface_STATUS"></a>GatewayLoadBalancerTunnelInterface_STATUS
------------------------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface_STATUS{#GatewayLoadBalancerTunnelInterface_STATUS}
+-------------------------------------------------------------------------------------
 
 Gateway load balancer tunnel interface of a load balancer backend address pool.
 
@@ -4767,8 +4767,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | protocol   | Protocol of gateway load balancer tunnel interface.     | [GatewayLoadBalancerTunnelInterface_Protocol_STATUS](#GatewayLoadBalancerTunnelInterface_Protocol_STATUS)<br/><small>Optional</small> |
 | type       | Traffic type of gateway load balancer tunnel interface. | [GatewayLoadBalancerTunnelInterface_Type_STATUS](#GatewayLoadBalancerTunnelInterface_Type_STATUS)<br/><small>Optional</small>         |
 
-<a id="InboundNatRule_NetworkInterface_SubResourceEmbedded"></a>InboundNatRule_NetworkInterface_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------
+InboundNatRule_NetworkInterface_SubResourceEmbedded{#InboundNatRule_NetworkInterface_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -4778,8 +4778,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded"></a>InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded{#InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Inbound NAT rule of the load balancer.
 
@@ -4789,8 +4789,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="IPConfigurationBgpPeeringAddress"></a>IPConfigurationBgpPeeringAddress
------------------------------------------------------------------------------
+IPConfigurationBgpPeeringAddress{#IPConfigurationBgpPeeringAddress}
+-------------------------------------------------------------------
 
 Properties of IPConfigurationBgpPeeringAddress.
 
@@ -4801,8 +4801,8 @@ Used by: [BgpSettings](#BgpSettings).
 | customBgpIpAddresses | The list of custom BGP peering addresses which belong to IP configuration. | string[]<br/><small>Optional</small> |
 | ipconfigurationId    | The ID of IP configuration which belongs to gateway.                       | string<br/><small>Optional</small>   |
 
-<a id="IPConfigurationBgpPeeringAddress_STATUS"></a>IPConfigurationBgpPeeringAddress_STATUS
--------------------------------------------------------------------------------------------
+IPConfigurationBgpPeeringAddress_STATUS{#IPConfigurationBgpPeeringAddress_STATUS}
+---------------------------------------------------------------------------------
 
 Properties of IPConfigurationBgpPeeringAddress.
 
@@ -4815,8 +4815,8 @@ Used by: [BgpSettings_STATUS](#BgpSettings_STATUS).
 | ipconfigurationId     | The ID of IP configuration which belongs to gateway.                        | string<br/><small>Optional</small>   |
 | tunnelIpAddresses     | The list of tunnel public IP addresses which belong to IP configuration.    | string[]<br/><small>Optional</small> |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 Used by: [BastionHostPropertiesFormat_NetworkAcls](#BastionHostPropertiesFormat_NetworkAcls).
 
@@ -4824,8 +4824,8 @@ Used by: [BastionHostPropertiesFormat_NetworkAcls](#BastionHostPropertiesFormat_
 |---------------|----------------------------------------------------------------------------|------------------------------------|
 | addressPrefix | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small> |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 Used by: [BastionHostPropertiesFormat_NetworkAcls_STATUS](#BastionHostPropertiesFormat_NetworkAcls_STATUS).
 
@@ -4833,8 +4833,8 @@ Used by: [BastionHostPropertiesFormat_NetworkAcls_STATUS](#BastionHostProperties
 |---------------|----------------------------------------------------------------------------|------------------------------------|
 | addressPrefix | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small> |
 
-<a id="IpsecPolicy"></a>IpsecPolicy
------------------------------------
+IpsecPolicy{#IpsecPolicy}
+-------------------------
 
 An IPSec Policy configuration for a virtual network gateway connection.
 
@@ -4851,8 +4851,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | saDataSizeKilobytes | The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel.  | int<br/><small>Required</small>                                 |
 | saLifeTimeSeconds   | The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel. | int<br/><small>Required</small>                                 |
 
-<a id="IpsecPolicy_STATUS"></a>IpsecPolicy_STATUS
--------------------------------------------------
+IpsecPolicy_STATUS{#IpsecPolicy_STATUS}
+---------------------------------------
 
 An IPSec Policy configuration for a virtual network gateway connection.
 
@@ -4869,8 +4869,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | saDataSizeKilobytes | The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel.  | int<br/><small>Optional</small>                                               |
 | saLifeTimeSeconds   | The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel. | int<br/><small>Optional</small>                                               |
 
-<a id="LoadBalancerBackendAddress"></a>LoadBalancerBackendAddress
------------------------------------------------------------------
+LoadBalancerBackendAddress{#LoadBalancerBackendAddress}
+-------------------------------------------------------
 
 Load balancer backend addresses.
 
@@ -4885,8 +4885,8 @@ Used by: [BackendAddressPool_LoadBalancer_SubResourceEmbedded](#BackendAddressPo
 | subnet                              | Reference to an existing subnet.                                                                                                                                                                       | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                     |
 | virtualNetwork                      | Reference to an existing virtual network.                                                                                                                                                              | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                     |
 
-<a id="LoadBalancerBackendAddress_STATUS"></a>LoadBalancerBackendAddress_STATUS
--------------------------------------------------------------------------------
+LoadBalancerBackendAddress_STATUS{#LoadBalancerBackendAddress_STATUS}
+---------------------------------------------------------------------
 
 Load balancer backend addresses.
 
@@ -4903,8 +4903,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 | subnet                              | Reference to an existing subnet.                                                                                                                                                                       | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                     |
 | virtualNetwork                      | Reference to an existing virtual network.                                                                                                                                                              | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                     |
 
-<a id="LoadBalancerSku_Name"></a>LoadBalancerSku_Name
------------------------------------------------------
+LoadBalancerSku_Name{#LoadBalancerSku_Name}
+-------------------------------------------
 
 Used by: [LoadBalancerSku](#LoadBalancerSku).
 
@@ -4914,8 +4914,8 @@ Used by: [LoadBalancerSku](#LoadBalancerSku).
 | "Gateway"  |             |
 | "Standard" |             |
 
-<a id="LoadBalancerSku_Name_STATUS"></a>LoadBalancerSku_Name_STATUS
--------------------------------------------------------------------
+LoadBalancerSku_Name_STATUS{#LoadBalancerSku_Name_STATUS}
+---------------------------------------------------------
 
 Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 
@@ -4925,8 +4925,8 @@ Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 | "Gateway"  |             |
 | "Standard" |             |
 
-<a id="LoadBalancerSku_Tier"></a>LoadBalancerSku_Tier
------------------------------------------------------
+LoadBalancerSku_Tier{#LoadBalancerSku_Tier}
+-------------------------------------------
 
 Used by: [LoadBalancerSku](#LoadBalancerSku).
 
@@ -4935,8 +4935,8 @@ Used by: [LoadBalancerSku](#LoadBalancerSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="LoadBalancerSku_Tier_STATUS"></a>LoadBalancerSku_Tier_STATUS
--------------------------------------------------------------------
+LoadBalancerSku_Tier_STATUS{#LoadBalancerSku_Tier_STATUS}
+---------------------------------------------------------
 
 Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 
@@ -4945,8 +4945,8 @@ Used by: [LoadBalancerSku_STATUS](#LoadBalancerSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="LoadBalancingRulePropertiesFormat_LoadDistribution"></a>LoadBalancingRulePropertiesFormat_LoadDistribution
------------------------------------------------------------------------------------------------------------------
+LoadBalancingRulePropertiesFormat_LoadDistribution{#LoadBalancingRulePropertiesFormat_LoadDistribution}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancingRule](#LoadBalancingRule).
 
@@ -4956,8 +4956,8 @@ Used by: [LoadBalancingRule](#LoadBalancingRule).
 | "SourceIP"         |             |
 | "SourceIPProtocol" |             |
 
-<a id="LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS"></a>LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS
--------------------------------------------------------------------------------------------------------------------------------
+LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS{#LoadBalancingRulePropertiesFormat_LoadDistribution_STATUS}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancingRule_STATUS](#LoadBalancingRule_STATUS).
 
@@ -4967,8 +4967,8 @@ Used by: [LoadBalancingRule_STATUS](#LoadBalancingRule_STATUS).
 | "SourceIP"         |             |
 | "SourceIPProtocol" |             |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -4979,8 +4979,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -4991,8 +4991,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentity_UserAssignedIdentities_STATUS"></a>ManagedServiceIdentity_UserAssignedIdentities_STATUS
----------------------------------------------------------------------------------------------------------------------
+ManagedServiceIdentity_UserAssignedIdentities_STATUS{#ManagedServiceIdentity_UserAssignedIdentities_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -5001,8 +5001,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | The client id of user assigned identity.    | string<br/><small>Optional</small> |
 | principalId | The principal id of user assigned identity. | string<br/><small>Optional</small> |
 
-<a id="NatGatewaySku_Name"></a>NatGatewaySku_Name
--------------------------------------------------
+NatGatewaySku_Name{#NatGatewaySku_Name}
+---------------------------------------
 
 Used by: [NatGatewaySku](#NatGatewaySku).
 
@@ -5010,8 +5010,8 @@ Used by: [NatGatewaySku](#NatGatewaySku).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="NatGatewaySku_Name_STATUS"></a>NatGatewaySku_Name_STATUS
----------------------------------------------------------------
+NatGatewaySku_Name_STATUS{#NatGatewaySku_Name_STATUS}
+-----------------------------------------------------
 
 Used by: [NatGatewaySku_STATUS](#NatGatewaySku_STATUS).
 
@@ -5019,8 +5019,8 @@ Used by: [NatGatewaySku_STATUS](#NatGatewaySku_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded"></a>NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded{#NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 IPConfiguration in a network interface.
 
@@ -5030,8 +5030,8 @@ Used by: [BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded](#BackendAd
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS"></a>NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------
+NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS{#NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 PrivateLinkConnection properties for the network interface.
 
@@ -5043,8 +5043,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 | groupId            | The group ID for current private link connection.             | string<br/><small>Optional</small>   |
 | requiredMemberName | The required member name for current private link connection. | string<br/><small>Optional</small>   |
 
-<a id="OutboundRulePropertiesFormat_Protocol"></a>OutboundRulePropertiesFormat_Protocol
----------------------------------------------------------------------------------------
+OutboundRulePropertiesFormat_Protocol{#OutboundRulePropertiesFormat_Protocol}
+-----------------------------------------------------------------------------
 
 Used by: [OutboundRule](#OutboundRule).
 
@@ -5054,8 +5054,8 @@ Used by: [OutboundRule](#OutboundRule).
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="OutboundRulePropertiesFormat_Protocol_STATUS"></a>OutboundRulePropertiesFormat_Protocol_STATUS
------------------------------------------------------------------------------------------------------
+OutboundRulePropertiesFormat_Protocol_STATUS{#OutboundRulePropertiesFormat_Protocol_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 
@@ -5065,8 +5065,8 @@ Used by: [OutboundRule_STATUS](#OutboundRule_STATUS).
 | "Tcp" |             |
 | "Udp" |             |
 
-<a id="PrivateEndpointOperatorConfigMaps"></a>PrivateEndpointOperatorConfigMaps
--------------------------------------------------------------------------------
+PrivateEndpointOperatorConfigMaps{#PrivateEndpointOperatorConfigMaps}
+---------------------------------------------------------------------
 
 Used by: [PrivateEndpointOperatorSpec](#PrivateEndpointOperatorSpec).
 
@@ -5074,8 +5074,8 @@ Used by: [PrivateEndpointOperatorSpec](#PrivateEndpointOperatorSpec).
 |----------------------------|------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | primaryNicPrivateIpAddress | indicates where the PrimaryNicPrivateIpAddress config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnectionState"></a>PrivateLinkServiceConnectionState
--------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState{#PrivateLinkServiceConnectionState}
+---------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -5087,8 +5087,8 @@ Used by: [PrivateLinkServiceConnection](#PrivateLinkServiceConnection).
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small> |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnectionState_STATUS"></a>PrivateLinkServiceConnectionState_STATUS
----------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionState_STATUS{#PrivateLinkServiceConnectionState_STATUS}
+-----------------------------------------------------------------------------------
 
 A collection of information about the state of the connection between service consumer and provider.
 
@@ -5100,8 +5100,8 @@ Used by: [PrivateLinkServiceConnection_STATUS](#PrivateLinkServiceConnection_STA
 | description     | The reason for approval/rejection of the connection.                                             | string<br/><small>Optional</small> |
 | status          | Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceOperatorConfigMaps"></a>PrivateLinkServiceOperatorConfigMaps
--------------------------------------------------------------------------------------
+PrivateLinkServiceOperatorConfigMaps{#PrivateLinkServiceOperatorConfigMaps}
+---------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceOperatorSpec](#PrivateLinkServiceOperatorSpec).
 
@@ -5109,8 +5109,8 @@ Used by: [PrivateLinkServiceOperatorSpec](#PrivateLinkServiceOperatorSpec).
 |----------|---------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | alias    | indicates where the Alias config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="ProbePropertiesFormat_NoHealthyBackendsBehavior"></a>ProbePropertiesFormat_NoHealthyBackendsBehavior
------------------------------------------------------------------------------------------------------------
+ProbePropertiesFormat_NoHealthyBackendsBehavior{#ProbePropertiesFormat_NoHealthyBackendsBehavior}
+-------------------------------------------------------------------------------------------------
 
 Used by: [Probe](#Probe).
 
@@ -5119,8 +5119,8 @@ Used by: [Probe](#Probe).
 | "AllProbedDown" |             |
 | "AllProbedUp"   |             |
 
-<a id="ProbePropertiesFormat_NoHealthyBackendsBehavior_STATUS"></a>ProbePropertiesFormat_NoHealthyBackendsBehavior_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ProbePropertiesFormat_NoHealthyBackendsBehavior_STATUS{#ProbePropertiesFormat_NoHealthyBackendsBehavior_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [Probe_STATUS](#Probe_STATUS).
 
@@ -5129,8 +5129,8 @@ Used by: [Probe_STATUS](#Probe_STATUS).
 | "AllProbedDown" |             |
 | "AllProbedUp"   |             |
 
-<a id="ProbePropertiesFormat_Protocol"></a>ProbePropertiesFormat_Protocol
--------------------------------------------------------------------------
+ProbePropertiesFormat_Protocol{#ProbePropertiesFormat_Protocol}
+---------------------------------------------------------------
 
 Used by: [Probe](#Probe).
 
@@ -5140,8 +5140,8 @@ Used by: [Probe](#Probe).
 | "Https" |             |
 | "Tcp"   |             |
 
-<a id="ProbePropertiesFormat_Protocol_STATUS"></a>ProbePropertiesFormat_Protocol_STATUS
----------------------------------------------------------------------------------------
+ProbePropertiesFormat_Protocol_STATUS{#ProbePropertiesFormat_Protocol_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [Probe_STATUS](#Probe_STATUS).
 
@@ -5151,8 +5151,8 @@ Used by: [Probe_STATUS](#Probe_STATUS).
 | "Https" |             |
 | "Tcp"   |             |
 
-<a id="PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded"></a>PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------
+PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded{#PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -5162,8 +5162,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded"></a>PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------------
+PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded{#PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -5173,8 +5173,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="PublicIPAddressDnsSettings_DomainNameLabelScope"></a>PublicIPAddressDnsSettings_DomainNameLabelScope
------------------------------------------------------------------------------------------------------------
+PublicIPAddressDnsSettings_DomainNameLabelScope{#PublicIPAddressDnsSettings_DomainNameLabelScope}
+-------------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddressDnsSettings](#PublicIPAddressDnsSettings).
 
@@ -5185,8 +5185,8 @@ Used by: [PublicIPAddressDnsSettings](#PublicIPAddressDnsSettings).
 | "SubscriptionReuse"  |             |
 | "TenantReuse"        |             |
 
-<a id="PublicIPAddressDnsSettings_DomainNameLabelScope_STATUS"></a>PublicIPAddressDnsSettings_DomainNameLabelScope_STATUS
--------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressDnsSettings_DomainNameLabelScope_STATUS{#PublicIPAddressDnsSettings_DomainNameLabelScope_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [PublicIPAddressDnsSettings_STATUS](#PublicIPAddressDnsSettings_STATUS).
 
@@ -5197,8 +5197,8 @@ Used by: [PublicIPAddressDnsSettings_STATUS](#PublicIPAddressDnsSettings_STATUS)
 | "SubscriptionReuse"  |             |
 | "TenantReuse"        |             |
 
-<a id="PublicIPAddressSku_Name"></a>PublicIPAddressSku_Name
------------------------------------------------------------
+PublicIPAddressSku_Name{#PublicIPAddressSku_Name}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -5207,8 +5207,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Name_STATUS"></a>PublicIPAddressSku_Name_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Name_STATUS{#PublicIPAddressSku_Name_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -5217,8 +5217,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Basic"    |             |
 | "Standard" |             |
 
-<a id="PublicIPAddressSku_Tier"></a>PublicIPAddressSku_Tier
------------------------------------------------------------
+PublicIPAddressSku_Tier{#PublicIPAddressSku_Tier}
+-------------------------------------------------
 
 Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 
@@ -5227,8 +5227,8 @@ Used by: [PublicIPAddressSku](#PublicIPAddressSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPAddressSku_Tier_STATUS"></a>PublicIPAddressSku_Tier_STATUS
--------------------------------------------------------------------------
+PublicIPAddressSku_Tier_STATUS{#PublicIPAddressSku_Tier_STATUS}
+---------------------------------------------------------------
 
 Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 
@@ -5237,8 +5237,8 @@ Used by: [PublicIPAddressSku_STATUS](#PublicIPAddressSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded"></a>PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded{#PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -5248,8 +5248,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded"></a>PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------------------
+PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded{#PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------------------
 
 Public IP address resource.
 
@@ -5259,8 +5259,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PublicIPPrefixSku_Name"></a>PublicIPPrefixSku_Name
----------------------------------------------------------
+PublicIPPrefixSku_Name{#PublicIPPrefixSku_Name}
+-----------------------------------------------
 
 Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 
@@ -5268,8 +5268,8 @@ Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="PublicIPPrefixSku_Name_STATUS"></a>PublicIPPrefixSku_Name_STATUS
------------------------------------------------------------------------
+PublicIPPrefixSku_Name_STATUS{#PublicIPPrefixSku_Name_STATUS}
+-------------------------------------------------------------
 
 Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 
@@ -5277,8 +5277,8 @@ Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 |------------|-------------|
 | "Standard" |             |
 
-<a id="PublicIPPrefixSku_Tier"></a>PublicIPPrefixSku_Tier
----------------------------------------------------------
+PublicIPPrefixSku_Tier{#PublicIPPrefixSku_Tier}
+-----------------------------------------------
 
 Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 
@@ -5287,8 +5287,8 @@ Used by: [PublicIPPrefixSku](#PublicIPPrefixSku).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="PublicIPPrefixSku_Tier_STATUS"></a>PublicIPPrefixSku_Tier_STATUS
------------------------------------------------------------------------
+PublicIPPrefixSku_Tier_STATUS{#PublicIPPrefixSku_Tier_STATUS}
+-------------------------------------------------------------
 
 Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 
@@ -5297,8 +5297,8 @@ Used by: [PublicIPPrefixSku_STATUS](#PublicIPPrefixSku_STATUS).
 | "Global"   |             |
 | "Regional" |             |
 
-<a id="RadiusServer"></a>RadiusServer
--------------------------------------
+RadiusServer{#RadiusServer}
+---------------------------
 
 Radius Server Settings.
 
@@ -5310,8 +5310,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | radiusServerScore   | The initial score assigned to this radius server. | int<br/><small>Optional</small>    |
 | radiusServerSecret  | The secret used for this radius server.           | string<br/><small>Optional</small> |
 
-<a id="RadiusServer_STATUS"></a>RadiusServer_STATUS
----------------------------------------------------
+RadiusServer_STATUS{#RadiusServer_STATUS}
+-----------------------------------------
 
 Radius Server Settings.
 
@@ -5323,8 +5323,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | radiusServerScore   | The initial score assigned to this radius server. | int<br/><small>Optional</small>    |
 | radiusServerSecret  | The secret used for this radius server.           | string<br/><small>Optional</small> |
 
-<a id="RecordSet_STATUS"></a>RecordSet_STATUS
----------------------------------------------
+RecordSet_STATUS{#RecordSet_STATUS}
+-----------------------------------
 
 A collective group of information about the record set information.
 
@@ -5339,8 +5339,8 @@ Used by: [PrivateDnsZoneConfig_STATUS](#PrivateDnsZoneConfig_STATUS).
 | recordType        | Resource record type.                              | string<br/><small>Optional</small>                                                |
 | ttl               | Recordset time to live.                            | int<br/><small>Optional</small>                                                   |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -5351,8 +5351,8 @@ Used by: [Sku](#Sku).
 | "Premium"   |             |
 | "Standard"  |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -5363,8 +5363,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"   |             |
 | "Standard"  |             |
 
-<a id="Subnet_LoadBalancer_SubResourceEmbedded"></a>Subnet_LoadBalancer_SubResourceEmbedded
--------------------------------------------------------------------------------------------
+Subnet_LoadBalancer_SubResourceEmbedded{#Subnet_LoadBalancer_SubResourceEmbedded}
+---------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5374,8 +5374,8 @@ Used by: [FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded](#FrontendIPC
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_NetworkInterface_SubResourceEmbedded"></a>Subnet_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------
+Subnet_NetworkInterface_SubResourceEmbedded{#Subnet_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5385,8 +5385,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_PrivateLinkService_SubResourceEmbedded"></a>Subnet_PrivateLinkService_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------
+Subnet_PrivateLinkService_SubResourceEmbedded{#Subnet_PrivateLinkService_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5396,8 +5396,8 @@ Used by: [PrivateLinkServiceIpConfiguration](#PrivateLinkServiceIpConfiguration)
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_LoadBalancer_SubResourceEmbedded"></a>Subnet_STATUS_LoadBalancer_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------
+Subnet_STATUS_LoadBalancer_SubResourceEmbedded{#Subnet_STATUS_LoadBalancer_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5407,8 +5407,8 @@ Used by: [FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded](#Fron
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_NetworkInterface_SubResourceEmbedded"></a>Subnet_STATUS_NetworkInterface_SubResourceEmbedded
------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_NetworkInterface_SubResourceEmbedded{#Subnet_STATUS_NetworkInterface_SubResourceEmbedded}
+-------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5418,8 +5418,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="Subnet_STATUS_PrivateLinkService_SubResourceEmbedded"></a>Subnet_STATUS_PrivateLinkService_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------
+Subnet_STATUS_PrivateLinkService_SubResourceEmbedded{#Subnet_STATUS_PrivateLinkService_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------
 
 Subnet in a virtual network resource.
 
@@ -5429,8 +5429,8 @@ Used by: [PrivateLinkServiceIpConfiguration_STATUS](#PrivateLinkServiceIpConfigu
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -5440,8 +5440,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkEncryption_Enforcement"></a>VirtualNetworkEncryption_Enforcement
--------------------------------------------------------------------------------------
+VirtualNetworkEncryption_Enforcement{#VirtualNetworkEncryption_Enforcement}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkEncryption](#VirtualNetworkEncryption).
 
@@ -5450,8 +5450,8 @@ Used by: [VirtualNetworkEncryption](#VirtualNetworkEncryption).
 | "AllowUnencrypted" |             |
 | "DropUnencrypted"  |             |
 
-<a id="VirtualNetworkEncryption_Enforcement_STATUS"></a>VirtualNetworkEncryption_Enforcement_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworkEncryption_Enforcement_STATUS{#VirtualNetworkEncryption_Enforcement_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkEncryption_STATUS](#VirtualNetworkEncryption_STATUS).
 
@@ -5460,8 +5460,8 @@ Used by: [VirtualNetworkEncryption_STATUS](#VirtualNetworkEncryption_STATUS).
 | "AllowUnencrypted" |             |
 | "DropUnencrypted"  |             |
 
-<a id="VirtualNetworkGatewayAutoScaleBounds"></a>VirtualNetworkGatewayAutoScaleBounds
--------------------------------------------------------------------------------------
+VirtualNetworkGatewayAutoScaleBounds{#VirtualNetworkGatewayAutoScaleBounds}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewayAutoScaleConfiguration](#VirtualNetworkGatewayAutoScaleConfiguration).
 
@@ -5470,8 +5470,8 @@ Used by: [VirtualNetworkGatewayAutoScaleConfiguration](#VirtualNetworkGatewayAut
 | max      | Maximum Scale Units for Autoscale configuration | int<br/><small>Optional</small> |
 | min      | Minimum scale Units for Autoscale configuration | int<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayAutoScaleBounds_STATUS"></a>VirtualNetworkGatewayAutoScaleBounds_STATUS
----------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayAutoScaleBounds_STATUS{#VirtualNetworkGatewayAutoScaleBounds_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewayAutoScaleConfiguration_STATUS](#VirtualNetworkGatewayAutoScaleConfiguration_STATUS).
 
@@ -5480,48 +5480,48 @@ Used by: [VirtualNetworkGatewayAutoScaleConfiguration_STATUS](#VirtualNetworkGat
 | max      | Maximum Scale Units for Autoscale configuration | int<br/><small>Optional</small> |
 | min      | Minimum scale Units for Autoscale configuration | int<br/><small>Optional</small> |
 
-<a id="VirtualNetworkGatewayNatRuleProperties_Mode"></a>VirtualNetworkGatewayNatRuleProperties_Mode
----------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGatewayNatRule](#VirtualNetworkGatewayNatRule).
-
-| Value         | Description |
-|---------------|-------------|
-| "EgressSnat"  |             |
-| "IngressSnat" |             |
-
-<a id="VirtualNetworkGatewayNatRuleProperties_Mode_STATUS"></a>VirtualNetworkGatewayNatRuleProperties_Mode_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGatewayNatRule_STATUS](#VirtualNetworkGatewayNatRule_STATUS).
-
-| Value         | Description |
-|---------------|-------------|
-| "EgressSnat"  |             |
-| "IngressSnat" |             |
-
-<a id="VirtualNetworkGatewayNatRuleProperties_Type"></a>VirtualNetworkGatewayNatRuleProperties_Type
----------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGatewayNatRule](#VirtualNetworkGatewayNatRule).
-
-| Value     | Description |
-|-----------|-------------|
-| "Dynamic" |             |
-| "Static"  |             |
-
-<a id="VirtualNetworkGatewayNatRuleProperties_Type_STATUS"></a>VirtualNetworkGatewayNatRuleProperties_Type_STATUS
------------------------------------------------------------------------------------------------------------------
-
-Used by: [VirtualNetworkGatewayNatRule_STATUS](#VirtualNetworkGatewayNatRule_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Dynamic" |             |
-| "Static"  |             |
-
-<a id="VirtualNetworkGatewayPolicyGroupMember"></a>VirtualNetworkGatewayPolicyGroupMember
+VirtualNetworkGatewayNatRuleProperties_Mode{#VirtualNetworkGatewayNatRuleProperties_Mode}
 -----------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGatewayNatRule](#VirtualNetworkGatewayNatRule).
+
+| Value         | Description |
+|---------------|-------------|
+| "EgressSnat"  |             |
+| "IngressSnat" |             |
+
+VirtualNetworkGatewayNatRuleProperties_Mode_STATUS{#VirtualNetworkGatewayNatRuleProperties_Mode_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGatewayNatRule_STATUS](#VirtualNetworkGatewayNatRule_STATUS).
+
+| Value         | Description |
+|---------------|-------------|
+| "EgressSnat"  |             |
+| "IngressSnat" |             |
+
+VirtualNetworkGatewayNatRuleProperties_Type{#VirtualNetworkGatewayNatRuleProperties_Type}
+-----------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGatewayNatRule](#VirtualNetworkGatewayNatRule).
+
+| Value     | Description |
+|-----------|-------------|
+| "Dynamic" |             |
+| "Static"  |             |
+
+VirtualNetworkGatewayNatRuleProperties_Type_STATUS{#VirtualNetworkGatewayNatRuleProperties_Type_STATUS}
+-------------------------------------------------------------------------------------------------------
+
+Used by: [VirtualNetworkGatewayNatRule_STATUS](#VirtualNetworkGatewayNatRule_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Dynamic" |             |
+| "Static"  |             |
+
+VirtualNetworkGatewayPolicyGroupMember{#VirtualNetworkGatewayPolicyGroupMember}
+-------------------------------------------------------------------------------
 
 Vpn Client Connection configuration PolicyGroup member
 
@@ -5533,8 +5533,8 @@ Used by: [VirtualNetworkGatewayPolicyGroup](#VirtualNetworkGatewayPolicyGroup).
 | attributeValue | The value of Attribute used for this VirtualNetworkGatewayPolicyGroupMember. | string<br/><small>Optional</small>                                                                                                        |
 | name           | Name of the VirtualNetworkGatewayPolicyGroupMember.                          | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="VirtualNetworkGatewayPolicyGroupMember_STATUS"></a>VirtualNetworkGatewayPolicyGroupMember_STATUS
--------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPolicyGroupMember_STATUS{#VirtualNetworkGatewayPolicyGroupMember_STATUS}
+---------------------------------------------------------------------------------------------
 
 Vpn Client Connection configuration PolicyGroup member
 
@@ -5546,8 +5546,8 @@ Used by: [VirtualNetworkGatewayPolicyGroup_STATUS](#VirtualNetworkGatewayPolicyG
 | attributeValue | The value of Attribute used for this VirtualNetworkGatewayPolicyGroupMember. | string<br/><small>Optional</small>                                                                                                                      |
 | name           | Name of the VirtualNetworkGatewayPolicyGroupMember.                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="VirtualNetworkGatewaySku_Name"></a>VirtualNetworkGatewaySku_Name
------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Name{#VirtualNetworkGatewaySku_Name}
+-------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 
@@ -5572,8 +5572,8 @@ Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Name_STATUS"></a>VirtualNetworkGatewaySku_Name_STATUS
--------------------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Name_STATUS{#VirtualNetworkGatewaySku_Name_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 
@@ -5598,8 +5598,8 @@ Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Tier"></a>VirtualNetworkGatewaySku_Tier
------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Tier{#VirtualNetworkGatewaySku_Tier}
+-------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 
@@ -5624,8 +5624,8 @@ Used by: [VirtualNetworkGatewaySku](#VirtualNetworkGatewaySku).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkGatewaySku_Tier_STATUS"></a>VirtualNetworkGatewaySku_Tier_STATUS
--------------------------------------------------------------------------------------
+VirtualNetworkGatewaySku_Tier_STATUS{#VirtualNetworkGatewaySku_Tier_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 
@@ -5650,8 +5650,8 @@ Used by: [VirtualNetworkGatewaySku_STATUS](#VirtualNetworkGatewaySku_STATUS).
 | "VpnGw5"           |             |
 | "VpnGw5AZ"         |             |
 
-<a id="VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded"></a>VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded{#VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Virtual Network Tap resource.
 
@@ -5661,8 +5661,8 @@ Used by: [NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmb
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded"></a>VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded
----------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded{#VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded}
+-----------------------------------------------------------------------------------------------------------------------
 
 Virtual Network Tap resource.
 
@@ -5672,8 +5672,8 @@ Used by: [NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded](
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VngClientConnectionConfiguration"></a>VngClientConnectionConfiguration
------------------------------------------------------------------------------
+VngClientConnectionConfiguration{#VngClientConnectionConfiguration}
+-------------------------------------------------------------------
 
 A vpn client connection configuration for client connection configuration.
 
@@ -5683,8 +5683,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VngClientConnectionConfiguration_STATUS"></a>VngClientConnectionConfiguration_STATUS
--------------------------------------------------------------------------------------------
+VngClientConnectionConfiguration_STATUS{#VngClientConnectionConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 A vpn client connection configuration for client connection configuration.
 
@@ -5694,8 +5694,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="VpnClientConfiguration_VpnAuthenticationTypes"></a>VpnClientConfiguration_VpnAuthenticationTypes
--------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnAuthenticationTypes{#VpnClientConfiguration_VpnAuthenticationTypes}
+---------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 
@@ -5705,8 +5705,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | "Certificate" |             |
 | "Radius"      |             |
 
-<a id="VpnClientConfiguration_VpnAuthenticationTypes_STATUS"></a>VpnClientConfiguration_VpnAuthenticationTypes_STATUS
----------------------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnAuthenticationTypes_STATUS{#VpnClientConfiguration_VpnAuthenticationTypes_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 
@@ -5716,8 +5716,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | "Certificate" |             |
 | "Radius"      |             |
 
-<a id="VpnClientConfiguration_VpnClientProtocols"></a>VpnClientConfiguration_VpnClientProtocols
------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnClientProtocols{#VpnClientConfiguration_VpnClientProtocols}
+-------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 
@@ -5727,8 +5727,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | "OpenVPN" |             |
 | "SSTP"    |             |
 
-<a id="VpnClientConfiguration_VpnClientProtocols_STATUS"></a>VpnClientConfiguration_VpnClientProtocols_STATUS
--------------------------------------------------------------------------------------------------------------
+VpnClientConfiguration_VpnClientProtocols_STATUS{#VpnClientConfiguration_VpnClientProtocols_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 
@@ -5738,8 +5738,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | "OpenVPN" |             |
 | "SSTP"    |             |
 
-<a id="VpnClientRevokedCertificate"></a>VpnClientRevokedCertificate
--------------------------------------------------------------------
+VpnClientRevokedCertificate{#VpnClientRevokedCertificate}
+---------------------------------------------------------
 
 VPN client revoked certificate of virtual network gateway.
 
@@ -5750,8 +5750,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | name       | The name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | thumbprint | The revoked VPN client certificate thumbprint.                                                                 | string<br/><small>Optional</small> |
 
-<a id="VpnClientRevokedCertificate_STATUS"></a>VpnClientRevokedCertificate_STATUS
----------------------------------------------------------------------------------
+VpnClientRevokedCertificate_STATUS{#VpnClientRevokedCertificate_STATUS}
+-----------------------------------------------------------------------
 
 VPN client revoked certificate of virtual network gateway.
 
@@ -5765,8 +5765,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | provisioningState | The provisioning state of the VPN client revoked certificate resource.                                         | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | thumbprint        | The revoked VPN client certificate thumbprint.                                                                 | string<br/><small>Optional</small>                                                |
 
-<a id="VpnClientRootCertificate"></a>VpnClientRootCertificate
--------------------------------------------------------------
+VpnClientRootCertificate{#VpnClientRootCertificate}
+---------------------------------------------------
 
 VPN client root certificate of virtual network gateway.
 
@@ -5777,8 +5777,8 @@ Used by: [VpnClientConfiguration](#VpnClientConfiguration).
 | name           | The name of the resource that is unique within a resource group. This name can be used to access the resource. | string<br/><small>Optional</small> |
 | publicCertData | The certificate public data.                                                                                   | string<br/><small>Required</small> |
 
-<a id="VpnClientRootCertificate_STATUS"></a>VpnClientRootCertificate_STATUS
----------------------------------------------------------------------------
+VpnClientRootCertificate_STATUS{#VpnClientRootCertificate_STATUS}
+-----------------------------------------------------------------
 
 VPN client root certificate of virtual network gateway.
 
@@ -5792,8 +5792,8 @@ Used by: [VpnClientConfiguration_STATUS](#VpnClientConfiguration_STATUS).
 | provisioningState | The provisioning state of the VPN client root certificate resource.                                            | [ProvisioningState_STATUS](#ProvisioningState_STATUS)<br/><small>Optional</small> |
 | publicCertData    | The certificate public data.                                                                                   | string<br/><small>Optional</small>                                                |
 
-<a id="VpnNatRuleMapping"></a>VpnNatRuleMapping
------------------------------------------------
+VpnNatRuleMapping{#VpnNatRuleMapping}
+-------------------------------------
 
 Vpn NatRule mapping.
 
@@ -5804,8 +5804,8 @@ Used by: [VirtualNetworkGatewayNatRule](#VirtualNetworkGatewayNatRule), and [Vir
 | addressSpace | Address space for Vpn NatRule mapping. | string<br/><small>Optional</small> |
 | portRange    | Port range for Vpn NatRule mapping.    | string<br/><small>Optional</small> |
 
-<a id="VpnNatRuleMapping_STATUS"></a>VpnNatRuleMapping_STATUS
--------------------------------------------------------------
+VpnNatRuleMapping_STATUS{#VpnNatRuleMapping_STATUS}
+---------------------------------------------------
 
 Vpn NatRule mapping.
 
@@ -5816,8 +5816,8 @@ Used by: [VirtualNetworkGatewayNatRule_STATUS](#VirtualNetworkGatewayNatRule_STA
 | addressSpace | Address space for Vpn NatRule mapping. | string<br/><small>Optional</small> |
 | portRange    | Port range for Vpn NatRule mapping.    | string<br/><small>Optional</small> |
 
-<a id="DhGroup"></a>DhGroup
----------------------------
+DhGroup{#DhGroup}
+-----------------
 
 The DH Groups used in IKE Phase 1 for initial SA.
 
@@ -5834,8 +5834,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "ECP384"      |             |
 | "None"        |             |
 
-<a id="DhGroup_STATUS"></a>DhGroup_STATUS
------------------------------------------
+DhGroup_STATUS{#DhGroup_STATUS}
+-------------------------------
 
 The DH Groups used in IKE Phase 1 for initial SA.
 
@@ -5852,8 +5852,8 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "ECP384"      |             |
 | "None"        |             |
 
-<a id="GatewayLoadBalancerTunnelInterface_Protocol"></a>GatewayLoadBalancerTunnelInterface_Protocol
----------------------------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface_Protocol{#GatewayLoadBalancerTunnelInterface_Protocol}
+-----------------------------------------------------------------------------------------
 
 Used by: [GatewayLoadBalancerTunnelInterface](#GatewayLoadBalancerTunnelInterface).
 
@@ -5863,8 +5863,8 @@ Used by: [GatewayLoadBalancerTunnelInterface](#GatewayLoadBalancerTunnelInterfac
 | "None"   |             |
 | "VXLAN"  |             |
 
-<a id="GatewayLoadBalancerTunnelInterface_Protocol_STATUS"></a>GatewayLoadBalancerTunnelInterface_Protocol_STATUS
------------------------------------------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface_Protocol_STATUS{#GatewayLoadBalancerTunnelInterface_Protocol_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [GatewayLoadBalancerTunnelInterface_STATUS](#GatewayLoadBalancerTunnelInterface_STATUS).
 
@@ -5874,8 +5874,8 @@ Used by: [GatewayLoadBalancerTunnelInterface_STATUS](#GatewayLoadBalancerTunnelI
 | "None"   |             |
 | "VXLAN"  |             |
 
-<a id="GatewayLoadBalancerTunnelInterface_Type"></a>GatewayLoadBalancerTunnelInterface_Type
--------------------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface_Type{#GatewayLoadBalancerTunnelInterface_Type}
+---------------------------------------------------------------------------------
 
 Used by: [GatewayLoadBalancerTunnelInterface](#GatewayLoadBalancerTunnelInterface).
 
@@ -5885,8 +5885,8 @@ Used by: [GatewayLoadBalancerTunnelInterface](#GatewayLoadBalancerTunnelInterfac
 | "Internal" |             |
 | "None"     |             |
 
-<a id="GatewayLoadBalancerTunnelInterface_Type_STATUS"></a>GatewayLoadBalancerTunnelInterface_Type_STATUS
----------------------------------------------------------------------------------------------------------
+GatewayLoadBalancerTunnelInterface_Type_STATUS{#GatewayLoadBalancerTunnelInterface_Type_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [GatewayLoadBalancerTunnelInterface_STATUS](#GatewayLoadBalancerTunnelInterface_STATUS).
 
@@ -5896,8 +5896,8 @@ Used by: [GatewayLoadBalancerTunnelInterface_STATUS](#GatewayLoadBalancerTunnelI
 | "Internal" |             |
 | "None"     |             |
 
-<a id="IkeEncryption"></a>IkeEncryption
----------------------------------------
+IkeEncryption{#IkeEncryption}
+-----------------------------
 
 The IKE encryption algorithm (IKE phase 2).
 
@@ -5913,78 +5913,10 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "GCMAES128" |             |
 | "GCMAES256" |             |
 
-<a id="IkeEncryption_STATUS"></a>IkeEncryption_STATUS
------------------------------------------------------
-
-The IKE encryption algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "AES128"    |             |
-| "AES192"    |             |
-| "AES256"    |             |
-| "DES"       |             |
-| "DES3"      |             |
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-
-<a id="IkeIntegrity"></a>IkeIntegrity
--------------------------------------
-
-The IKE integrity algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy](#IpsecPolicy).
-
-| Value       | Description |
-|-------------|-------------|
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-| "MD5"       |             |
-| "SHA1"      |             |
-| "SHA256"    |             |
-| "SHA384"    |             |
-
-<a id="IkeIntegrity_STATUS"></a>IkeIntegrity_STATUS
----------------------------------------------------
-
-The IKE integrity algorithm (IKE phase 2).
-
-Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
-
-| Value       | Description |
-|-------------|-------------|
-| "GCMAES128" |             |
-| "GCMAES256" |             |
-| "MD5"       |             |
-| "SHA1"      |             |
-| "SHA256"    |             |
-| "SHA384"    |             |
-
-<a id="IpsecEncryption"></a>IpsecEncryption
+IkeEncryption_STATUS{#IkeEncryption_STATUS}
 -------------------------------------------
 
-The IPSec encryption algorithm (IKE phase 1).
-
-Used by: [IpsecPolicy](#IpsecPolicy).
-
-| Value       | Description |
-|-------------|-------------|
-| "AES128"    |             |
-| "AES192"    |             |
-| "AES256"    |             |
-| "DES"       |             |
-| "DES3"      |             |
-| "GCMAES128" |             |
-| "GCMAES192" |             |
-| "GCMAES256" |             |
-| "None"      |             |
-
-<a id="IpsecEncryption_STATUS"></a>IpsecEncryption_STATUS
----------------------------------------------------------
-
-The IPSec encryption algorithm (IKE phase 1).
+The IKE encryption algorithm (IKE phase 2).
 
 Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 
@@ -5996,13 +5928,81 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "DES"       |             |
 | "DES3"      |             |
 | "GCMAES128" |             |
-| "GCMAES192" |             |
 | "GCMAES256" |             |
-| "None"      |             |
 
-<a id="IpsecIntegrity"></a>IpsecIntegrity
+IkeIntegrity{#IkeIntegrity}
+---------------------------
+
+The IKE integrity algorithm (IKE phase 2).
+
+Used by: [IpsecPolicy](#IpsecPolicy).
+
+| Value       | Description |
+|-------------|-------------|
+| "GCMAES128" |             |
+| "GCMAES256" |             |
+| "MD5"       |             |
+| "SHA1"      |             |
+| "SHA256"    |             |
+| "SHA384"    |             |
+
+IkeIntegrity_STATUS{#IkeIntegrity_STATUS}
 -----------------------------------------
 
+The IKE integrity algorithm (IKE phase 2).
+
+Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "GCMAES128" |             |
+| "GCMAES256" |             |
+| "MD5"       |             |
+| "SHA1"      |             |
+| "SHA256"    |             |
+| "SHA384"    |             |
+
+IpsecEncryption{#IpsecEncryption}
+---------------------------------
+
+The IPSec encryption algorithm (IKE phase 1).
+
+Used by: [IpsecPolicy](#IpsecPolicy).
+
+| Value       | Description |
+|-------------|-------------|
+| "AES128"    |             |
+| "AES192"    |             |
+| "AES256"    |             |
+| "DES"       |             |
+| "DES3"      |             |
+| "GCMAES128" |             |
+| "GCMAES192" |             |
+| "GCMAES256" |             |
+| "None"      |             |
+
+IpsecEncryption_STATUS{#IpsecEncryption_STATUS}
+-----------------------------------------------
+
+The IPSec encryption algorithm (IKE phase 1).
+
+Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
+
+| Value       | Description |
+|-------------|-------------|
+| "AES128"    |             |
+| "AES192"    |             |
+| "AES256"    |             |
+| "DES"       |             |
+| "DES3"      |             |
+| "GCMAES128" |             |
+| "GCMAES192" |             |
+| "GCMAES256" |             |
+| "None"      |             |
+
+IpsecIntegrity{#IpsecIntegrity}
+-------------------------------
+
 The IPSec integrity algorithm (IKE phase 1).
 
 Used by: [IpsecPolicy](#IpsecPolicy).
@@ -6016,8 +6016,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "SHA1"      |             |
 | "SHA256"    |             |
 
-<a id="IpsecIntegrity_STATUS"></a>IpsecIntegrity_STATUS
--------------------------------------------------------
+IpsecIntegrity_STATUS{#IpsecIntegrity_STATUS}
+---------------------------------------------
 
 The IPSec integrity algorithm (IKE phase 1).
 
@@ -6032,8 +6032,8 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "SHA1"      |             |
 | "SHA256"    |             |
 
-<a id="LoadBalancerBackendAddressPropertiesFormat_AdminState"></a>LoadBalancerBackendAddressPropertiesFormat_AdminState
------------------------------------------------------------------------------------------------------------------------
+LoadBalancerBackendAddressPropertiesFormat_AdminState{#LoadBalancerBackendAddressPropertiesFormat_AdminState}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancerBackendAddress](#LoadBalancerBackendAddress).
 
@@ -6043,8 +6043,8 @@ Used by: [LoadBalancerBackendAddress](#LoadBalancerBackendAddress).
 | "None" |             |
 | "Up"   |             |
 
-<a id="LoadBalancerBackendAddressPropertiesFormat_AdminState_STATUS"></a>LoadBalancerBackendAddressPropertiesFormat_AdminState_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+LoadBalancerBackendAddressPropertiesFormat_AdminState_STATUS{#LoadBalancerBackendAddressPropertiesFormat_AdminState_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [LoadBalancerBackendAddress_STATUS](#LoadBalancerBackendAddress_STATUS).
 
@@ -6054,8 +6054,8 @@ Used by: [LoadBalancerBackendAddress_STATUS](#LoadBalancerBackendAddress_STATUS)
 | "None" |             |
 | "Up"   |             |
 
-<a id="NatRulePortMapping_STATUS"></a>NatRulePortMapping_STATUS
----------------------------------------------------------------
+NatRulePortMapping_STATUS{#NatRulePortMapping_STATUS}
+-----------------------------------------------------
 
 Individual port mappings for inbound NAT rule created for backend pool.
 
@@ -6067,8 +6067,8 @@ Used by: [LoadBalancerBackendAddress_STATUS](#LoadBalancerBackendAddress_STATUS)
 | frontendPort       | Frontend port.            | int<br/><small>Optional</small>    |
 | inboundNatRuleName | Name of inbound NAT rule. | string<br/><small>Optional</small> |
 
-<a id="PfsGroup"></a>PfsGroup
------------------------------
+PfsGroup{#PfsGroup}
+-------------------
 
 The Pfs Groups used in IKE Phase 2 for new child SA.
 
@@ -6086,8 +6086,8 @@ Used by: [IpsecPolicy](#IpsecPolicy).
 | "PFS24"   |             |
 | "PFSMM"   |             |
 
-<a id="PfsGroup_STATUS"></a>PfsGroup_STATUS
--------------------------------------------
+PfsGroup_STATUS{#PfsGroup_STATUS}
+---------------------------------
 
 The Pfs Groups used in IKE Phase 2 for new child SA.
 
@@ -6105,8 +6105,8 @@ Used by: [IpsecPolicy_STATUS](#IpsecPolicy_STATUS).
 | "PFS24"   |             |
 | "PFSMM"   |             |
 
-<a id="VirtualNetworkGatewayPolicyGroupMember_AttributeType"></a>VirtualNetworkGatewayPolicyGroupMember_AttributeType
----------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPolicyGroupMember_AttributeType{#VirtualNetworkGatewayPolicyGroupMember_AttributeType}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewayPolicyGroupMember](#VirtualNetworkGatewayPolicyGroupMember).
 
@@ -6116,8 +6116,8 @@ Used by: [VirtualNetworkGatewayPolicyGroupMember](#VirtualNetworkGatewayPolicyGr
 | "CertificateGroupId" |             |
 | "RadiusAzureGroupId" |             |
 
-<a id="VirtualNetworkGatewayPolicyGroupMember_AttributeType_STATUS"></a>VirtualNetworkGatewayPolicyGroupMember_AttributeType_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkGatewayPolicyGroupMember_AttributeType_STATUS{#VirtualNetworkGatewayPolicyGroupMember_AttributeType_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [VirtualNetworkGatewayPolicyGroupMember_STATUS](#VirtualNetworkGatewayPolicyGroupMember_STATUS).
 

--- a/docs/hugo/content/reference/network/v1api20240601.md
+++ b/docs/hugo/content/reference/network/v1api20240601.md
@@ -5,15 +5,15 @@ title: network.azure.com/v1api20240601
 linktitle: v1api20240601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-06-01" |             |
 
-<a id="PrivateDnsZone"></a>PrivateDnsZone
------------------------------------------
+PrivateDnsZone{#PrivateDnsZone}
+-------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}
 
@@ -26,7 +26,7 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | spec                                                                                    |             | [PrivateDnsZone_Spec](#PrivateDnsZone_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZone_STATUS](#PrivateDnsZone_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZone_Spec"></a>PrivateDnsZone_Spec
+### PrivateDnsZone_Spec {#PrivateDnsZone_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -37,7 +37,7 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="PrivateDnsZone_STATUS"></a>PrivateDnsZone_STATUS
+### PrivateDnsZone_STATUS{#PrivateDnsZone_STATUS}
 
 | Property                                       | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -57,8 +57,8 @@ Used by: [PrivateDnsZoneList](#PrivateDnsZoneList).
 | tags                                           | Resource tags.                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                           | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZoneList"></a>PrivateDnsZoneList
--------------------------------------------------
+PrivateDnsZoneList{#PrivateDnsZoneList}
+---------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}
 
@@ -68,8 +68,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [PrivateDnsZone[]](#PrivateDnsZone)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesAAAARecord"></a>PrivateDnsZonesAAAARecord
----------------------------------------------------------------
+PrivateDnsZonesAAAARecord{#PrivateDnsZonesAAAARecord}
+-----------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/AAAA/{relativeRecordSetName}
 
@@ -82,7 +82,7 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | spec                                                                                    |             | [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesAAAARecord_Spec"></a>PrivateDnsZonesAAAARecord_Spec
+### PrivateDnsZonesAAAARecord_Spec {#PrivateDnsZonesAAAARecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,7 +101,7 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesAAAARecord_STATUS"></a>PrivateDnsZonesAAAARecord_STATUS
+### PrivateDnsZonesAAAARecord_STATUS{#PrivateDnsZonesAAAARecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -123,8 +123,8 @@ Used by: [PrivateDnsZonesAAAARecordList](#PrivateDnsZonesAAAARecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesAAAARecordList"></a>PrivateDnsZonesAAAARecordList
------------------------------------------------------------------------
+PrivateDnsZonesAAAARecordList{#PrivateDnsZonesAAAARecordList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/AAAA/{relativeRecordSetName}
 
@@ -134,8 +134,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [PrivateDnsZonesAAAARecord[]](#PrivateDnsZonesAAAARecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesARecord"></a>PrivateDnsZonesARecord
----------------------------------------------------------
+PrivateDnsZonesARecord{#PrivateDnsZonesARecord}
+-----------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/A/{relativeRecordSetName}
 
@@ -148,7 +148,7 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | spec                                                                                    |             | [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesARecord_Spec"></a>PrivateDnsZonesARecord_Spec
+### PrivateDnsZonesARecord_Spec {#PrivateDnsZonesARecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesARecord_STATUS"></a>PrivateDnsZonesARecord_STATUS
+### PrivateDnsZonesARecord_STATUS{#PrivateDnsZonesARecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -189,8 +189,8 @@ Used by: [PrivateDnsZonesARecordList](#PrivateDnsZonesARecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesARecordList"></a>PrivateDnsZonesARecordList
------------------------------------------------------------------
+PrivateDnsZonesARecordList{#PrivateDnsZonesARecordList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/A/{relativeRecordSetName}
 
@@ -200,8 +200,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [PrivateDnsZonesARecord[]](#PrivateDnsZonesARecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesCNAMERecord"></a>PrivateDnsZonesCNAMERecord
------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord{#PrivateDnsZonesCNAMERecord}
+-------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/CNAME/{relativeRecordSetName}
 
@@ -214,7 +214,7 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | spec                                                                                    |             | [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesCNAMERecord_Spec"></a>PrivateDnsZonesCNAMERecord_Spec
+### PrivateDnsZonesCNAMERecord_Spec {#PrivateDnsZonesCNAMERecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -233,7 +233,7 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesCNAMERecord_STATUS"></a>PrivateDnsZonesCNAMERecord_STATUS
+### PrivateDnsZonesCNAMERecord_STATUS{#PrivateDnsZonesCNAMERecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -255,8 +255,8 @@ Used by: [PrivateDnsZonesCNAMERecordList](#PrivateDnsZonesCNAMERecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesCNAMERecordList"></a>PrivateDnsZonesCNAMERecordList
--------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecordList{#PrivateDnsZonesCNAMERecordList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/CNAME/{relativeRecordSetName}
 
@@ -266,8 +266,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [PrivateDnsZonesCNAMERecord[]](#PrivateDnsZonesCNAMERecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesMXRecord"></a>PrivateDnsZonesMXRecord
------------------------------------------------------------
+PrivateDnsZonesMXRecord{#PrivateDnsZonesMXRecord}
+-------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/MX/{relativeRecordSetName}
 
@@ -280,7 +280,7 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesMXRecord_Spec"></a>PrivateDnsZonesMXRecord_Spec
+### PrivateDnsZonesMXRecord_Spec {#PrivateDnsZonesMXRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -299,7 +299,7 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesMXRecord_STATUS"></a>PrivateDnsZonesMXRecord_STATUS
+### PrivateDnsZonesMXRecord_STATUS{#PrivateDnsZonesMXRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -321,8 +321,8 @@ Used by: [PrivateDnsZonesMXRecordList](#PrivateDnsZonesMXRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesMXRecordList"></a>PrivateDnsZonesMXRecordList
--------------------------------------------------------------------
+PrivateDnsZonesMXRecordList{#PrivateDnsZonesMXRecordList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/MX/{relativeRecordSetName}
 
@@ -332,8 +332,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [PrivateDnsZonesMXRecord[]](#PrivateDnsZonesMXRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesPTRRecord"></a>PrivateDnsZonesPTRRecord
--------------------------------------------------------------
+PrivateDnsZonesPTRRecord{#PrivateDnsZonesPTRRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/PTR/{relativeRecordSetName}
 
@@ -346,7 +346,7 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesPTRRecord_Spec"></a>PrivateDnsZonesPTRRecord_Spec
+### PrivateDnsZonesPTRRecord_Spec {#PrivateDnsZonesPTRRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -365,7 +365,7 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesPTRRecord_STATUS"></a>PrivateDnsZonesPTRRecord_STATUS
+### PrivateDnsZonesPTRRecord_STATUS{#PrivateDnsZonesPTRRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -387,8 +387,8 @@ Used by: [PrivateDnsZonesPTRRecordList](#PrivateDnsZonesPTRRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesPTRRecordList"></a>PrivateDnsZonesPTRRecordList
----------------------------------------------------------------------
+PrivateDnsZonesPTRRecordList{#PrivateDnsZonesPTRRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/PTR/{relativeRecordSetName}
 
@@ -398,8 +398,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesPTRRecord[]](#PrivateDnsZonesPTRRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesSRVRecord"></a>PrivateDnsZonesSRVRecord
--------------------------------------------------------------
+PrivateDnsZonesSRVRecord{#PrivateDnsZonesSRVRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/SRV/{relativeRecordSetName}
 
@@ -412,7 +412,7 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesSRVRecord_Spec"></a>PrivateDnsZonesSRVRecord_Spec
+### PrivateDnsZonesSRVRecord_Spec {#PrivateDnsZonesSRVRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -431,7 +431,7 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesSRVRecord_STATUS"></a>PrivateDnsZonesSRVRecord_STATUS
+### PrivateDnsZonesSRVRecord_STATUS{#PrivateDnsZonesSRVRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -453,8 +453,8 @@ Used by: [PrivateDnsZonesSRVRecordList](#PrivateDnsZonesSRVRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesSRVRecordList"></a>PrivateDnsZonesSRVRecordList
----------------------------------------------------------------------
+PrivateDnsZonesSRVRecordList{#PrivateDnsZonesSRVRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/SRV/{relativeRecordSetName}
 
@@ -464,8 +464,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesSRVRecord[]](#PrivateDnsZonesSRVRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesTXTRecord"></a>PrivateDnsZonesTXTRecord
--------------------------------------------------------------
+PrivateDnsZonesTXTRecord{#PrivateDnsZonesTXTRecord}
+---------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/TXT/{relativeRecordSetName}
 
@@ -478,7 +478,7 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | spec                                                                                    |             | [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesTXTRecord_Spec"></a>PrivateDnsZonesTXTRecord_Spec
+### PrivateDnsZonesTXTRecord_Spec {#PrivateDnsZonesTXTRecord_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -497,7 +497,7 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-### <a id="PrivateDnsZonesTXTRecord_STATUS"></a>PrivateDnsZonesTXTRecord_STATUS
+### PrivateDnsZonesTXTRecord_STATUS{#PrivateDnsZonesTXTRecord_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -519,8 +519,8 @@ Used by: [PrivateDnsZonesTXTRecordList](#PrivateDnsZonesTXTRecordList).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesTXTRecordList"></a>PrivateDnsZonesTXTRecordList
----------------------------------------------------------------------
+PrivateDnsZonesTXTRecordList{#PrivateDnsZonesTXTRecordList}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/TXT/{relativeRecordSetName}
 
@@ -530,8 +530,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                     |
 | items                                                                               |             | [PrivateDnsZonesTXTRecord[]](#PrivateDnsZonesTXTRecord)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLink"></a>PrivateDnsZonesVirtualNetworkLink
--------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink{#PrivateDnsZonesVirtualNetworkLink}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -544,7 +544,7 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | spec                                                                                    |             | [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetworkLink_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS)<br/><small>Optional</small> |
 
-### <a id="PrivateDnsZonesVirtualNetworkLink_Spec"></a>PrivateDnsZonesVirtualNetworkLink_Spec
+### PrivateDnsZonesVirtualNetworkLink_Spec {#PrivateDnsZonesVirtualNetworkLink_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -558,7 +558,7 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | tags                | Resource tags.                                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork      | The reference of the virtual network.                                                                                                                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 
-### <a id="PrivateDnsZonesVirtualNetworkLink_STATUS"></a>PrivateDnsZonesVirtualNetworkLink_STATUS
+### PrivateDnsZonesVirtualNetworkLink_STATUS{#PrivateDnsZonesVirtualNetworkLink_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -575,8 +575,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLinkList](#PrivateDnsZonesVirtualNetworkL
 | virtualNetwork          | The reference of the virtual network.                                                                                                                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | virtualNetworkLinkState | The status of the virtual network link to the Private DNS zone. Possible values are 'InProgress' and 'Done'. This is a read-only property and any attempt to set this value will be ignored.                                                                                                                 | [VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS](#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLinkList"></a>PrivateDnsZonesVirtualNetworkLinkList
----------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLinkList{#PrivateDnsZonesVirtualNetworkLinkList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /privatedns/resource-manager/Microsoft.Network/stable/2024-06-01/privatedns.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}
 
@@ -586,8 +586,8 @@ Generator information: - Generated from: /privatedns/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [PrivateDnsZonesVirtualNetworkLink[]](#PrivateDnsZonesVirtualNetworkLink)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZone_Spec"></a>PrivateDnsZone_Spec
----------------------------------------------------
+PrivateDnsZone_Spec{#PrivateDnsZone_Spec}
+-----------------------------------------
 
 Used by: [PrivateDnsZone](#PrivateDnsZone).
 
@@ -600,8 +600,8 @@ Used by: [PrivateDnsZone](#PrivateDnsZone).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a resources.azure.com/ResourceGroup resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="PrivateDnsZone_STATUS"></a>PrivateDnsZone_STATUS
--------------------------------------------------------
+PrivateDnsZone_STATUS{#PrivateDnsZone_STATUS}
+---------------------------------------------
 
 Used by: [PrivateDnsZone](#PrivateDnsZone).
 
@@ -623,8 +623,8 @@ Used by: [PrivateDnsZone](#PrivateDnsZone).
 | tags                                           | Resource tags.                                                                                                                                                                                                                                                                                 | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                           | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesAAAARecord_Spec"></a>PrivateDnsZonesAAAARecord_Spec
--------------------------------------------------------------------------
+PrivateDnsZonesAAAARecord_Spec{#PrivateDnsZonesAAAARecord_Spec}
+---------------------------------------------------------------
 
 Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 
@@ -645,8 +645,8 @@ Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesAAAARecord_STATUS"></a>PrivateDnsZonesAAAARecord_STATUS
------------------------------------------------------------------------------
+PrivateDnsZonesAAAARecord_STATUS{#PrivateDnsZonesAAAARecord_STATUS}
+-------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 
@@ -670,8 +670,8 @@ Used by: [PrivateDnsZonesAAAARecord](#PrivateDnsZonesAAAARecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesARecord_Spec"></a>PrivateDnsZonesARecord_Spec
--------------------------------------------------------------------
+PrivateDnsZonesARecord_Spec{#PrivateDnsZonesARecord_Spec}
+---------------------------------------------------------
 
 Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 
@@ -692,8 +692,8 @@ Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesARecord_STATUS"></a>PrivateDnsZonesARecord_STATUS
------------------------------------------------------------------------
+PrivateDnsZonesARecord_STATUS{#PrivateDnsZonesARecord_STATUS}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 
@@ -717,8 +717,8 @@ Used by: [PrivateDnsZonesARecord](#PrivateDnsZonesARecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesCNAMERecord_Spec"></a>PrivateDnsZonesCNAMERecord_Spec
----------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord_Spec{#PrivateDnsZonesCNAMERecord_Spec}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 
@@ -739,8 +739,8 @@ Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesCNAMERecord_STATUS"></a>PrivateDnsZonesCNAMERecord_STATUS
--------------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecord_STATUS{#PrivateDnsZonesCNAMERecord_STATUS}
+---------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 
@@ -764,8 +764,8 @@ Used by: [PrivateDnsZonesCNAMERecord](#PrivateDnsZonesCNAMERecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesMXRecord_Spec"></a>PrivateDnsZonesMXRecord_Spec
----------------------------------------------------------------------
+PrivateDnsZonesMXRecord_Spec{#PrivateDnsZonesMXRecord_Spec}
+-----------------------------------------------------------
 
 Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 
@@ -786,8 +786,8 @@ Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesMXRecord_STATUS"></a>PrivateDnsZonesMXRecord_STATUS
--------------------------------------------------------------------------
+PrivateDnsZonesMXRecord_STATUS{#PrivateDnsZonesMXRecord_STATUS}
+---------------------------------------------------------------
 
 Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 
@@ -811,8 +811,8 @@ Used by: [PrivateDnsZonesMXRecord](#PrivateDnsZonesMXRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesPTRRecord_Spec"></a>PrivateDnsZonesPTRRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesPTRRecord_Spec{#PrivateDnsZonesPTRRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 
@@ -833,8 +833,8 @@ Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesPTRRecord_STATUS"></a>PrivateDnsZonesPTRRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesPTRRecord_STATUS{#PrivateDnsZonesPTRRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 
@@ -858,8 +858,8 @@ Used by: [PrivateDnsZonesPTRRecord](#PrivateDnsZonesPTRRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesSRVRecord_Spec"></a>PrivateDnsZonesSRVRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesSRVRecord_Spec{#PrivateDnsZonesSRVRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 
@@ -880,8 +880,8 @@ Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesSRVRecord_STATUS"></a>PrivateDnsZonesSRVRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesSRVRecord_STATUS{#PrivateDnsZonesSRVRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 
@@ -905,8 +905,8 @@ Used by: [PrivateDnsZonesSRVRecord](#PrivateDnsZonesSRVRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesTXTRecord_Spec"></a>PrivateDnsZonesTXTRecord_Spec
------------------------------------------------------------------------
+PrivateDnsZonesTXTRecord_Spec{#PrivateDnsZonesTXTRecord_Spec}
+-------------------------------------------------------------
 
 Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 
@@ -927,8 +927,8 @@ Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 | ttl          | The TTL (time-to-live) of the records in the record set.                                                                                                                                                                                                                                    | int<br/><small>Optional</small>                                                                                                                                      |
 | txtRecords   | The list of TXT records in the record set.                                                                                                                                                                                                                                                  | [TxtRecord[]](#TxtRecord)<br/><small>Optional</small>                                                                                                                |
 
-<a id="PrivateDnsZonesTXTRecord_STATUS"></a>PrivateDnsZonesTXTRecord_STATUS
----------------------------------------------------------------------------
+PrivateDnsZonesTXTRecord_STATUS{#PrivateDnsZonesTXTRecord_STATUS}
+-----------------------------------------------------------------
 
 Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 
@@ -952,8 +952,8 @@ Used by: [PrivateDnsZonesTXTRecord](#PrivateDnsZonesTXTRecord).
 | txtRecords       | The list of TXT records in the record set.                                                                                                                                                                                                                                                     | [TxtRecord_STATUS[]](#TxtRecord_STATUS)<br/><small>Optional</small>                                                                                     |
 | type             | The type of the resource. Example - 'Microsoft.Network/privateDnsZones'.                                                                                                                                                                                                                       | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="PrivateDnsZonesVirtualNetworkLink_Spec"></a>PrivateDnsZonesVirtualNetworkLink_Spec
------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink_Spec{#PrivateDnsZonesVirtualNetworkLink_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink).
 
@@ -969,8 +969,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink)
 | tags                | Resource tags.                                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | virtualNetwork      | The reference of the virtual network.                                                                                                                                                                                                                                                                        | [SubResource](#SubResource)<br/><small>Optional</small>                                                                                                              |
 
-<a id="PrivateDnsZonesVirtualNetworkLink_STATUS"></a>PrivateDnsZonesVirtualNetworkLink_STATUS
----------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLink_STATUS{#PrivateDnsZonesVirtualNetworkLink_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink).
 
@@ -989,87 +989,87 @@ Used by: [PrivateDnsZonesVirtualNetworkLink](#PrivateDnsZonesVirtualNetworkLink)
 | virtualNetwork          | The reference of the virtual network.                                                                                                                                                                                                                                                                        | [SubResource_STATUS](#SubResource_STATUS)<br/><small>Optional</small>                                                                                   |
 | virtualNetworkLinkState | The status of the virtual network link to the Private DNS zone. Possible values are 'InProgress' and 'Done'. This is a read-only property and any attempt to set this value will be ignored.                                                                                                                 | [VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS](#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS)<br/><small>Optional</small> |
 
-<a id="AaaaRecord"></a>AaaaRecord
+AaaaRecord{#AaaaRecord}
+-----------------------
+
+An AAAA record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property    | Description                           | Type                               |
+|-------------|---------------------------------------|------------------------------------|
+| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
+
+AaaaRecord_STATUS{#AaaaRecord_STATUS}
+-------------------------------------
+
+An AAAA record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property    | Description                           | Type                               |
+|-------------|---------------------------------------|------------------------------------|
+| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
+
+ARecord{#ARecord}
+-----------------
+
+An A record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property    | Description                        | Type                               |
+|-------------|------------------------------------|------------------------------------|
+| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
+
+ARecord_STATUS{#ARecord_STATUS}
+-------------------------------
+
+An A record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property    | Description                        | Type                               |
+|-------------|------------------------------------|------------------------------------|
+| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
+
+CnameRecord{#CnameRecord}
+-------------------------
+
+A CNAME record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property | Description                               | Type                               |
+|----------|-------------------------------------------|------------------------------------|
+| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
+
+CnameRecord_STATUS{#CnameRecord_STATUS}
+---------------------------------------
+
+A CNAME record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                               | Type                               |
+|----------|-------------------------------------------|------------------------------------|
+| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
+
+MxRecord{#MxRecord}
+-------------------
+
+An MX record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property   | Description                                          | Type                               |
+|------------|------------------------------------------------------|------------------------------------|
+| exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
+| preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
+
+MxRecord_STATUS{#MxRecord_STATUS}
 ---------------------------------
 
-An AAAA record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property    | Description                           | Type                               |
-|-------------|---------------------------------------|------------------------------------|
-| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
-
-<a id="AaaaRecord_STATUS"></a>AaaaRecord_STATUS
------------------------------------------------
-
-An AAAA record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property    | Description                           | Type                               |
-|-------------|---------------------------------------|------------------------------------|
-| ipv6Address | The IPv6 address of this AAAA record. | string<br/><small>Optional</small> |
-
-<a id="ARecord"></a>ARecord
----------------------------
-
-An A record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property    | Description                        | Type                               |
-|-------------|------------------------------------|------------------------------------|
-| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
-
-<a id="ARecord_STATUS"></a>ARecord_STATUS
------------------------------------------
-
-An A record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property    | Description                        | Type                               |
-|-------------|------------------------------------|------------------------------------|
-| ipv4Address | The IPv4 address of this A record. | string<br/><small>Optional</small> |
-
-<a id="CnameRecord"></a>CnameRecord
------------------------------------
-
-A CNAME record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property | Description                               | Type                               |
-|----------|-------------------------------------------|------------------------------------|
-| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
-
-<a id="CnameRecord_STATUS"></a>CnameRecord_STATUS
--------------------------------------------------
-
-A CNAME record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                               | Type                               |
-|----------|-------------------------------------------|------------------------------------|
-| cname    | The canonical name for this CNAME record. | string<br/><small>Optional</small> |
-
-<a id="MxRecord"></a>MxRecord
------------------------------
-
-An MX record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property   | Description                                          | Type                               |
-|------------|------------------------------------------------------|------------------------------------|
-| exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
-| preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
-
-<a id="MxRecord_STATUS"></a>MxRecord_STATUS
--------------------------------------------
-
 An MX record.
 
 Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
@@ -1079,8 +1079,8 @@ Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), 
 | exchange   | The domain name of the mail host for this MX record. | string<br/><small>Optional</small> |
 | preference | The preference value for this MX record.             | int<br/><small>Optional</small>    |
 
-<a id="PrivateDnsZoneOperatorSpec"></a>PrivateDnsZoneOperatorSpec
------------------------------------------------------------------
+PrivateDnsZoneOperatorSpec{#PrivateDnsZoneOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1091,8 +1091,8 @@ Used by: [PrivateDnsZone_Spec](#PrivateDnsZone_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesAAAARecordOperatorSpec"></a>PrivateDnsZonesAAAARecordOperatorSpec
----------------------------------------------------------------------------------------
+PrivateDnsZonesAAAARecordOperatorSpec{#PrivateDnsZonesAAAARecordOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1103,8 +1103,8 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesARecordOperatorSpec"></a>PrivateDnsZonesARecordOperatorSpec
----------------------------------------------------------------------------------
+PrivateDnsZonesARecordOperatorSpec{#PrivateDnsZonesARecordOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1115,8 +1115,8 @@ Used by: [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesCNAMERecordOperatorSpec"></a>PrivateDnsZonesCNAMERecordOperatorSpec
------------------------------------------------------------------------------------------
+PrivateDnsZonesCNAMERecordOperatorSpec{#PrivateDnsZonesCNAMERecordOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1127,8 +1127,8 @@ Used by: [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesMXRecordOperatorSpec"></a>PrivateDnsZonesMXRecordOperatorSpec
------------------------------------------------------------------------------------
+PrivateDnsZonesMXRecordOperatorSpec{#PrivateDnsZonesMXRecordOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1139,8 +1139,8 @@ Used by: [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesPTRRecordOperatorSpec"></a>PrivateDnsZonesPTRRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesPTRRecordOperatorSpec{#PrivateDnsZonesPTRRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1151,8 +1151,8 @@ Used by: [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesSRVRecordOperatorSpec"></a>PrivateDnsZonesSRVRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesSRVRecordOperatorSpec{#PrivateDnsZonesSRVRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1163,8 +1163,8 @@ Used by: [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesTXTRecordOperatorSpec"></a>PrivateDnsZonesTXTRecordOperatorSpec
--------------------------------------------------------------------------------------
+PrivateDnsZonesTXTRecordOperatorSpec{#PrivateDnsZonesTXTRecordOperatorSpec}
+---------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1175,8 +1175,8 @@ Used by: [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateDnsZonesVirtualNetworkLinkOperatorSpec"></a>PrivateDnsZonesVirtualNetworkLinkOperatorSpec
--------------------------------------------------------------------------------------------------------
+PrivateDnsZonesVirtualNetworkLinkOperatorSpec{#PrivateDnsZonesVirtualNetworkLinkOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1187,8 +1187,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetwork
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateZoneProperties_ProvisioningState_STATUS"></a>PrivateZoneProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+PrivateZoneProperties_ProvisioningState_STATUS{#PrivateZoneProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZone_STATUS](#PrivateDnsZone_STATUS).
 
@@ -1201,8 +1201,8 @@ Used by: [PrivateDnsZone_STATUS](#PrivateDnsZone_STATUS).
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="PtrRecord"></a>PtrRecord
--------------------------------
+PtrRecord{#PtrRecord}
+---------------------
 
 A PTR record.
 
@@ -1212,81 +1212,81 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [Pri
 |----------|-------------------------------------------------|------------------------------------|
 | ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
 
-<a id="PtrRecord_STATUS"></a>PtrRecord_STATUS
----------------------------------------------
-
-A PTR record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                                     | Type                               |
-|----------|-------------------------------------------------|------------------------------------|
-| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
-
-<a id="SoaRecord"></a>SoaRecord
--------------------------------
-
-An SOA record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SoaRecord_STATUS"></a>SoaRecord_STATUS
----------------------------------------------
-
-An SOA record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property     | Description                                                                                                   | Type                               |
-|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
-| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
-| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
-| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
-| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
-| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord"></a>SrvRecord
--------------------------------
-
-An SRV record.
-
-Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SrvRecord_STATUS"></a>SrvRecord_STATUS
----------------------------------------------
-
-An SRV record.
-
-Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
-
-| Property | Description                                 | Type                               |
-|----------|---------------------------------------------|------------------------------------|
-| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
-| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
-| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
-| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
-
-<a id="SubResource"></a>SubResource
+PtrRecord_STATUS{#PtrRecord_STATUS}
 -----------------------------------
+
+A PTR record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                                     | Type                               |
+|----------|-------------------------------------------------|------------------------------------|
+| ptrdname | The PTR target domain name for this PTR record. | string<br/><small>Optional</small> |
+
+SoaRecord{#SoaRecord}
+---------------------
+
+An SOA record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SoaRecord_STATUS{#SoaRecord_STATUS}
+-----------------------------------
+
+An SOA record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property     | Description                                                                                                   | Type                               |
+|--------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| email        | The email contact for this SOA record.                                                                        | string<br/><small>Optional</small> |
+| expireTime   | The expire time for this SOA record.                                                                          | int<br/><small>Optional</small>    |
+| host         | The domain name of the authoritative name server for this SOA record.                                         | string<br/><small>Optional</small> |
+| minimumTtl   | The minimum value for this SOA record. By convention this is used to determine the negative caching duration. | int<br/><small>Optional</small>    |
+| refreshTime  | The refresh value for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+| retryTime    | The retry time for this SOA record.                                                                           | int<br/><small>Optional</small>    |
+| serialNumber | The serial number for this SOA record.                                                                        | int<br/><small>Optional</small>    |
+
+SrvRecord{#SrvRecord}
+---------------------
+
+An SRV record.
+
+Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [PrivateDnsZonesARecord_Spec](#PrivateDnsZonesARecord_Spec), [PrivateDnsZonesCNAMERecord_Spec](#PrivateDnsZonesCNAMERecord_Spec), [PrivateDnsZonesMXRecord_Spec](#PrivateDnsZonesMXRecord_Spec), [PrivateDnsZonesPTRRecord_Spec](#PrivateDnsZonesPTRRecord_Spec), [PrivateDnsZonesSRVRecord_Spec](#PrivateDnsZonesSRVRecord_Spec), and [PrivateDnsZonesTXTRecord_Spec](#PrivateDnsZonesTXTRecord_Spec).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SrvRecord_STATUS{#SrvRecord_STATUS}
+-----------------------------------
+
+An SRV record.
+
+Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), [PrivateDnsZonesARecord_STATUS](#PrivateDnsZonesARecord_STATUS), [PrivateDnsZonesCNAMERecord_STATUS](#PrivateDnsZonesCNAMERecord_STATUS), [PrivateDnsZonesMXRecord_STATUS](#PrivateDnsZonesMXRecord_STATUS), [PrivateDnsZonesPTRRecord_STATUS](#PrivateDnsZonesPTRRecord_STATUS), [PrivateDnsZonesSRVRecord_STATUS](#PrivateDnsZonesSRVRecord_STATUS), and [PrivateDnsZonesTXTRecord_STATUS](#PrivateDnsZonesTXTRecord_STATUS).
+
+| Property | Description                                 | Type                               |
+|----------|---------------------------------------------|------------------------------------|
+| port     | The port value for this SRV record.         | int<br/><small>Optional</small>    |
+| priority | The priority value for this SRV record.     | int<br/><small>Optional</small>    |
+| target   | The target domain name for this SRV record. | string<br/><small>Optional</small> |
+| weight   | The weight value for this SRV record.       | int<br/><small>Optional</small>    |
+
+SubResource{#SubResource}
+-------------------------
 
 Reference to another subresource.
 
@@ -1296,8 +1296,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetwork
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SubResource_STATUS"></a>SubResource_STATUS
--------------------------------------------------
+SubResource_STATUS{#SubResource_STATUS}
+---------------------------------------
 
 Reference to another subresource.
 
@@ -1307,8 +1307,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetwo
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="TxtRecord"></a>TxtRecord
--------------------------------
+TxtRecord{#TxtRecord}
+---------------------
 
 A TXT record.
 
@@ -1318,8 +1318,8 @@ Used by: [PrivateDnsZonesAAAARecord_Spec](#PrivateDnsZonesAAAARecord_Spec), [Pri
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="TxtRecord_STATUS"></a>TxtRecord_STATUS
----------------------------------------------
+TxtRecord_STATUS{#TxtRecord_STATUS}
+-----------------------------------
 
 A TXT record.
 
@@ -1329,8 +1329,8 @@ Used by: [PrivateDnsZonesAAAARecord_STATUS](#PrivateDnsZonesAAAARecord_STATUS), 
 |----------|------------------------------------|--------------------------------------|
 | value    | The text value of this TXT record. | string[]<br/><small>Optional</small> |
 
-<a id="VirtualNetworkLinkProperties_ProvisioningState_STATUS"></a>VirtualNetworkLinkProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_ProvisioningState_STATUS{#VirtualNetworkLinkProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS).
 
@@ -1343,8 +1343,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetwo
 | "Succeeded" |             |
 | "Updating"  |             |
 
-<a id="VirtualNetworkLinkProperties_ResolutionPolicy"></a>VirtualNetworkLinkProperties_ResolutionPolicy
--------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_ResolutionPolicy{#VirtualNetworkLinkProperties_ResolutionPolicy}
+---------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetworkLink_Spec).
 
@@ -1353,8 +1353,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_Spec](#PrivateDnsZonesVirtualNetwork
 | "Default"          |             |
 | "NxDomainRedirect" |             |
 
-<a id="VirtualNetworkLinkProperties_ResolutionPolicy_STATUS"></a>VirtualNetworkLinkProperties_ResolutionPolicy_STATUS
----------------------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_ResolutionPolicy_STATUS{#VirtualNetworkLinkProperties_ResolutionPolicy_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS).
 
@@ -1363,8 +1363,8 @@ Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetwo
 | "Default"          |             |
 | "NxDomainRedirect" |             |
 
-<a id="VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS"></a>VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS
------------------------------------------------------------------------------------------------------------------------------------
+VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS{#VirtualNetworkLinkProperties_VirtualNetworkLinkState_STATUS}
+-------------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateDnsZonesVirtualNetworkLink_STATUS](#PrivateDnsZonesVirtualNetworkLink_STATUS).
 

--- a/docs/hugo/content/reference/notificationhubs/v1api20230901.md
+++ b/docs/hugo/content/reference/notificationhubs/v1api20230901.md
@@ -5,15 +5,15 @@ title: notificationhubs.azure.com/v1api20230901
 linktitle: v1api20230901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-09-01" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,7 +38,7 @@ Used by: [NamespaceList](#NamespaceList).
 | sku          | The Sku description for a namespace                                                                                                                                                                                                                                                          | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,8 +52,8 @@ Used by: [NamespaceList](#NamespaceList).
 | tags       | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}
 
@@ -63,8 +63,8 @@ Generator information: - Generated from: /notificationhubs/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -77,7 +77,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -88,7 +88,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | properties   | SharedAccessAuthorizationRule properties.                                                                                                                                                                                                                                                       | [SharedAccessAuthorizationRuleProperties](#SharedAccessAuthorizationRuleProperties)<br/><small>Optional</small>                                                      |
 | tags         | Deprecated - only for compatibility.                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,8 +101,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | tags       | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}
 
@@ -112,8 +112,8 @@ Generator information: - Generated from: /notificationhubs/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NotificationHub"></a>NotificationHub
--------------------------------------------
+NotificationHub{#NotificationHub}
+---------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/{notificationHubName}
 
@@ -126,7 +126,7 @@ Used by: [NotificationHubList](#NotificationHubList).
 | spec                                                                                    |             | [NotificationHub_Spec](#NotificationHub_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NotificationHub_STATUS](#NotificationHub_STATUS)<br/><small>Optional</small> |
 
-### <a id="NotificationHub_Spec"></a>NotificationHub_Spec
+### NotificationHub_Spec {#NotificationHub_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -138,7 +138,7 @@ Used by: [NotificationHubList](#NotificationHubList).
 | sku          | The Sku description for a namespace                                                                                                                                                                                                                                                             | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="NotificationHub_STATUS"></a>NotificationHub_STATUS
+### NotificationHub_STATUS{#NotificationHub_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -152,8 +152,8 @@ Used by: [NotificationHubList](#NotificationHubList).
 | tags       | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NotificationHubList"></a>NotificationHubList
----------------------------------------------------
+NotificationHubList{#NotificationHubList}
+-----------------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/{notificationHubName}
 
@@ -163,8 +163,8 @@ Generator information: - Generated from: /notificationhubs/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NotificationHub[]](#NotificationHub)<br/><small>Optional</small> |
 
-<a id="NotificationHubsAuthorizationRule"></a>NotificationHubsAuthorizationRule
--------------------------------------------------------------------------------
+NotificationHubsAuthorizationRule{#NotificationHubsAuthorizationRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/{notificationHubName}/authorizationRules/{authorizationRuleName}
 
@@ -177,7 +177,7 @@ Used by: [NotificationHubsAuthorizationRuleList](#NotificationHubsAuthorizationR
 | spec                                                                                    |             | [NotificationHubsAuthorizationRule_Spec](#NotificationHubsAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NotificationHubsAuthorizationRule_STATUS](#NotificationHubsAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NotificationHubsAuthorizationRule_Spec"></a>NotificationHubsAuthorizationRule_Spec
+### NotificationHubsAuthorizationRule_Spec {#NotificationHubsAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -188,7 +188,7 @@ Used by: [NotificationHubsAuthorizationRuleList](#NotificationHubsAuthorizationR
 | properties   | SharedAccessAuthorizationRule properties.                                                                                                                                                                                                                                                             | [SharedAccessAuthorizationRuleProperties](#SharedAccessAuthorizationRuleProperties)<br/><small>Optional</small>                                                      |
 | tags         | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="NotificationHubsAuthorizationRule_STATUS"></a>NotificationHubsAuthorizationRule_STATUS
+### NotificationHubsAuthorizationRule_STATUS{#NotificationHubsAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -201,8 +201,8 @@ Used by: [NotificationHubsAuthorizationRuleList](#NotificationHubsAuthorizationR
 | tags       | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NotificationHubsAuthorizationRuleList"></a>NotificationHubsAuthorizationRuleList
----------------------------------------------------------------------------------------
+NotificationHubsAuthorizationRuleList{#NotificationHubsAuthorizationRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /notificationhubs/resource-manager/Microsoft.NotificationHubs/stable/2023-09-01/notificationhubs.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/{notificationHubName}/authorizationRules/{authorizationRuleName}
 
@@ -212,8 +212,8 @@ Generator information: - Generated from: /notificationhubs/resource-manager/Micr
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NotificationHubsAuthorizationRule[]](#NotificationHubsAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -227,8 +227,8 @@ Used by: [Namespace](#Namespace).
 | sku          | The Sku description for a namespace                                                                                                                                                                                                                                                          | [Sku](#Sku)<br/><small>Required</small>                                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -244,8 +244,8 @@ Used by: [Namespace](#Namespace).
 | tags       | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -258,8 +258,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | properties   | SharedAccessAuthorizationRule properties.                                                                                                                                                                                                                                                       | [SharedAccessAuthorizationRuleProperties](#SharedAccessAuthorizationRuleProperties)<br/><small>Optional</small>                                                      |
 | tags         | Deprecated - only for compatibility.                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -274,8 +274,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | tags       | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NotificationHub_Spec"></a>NotificationHub_Spec
------------------------------------------------------
+NotificationHub_Spec{#NotificationHub_Spec}
+-------------------------------------------
 
 Used by: [NotificationHub](#NotificationHub).
 
@@ -289,8 +289,8 @@ Used by: [NotificationHub](#NotificationHub).
 | sku          | The Sku description for a namespace                                                                                                                                                                                                                                                             | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags         | Resource tags.                                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NotificationHub_STATUS"></a>NotificationHub_STATUS
----------------------------------------------------------
+NotificationHub_STATUS{#NotificationHub_STATUS}
+-----------------------------------------------
 
 Used by: [NotificationHub](#NotificationHub).
 
@@ -306,8 +306,8 @@ Used by: [NotificationHub](#NotificationHub).
 | tags       | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NotificationHubsAuthorizationRule_Spec"></a>NotificationHubsAuthorizationRule_Spec
------------------------------------------------------------------------------------------
+NotificationHubsAuthorizationRule_Spec{#NotificationHubsAuthorizationRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NotificationHubsAuthorizationRule](#NotificationHubsAuthorizationRule).
 
@@ -320,8 +320,8 @@ Used by: [NotificationHubsAuthorizationRule](#NotificationHubsAuthorizationRule)
 | properties   | SharedAccessAuthorizationRule properties.                                                                                                                                                                                                                                                             | [SharedAccessAuthorizationRuleProperties](#SharedAccessAuthorizationRuleProperties)<br/><small>Optional</small>                                                      |
 | tags         | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NotificationHubsAuthorizationRule_STATUS"></a>NotificationHubsAuthorizationRule_STATUS
----------------------------------------------------------------------------------------------
+NotificationHubsAuthorizationRule_STATUS{#NotificationHubsAuthorizationRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NotificationHubsAuthorizationRule](#NotificationHubsAuthorizationRule).
 
@@ -336,8 +336,8 @@ Used by: [NotificationHubsAuthorizationRule](#NotificationHubsAuthorizationRule)
 | tags       | Deprecated - only for compatibility.                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -350,8 +350,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="NamespaceProperties"></a>NamespaceProperties
----------------------------------------------------
+NamespaceProperties{#NamespaceProperties}
+-----------------------------------------
 
 Represents namespace properties.
 
@@ -368,8 +368,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | scaleUnit           | Gets or sets scaleUnit where the namespace gets created                       | string<br/><small>Optional</small>                                                |
 | zoneRedundancy      | Namespace SKU name.                                                           | [ZoneRedundancyPreference](#ZoneRedundancyPreference)<br/><small>Optional</small> |
 
-<a id="NamespaceProperties_STATUS"></a>NamespaceProperties_STATUS
------------------------------------------------------------------
+NamespaceProperties_STATUS{#NamespaceProperties_STATUS}
+-------------------------------------------------------
 
 Represents namespace properties.
 
@@ -398,8 +398,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | updatedAt                  | Time when the namespace was updated.                                                                                                 | string<br/><small>Optional</small>                                                                                  |
 | zoneRedundancy             | Namespace SKU name.                                                                                                                  | [ZoneRedundancyPreference_STATUS](#ZoneRedundancyPreference_STATUS)<br/><small>Optional</small>                     |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -410,8 +410,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NotificationHubOperatorSpec"></a>NotificationHubOperatorSpec
--------------------------------------------------------------------
+NotificationHubOperatorSpec{#NotificationHubOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -423,8 +423,8 @@ Used by: [NotificationHub_Spec](#NotificationHub_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NotificationHubOperatorSecrets](#NotificationHubOperatorSecrets)<br/><small>Optional</small>                                                                       |
 
-<a id="NotificationHubProperties"></a>NotificationHubProperties
----------------------------------------------------------------
+NotificationHubProperties{#NotificationHubProperties}
+-----------------------------------------------------
 
 NotificationHub properties.
 
@@ -443,8 +443,8 @@ Used by: [NotificationHub_Spec](#NotificationHub_Spec).
 | wnsCredential     | Description of a NotificationHub WnsCredential.                 | [WnsCredential](#WnsCredential)<br/><small>Optional</small>         |
 | xiaomiCredential  | Description of a NotificationHub XiaomiCredential.              | [XiaomiCredential](#XiaomiCredential)<br/><small>Optional</small>   |
 
-<a id="NotificationHubProperties_STATUS"></a>NotificationHubProperties_STATUS
------------------------------------------------------------------------------
+NotificationHubProperties_STATUS{#NotificationHubProperties_STATUS}
+-------------------------------------------------------------------
 
 NotificationHub properties.
 
@@ -465,8 +465,8 @@ Used by: [NotificationHub_STATUS](#NotificationHub_STATUS).
 | wnsCredential         | Description of a NotificationHub WnsCredential.                    | [WnsCredential_STATUS](#WnsCredential_STATUS)<br/><small>Optional</small>                                                       |
 | xiaomiCredential      | Description of a NotificationHub XiaomiCredential.                 | [XiaomiCredential_STATUS](#XiaomiCredential_STATUS)<br/><small>Optional</small>                                                 |
 
-<a id="NotificationHubsAuthorizationRuleOperatorSpec"></a>NotificationHubsAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NotificationHubsAuthorizationRuleOperatorSpec{#NotificationHubsAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -477,8 +477,8 @@ Used by: [NotificationHubsAuthorizationRule_Spec](#NotificationHubsAuthorization
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SharedAccessAuthorizationRuleProperties"></a>SharedAccessAuthorizationRuleProperties
--------------------------------------------------------------------------------------------
+SharedAccessAuthorizationRuleProperties{#SharedAccessAuthorizationRuleProperties}
+---------------------------------------------------------------------------------
 
 SharedAccessAuthorizationRule properties.
 
@@ -488,8 +488,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec), 
 |----------|---------------------------------------------------|-------------------------------------------------------------|
 | rights   | Gets or sets the rights associated with the rule. | [AccessRights[]](#AccessRights)<br/><small>Required</small> |
 
-<a id="SharedAccessAuthorizationRuleProperties_STATUS"></a>SharedAccessAuthorizationRuleProperties_STATUS
----------------------------------------------------------------------------------------------------------
+SharedAccessAuthorizationRuleProperties_STATUS{#SharedAccessAuthorizationRuleProperties_STATUS}
+-----------------------------------------------------------------------------------------------
 
 SharedAccessAuthorizationRule properties.
 
@@ -505,8 +505,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | revision     | Gets the revision number for the rule                | int<br/><small>Optional</small>                                           |
 | rights       | Gets or sets the rights associated with the rule.    | [AccessRights_STATUS[]](#AccessRights_STATUS)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The Sku description for a namespace
 
@@ -520,8 +520,8 @@ Used by: [Namespace_Spec](#Namespace_Spec), and [NotificationHub_Spec](#Notifica
 | size     | Gets or sets the Sku size                 | string<br/><small>Optional</small>              |
 | tier     | Gets or sets the tier of particular sku   | string<br/><small>Optional</small>              |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The Sku description for a namespace
 
@@ -535,8 +535,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), and [NotificationHub_STATUS](#No
 | size     | Gets or sets the Sku size                 | string<br/><small>Optional</small>                            |
 | tier     | Gets or sets the tier of particular sku   | string<br/><small>Optional</small>                            |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -551,8 +551,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="AccessRights"></a>AccessRights
--------------------------------------
+AccessRights{#AccessRights}
+---------------------------
 
 Defines values for AccessRights.
 
@@ -564,8 +564,8 @@ Used by: [IpRule](#IpRule), [PublicInternetAuthorizationRule](#PublicInternetAut
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="AccessRights_STATUS"></a>AccessRights_STATUS
----------------------------------------------------
+AccessRights_STATUS{#AccessRights_STATUS}
+-----------------------------------------
 
 Defines values for AccessRights.
 
@@ -577,8 +577,8 @@ Used by: [IpRule_STATUS](#IpRule_STATUS), [PublicInternetAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="AdmCredential"></a>AdmCredential
----------------------------------------
+AdmCredential{#AdmCredential}
+-----------------------------
 
 Description of a NotificationHub AdmCredential.
 
@@ -588,8 +588,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|-------------------------------------------------|---------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub AdmCredential. | [AdmCredentialProperties](#AdmCredentialProperties)<br/><small>Required</small> |
 
-<a id="AdmCredential_STATUS"></a>AdmCredential_STATUS
------------------------------------------------------
+AdmCredential_STATUS{#AdmCredential_STATUS}
+-------------------------------------------
 
 Description of a NotificationHub AdmCredential.
 
@@ -599,8 +599,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|-------------------------------------------------|------------------------------------------------------------|
 | properties | Description of a NotificationHub AdmCredential. | AdmCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="ApnsCredential"></a>ApnsCredential
------------------------------------------
+ApnsCredential{#ApnsCredential}
+-------------------------------
 
 Description of a NotificationHub ApnsCredential.
 
@@ -610,8 +610,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|--------------------------------------------------|-----------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub ApnsCredential. | [ApnsCredentialProperties](#ApnsCredentialProperties)<br/><small>Required</small> |
 
-<a id="ApnsCredential_STATUS"></a>ApnsCredential_STATUS
--------------------------------------------------------
+ApnsCredential_STATUS{#ApnsCredential_STATUS}
+---------------------------------------------
 
 Description of a NotificationHub ApnsCredential.
 
@@ -621,8 +621,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|--------------------------------------------------|-------------------------------------------------------------|
 | properties | Description of a NotificationHub ApnsCredential. | ApnsCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="BaiduCredential"></a>BaiduCredential
--------------------------------------------
+BaiduCredential{#BaiduCredential}
+---------------------------------
 
 Description of a NotificationHub BaiduCredential.
 
@@ -632,8 +632,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|---------------------------------------------------|-------------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub BaiduCredential. | [BaiduCredentialProperties](#BaiduCredentialProperties)<br/><small>Required</small> |
 
-<a id="BaiduCredential_STATUS"></a>BaiduCredential_STATUS
----------------------------------------------------------
+BaiduCredential_STATUS{#BaiduCredential_STATUS}
+-----------------------------------------------
 
 Description of a NotificationHub BaiduCredential.
 
@@ -643,8 +643,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|---------------------------------------------------|--------------------------------------------------------------|
 | properties | Description of a NotificationHub BaiduCredential. | BaiduCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="BrowserCredential"></a>BrowserCredential
------------------------------------------------
+BrowserCredential{#BrowserCredential}
+-------------------------------------
 
 Description of a NotificationHub BrowserCredential.
 
@@ -654,8 +654,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub BrowserCredential. | [BrowserCredentialProperties](#BrowserCredentialProperties)<br/><small>Required</small> |
 
-<a id="BrowserCredential_STATUS"></a>BrowserCredential_STATUS
--------------------------------------------------------------
+BrowserCredential_STATUS{#BrowserCredential_STATUS}
+---------------------------------------------------
 
 Description of a NotificationHub BrowserCredential.
 
@@ -665,8 +665,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|-----------------------------------------------------|----------------------------------------------------------------|
 | properties | Description of a NotificationHub BrowserCredential. | BrowserCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="GcmCredential"></a>GcmCredential
----------------------------------------
+GcmCredential{#GcmCredential}
+-----------------------------
 
 Description of a NotificationHub GcmCredential.
 
@@ -676,8 +676,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|-------------------------------------------------|---------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub GcmCredential. | [GcmCredentialProperties](#GcmCredentialProperties)<br/><small>Required</small> |
 
-<a id="GcmCredential_STATUS"></a>GcmCredential_STATUS
------------------------------------------------------
+GcmCredential_STATUS{#GcmCredential_STATUS}
+-------------------------------------------
 
 Description of a NotificationHub GcmCredential.
 
@@ -687,8 +687,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|-------------------------------------------------|------------------------------------------------------------|
 | properties | Description of a NotificationHub GcmCredential. | GcmCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="MpnsCredential"></a>MpnsCredential
------------------------------------------
+MpnsCredential{#MpnsCredential}
+-------------------------------
 
 Description of a NotificationHub MpnsCredential.
 
@@ -698,8 +698,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|--------------------------------------------------|-----------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub MpnsCredential. | [MpnsCredentialProperties](#MpnsCredentialProperties)<br/><small>Required</small> |
 
-<a id="MpnsCredential_STATUS"></a>MpnsCredential_STATUS
--------------------------------------------------------
+MpnsCredential_STATUS{#MpnsCredential_STATUS}
+---------------------------------------------
 
 Description of a NotificationHub MpnsCredential.
 
@@ -709,8 +709,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|--------------------------------------------------|-------------------------------------------------------------|
 | properties | Description of a NotificationHub MpnsCredential. | MpnsCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorConfigMaps"></a>NamespaceOperatorConfigMaps
--------------------------------------------------------------------
+NamespaceOperatorConfigMaps{#NamespaceOperatorConfigMaps}
+---------------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -718,8 +718,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 |--------------------|----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | serviceBusEndpoint | indicates where the ServiceBusEndpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -730,8 +730,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespaceStatus_STATUS"></a>NamespaceStatus_STATUS
----------------------------------------------------------
+NamespaceStatus_STATUS{#NamespaceStatus_STATUS}
+-----------------------------------------------
 
 Namespace status.
 
@@ -744,8 +744,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | "Deleting"  |             |
 | "Suspended" |             |
 
-<a id="NamespaceType"></a>NamespaceType
----------------------------------------
+NamespaceType{#NamespaceType}
+-----------------------------
 
 Defines values for NamespaceType.
 
@@ -756,8 +756,8 @@ Used by: [NamespaceProperties](#NamespaceProperties).
 | "Messaging"       |             |
 | "NotificationHub" |             |
 
-<a id="NamespaceType_STATUS"></a>NamespaceType_STATUS
------------------------------------------------------
+NamespaceType_STATUS{#NamespaceType_STATUS}
+-------------------------------------------
 
 Defines values for NamespaceType.
 
@@ -768,8 +768,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | "Messaging"       |             |
 | "NotificationHub" |             |
 
-<a id="NetworkAcls"></a>NetworkAcls
------------------------------------
+NetworkAcls{#NetworkAcls}
+-------------------------
 
 A collection of network authorization rules.
 
@@ -780,8 +780,8 @@ Used by: [NamespaceProperties](#NamespaceProperties).
 | ipRules           | List of IP rules.                                                                                               | [IpRule[]](#IpRule)<br/><small>Optional</small>                                                 |
 | publicNetworkRule | A default (public Internet) network authorization rule, which contains rights if no other network rule matches. | [PublicInternetAuthorizationRule](#PublicInternetAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NetworkAcls_STATUS"></a>NetworkAcls_STATUS
--------------------------------------------------
+NetworkAcls_STATUS{#NetworkAcls_STATUS}
+---------------------------------------
 
 A collection of network authorization rules.
 
@@ -792,8 +792,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | ipRules           | List of IP rules.                                                                                               | [IpRule_STATUS[]](#IpRule_STATUS)<br/><small>Optional</small>                                                 |
 | publicNetworkRule | A default (public Internet) network authorization rule, which contains rights if no other network rule matches. | [PublicInternetAuthorizationRule_STATUS](#PublicInternetAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-<a id="NotificationHubOperatorSecrets"></a>NotificationHubOperatorSecrets
--------------------------------------------------------------------------
+NotificationHubOperatorSecrets{#NotificationHubOperatorSecrets}
+---------------------------------------------------------------
 
 Used by: [NotificationHubOperatorSpec](#NotificationHubOperatorSpec).
 
@@ -804,8 +804,8 @@ Used by: [NotificationHubOperatorSpec](#NotificationHubOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="OperationProvisioningState_STATUS"></a>OperationProvisioningState_STATUS
--------------------------------------------------------------------------------
+OperationProvisioningState_STATUS{#OperationProvisioningState_STATUS}
+---------------------------------------------------------------------
 
 Defines values for OperationProvisioningState.
 
@@ -821,8 +821,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | "Succeeded"  |             |
 | "Unknown"    |             |
 
-<a id="PnsCredentials"></a>PnsCredentials
------------------------------------------
+PnsCredentials{#PnsCredentials}
+-------------------------------
 
 Collection of Notification Hub or Notification Hub Namespace PNS credentials.
 
@@ -839,8 +839,8 @@ Used by: [NamespaceProperties](#NamespaceProperties).
 | wnsCredential     | Description of a NotificationHub WnsCredential.     | [WnsCredential](#WnsCredential)<br/><small>Optional</small>         |
 | xiaomiCredential  | Description of a NotificationHub XiaomiCredential.  | [XiaomiCredential](#XiaomiCredential)<br/><small>Optional</small>   |
 
-<a id="PnsCredentials_STATUS"></a>PnsCredentials_STATUS
--------------------------------------------------------
+PnsCredentials_STATUS{#PnsCredentials_STATUS}
+---------------------------------------------
 
 Collection of Notification Hub or Notification Hub Namespace PNS credentials.
 
@@ -857,8 +857,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | wnsCredential     | Description of a NotificationHub WnsCredential.     | [WnsCredential_STATUS](#WnsCredential_STATUS)<br/><small>Optional</small>         |
 | xiaomiCredential  | Description of a NotificationHub XiaomiCredential.  | [XiaomiCredential_STATUS](#XiaomiCredential_STATUS)<br/><small>Optional</small>   |
 
-<a id="PrivateEndpointConnectionResource_STATUS"></a>PrivateEndpointConnectionResource_STATUS
----------------------------------------------------------------------------------------------
+PrivateEndpointConnectionResource_STATUS{#PrivateEndpointConnectionResource_STATUS}
+-----------------------------------------------------------------------------------
 
 Represents a Private Endpoint Connection ARM resource - a sub-resource of Notification Hubs namespace.
 
@@ -868,51 +868,51 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccess"></a>PublicNetworkAccess
+PublicNetworkAccess{#PublicNetworkAccess}
+-----------------------------------------
+
+Type of public network access.
+
+Used by: [NamespaceProperties](#NamespaceProperties).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+PublicNetworkAccess_STATUS{#PublicNetworkAccess_STATUS}
+-------------------------------------------------------
+
+Type of public network access.
+
+Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
+
+| Value      | Description |
+|------------|-------------|
+| "Disabled" |             |
+| "Enabled"  |             |
+
+ReplicationRegion{#ReplicationRegion}
+-------------------------------------
+
+Allowed replication region
+
+Used by: [NamespaceProperties](#NamespaceProperties).
+
+| Value              | Description |
+|--------------------|-------------|
+| "AustraliaEast"    |             |
+| "BrazilSouth"      |             |
+| "Default"          |             |
+| "None"             |             |
+| "NorthEurope"      |             |
+| "SouthAfricaNorth" |             |
+| "SouthEastAsia"    |             |
+| "WestUs2"          |             |
+
+ReplicationRegion_STATUS{#ReplicationRegion_STATUS}
 ---------------------------------------------------
 
-Type of public network access.
-
-Used by: [NamespaceProperties](#NamespaceProperties).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="PublicNetworkAccess_STATUS"></a>PublicNetworkAccess_STATUS
------------------------------------------------------------------
-
-Type of public network access.
-
-Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
-
-| Value      | Description |
-|------------|-------------|
-| "Disabled" |             |
-| "Enabled"  |             |
-
-<a id="ReplicationRegion"></a>ReplicationRegion
------------------------------------------------
-
-Allowed replication region
-
-Used by: [NamespaceProperties](#NamespaceProperties).
-
-| Value              | Description |
-|--------------------|-------------|
-| "AustraliaEast"    |             |
-| "BrazilSouth"      |             |
-| "Default"          |             |
-| "None"             |             |
-| "NorthEurope"      |             |
-| "SouthAfricaNorth" |             |
-| "SouthEastAsia"    |             |
-| "WestUs2"          |             |
-
-<a id="ReplicationRegion_STATUS"></a>ReplicationRegion_STATUS
--------------------------------------------------------------
-
 Allowed replication region
 
 Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
@@ -928,8 +928,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | "SouthEastAsia"    |             |
 | "WestUs2"          |             |
 
-<a id="SkuName"></a>SkuName
----------------------------
+SkuName{#SkuName}
+-----------------
 
 Namespace SKU name.
 
@@ -941,8 +941,8 @@ Used by: [Sku](#Sku).
 | "Free"     |             |
 | "Standard" |             |
 
-<a id="SkuName_STATUS"></a>SkuName_STATUS
------------------------------------------
+SkuName_STATUS{#SkuName_STATUS}
+-------------------------------
 
 Namespace SKU name.
 
@@ -954,7 +954,19 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Free"     |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -966,20 +978,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="WnsCredential"></a>WnsCredential
----------------------------------------
+WnsCredential{#WnsCredential}
+-----------------------------
 
 Description of a NotificationHub WnsCredential.
 
@@ -989,8 +989,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|-------------------------------------------------|---------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub WnsCredential. | [WnsCredentialProperties](#WnsCredentialProperties)<br/><small>Required</small> |
 
-<a id="WnsCredential_STATUS"></a>WnsCredential_STATUS
------------------------------------------------------
+WnsCredential_STATUS{#WnsCredential_STATUS}
+-------------------------------------------
 
 Description of a NotificationHub WnsCredential.
 
@@ -1000,8 +1000,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|-------------------------------------------------|------------------------------------------------------------|
 | properties | Description of a NotificationHub WnsCredential. | WnsCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="XiaomiCredential"></a>XiaomiCredential
----------------------------------------------
+XiaomiCredential{#XiaomiCredential}
+-----------------------------------
 
 Description of a NotificationHub XiaomiCredential.
 
@@ -1011,8 +1011,8 @@ Used by: [NotificationHubProperties](#NotificationHubProperties), and [PnsCreden
 |------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | properties | Description of a NotificationHub XiaomiCredentialProperties. | [XiaomiCredentialProperties](#XiaomiCredentialProperties)<br/><small>Required</small> |
 
-<a id="XiaomiCredential_STATUS"></a>XiaomiCredential_STATUS
------------------------------------------------------------
+XiaomiCredential_STATUS{#XiaomiCredential_STATUS}
+-------------------------------------------------
 
 Description of a NotificationHub XiaomiCredential.
 
@@ -1022,8 +1022,8 @@ Used by: [NotificationHubProperties_STATUS](#NotificationHubProperties_STATUS), 
 |------------|--------------------------------------------------------------|---------------------------------------------------------------|
 | properties | Description of a NotificationHub XiaomiCredentialProperties. | XiaomiCredentialProperties_STATUS<br/><small>Optional</small> |
 
-<a id="ZoneRedundancyPreference"></a>ZoneRedundancyPreference
--------------------------------------------------------------
+ZoneRedundancyPreference{#ZoneRedundancyPreference}
+---------------------------------------------------
 
 Namespace SKU name.
 
@@ -1034,8 +1034,8 @@ Used by: [NamespaceProperties](#NamespaceProperties).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ZoneRedundancyPreference_STATUS"></a>ZoneRedundancyPreference_STATUS
----------------------------------------------------------------------------
+ZoneRedundancyPreference_STATUS{#ZoneRedundancyPreference_STATUS}
+-----------------------------------------------------------------
 
 Namespace SKU name.
 
@@ -1046,8 +1046,8 @@ Used by: [NamespaceProperties_STATUS](#NamespaceProperties_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="AdmCredentialProperties"></a>AdmCredentialProperties
------------------------------------------------------------
+AdmCredentialProperties{#AdmCredentialProperties}
+-------------------------------------------------
 
 Description of a NotificationHub AdmCredential.
 
@@ -1059,8 +1059,8 @@ Used by: [AdmCredential](#AdmCredential).
 | clientId     | Gets or sets the client identifier.              | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 | clientSecret | Gets or sets the credential secret access key.   | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 
-<a id="ApnsCredentialProperties"></a>ApnsCredentialProperties
--------------------------------------------------------------
+ApnsCredentialProperties{#ApnsCredentialProperties}
+---------------------------------------------------
 
 Description of a NotificationHub ApnsCredential.
 
@@ -1077,8 +1077,8 @@ Used by: [ApnsCredential](#ApnsCredential).
 | thumbprint      | Gets or sets the APNS certificate Thumbprint                                                                                       | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | token           | Gets or sets provider Authentication Token, obtained through your developer account                                                | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="BaiduCredentialProperties"></a>BaiduCredentialProperties
----------------------------------------------------------------
+BaiduCredentialProperties{#BaiduCredentialProperties}
+-----------------------------------------------------
 
 Description of a NotificationHub BaiduCredential.
 
@@ -1090,8 +1090,8 @@ Used by: [BaiduCredential](#BaiduCredential).
 | baiduEndPoint  | Gets or sets baidu Endpoint.  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 | baiduSecretKey | Gets or sets baidu Secret Key | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 
-<a id="BrowserCredentialProperties"></a>BrowserCredentialProperties
--------------------------------------------------------------------
+BrowserCredentialProperties{#BrowserCredentialProperties}
+---------------------------------------------------------
 
 Description of a NotificationHub BrowserCredential.
 
@@ -1103,8 +1103,8 @@ Used by: [BrowserCredential](#BrowserCredential).
 | vapidPrivateKey | Gets or sets VAPID private key. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 | vapidPublicKey  | Gets or sets VAPID public key.  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 
-<a id="GcmCredentialProperties"></a>GcmCredentialProperties
------------------------------------------------------------
+GcmCredentialProperties{#GcmCredentialProperties}
+-------------------------------------------------
 
 Description of a NotificationHub GcmCredential.
 
@@ -1115,8 +1115,8 @@ Used by: [GcmCredential](#GcmCredential).
 | gcmEndpoint  | Gets or sets the GCM endpoint.   | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | googleApiKey | Gets or sets the Google API key. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 
-<a id="IpRule"></a>IpRule
--------------------------
+IpRule{#IpRule}
+---------------
 
 A network authorization rule that filters traffic based on IP address.
 
@@ -1127,8 +1127,8 @@ Used by: [NetworkAcls](#NetworkAcls).
 | ipMask   | IP mask.               | string<br/><small>Required</small>                          |
 | rights   | List of access rights. | [AccessRights[]](#AccessRights)<br/><small>Required</small> |
 
-<a id="IpRule_STATUS"></a>IpRule_STATUS
----------------------------------------
+IpRule_STATUS{#IpRule_STATUS}
+-----------------------------
 
 A network authorization rule that filters traffic based on IP address.
 
@@ -1139,8 +1139,8 @@ Used by: [NetworkAcls_STATUS](#NetworkAcls_STATUS).
 | ipMask   | IP mask.               | string<br/><small>Optional</small>                                        |
 | rights   | List of access rights. | [AccessRights_STATUS[]](#AccessRights_STATUS)<br/><small>Optional</small> |
 
-<a id="MpnsCredentialProperties"></a>MpnsCredentialProperties
--------------------------------------------------------------
+MpnsCredentialProperties{#MpnsCredentialProperties}
+---------------------------------------------------
 
 Description of a NotificationHub MpnsCredential.
 
@@ -1152,8 +1152,8 @@ Used by: [MpnsCredential](#MpnsCredential).
 | mpnsCertificate | Gets or sets the MPNS certificate.                    | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 | thumbprint      | Gets or sets the MPNS certificate Thumbprint          | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Required</small> |
 
-<a id="PublicInternetAuthorizationRule"></a>PublicInternetAuthorizationRule
----------------------------------------------------------------------------
+PublicInternetAuthorizationRule{#PublicInternetAuthorizationRule}
+-----------------------------------------------------------------
 
 A default (public Internet) network authorization rule, which contains rights if no other network rule matches.
 
@@ -1163,8 +1163,8 @@ Used by: [NetworkAcls](#NetworkAcls).
 |----------|------------------------|-------------------------------------------------------------|
 | rights   | List of access rights. | [AccessRights[]](#AccessRights)<br/><small>Required</small> |
 
-<a id="PublicInternetAuthorizationRule_STATUS"></a>PublicInternetAuthorizationRule_STATUS
------------------------------------------------------------------------------------------
+PublicInternetAuthorizationRule_STATUS{#PublicInternetAuthorizationRule_STATUS}
+-------------------------------------------------------------------------------
 
 A default (public Internet) network authorization rule, which contains rights if no other network rule matches.
 
@@ -1174,8 +1174,8 @@ Used by: [NetworkAcls_STATUS](#NetworkAcls_STATUS).
 |----------|------------------------|---------------------------------------------------------------------------|
 | rights   | List of access rights. | [AccessRights_STATUS[]](#AccessRights_STATUS)<br/><small>Optional</small> |
 
-<a id="WnsCredentialProperties"></a>WnsCredentialProperties
------------------------------------------------------------
+WnsCredentialProperties{#WnsCredentialProperties}
+-------------------------------------------------
 
 Description of a NotificationHub WnsCredential.
 
@@ -1189,8 +1189,8 @@ Used by: [WnsCredential](#WnsCredential).
 | windowsLiveEndpoint | Gets or sets the Windows Live endpoint.          | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 | wnsCertificate      | Gets or sets the WNS Certificate.                | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small> |
 
-<a id="XiaomiCredentialProperties"></a>XiaomiCredentialProperties
------------------------------------------------------------------
+XiaomiCredentialProperties{#XiaomiCredentialProperties}
+-------------------------------------------------------
 
 Description of a NotificationHub XiaomiCredentialProperties.
 

--- a/docs/hugo/content/reference/operationalinsights/v1api20210601.md
+++ b/docs/hugo/content/reference/operationalinsights/v1api20210601.md
@@ -5,15 +5,15 @@ title: operationalinsights.azure.com/v1api20210601
 linktitle: v1api20210601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-06-01" |             |
 
-<a id="Workspace"></a>Workspace
--------------------------------
+Workspace{#Workspace}
+---------------------
 
 Generator information: - Generated from: /operationalinsights/resource-manager/Microsoft.OperationalInsights/stable/2021-06-01/Workspaces.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/{workspaceName}
 
@@ -26,7 +26,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | spec                                                                                    |             | [Workspace_Spec](#Workspace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Workspace_STATUS](#Workspace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Workspace_Spec"></a>Workspace_Spec
+### Workspace_Spec {#Workspace_Spec}
 
 | Property                        | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | tags                            | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workspaceCapping                | The daily volume cap for ingestion.                                                                                                                                                                                                                                                          | [WorkspaceCapping](#WorkspaceCapping)<br/><small>Optional</small>                                                                                                    |
 
-### <a id="Workspace_STATUS"></a>Workspace_STATUS
+### Workspace_STATUS{#Workspace_STATUS}
 
 | Property                        | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,8 +69,8 @@ Used by: [WorkspaceList](#WorkspaceList).
 | type                            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceCapping                | The daily volume cap for ingestion.                                                                                                                                                                                                                                                                                       | [WorkspaceCapping_STATUS](#WorkspaceCapping_STATUS)<br/><small>Optional</small>                                                                         |
 
-<a id="WorkspaceList"></a>WorkspaceList
----------------------------------------
+WorkspaceList{#WorkspaceList}
+-----------------------------
 
 Generator information: - Generated from: /operationalinsights/resource-manager/Microsoft.OperationalInsights/stable/2021-06-01/Workspaces.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.OperationalInsights/workspaces/{workspaceName}
 
@@ -80,8 +80,8 @@ Generator information: - Generated from: /operationalinsights/resource-manager/M
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Workspace[]](#Workspace)<br/><small>Optional</small> |
 
-<a id="Workspace_Spec"></a>Workspace_Spec
------------------------------------------
+Workspace_Spec{#Workspace_Spec}
+-------------------------------
 
 Used by: [Workspace](#Workspace).
 
@@ -102,8 +102,8 @@ Used by: [Workspace](#Workspace).
 | tags                            | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workspaceCapping                | The daily volume cap for ingestion.                                                                                                                                                                                                                                                          | [WorkspaceCapping](#WorkspaceCapping)<br/><small>Optional</small>                                                                                                    |
 
-<a id="Workspace_STATUS"></a>Workspace_STATUS
----------------------------------------------
+Workspace_STATUS{#Workspace_STATUS}
+-----------------------------------
 
 The top level Workspace resource container.
 
@@ -131,8 +131,8 @@ Used by: [Workspace](#Workspace).
 | type                            | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceCapping                | The daily volume cap for ingestion.                                                                                                                                                                                                                                                                                       | [WorkspaceCapping_STATUS](#WorkspaceCapping_STATUS)<br/><small>Optional</small>                                                                         |
 
-<a id="PrivateLinkScopedResource_STATUS"></a>PrivateLinkScopedResource_STATUS
------------------------------------------------------------------------------
+PrivateLinkScopedResource_STATUS{#PrivateLinkScopedResource_STATUS}
+-------------------------------------------------------------------
 
 The private link scope resource reference.
 
@@ -143,8 +143,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | resourceId | The full resource Id of the private link scope resource. | string<br/><small>Optional</small> |
 | scopeId    | The private link scope unique Identifier.                | string<br/><small>Optional</small> |
 
-<a id="PublicNetworkAccessType"></a>PublicNetworkAccessType
------------------------------------------------------------
+PublicNetworkAccessType{#PublicNetworkAccessType}
+-------------------------------------------------
 
 The network access type for operating on the Log Analytics Workspace. By default it is Enabled
 
@@ -155,8 +155,8 @@ Used by: [Workspace_Spec](#Workspace_Spec), and [Workspace_Spec](#Workspace_Spec
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PublicNetworkAccessType_STATUS"></a>PublicNetworkAccessType_STATUS
--------------------------------------------------------------------------
+PublicNetworkAccessType_STATUS{#PublicNetworkAccessType_STATUS}
+---------------------------------------------------------------
 
 The network access type for operating on the Log Analytics Workspace. By default it is Enabled
 
@@ -167,8 +167,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS), and [Workspace_STATUS](#Workspac
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspaceCapping"></a>WorkspaceCapping
----------------------------------------------
+WorkspaceCapping{#WorkspaceCapping}
+-----------------------------------
 
 The daily volume cap for ingestion.
 
@@ -178,8 +178,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |--------------|------------------------------------------|-------------------------------------|
 | dailyQuotaGb | The workspace daily quota for ingestion. | float64<br/><small>Optional</small> |
 
-<a id="WorkspaceCapping_STATUS"></a>WorkspaceCapping_STATUS
------------------------------------------------------------
+WorkspaceCapping_STATUS{#WorkspaceCapping_STATUS}
+-------------------------------------------------
 
 The daily volume cap for ingestion.
 
@@ -191,8 +191,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | dataIngestionStatus | The status of data ingestion for this workspace. | [WorkspaceCapping_DataIngestionStatus_STATUS](#WorkspaceCapping_DataIngestionStatus_STATUS)<br/><small>Optional</small> |
 | quotaNextResetTime  | The time when the quota will be rest.            | string<br/><small>Optional</small>                                                                                      |
 
-<a id="WorkspaceFeatures"></a>WorkspaceFeatures
------------------------------------------------
+WorkspaceFeatures{#WorkspaceFeatures}
+-------------------------------------
 
 Workspace features.
 
@@ -206,8 +206,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | enableLogAccessUsingOnlyResourcePermissions | Flag that indicate which permission to use - resource or workspace or both. | bool<br/><small>Optional</small>                                                                                                                           |
 | immediatePurgeDataOn30Days                  | Flag that describes if we want to remove the data after 30 days.            | bool<br/><small>Optional</small>                                                                                                                           |
 
-<a id="WorkspaceFeatures_STATUS"></a>WorkspaceFeatures_STATUS
--------------------------------------------------------------
+WorkspaceFeatures_STATUS{#WorkspaceFeatures_STATUS}
+---------------------------------------------------
 
 Workspace features.
 
@@ -221,8 +221,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | enableLogAccessUsingOnlyResourcePermissions | Flag that indicate which permission to use - resource or workspace or both. | bool<br/><small>Optional</small>   |
 | immediatePurgeDataOn30Days                  | Flag that describes if we want to remove the data after 30 days.            | bool<br/><small>Optional</small>   |
 
-<a id="WorkspaceOperatorSpec"></a>WorkspaceOperatorSpec
--------------------------------------------------------
+WorkspaceOperatorSpec{#WorkspaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -233,8 +233,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WorkspaceProperties_ProvisioningState"></a>WorkspaceProperties_ProvisioningState
----------------------------------------------------------------------------------------
+WorkspaceProperties_ProvisioningState{#WorkspaceProperties_ProvisioningState}
+-----------------------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -248,8 +248,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | "Succeeded"           |             |
 | "Updating"            |             |
 
-<a id="WorkspaceProperties_ProvisioningState_STATUS"></a>WorkspaceProperties_ProvisioningState_STATUS
------------------------------------------------------------------------------------------------------
+WorkspaceProperties_ProvisioningState_STATUS{#WorkspaceProperties_ProvisioningState_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -263,8 +263,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Succeeded"           |             |
 | "Updating"            |             |
 
-<a id="WorkspaceSku"></a>WorkspaceSku
--------------------------------------
+WorkspaceSku{#WorkspaceSku}
+---------------------------
 
 The SKU (tier) of a workspace.
 
@@ -275,8 +275,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | capacityReservationLevel | The capacity reservation level in GB for this workspace, when CapacityReservation sku is selected. | [WorkspaceSku_CapacityReservationLevel](#WorkspaceSku_CapacityReservationLevel)<br/><small>Optional</small> |
 | name                     | The name of the SKU.                                                                               | [WorkspaceSku_Name](#WorkspaceSku_Name)<br/><small>Required</small>                                         |
 
-<a id="WorkspaceSku_STATUS"></a>WorkspaceSku_STATUS
----------------------------------------------------
+WorkspaceSku_STATUS{#WorkspaceSku_STATUS}
+-----------------------------------------
 
 The SKU (tier) of a workspace.
 
@@ -288,8 +288,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | lastSkuUpdate            | The last time when the sku was updated.                                                            | string<br/><small>Optional</small>                                                                                        |
 | name                     | The name of the SKU.                                                                               | [WorkspaceSku_Name_STATUS](#WorkspaceSku_Name_STATUS)<br/><small>Optional</small>                                         |
 
-<a id="WorkspaceCapping_DataIngestionStatus_STATUS"></a>WorkspaceCapping_DataIngestionStatus_STATUS
----------------------------------------------------------------------------------------------------
+WorkspaceCapping_DataIngestionStatus_STATUS{#WorkspaceCapping_DataIngestionStatus_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [WorkspaceCapping_STATUS](#WorkspaceCapping_STATUS).
 
@@ -302,8 +302,8 @@ Used by: [WorkspaceCapping_STATUS](#WorkspaceCapping_STATUS).
 | "RespectQuota"          |             |
 | "SubscriptionSuspended" |             |
 
-<a id="WorkspaceSku_CapacityReservationLevel"></a>WorkspaceSku_CapacityReservationLevel
----------------------------------------------------------------------------------------
+WorkspaceSku_CapacityReservationLevel{#WorkspaceSku_CapacityReservationLevel}
+-----------------------------------------------------------------------------
 
 Used by: [WorkspaceSku](#WorkspaceSku).
 
@@ -318,8 +318,8 @@ Used by: [WorkspaceSku](#WorkspaceSku).
 | 2000  |             |
 | 5000  |             |
 
-<a id="WorkspaceSku_CapacityReservationLevel_STATUS"></a>WorkspaceSku_CapacityReservationLevel_STATUS
------------------------------------------------------------------------------------------------------
+WorkspaceSku_CapacityReservationLevel_STATUS{#WorkspaceSku_CapacityReservationLevel_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [WorkspaceSku_STATUS](#WorkspaceSku_STATUS).
 
@@ -334,8 +334,8 @@ Used by: [WorkspaceSku_STATUS](#WorkspaceSku_STATUS).
 | 2000  |             |
 | 5000  |             |
 
-<a id="WorkspaceSku_Name"></a>WorkspaceSku_Name
------------------------------------------------
+WorkspaceSku_Name{#WorkspaceSku_Name}
+-------------------------------------
 
 Used by: [WorkspaceSku](#WorkspaceSku).
 
@@ -350,8 +350,8 @@ Used by: [WorkspaceSku](#WorkspaceSku).
 | "Standalone"          |             |
 | "Standard"            |             |
 
-<a id="WorkspaceSku_Name_STATUS"></a>WorkspaceSku_Name_STATUS
--------------------------------------------------------------
+WorkspaceSku_Name_STATUS{#WorkspaceSku_Name_STATUS}
+---------------------------------------------------
 
 Used by: [WorkspaceSku_STATUS](#WorkspaceSku_STATUS).
 

--- a/docs/hugo/content/reference/redhatopenshift/v1api20231122.md
+++ b/docs/hugo/content/reference/redhatopenshift/v1api20231122.md
@@ -5,15 +5,15 @@ title: redhatopenshift.azure.com/v1api20231122
 linktitle: v1api20231122
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-11-22" |             |
 
-<a id="OpenShiftCluster"></a>OpenShiftCluster
----------------------------------------------
+OpenShiftCluster{#OpenShiftCluster}
+-----------------------------------
 
 Generator information: - Generated from: /redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/openshiftclusters/stable/2023-11-22/redhatopenshift.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [OpenShiftClusterList](#OpenShiftClusterList).
 | spec                                                                                    |             | [OpenShiftCluster_Spec](#OpenShiftCluster_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS)<br/><small>Optional</small> |
 
-### <a id="OpenShiftCluster_Spec"></a>OpenShiftCluster_Spec
+### OpenShiftCluster_Spec {#OpenShiftCluster_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -43,7 +43,7 @@ Used by: [OpenShiftClusterList](#OpenShiftClusterList).
 | tags                    | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workerProfiles          | The cluster worker profiles.                                                                                                                                                                                                                                                                 | [WorkerProfile[]](#WorkerProfile)<br/><small>Optional</small>                                                                                                        |
 
-### <a id="OpenShiftCluster_STATUS"></a>OpenShiftCluster_STATUS
+### OpenShiftCluster_STATUS{#OpenShiftCluster_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -65,8 +65,8 @@ Used by: [OpenShiftClusterList](#OpenShiftClusterList).
 | workerProfiles          | The cluster worker profiles.                                                                                                                                                                                                                                                                                              | [WorkerProfile_STATUS[]](#WorkerProfile_STATUS)<br/><small>Optional</small>                                                                             |
 | workerProfilesStatus    | The cluster worker profiles status.                                                                                                                                                                                                                                                                                       | [WorkerProfile_STATUS[]](#WorkerProfile_STATUS)<br/><small>Optional</small>                                                                             |
 
-<a id="OpenShiftClusterList"></a>OpenShiftClusterList
------------------------------------------------------
+OpenShiftClusterList{#OpenShiftClusterList}
+-------------------------------------------
 
 Generator information: - Generated from: /redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/openshiftclusters/stable/2023-11-22/redhatopenshift.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}
 
@@ -76,8 +76,8 @@ Generator information: - Generated from: /redhatopenshift/resource-manager/Micro
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                     |
 | items                                                                               |             | [OpenShiftCluster[]](#OpenShiftCluster)<br/><small>Optional</small> |
 
-<a id="OpenShiftCluster_Spec"></a>OpenShiftCluster_Spec
--------------------------------------------------------
+OpenShiftCluster_Spec{#OpenShiftCluster_Spec}
+---------------------------------------------
 
 Used by: [OpenShiftCluster](#OpenShiftCluster).
 
@@ -96,8 +96,8 @@ Used by: [OpenShiftCluster](#OpenShiftCluster).
 | tags                    | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | workerProfiles          | The cluster worker profiles.                                                                                                                                                                                                                                                                 | [WorkerProfile[]](#WorkerProfile)<br/><small>Optional</small>                                                                                                        |
 
-<a id="OpenShiftCluster_STATUS"></a>OpenShiftCluster_STATUS
------------------------------------------------------------
+OpenShiftCluster_STATUS{#OpenShiftCluster_STATUS}
+-------------------------------------------------
 
 OpenShiftCluster represents an Azure Red Hat OpenShift cluster.
 
@@ -123,8 +123,8 @@ Used by: [OpenShiftCluster](#OpenShiftCluster).
 | workerProfiles          | The cluster worker profiles.                                                                                                                                                                                                                                                                                              | [WorkerProfile_STATUS[]](#WorkerProfile_STATUS)<br/><small>Optional</small>                                                                             |
 | workerProfilesStatus    | The cluster worker profiles status.                                                                                                                                                                                                                                                                                       | [WorkerProfile_STATUS[]](#WorkerProfile_STATUS)<br/><small>Optional</small>                                                                             |
 
-<a id="APIServerProfile"></a>APIServerProfile
----------------------------------------------
+APIServerProfile{#APIServerProfile}
+-----------------------------------
 
 APIServerProfile represents an API server profile.
 
@@ -134,8 +134,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 |------------|------------------------|-------------------------------------------------------|
 | visibility | API server visibility. | [Visibility](#Visibility)<br/><small>Optional</small> |
 
-<a id="APIServerProfile_STATUS"></a>APIServerProfile_STATUS
------------------------------------------------------------
+APIServerProfile_STATUS{#APIServerProfile_STATUS}
+-------------------------------------------------
 
 APIServerProfile represents an API server profile.
 
@@ -147,8 +147,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | url        | The URL to access the cluster API server. | string<br/><small>Optional</small>                                  |
 | visibility | API server visibility.                    | [Visibility_STATUS](#Visibility_STATUS)<br/><small>Optional</small> |
 
-<a id="ClusterProfile"></a>ClusterProfile
------------------------------------------
+ClusterProfile{#ClusterProfile}
+-------------------------------
 
 ClusterProfile represents a cluster profile.
 
@@ -162,8 +162,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | resourceGroupId      | The ID of the cluster resource group.     | string<br/><small>Optional</small>                                                                                                                     |
 | version              | The version of the cluster.               | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="ClusterProfile_STATUS"></a>ClusterProfile_STATUS
--------------------------------------------------------
+ClusterProfile_STATUS{#ClusterProfile_STATUS}
+---------------------------------------------
 
 ClusterProfile represents a cluster profile.
 
@@ -176,8 +176,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | resourceGroupId      | The ID of the cluster resource group.     | string<br/><small>Optional</small>                                                      |
 | version              | The version of the cluster.               | string<br/><small>Optional</small>                                                      |
 
-<a id="ConsoleProfile_STATUS"></a>ConsoleProfile_STATUS
--------------------------------------------------------
+ConsoleProfile_STATUS{#ConsoleProfile_STATUS}
+---------------------------------------------
 
 ConsoleProfile represents a console profile.
 
@@ -187,8 +187,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 |----------|----------------------------------------|------------------------------------|
 | url      | The URL to access the cluster console. | string<br/><small>Optional</small> |
 
-<a id="IngressProfile"></a>IngressProfile
------------------------------------------
+IngressProfile{#IngressProfile}
+-------------------------------
 
 IngressProfile represents an ingress profile.
 
@@ -199,8 +199,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | name       | The ingress profile name. | string<br/><small>Optional</small>                    |
 | visibility | Ingress visibility.       | [Visibility](#Visibility)<br/><small>Optional</small> |
 
-<a id="IngressProfile_STATUS"></a>IngressProfile_STATUS
--------------------------------------------------------
+IngressProfile_STATUS{#IngressProfile_STATUS}
+---------------------------------------------
 
 IngressProfile represents an ingress profile.
 
@@ -212,8 +212,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | name       | The ingress profile name. | string<br/><small>Optional</small>                                  |
 | visibility | Ingress visibility.       | [Visibility_STATUS](#Visibility_STATUS)<br/><small>Optional</small> |
 
-<a id="MasterProfile"></a>MasterProfile
----------------------------------------
+MasterProfile{#MasterProfile}
+-----------------------------
 
 MasterProfile represents a master profile.
 
@@ -226,8 +226,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | subnetReference            | The Azure resource ID of the master subnet.                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | vmSize                     | The size of the master VMs.                                        | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="MasterProfile_STATUS"></a>MasterProfile_STATUS
------------------------------------------------------
+MasterProfile_STATUS{#MasterProfile_STATUS}
+-------------------------------------------
 
 MasterProfile represents a master profile.
 
@@ -240,8 +240,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | subnetId            | The Azure resource ID of the master subnet.                        | string<br/><small>Optional</small>                                              |
 | vmSize              | The size of the master VMs.                                        | string<br/><small>Optional</small>                                              |
 
-<a id="NetworkProfile"></a>NetworkProfile
------------------------------------------
+NetworkProfile{#NetworkProfile}
+-------------------------------
 
 NetworkProfile represents a network profile.
 
@@ -255,8 +255,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | preconfiguredNSG    | Specifies whether subnets are pre-attached with an NSG | [PreconfiguredNSG](#PreconfiguredNSG)<br/><small>Optional</small>       |
 | serviceCidr         | The CIDR used for OpenShift/Kubernetes Services.       | string<br/><small>Optional</small>                                      |
 
-<a id="NetworkProfile_STATUS"></a>NetworkProfile_STATUS
--------------------------------------------------------
+NetworkProfile_STATUS{#NetworkProfile_STATUS}
+---------------------------------------------
 
 NetworkProfile represents a network profile.
 
@@ -270,8 +270,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | preconfiguredNSG    | Specifies whether subnets are pre-attached with an NSG | [PreconfiguredNSG_STATUS](#PreconfiguredNSG_STATUS)<br/><small>Optional</small>       |
 | serviceCidr         | The CIDR used for OpenShift/Kubernetes Services.       | string<br/><small>Optional</small>                                                    |
 
-<a id="OpenShiftClusterOperatorSpec"></a>OpenShiftClusterOperatorSpec
----------------------------------------------------------------------
+OpenShiftClusterOperatorSpec{#OpenShiftClusterOperatorSpec}
+-----------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -282,8 +282,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 ProvisioningState represents a provisioning state.
 
@@ -299,8 +299,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | "Succeeded"     |             |
 | "Updating"      |             |
 
-<a id="ServicePrincipalProfile"></a>ServicePrincipalProfile
------------------------------------------------------------
+ServicePrincipalProfile{#ServicePrincipalProfile}
+-------------------------------------------------
 
 ServicePrincipalProfile represents a service principal profile.
 
@@ -312,8 +312,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | clientIdFromConfig | The client ID used for the cluster.     | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small> |
 | clientSecret       | The client secret used for the cluster. | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>       |
 
-<a id="ServicePrincipalProfile_STATUS"></a>ServicePrincipalProfile_STATUS
--------------------------------------------------------------------------
+ServicePrincipalProfile_STATUS{#ServicePrincipalProfile_STATUS}
+---------------------------------------------------------------
 
 ServicePrincipalProfile represents a service principal profile.
 
@@ -323,8 +323,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 |----------|-------------------------------------|------------------------------------|
 | clientId | The client ID used for the cluster. | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -339,8 +339,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="WorkerProfile"></a>WorkerProfile
----------------------------------------
+WorkerProfile{#WorkerProfile}
+-----------------------------
 
 WorkerProfile represents a worker profile.
 
@@ -356,8 +356,8 @@ Used by: [OpenShiftCluster_Spec](#OpenShiftCluster_Spec).
 | subnetReference            | The Azure resource ID of the worker subnet.                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | vmSize                     | The size of the worker VMs.                                        | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="WorkerProfile_STATUS"></a>WorkerProfile_STATUS
------------------------------------------------------
+WorkerProfile_STATUS{#WorkerProfile_STATUS}
+-------------------------------------------
 
 WorkerProfile represents a worker profile.
 
@@ -373,8 +373,8 @@ Used by: [OpenShiftCluster_STATUS](#OpenShiftCluster_STATUS), and [OpenShiftClus
 | subnetId            | The Azure resource ID of the worker subnet.                        | string<br/><small>Optional</small>                                              |
 | vmSize              | The size of the worker VMs.                                        | string<br/><small>Optional</small>                                              |
 
-<a id="EncryptionAtHost"></a>EncryptionAtHost
----------------------------------------------
+EncryptionAtHost{#EncryptionAtHost}
+-----------------------------------
 
 EncryptionAtHost represents encryption at host state
 
@@ -385,8 +385,8 @@ Used by: [MasterProfile](#MasterProfile), and [WorkerProfile](#WorkerProfile).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="EncryptionAtHost_STATUS"></a>EncryptionAtHost_STATUS
------------------------------------------------------------
+EncryptionAtHost_STATUS{#EncryptionAtHost_STATUS}
+-------------------------------------------------
 
 EncryptionAtHost represents encryption at host state
 
@@ -397,8 +397,8 @@ Used by: [MasterProfile_STATUS](#MasterProfile_STATUS), and [WorkerProfile_STATU
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FipsValidatedModules"></a>FipsValidatedModules
------------------------------------------------------
+FipsValidatedModules{#FipsValidatedModules}
+-------------------------------------------
 
 FipsValidatedModules determines if FIPS is used.
 
@@ -409,8 +409,8 @@ Used by: [ClusterProfile](#ClusterProfile).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FipsValidatedModules_STATUS"></a>FipsValidatedModules_STATUS
--------------------------------------------------------------------
+FipsValidatedModules_STATUS{#FipsValidatedModules_STATUS}
+---------------------------------------------------------
 
 FipsValidatedModules determines if FIPS is used.
 
@@ -421,8 +421,8 @@ Used by: [ClusterProfile_STATUS](#ClusterProfile_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="LoadBalancerProfile"></a>LoadBalancerProfile
----------------------------------------------------
+LoadBalancerProfile{#LoadBalancerProfile}
+-----------------------------------------
 
 LoadBalancerProfile represents the profile of the cluster public load balancer.
 
@@ -432,8 +432,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 |--------------------|------------------------------------------------------------------------|-----------------------------------------------------------------------|
 | managedOutboundIps | The desired managed outbound IPs for the cluster public load balancer. | [ManagedOutboundIPs](#ManagedOutboundIPs)<br/><small>Optional</small> |
 
-<a id="LoadBalancerProfile_STATUS"></a>LoadBalancerProfile_STATUS
------------------------------------------------------------------
+LoadBalancerProfile_STATUS{#LoadBalancerProfile_STATUS}
+-------------------------------------------------------
 
 LoadBalancerProfile represents the profile of the cluster public load balancer.
 
@@ -444,8 +444,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | effectiveOutboundIps | The list of effective outbound IP addresses of the public load balancer. | [EffectiveOutboundIP_STATUS[]](#EffectiveOutboundIP_STATUS)<br/><small>Optional</small> |
 | managedOutboundIps   | The desired managed outbound IPs for the cluster public load balancer.   | [ManagedOutboundIPs_STATUS](#ManagedOutboundIPs_STATUS)<br/><small>Optional</small>     |
 
-<a id="OutboundType"></a>OutboundType
--------------------------------------
+OutboundType{#OutboundType}
+---------------------------
 
 The outbound routing strategy used to provide your cluster egress to the internet.
 
@@ -456,8 +456,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 | "Loadbalancer"       |             |
 | "UserDefinedRouting" |             |
 
-<a id="OutboundType_STATUS"></a>OutboundType_STATUS
----------------------------------------------------
+OutboundType_STATUS{#OutboundType_STATUS}
+-----------------------------------------
 
 The outbound routing strategy used to provide your cluster egress to the internet.
 
@@ -468,8 +468,8 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | "Loadbalancer"       |             |
 | "UserDefinedRouting" |             |
 
-<a id="PreconfiguredNSG"></a>PreconfiguredNSG
----------------------------------------------
+PreconfiguredNSG{#PreconfiguredNSG}
+-----------------------------------
 
 PreconfiguredNSG represents whether customers want to use their own NSG attached to the subnets
 
@@ -480,8 +480,8 @@ Used by: [NetworkProfile](#NetworkProfile).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="PreconfiguredNSG_STATUS"></a>PreconfiguredNSG_STATUS
------------------------------------------------------------
+PreconfiguredNSG_STATUS{#PreconfiguredNSG_STATUS}
+-------------------------------------------------
 
 PreconfiguredNSG represents whether customers want to use their own NSG attached to the subnets
 
@@ -492,7 +492,19 @@ Used by: [NetworkProfile_STATUS](#NetworkProfile_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -504,20 +516,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="Visibility"></a>Visibility
----------------------------------
+Visibility{#Visibility}
+-----------------------
 
 Visibility represents visibility.
 
@@ -528,8 +528,8 @@ Used by: [APIServerProfile](#APIServerProfile), and [IngressProfile](#IngressPro
 | "Private" |             |
 | "Public"  |             |
 
-<a id="Visibility_STATUS"></a>Visibility_STATUS
------------------------------------------------
+Visibility_STATUS{#Visibility_STATUS}
+-------------------------------------
 
 Visibility represents visibility.
 
@@ -540,8 +540,8 @@ Used by: [APIServerProfile_STATUS](#APIServerProfile_STATUS), and [IngressProfil
 | "Private" |             |
 | "Public"  |             |
 
-<a id="EffectiveOutboundIP_STATUS"></a>EffectiveOutboundIP_STATUS
------------------------------------------------------------------
+EffectiveOutboundIP_STATUS{#EffectiveOutboundIP_STATUS}
+-------------------------------------------------------
 
 EffectiveOutboundIP represents an effective outbound IP resource of the cluster public load balancer.
 
@@ -551,8 +551,8 @@ Used by: [LoadBalancerProfile_STATUS](#LoadBalancerProfile_STATUS).
 |----------|------------------------------------------------------------------|------------------------------------|
 | id       | The fully qualified Azure resource id of an IP address resource. | string<br/><small>Optional</small> |
 
-<a id="ManagedOutboundIPs"></a>ManagedOutboundIPs
--------------------------------------------------
+ManagedOutboundIPs{#ManagedOutboundIPs}
+---------------------------------------
 
 ManagedOutboundIPs represents the desired managed outbound IPs for the cluster public load balancer.
 
@@ -562,8 +562,8 @@ Used by: [LoadBalancerProfile](#LoadBalancerProfile).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | count    | Count represents the desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer. Allowed values are in the range of 1 - 20. The default value is 1. | int<br/><small>Optional</small> |
 
-<a id="ManagedOutboundIPs_STATUS"></a>ManagedOutboundIPs_STATUS
----------------------------------------------------------------
+ManagedOutboundIPs_STATUS{#ManagedOutboundIPs_STATUS}
+-----------------------------------------------------
 
 ManagedOutboundIPs represents the desired managed outbound IPs for the cluster public load balancer.
 

--- a/docs/hugo/content/reference/resources/v1api20200601.md
+++ b/docs/hugo/content/reference/resources/v1api20200601.md
@@ -5,15 +5,15 @@ title: resources.azure.com/v1api20200601
 linktitle: v1api20200601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2020-06-01" |             |
 
-<a id="ResourceGroup"></a>ResourceGroup
----------------------------------------
+ResourceGroup{#ResourceGroup}
+-----------------------------
 
 Generator information: - Generated from: /resources/resource-manager/Microsoft.Resources/stable/2020-06-01/resources.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}
 
@@ -26,7 +26,7 @@ Used by: [ResourceGroupList](#ResourceGroupList).
 | spec                                                                                    |             | [ResourceGroup_Spec](#ResourceGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ResourceGroup_STATUS](#ResourceGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="ResourceGroup_Spec"></a>ResourceGroup_Spec
+### ResourceGroup_Spec {#ResourceGroup_Spec}
 
 | Property     | Description                                                                                                                                          | Type                                                                                |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
@@ -36,7 +36,7 @@ Used by: [ResourceGroupList](#ResourceGroupList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                      | [ResourceGroupOperatorSpec](#ResourceGroupOperatorSpec)<br/><small>Optional</small> |
 | tags         | The tags attached to the resource group.                                                                                                             | map[string]string<br/><small>Optional</small>                                       |
 
-### <a id="ResourceGroup_STATUS"></a>ResourceGroup_STATUS
+### ResourceGroup_STATUS{#ResourceGroup_STATUS}
 
 | Property   | Description                                                                                                                                          | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,8 +49,8 @@ Used by: [ResourceGroupList](#ResourceGroupList).
 | tags       | The tags attached to the resource group.                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource group.                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ResourceGroupList"></a>ResourceGroupList
------------------------------------------------
+ResourceGroupList{#ResourceGroupList}
+-------------------------------------
 
 Generator information: - Generated from: /resources/resource-manager/Microsoft.Resources/stable/2020-06-01/resources.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourcegroups/&ZeroWidthSpace;{resourceGroupName}
 
@@ -60,8 +60,8 @@ Generator information: - Generated from: /resources/resource-manager/Microsoft.R
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [ResourceGroup[]](#ResourceGroup)<br/><small>Optional</small> |
 
-<a id="ResourceGroup_Spec"></a>ResourceGroup_Spec
--------------------------------------------------
+ResourceGroup_Spec{#ResourceGroup_Spec}
+---------------------------------------
 
 Used by: [ResourceGroup](#ResourceGroup).
 
@@ -73,8 +73,8 @@ Used by: [ResourceGroup](#ResourceGroup).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                      | [ResourceGroupOperatorSpec](#ResourceGroupOperatorSpec)<br/><small>Optional</small> |
 | tags         | The tags attached to the resource group.                                                                                                             | map[string]string<br/><small>Optional</small>                                       |
 
-<a id="ResourceGroup_STATUS"></a>ResourceGroup_STATUS
------------------------------------------------------
+ResourceGroup_STATUS{#ResourceGroup_STATUS}
+-------------------------------------------
 
 Resource group information.
 
@@ -91,8 +91,8 @@ Used by: [ResourceGroup](#ResourceGroup).
 | tags       | The tags attached to the resource group.                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type       | The type of the resource group.                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ResourceGroupOperatorSpec"></a>ResourceGroupOperatorSpec
----------------------------------------------------------------
+ResourceGroupOperatorSpec{#ResourceGroupOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -103,8 +103,8 @@ Used by: [ResourceGroup_Spec](#ResourceGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ResourceGroupProperties_STATUS"></a>ResourceGroupProperties_STATUS
--------------------------------------------------------------------------
+ResourceGroupProperties_STATUS{#ResourceGroupProperties_STATUS}
+---------------------------------------------------------------
 
 The resource group properties.
 

--- a/docs/hugo/content/reference/search/v1api20220901.md
+++ b/docs/hugo/content/reference/search/v1api20220901.md
@@ -5,15 +5,15 @@ title: search.azure.com/v1api20220901
 linktitle: v1api20220901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-09-01" |             |
 
-<a id="SearchService"></a>SearchService
----------------------------------------
+SearchService{#SearchService}
+-----------------------------
 
 Generator information: - Generated from: /search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Search/searchServices/{searchServiceName}
 
@@ -26,7 +26,7 @@ Used by: [SearchServiceList](#SearchServiceList).
 | spec                                                                                    |             | [SearchService_Spec](#SearchService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SearchService_STATUS](#SearchService_STATUS)<br/><small>Optional</small> |
 
-### <a id="SearchService_Spec"></a>SearchService_Spec
+### SearchService_Spec {#SearchService_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ Used by: [SearchServiceList](#SearchServiceList).
 | sku                 | The SKU of the Search Service, which determines price tier and capacity limits. This property is required when creating a new Search Service.                                                                                                                                                                                               | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="SearchService_STATUS"></a>SearchService_STATUS
+### SearchService_STATUS{#SearchService_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -72,8 +72,8 @@ Used by: [SearchServiceList](#SearchServiceList).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SearchServiceList"></a>SearchServiceList
------------------------------------------------
+SearchServiceList{#SearchServiceList}
+-------------------------------------
 
 Generator information: - Generated from: /search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Search/searchServices/{searchServiceName}
 
@@ -83,8 +83,8 @@ Generator information: - Generated from: /search/resource-manager/Microsoft.Sear
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                               |
 | items                                                                               |             | [SearchService[]](#SearchService)<br/><small>Optional</small> |
 
-<a id="SearchService_Spec"></a>SearchService_Spec
--------------------------------------------------
+SearchService_Spec{#SearchService_Spec}
+---------------------------------------
 
 Used by: [SearchService](#SearchService).
 
@@ -106,8 +106,8 @@ Used by: [SearchService](#SearchService).
 | sku                 | The SKU of the Search Service, which determines price tier and capacity limits. This property is required when creating a new Search Service.                                                                                                                                                                                               | [Sku](#Sku)<br/><small>Optional</small>                                                                                                                              |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SearchService_STATUS"></a>SearchService_STATUS
------------------------------------------------------
+SearchService_STATUS{#SearchService_STATUS}
+-------------------------------------------
 
 Describes an Azure Cognitive Search service and its current state.
 
@@ -137,8 +137,8 @@ Used by: [SearchService](#SearchService).
 | tags                       | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="DataPlaneAuthOptions"></a>DataPlaneAuthOptions
------------------------------------------------------
+DataPlaneAuthOptions{#DataPlaneAuthOptions}
+-------------------------------------------
 
 Defines the options for how the data plane API of a Search service authenticates requests. This cannot be set if 'disableLocalAuth' is set to true.
 
@@ -148,8 +148,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 |-------------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | aadOrApiKey | Indicates that either the API key or an access token from Azure Active Directory can be used for authentication. | [DataPlaneAadOrApiKeyAuthOption](#DataPlaneAadOrApiKeyAuthOption)<br/><small>Optional</small> |
 
-<a id="DataPlaneAuthOptions_STATUS"></a>DataPlaneAuthOptions_STATUS
--------------------------------------------------------------------
+DataPlaneAuthOptions_STATUS{#DataPlaneAuthOptions_STATUS}
+---------------------------------------------------------
 
 Defines the options for how the data plane API of a Search service authenticates requests. This cannot be set if 'disableLocalAuth' is set to true.
 
@@ -160,8 +160,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | aadOrApiKey | Indicates that either the API key or an access token from Azure Active Directory can be used for authentication. | [DataPlaneAadOrApiKeyAuthOption_STATUS](#DataPlaneAadOrApiKeyAuthOption_STATUS)<br/><small>Optional</small> |
 | apiKeyOnly  | Indicates that only the API key needs to be used for authentication.                                             | map[string]v1.JSON<br/><small>Optional</small>                                                              |
 
-<a id="EncryptionWithCmk"></a>EncryptionWithCmk
------------------------------------------------
+EncryptionWithCmk{#EncryptionWithCmk}
+-------------------------------------
 
 Describes a policy that determines how resources within the search service are to be encrypted with Customer Managed Keys.
 
@@ -171,8 +171,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 |-------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | enforcement | Describes how a search service should enforce having one or more non customer encrypted resources. | [EncryptionWithCmk_Enforcement](#EncryptionWithCmk_Enforcement)<br/><small>Optional</small> |
 
-<a id="EncryptionWithCmk_STATUS"></a>EncryptionWithCmk_STATUS
--------------------------------------------------------------
+EncryptionWithCmk_STATUS{#EncryptionWithCmk_STATUS}
+---------------------------------------------------
 
 Describes a policy that determines how resources within the search service are to be encrypted with Customer Managed Keys.
 
@@ -183,8 +183,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | encryptionComplianceStatus | Describes whether the search service is compliant or not with respect to having non customer encrypted resources. If a service has more than one non customer encrypted resource and 'Enforcement' is 'enabled' then the service will be marked as 'nonCompliant'. | [EncryptionWithCmk_EncryptionComplianceStatus_STATUS](#EncryptionWithCmk_EncryptionComplianceStatus_STATUS)<br/><small>Optional</small> |
 | enforcement                | Describes how a search service should enforce having one or more non customer encrypted resources.                                                                                                                                                                 | [EncryptionWithCmk_Enforcement_STATUS](#EncryptionWithCmk_Enforcement_STATUS)<br/><small>Optional</small>                               |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -194,8 +194,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 |----------|--------------------|-------------------------------------------------------------|
 | type     | The identity type. | [Identity_Type](#Identity_Type)<br/><small>Required</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -207,8 +207,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | tenantId    | The tenant ID of the system-assigned identity of the search service.    | string<br/><small>Optional</small>                                        |
 | type        | The identity type.                                                      | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 Network specific rules that determine how the Azure Cognitive Search service may be reached.
 
@@ -218,8 +218,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
 | ipRules  | A list of IP restriction rules that defines the inbound network(s) with allowing access to the search service endpoint. At the meantime, all other public IP networks are blocked by the firewall. These restriction rules are applied only when the 'publicNetworkAccess' of the search service is 'enabled'; otherwise, traffic over public interface is not allowed even with any public IP rules, and private endpoint connections would be the exclusive access method. | [IpRule[]](#IpRule)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 Network specific rules that determine how the Azure Cognitive Search service may be reached.
 
@@ -229,8 +229,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | ipRules  | A list of IP restriction rules that defines the inbound network(s) with allowing access to the search service endpoint. At the meantime, all other public IP networks are blocked by the firewall. These restriction rules are applied only when the 'publicNetworkAccess' of the search service is 'enabled'; otherwise, traffic over public interface is not allowed even with any public IP rules, and private endpoint connections would be the exclusive access method. | [IpRule_STATUS[]](#IpRule_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Describes an existing Private Endpoint connection to the Azure Cognitive Search service.
 
@@ -240,8 +240,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="SearchServiceOperatorSpec"></a>SearchServiceOperatorSpec
----------------------------------------------------------------
+SearchServiceOperatorSpec{#SearchServiceOperatorSpec}
+-----------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -253,8 +253,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [SearchServiceOperatorSecrets](#SearchServiceOperatorSecrets)<br/><small>Optional</small>                                                                           |
 
-<a id="SearchServiceProperties_HostingMode"></a>SearchServiceProperties_HostingMode
------------------------------------------------------------------------------------
+SearchServiceProperties_HostingMode{#SearchServiceProperties_HostingMode}
+-------------------------------------------------------------------------
 
 Used by: [SearchService_Spec](#SearchService_Spec).
 
@@ -263,8 +263,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 | "default"     |             |
 | "highDensity" |             |
 
-<a id="SearchServiceProperties_HostingMode_STATUS"></a>SearchServiceProperties_HostingMode_STATUS
--------------------------------------------------------------------------------------------------
+SearchServiceProperties_HostingMode_STATUS{#SearchServiceProperties_HostingMode_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [SearchService_STATUS](#SearchService_STATUS).
 
@@ -273,8 +273,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | "default"     |             |
 | "highDensity" |             |
 
-<a id="SearchServiceProperties_ProvisioningState_STATUS"></a>SearchServiceProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------
+SearchServiceProperties_ProvisioningState_STATUS{#SearchServiceProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [SearchService_STATUS](#SearchService_STATUS).
 
@@ -284,8 +284,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | "provisioning" |             |
 | "succeeded"    |             |
 
-<a id="SearchServiceProperties_PublicNetworkAccess"></a>SearchServiceProperties_PublicNetworkAccess
----------------------------------------------------------------------------------------------------
+SearchServiceProperties_PublicNetworkAccess{#SearchServiceProperties_PublicNetworkAccess}
+-----------------------------------------------------------------------------------------
 
 Used by: [SearchService_Spec](#SearchService_Spec).
 
@@ -294,8 +294,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="SearchServiceProperties_PublicNetworkAccess_STATUS"></a>SearchServiceProperties_PublicNetworkAccess_STATUS
------------------------------------------------------------------------------------------------------------------
+SearchServiceProperties_PublicNetworkAccess_STATUS{#SearchServiceProperties_PublicNetworkAccess_STATUS}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [SearchService_STATUS](#SearchService_STATUS).
 
@@ -304,8 +304,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | "disabled" |             |
 | "enabled"  |             |
 
-<a id="SearchServiceProperties_Status_STATUS"></a>SearchServiceProperties_Status_STATUS
----------------------------------------------------------------------------------------
+SearchServiceProperties_Status_STATUS{#SearchServiceProperties_Status_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [SearchService_STATUS](#SearchService_STATUS).
 
@@ -318,8 +318,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 | "provisioning" |             |
 | "running"      |             |
 
-<a id="SharedPrivateLinkResource_STATUS"></a>SharedPrivateLinkResource_STATUS
------------------------------------------------------------------------------
+SharedPrivateLinkResource_STATUS{#SharedPrivateLinkResource_STATUS}
+-------------------------------------------------------------------
 
 Describes a Shared Private Link Resource managed by the Azure Cognitive Search service.
 
@@ -329,8 +329,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 Defines the SKU of an Azure Cognitive Search Service, which determines price tier and capacity limits.
 
@@ -340,8 +340,8 @@ Used by: [SearchService_Spec](#SearchService_Spec).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
 | name     | The SKU of the search service. Valid values include: 'free': Shared service. 'basic': Dedicated service with up to 3 replicas. 'standard': Dedicated service with up to 12 partitions and 12 replicas. 'standard2': Similar to standard, but with more capacity per search unit. 'standard3': The largest Standard offering with up to 12 partitions and 12 replicas (or up to 3 partitions with more indexes if you also set the hostingMode property to 'highDensity'). 'storage_optimized_l1': Supports 1TB per partition, up to 12 partitions. 'storage_optimized_l2': Supports 2TB per partition, up to 12 partitions.' | [Sku_Name](#Sku_Name)<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 Defines the SKU of an Azure Cognitive Search Service, which determines price tier and capacity limits.
 
@@ -351,8 +351,8 @@ Used by: [SearchService_STATUS](#SearchService_STATUS).
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | name     | The SKU of the search service. Valid values include: 'free': Shared service. 'basic': Dedicated service with up to 3 replicas. 'standard': Dedicated service with up to 12 partitions and 12 replicas. 'standard2': Similar to standard, but with more capacity per search unit. 'standard3': The largest Standard offering with up to 12 partitions and 12 replicas (or up to 3 partitions with more indexes if you also set the hostingMode property to 'highDensity'). 'storage_optimized_l1': Supports 1TB per partition, up to 12 partitions. 'storage_optimized_l2': Supports 2TB per partition, up to 12 partitions.' | [Sku_Name_STATUS](#Sku_Name_STATUS)<br/><small>Optional</small> |
 
-<a id="DataPlaneAadOrApiKeyAuthOption"></a>DataPlaneAadOrApiKeyAuthOption
--------------------------------------------------------------------------
+DataPlaneAadOrApiKeyAuthOption{#DataPlaneAadOrApiKeyAuthOption}
+---------------------------------------------------------------
 
 Indicates that either the API key or an access token from Azure Active Directory can be used for authentication.
 
@@ -362,8 +362,8 @@ Used by: [DataPlaneAuthOptions](#DataPlaneAuthOptions).
 |--------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | aadAuthFailureMode | Describes what response the data plane API of a Search service would send for requests that failed authentication. | [DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode](#DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode)<br/><small>Optional</small> |
 
-<a id="DataPlaneAadOrApiKeyAuthOption_STATUS"></a>DataPlaneAadOrApiKeyAuthOption_STATUS
----------------------------------------------------------------------------------------
+DataPlaneAadOrApiKeyAuthOption_STATUS{#DataPlaneAadOrApiKeyAuthOption_STATUS}
+-----------------------------------------------------------------------------
 
 Indicates that either the API key or an access token from Azure Active Directory can be used for authentication.
 
@@ -373,8 +373,8 @@ Used by: [DataPlaneAuthOptions_STATUS](#DataPlaneAuthOptions_STATUS).
 |--------------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | aadAuthFailureMode | Describes what response the data plane API of a Search service would send for requests that failed authentication. | [DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS](#DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS)<br/><small>Optional</small> |
 
-<a id="EncryptionWithCmk_EncryptionComplianceStatus_STATUS"></a>EncryptionWithCmk_EncryptionComplianceStatus_STATUS
--------------------------------------------------------------------------------------------------------------------
+EncryptionWithCmk_EncryptionComplianceStatus_STATUS{#EncryptionWithCmk_EncryptionComplianceStatus_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [EncryptionWithCmk_STATUS](#EncryptionWithCmk_STATUS).
 
@@ -383,8 +383,8 @@ Used by: [EncryptionWithCmk_STATUS](#EncryptionWithCmk_STATUS).
 | "Compliant"    |             |
 | "NonCompliant" |             |
 
-<a id="EncryptionWithCmk_Enforcement"></a>EncryptionWithCmk_Enforcement
------------------------------------------------------------------------
+EncryptionWithCmk_Enforcement{#EncryptionWithCmk_Enforcement}
+-------------------------------------------------------------
 
 Used by: [EncryptionWithCmk](#EncryptionWithCmk).
 
@@ -394,8 +394,8 @@ Used by: [EncryptionWithCmk](#EncryptionWithCmk).
 | "Enabled"     |             |
 | "Unspecified" |             |
 
-<a id="EncryptionWithCmk_Enforcement_STATUS"></a>EncryptionWithCmk_Enforcement_STATUS
--------------------------------------------------------------------------------------
+EncryptionWithCmk_Enforcement_STATUS{#EncryptionWithCmk_Enforcement_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [EncryptionWithCmk_STATUS](#EncryptionWithCmk_STATUS).
 
@@ -405,8 +405,8 @@ Used by: [EncryptionWithCmk_STATUS](#EncryptionWithCmk_STATUS).
 | "Enabled"     |             |
 | "Unspecified" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -415,8 +415,8 @@ Used by: [Identity](#Identity).
 | "None"           |             |
 | "SystemAssigned" |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -425,8 +425,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "None"           |             |
 | "SystemAssigned" |             |
 
-<a id="IpRule"></a>IpRule
--------------------------
+IpRule{#IpRule}
+---------------
 
 The IP restriction rule of the Azure Cognitive Search service.
 
@@ -436,8 +436,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 |----------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | Value corresponding to a single IPv4 address (eg., 123.1.2.3) or an IP range in CIDR format (eg., 123.1.2.3/24) to be allowed. | string<br/><small>Optional</small> |
 
-<a id="IpRule_STATUS"></a>IpRule_STATUS
----------------------------------------
+IpRule_STATUS{#IpRule_STATUS}
+-----------------------------
 
 The IP restriction rule of the Azure Cognitive Search service.
 
@@ -447,8 +447,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 |----------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | value    | Value corresponding to a single IPv4 address (eg., 123.1.2.3) or an IP range in CIDR format (eg., 123.1.2.3/24) to be allowed. | string<br/><small>Optional</small> |
 
-<a id="SearchServiceOperatorSecrets"></a>SearchServiceOperatorSecrets
----------------------------------------------------------------------
+SearchServiceOperatorSecrets{#SearchServiceOperatorSecrets}
+-----------------------------------------------------------
 
 Used by: [SearchServiceOperatorSpec](#SearchServiceOperatorSpec).
 
@@ -458,8 +458,8 @@ Used by: [SearchServiceOperatorSpec](#SearchServiceOperatorSpec).
 | adminSecondaryKey | indicates where the AdminSecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | queryKey          | indicates where the QueryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.          | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="Sku_Name"></a>Sku_Name
------------------------------
+Sku_Name{#Sku_Name}
+-------------------
 
 Used by: [Sku](#Sku).
 
@@ -473,8 +473,8 @@ Used by: [Sku](#Sku).
 | "storage_optimized_l1" |             |
 | "storage_optimized_l2" |             |
 
-<a id="Sku_Name_STATUS"></a>Sku_Name_STATUS
--------------------------------------------
+Sku_Name_STATUS{#Sku_Name_STATUS}
+---------------------------------
 
 Used by: [Sku_STATUS](#Sku_STATUS).
 
@@ -488,8 +488,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "storage_optimized_l1" |             |
 | "storage_optimized_l2" |             |
 
-<a id="DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode"></a>DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode
----------------------------------------------------------------------------------------------------------------
+DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode{#DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [DataPlaneAadOrApiKeyAuthOption](#DataPlaneAadOrApiKeyAuthOption).
 
@@ -498,8 +498,8 @@ Used by: [DataPlaneAadOrApiKeyAuthOption](#DataPlaneAadOrApiKeyAuthOption).
 | "http401WithBearerChallenge" |             |
 | "http403"                    |             |
 
-<a id="DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS"></a>DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS
------------------------------------------------------------------------------------------------------------------------------
+DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS{#DataPlaneAadOrApiKeyAuthOption_AadAuthFailureMode_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [DataPlaneAadOrApiKeyAuthOption_STATUS](#DataPlaneAadOrApiKeyAuthOption_STATUS).
 

--- a/docs/hugo/content/reference/servicebus/v1api20210101preview.md
+++ b/docs/hugo/content/reference/servicebus/v1api20210101preview.md
@@ -5,15 +5,15 @@ title: servicebus.azure.com/v1api20210101preview
 linktitle: v1api20210101preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2021-01-01-preview" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property      | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags          | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                             | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,8 +63,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the namespace was updated.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -74,8 +74,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -88,7 +88,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -97,7 +97,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                     | Type                                                                                                                                                    |
 |------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -108,8 +108,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -119,8 +119,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesQueue"></a>NamespacesQueue
--------------------------------------------
+NamespacesQueue{#NamespacesQueue}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -133,7 +133,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | spec                                                                                    |             | [NamespacesQueue_Spec](#NamespacesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesQueue_STATUS](#NamespacesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
+### NamespacesQueue_Spec {#NamespacesQueue_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -155,7 +155,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
+### NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -186,8 +186,8 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | type                                | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueueList"></a>NamespacesQueueList
----------------------------------------------------
+NamespacesQueueList{#NamespacesQueueList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -197,8 +197,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesQueue[]](#NamespacesQueue)<br/><small>Optional</small> |
 
-<a id="NamespacesTopic"></a>NamespacesTopic
--------------------------------------------
+NamespacesTopic{#NamespacesTopic}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -211,7 +211,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | spec                                                                                    |             | [NamespacesTopic_Spec](#NamespacesTopic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopic_STATUS](#NamespacesTopic_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
+### NamespacesTopic_Spec {#NamespacesTopic_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -228,7 +228,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
+### NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -254,8 +254,8 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | type                                | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicList"></a>NamespacesTopicList
----------------------------------------------------
+NamespacesTopicList{#NamespacesTopicList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -265,8 +265,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesTopic[]](#NamespacesTopic)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscription"></a>NamespacesTopicsSubscription
----------------------------------------------------------------------
+NamespacesTopicsSubscription{#NamespacesTopicsSubscription}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -279,7 +279,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | spec                                                                                    |             | [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
+### NamespacesTopicsSubscription_Spec {#NamespacesTopicsSubscription_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -298,7 +298,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
+### NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
 
 | Property                                  | Description                                                                                                                                                                                                                                  | Type                                                                                                                                                    |
 |-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -325,8 +325,8 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | type                                      | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionList"></a>NamespacesTopicsSubscriptionList
------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionList{#NamespacesTopicsSubscriptionList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -336,8 +336,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [NamespacesTopicsSubscription[]](#NamespacesTopicsSubscription)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRule"></a>NamespacesTopicsSubscriptionsRule
--------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule{#NamespacesTopicsSubscriptionsRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -350,7 +350,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | spec                                                                                    |             | [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptionsRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptionsRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
+### NamespacesTopicsSubscriptionsRule_Spec {#NamespacesTopicsSubscriptionsRule_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -362,7 +362,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-### <a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
+### NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
 
 | Property          | Description                                                                                                                        | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -376,8 +376,8 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | systemData        | The system meta data relating to this resource.                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRuleList"></a>NamespacesTopicsSubscriptionsRuleList
----------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleList{#NamespacesTopicsSubscriptionsRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2021-01-01-preview/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -387,8 +387,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NamespacesTopicsSubscriptionsRule[]](#NamespacesTopicsSubscriptionsRule)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -404,8 +404,8 @@ Used by: [Namespace](#Namespace).
 | tags          | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -430,8 +430,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the namespace was updated.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -442,8 +442,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -456,8 +456,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
------------------------------------------------------
+NamespacesQueue_Spec{#NamespacesQueue_Spec}
+-------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -481,8 +481,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
----------------------------------------------------------
+NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -515,8 +515,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | type                                | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
------------------------------------------------------
+NamespacesTopic_Spec{#NamespacesTopic_Spec}
+-------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -535,8 +535,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
----------------------------------------------------------
+NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -564,8 +564,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | type                                | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
--------------------------------------------------------------------------------
+NamespacesTopicsSubscription_Spec{#NamespacesTopicsSubscription_Spec}
+---------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -586,8 +586,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
------------------------------------------------------------------------------------
+NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -616,8 +616,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | type                                      | Resource type                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_Spec{#NamespacesTopicsSubscriptionsRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -631,8 +631,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-<a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -648,8 +648,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | systemData        | The system meta data relating to this resource.                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | Resource type                                                                                                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Action"></a>Action
--------------------------
+Action{#Action}
+---------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -661,8 +661,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="Action_STATUS"></a>Action_STATUS
----------------------------------------
+Action_STATUS{#Action_STATUS}
+-----------------------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -674,8 +674,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="CorrelationFilter"></a>CorrelationFilter
------------------------------------------------
+CorrelationFilter{#CorrelationFilter}
+-------------------------------------
 
 Represents the correlation filter expression.
 
@@ -694,8 +694,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="CorrelationFilter_STATUS"></a>CorrelationFilter_STATUS
--------------------------------------------------------------
+CorrelationFilter_STATUS{#CorrelationFilter_STATUS}
+---------------------------------------------------
 
 Represents the correlation filter expression.
 
@@ -714,8 +714,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -727,8 +727,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -740,8 +740,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="EntityStatus_STATUS"></a>EntityStatus_STATUS
----------------------------------------------------
+EntityStatus_STATUS{#EntityStatus_STATUS}
+-----------------------------------------
 
 Entity status.
 
@@ -759,8 +759,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="FilterType"></a>FilterType
----------------------------------
+FilterType{#FilterType}
+-----------------------
 
 Rule filter types
 
@@ -771,8 +771,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="FilterType_STATUS"></a>FilterType_STATUS
------------------------------------------------
+FilterType_STATUS{#FilterType_STATUS}
+-------------------------------------
 
 Rule filter types
 
@@ -783,8 +783,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -795,8 +795,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -809,8 +809,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]DictionaryValue_STATUS](#DictionaryValue_STATUS)<br/><small>Optional</small> |
 
-<a id="MessageCountDetails_STATUS"></a>MessageCountDetails_STATUS
------------------------------------------------------------------
+MessageCountDetails_STATUS{#MessageCountDetails_STATUS}
+-------------------------------------------------------
 
 Message Count Details.
 
@@ -824,8 +824,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | transferDeadLetterMessageCount | Number of messages transferred into dead letters.                        | int<br/><small>Optional</small> |
 | transferMessageCount           | Number of messages transferred to another queue, topic, or subscription. | int<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -837,8 +837,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -848,8 +848,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -859,8 +859,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -872,8 +872,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesQueueOperatorSpec"></a>NamespacesQueueOperatorSpec
--------------------------------------------------------------------
+NamespacesQueueOperatorSpec{#NamespacesQueueOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -884,8 +884,8 @@ Used by: [NamespacesQueue_Spec](#NamespacesQueue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicOperatorSpec"></a>NamespacesTopicOperatorSpec
--------------------------------------------------------------------
+NamespacesTopicOperatorSpec{#NamespacesTopicOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -896,8 +896,8 @@ Used by: [NamespacesTopic_Spec](#NamespacesTopic_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionOperatorSpec"></a>NamespacesTopicsSubscriptionOperatorSpec
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionOperatorSpec{#NamespacesTopicsSubscriptionOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -908,8 +908,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRuleOperatorSpec"></a>NamespacesTopicsSubscriptionsRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleOperatorSpec{#NamespacesTopicsSubscriptionsRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -920,8 +920,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -931,8 +931,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|-------------|------------------------------------|
 | id       | Resource Id | string<br/><small>Optional</small> |
 
-<a id="SBSku"></a>SBSku
------------------------
+SBSku{#SBSku}
+-------------
 
 SKU of the namespace.
 
@@ -944,8 +944,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                     | [SBSku_Name](#SBSku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                              | [SBSku_Tier](#SBSku_Tier)<br/><small>Optional</small> |
 
-<a id="SBSku_STATUS"></a>SBSku_STATUS
--------------------------------------
+SBSku_STATUS{#SBSku_STATUS}
+---------------------------
 
 SKU of the namespace.
 
@@ -957,8 +957,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                     | [SBSku_Name_STATUS](#SBSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                              | [SBSku_Tier_STATUS](#SBSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlFilter"></a>SqlFilter
--------------------------------
+SqlFilter{#SqlFilter}
+---------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -970,8 +970,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SqlFilter_STATUS"></a>SqlFilter_STATUS
----------------------------------------------
+SqlFilter_STATUS{#SqlFilter_STATUS}
+-----------------------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -983,8 +983,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -999,8 +999,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="DictionaryValue_STATUS"></a>DictionaryValue_STATUS
----------------------------------------------------------
+DictionaryValue_STATUS{#DictionaryValue_STATUS}
+-----------------------------------------------
 
 Recognized Dictionary value.
 
@@ -1011,8 +1011,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -1020,8 +1020,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -1029,8 +1029,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -1041,8 +1041,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -1053,8 +1053,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1067,8 +1067,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1081,8 +1081,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -1094,8 +1094,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -1106,8 +1106,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SBSku_Name"></a>SBSku_Name
----------------------------------
+SBSku_Name{#SBSku_Name}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1117,8 +1117,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Name_STATUS"></a>SBSku_Name_STATUS
------------------------------------------------
+SBSku_Name_STATUS{#SBSku_Name_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1128,8 +1128,8 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier"></a>SBSku_Tier
----------------------------------
+SBSku_Tier{#SBSku_Tier}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1139,8 +1139,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier_STATUS"></a>SBSku_Tier_STATUS
------------------------------------------------
+SBSku_Tier_STATUS{#SBSku_Tier_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1150,7 +1150,19 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1162,20 +1174,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1185,8 +1185,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -1194,8 +1194,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 

--- a/docs/hugo/content/reference/servicebus/v1api20211101.md
+++ b/docs/hugo/content/reference/servicebus/v1api20211101.md
@@ -5,15 +5,15 @@ title: servicebus.azure.com/v1api20211101
 linktitle: v1api20211101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-11-01" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags             | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant    | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                             | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -67,8 +67,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the namespace was updated.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -78,8 +78,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -92,7 +92,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,7 +101,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -113,8 +113,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -124,8 +124,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesQueue"></a>NamespacesQueue
--------------------------------------------
+NamespacesQueue{#NamespacesQueue}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -138,7 +138,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | spec                                                                                    |             | [NamespacesQueue_Spec](#NamespacesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesQueue_STATUS](#NamespacesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
+### NamespacesQueue_Spec {#NamespacesQueue_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -161,7 +161,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
+### NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -194,8 +194,8 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueueList"></a>NamespacesQueueList
----------------------------------------------------
+NamespacesQueueList{#NamespacesQueueList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -205,8 +205,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesQueue[]](#NamespacesQueue)<br/><small>Optional</small> |
 
-<a id="NamespacesTopic"></a>NamespacesTopic
--------------------------------------------
+NamespacesTopic{#NamespacesTopic}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -219,7 +219,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | spec                                                                                    |             | [NamespacesTopic_Spec](#NamespacesTopic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopic_STATUS](#NamespacesTopic_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
+### NamespacesTopic_Spec {#NamespacesTopic_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -237,7 +237,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
+### NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -265,8 +265,8 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicList"></a>NamespacesTopicList
----------------------------------------------------
+NamespacesTopicList{#NamespacesTopicList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -276,8 +276,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesTopic[]](#NamespacesTopic)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscription"></a>NamespacesTopicsSubscription
----------------------------------------------------------------------
+NamespacesTopicsSubscription{#NamespacesTopicsSubscription}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -290,7 +290,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | spec                                                                                    |             | [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
+### NamespacesTopicsSubscription_Spec {#NamespacesTopicsSubscription_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -311,7 +311,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
+### NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -341,8 +341,8 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionList"></a>NamespacesTopicsSubscriptionList
------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionList{#NamespacesTopicsSubscriptionList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -352,8 +352,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [NamespacesTopicsSubscription[]](#NamespacesTopicsSubscription)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRule"></a>NamespacesTopicsSubscriptionsRule
--------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule{#NamespacesTopicsSubscriptionsRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -366,7 +366,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | spec                                                                                    |             | [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptionsRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptionsRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
+### NamespacesTopicsSubscriptionsRule_Spec {#NamespacesTopicsSubscriptionsRule_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -378,7 +378,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-### <a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
+### NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -393,8 +393,8 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRuleList"></a>NamespacesTopicsSubscriptionsRuleList
----------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleList{#NamespacesTopicsSubscriptionsRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -404,8 +404,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NamespacesTopicsSubscriptionsRule[]](#NamespacesTopicsSubscriptionsRule)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -423,8 +423,8 @@ Used by: [Namespace](#Namespace).
 | tags             | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant    | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -451,8 +451,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the namespace was updated.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones. | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -463,8 +463,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -478,8 +478,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
------------------------------------------------------
+NamespacesQueue_Spec{#NamespacesQueue_Spec}
+-------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -504,8 +504,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
----------------------------------------------------------
+NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -540,8 +540,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
------------------------------------------------------
+NamespacesTopic_Spec{#NamespacesTopic_Spec}
+-------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -561,8 +561,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
----------------------------------------------------------
+NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -592,8 +592,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
--------------------------------------------------------------------------------
+NamespacesTopicsSubscription_Spec{#NamespacesTopicsSubscription_Spec}
+---------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -616,8 +616,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
------------------------------------------------------------------------------------
+NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -649,8 +649,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_Spec{#NamespacesTopicsSubscriptionsRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -664,8 +664,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-<a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -682,8 +682,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Action"></a>Action
--------------------------
+Action{#Action}
+---------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -695,8 +695,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="Action_STATUS"></a>Action_STATUS
----------------------------------------
+Action_STATUS{#Action_STATUS}
+-----------------------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -708,8 +708,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="CorrelationFilter"></a>CorrelationFilter
------------------------------------------------
+CorrelationFilter{#CorrelationFilter}
+-------------------------------------
 
 Represents the correlation filter expression.
 
@@ -728,8 +728,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="CorrelationFilter_STATUS"></a>CorrelationFilter_STATUS
--------------------------------------------------------------
+CorrelationFilter_STATUS{#CorrelationFilter_STATUS}
+---------------------------------------------------
 
 Represents the correlation filter expression.
 
@@ -748,8 +748,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -761,8 +761,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -774,8 +774,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="EntityStatus_STATUS"></a>EntityStatus_STATUS
----------------------------------------------------
+EntityStatus_STATUS{#EntityStatus_STATUS}
+-----------------------------------------
 
 Entity status.
 
@@ -793,8 +793,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="FilterType"></a>FilterType
----------------------------------
+FilterType{#FilterType}
+-----------------------
 
 Rule filter types
 
@@ -805,8 +805,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="FilterType_STATUS"></a>FilterType_STATUS
------------------------------------------------
+FilterType_STATUS{#FilterType_STATUS}
+-------------------------------------
 
 Rule filter types
 
@@ -817,8 +817,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -829,8 +829,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -843,8 +843,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="MessageCountDetails_STATUS"></a>MessageCountDetails_STATUS
------------------------------------------------------------------
+MessageCountDetails_STATUS{#MessageCountDetails_STATUS}
+-------------------------------------------------------
 
 Message Count Details.
 
@@ -858,8 +858,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | transferDeadLetterMessageCount | Number of messages transferred into dead letters.                        | int<br/><small>Optional</small> |
 | transferMessageCount           | Number of messages transferred to another queue, topic, or subscription. | int<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -871,8 +871,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -882,8 +882,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -893,8 +893,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -906,8 +906,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesQueueOperatorSpec"></a>NamespacesQueueOperatorSpec
--------------------------------------------------------------------
+NamespacesQueueOperatorSpec{#NamespacesQueueOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -918,8 +918,8 @@ Used by: [NamespacesQueue_Spec](#NamespacesQueue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicOperatorSpec"></a>NamespacesTopicOperatorSpec
--------------------------------------------------------------------
+NamespacesTopicOperatorSpec{#NamespacesTopicOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -930,8 +930,8 @@ Used by: [NamespacesTopic_Spec](#NamespacesTopic_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionOperatorSpec"></a>NamespacesTopicsSubscriptionOperatorSpec
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionOperatorSpec{#NamespacesTopicsSubscriptionOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -942,8 +942,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRuleOperatorSpec"></a>NamespacesTopicsSubscriptionsRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleOperatorSpec{#NamespacesTopicsSubscriptionsRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -954,8 +954,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -965,8 +965,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="SBClientAffineProperties"></a>SBClientAffineProperties
--------------------------------------------------------------
+SBClientAffineProperties{#SBClientAffineProperties}
+---------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -978,8 +978,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBClientAffineProperties_STATUS"></a>SBClientAffineProperties_STATUS
----------------------------------------------------------------------------
+SBClientAffineProperties_STATUS{#SBClientAffineProperties_STATUS}
+-----------------------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -991,8 +991,8 @@ Used by: [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STA
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBSku"></a>SBSku
------------------------
+SBSku{#SBSku}
+-------------
 
 SKU of the namespace.
 
@@ -1004,8 +1004,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                     | [SBSku_Name](#SBSku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                              | [SBSku_Tier](#SBSku_Tier)<br/><small>Optional</small> |
 
-<a id="SBSku_STATUS"></a>SBSku_STATUS
--------------------------------------
+SBSku_STATUS{#SBSku_STATUS}
+---------------------------
 
 SKU of the namespace.
 
@@ -1017,8 +1017,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                     | [SBSku_Name_STATUS](#SBSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                              | [SBSku_Tier_STATUS](#SBSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlFilter"></a>SqlFilter
--------------------------------
+SqlFilter{#SqlFilter}
+---------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1030,8 +1030,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SqlFilter_STATUS"></a>SqlFilter_STATUS
----------------------------------------------
+SqlFilter_STATUS{#SqlFilter_STATUS}
+-----------------------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1043,8 +1043,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -1059,8 +1059,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -1068,8 +1068,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -1077,8 +1077,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -1089,8 +1089,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -1101,8 +1101,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1115,8 +1115,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1129,8 +1129,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -1142,8 +1142,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -1154,8 +1154,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SBSku_Name"></a>SBSku_Name
----------------------------------
+SBSku_Name{#SBSku_Name}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1165,8 +1165,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Name_STATUS"></a>SBSku_Name_STATUS
------------------------------------------------
+SBSku_Name_STATUS{#SBSku_Name_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1176,8 +1176,8 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier"></a>SBSku_Tier
----------------------------------
+SBSku_Tier{#SBSku_Tier}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1187,8 +1187,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier_STATUS"></a>SBSku_Tier_STATUS
------------------------------------------------
+SBSku_Tier_STATUS{#SBSku_Tier_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1198,7 +1198,19 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1210,20 +1222,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Recognized Dictionary value.
 
@@ -1234,8 +1234,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1245,8 +1245,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -1254,8 +1254,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 

--- a/docs/hugo/content/reference/servicebus/v1api20221001preview.md
+++ b/docs/hugo/content/reference/servicebus/v1api20221001preview.md
@@ -5,15 +5,15 @@ title: servicebus.azure.com/v1api20221001preview
 linktitle: v1api20221001preview
 -------------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value                | Description |
 |----------------------|-------------|
 | "2022-10-01-preview" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags                       | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -73,8 +73,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the namespace was updated.                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                    | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -84,8 +84,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -98,7 +98,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -107,7 +107,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -119,8 +119,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -130,8 +130,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesQueue"></a>NamespacesQueue
--------------------------------------------
+NamespacesQueue{#NamespacesQueue}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -144,7 +144,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | spec                                                                                    |             | [NamespacesQueue_Spec](#NamespacesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesQueue_STATUS](#NamespacesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
+### NamespacesQueue_Spec {#NamespacesQueue_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
+### NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -200,8 +200,8 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueueList"></a>NamespacesQueueList
----------------------------------------------------
+NamespacesQueueList{#NamespacesQueueList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -211,8 +211,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesQueue[]](#NamespacesQueue)<br/><small>Optional</small> |
 
-<a id="NamespacesTopic"></a>NamespacesTopic
--------------------------------------------
+NamespacesTopic{#NamespacesTopic}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -225,7 +225,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | spec                                                                                    |             | [NamespacesTopic_Spec](#NamespacesTopic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopic_STATUS](#NamespacesTopic_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
+### NamespacesTopic_Spec {#NamespacesTopic_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,7 +243,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
+### NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -271,8 +271,8 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicList"></a>NamespacesTopicList
----------------------------------------------------
+NamespacesTopicList{#NamespacesTopicList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -282,8 +282,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesTopic[]](#NamespacesTopic)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscription"></a>NamespacesTopicsSubscription
----------------------------------------------------------------------
+NamespacesTopicsSubscription{#NamespacesTopicsSubscription}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -296,7 +296,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | spec                                                                                    |             | [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
+### NamespacesTopicsSubscription_Spec {#NamespacesTopicsSubscription_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -317,7 +317,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
+### NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -347,8 +347,8 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionList"></a>NamespacesTopicsSubscriptionList
------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionList{#NamespacesTopicsSubscriptionList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -358,8 +358,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [NamespacesTopicsSubscription[]](#NamespacesTopicsSubscription)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRule"></a>NamespacesTopicsSubscriptionsRule
--------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule{#NamespacesTopicsSubscriptionsRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -372,7 +372,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | spec                                                                                    |             | [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptionsRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptionsRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
+### NamespacesTopicsSubscriptionsRule_Spec {#NamespacesTopicsSubscriptionsRule_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -384,7 +384,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-### <a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
+### NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -399,8 +399,8 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRuleList"></a>NamespacesTopicsSubscriptionsRuleList
----------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleList{#NamespacesTopicsSubscriptionsRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/preview/2022-10-01-preview/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -410,8 +410,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NamespacesTopicsSubscriptionsRule[]](#NamespacesTopicsSubscriptionsRule)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -432,8 +432,8 @@ Used by: [Namespace](#Namespace).
 | tags                       | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -463,8 +463,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the namespace was updated.                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                    | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -475,8 +475,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -490,8 +490,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
------------------------------------------------------
+NamespacesQueue_Spec{#NamespacesQueue_Spec}
+-------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -516,8 +516,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
----------------------------------------------------------
+NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -552,8 +552,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
------------------------------------------------------
+NamespacesTopic_Spec{#NamespacesTopic_Spec}
+-------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -573,8 +573,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
----------------------------------------------------------
+NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -604,8 +604,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
--------------------------------------------------------------------------------
+NamespacesTopicsSubscription_Spec{#NamespacesTopicsSubscription_Spec}
+---------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -628,8 +628,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
------------------------------------------------------------------------------------
+NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -661,8 +661,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_Spec{#NamespacesTopicsSubscriptionsRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -676,8 +676,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-<a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -694,8 +694,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Action"></a>Action
--------------------------
+Action{#Action}
+---------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -707,8 +707,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="Action_STATUS"></a>Action_STATUS
----------------------------------------
+Action_STATUS{#Action_STATUS}
+-----------------------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -720,8 +720,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="CorrelationFilter"></a>CorrelationFilter
------------------------------------------------
+CorrelationFilter{#CorrelationFilter}
+-------------------------------------
 
 Represents the correlation filter expression.
 
@@ -740,8 +740,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="CorrelationFilter_STATUS"></a>CorrelationFilter_STATUS
--------------------------------------------------------------
+CorrelationFilter_STATUS{#CorrelationFilter_STATUS}
+---------------------------------------------------
 
 Represents the correlation filter expression.
 
@@ -760,8 +760,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -773,8 +773,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -786,8 +786,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="EntityStatus_STATUS"></a>EntityStatus_STATUS
----------------------------------------------------
+EntityStatus_STATUS{#EntityStatus_STATUS}
+-----------------------------------------
 
 Entity status.
 
@@ -805,8 +805,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="FilterType"></a>FilterType
----------------------------------
+FilterType{#FilterType}
+-----------------------
 
 Rule filter types
 
@@ -817,8 +817,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="FilterType_STATUS"></a>FilterType_STATUS
------------------------------------------------
+FilterType_STATUS{#FilterType_STATUS}
+-------------------------------------
 
 Rule filter types
 
@@ -829,8 +829,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -841,8 +841,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -855,8 +855,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="MessageCountDetails_STATUS"></a>MessageCountDetails_STATUS
------------------------------------------------------------------
+MessageCountDetails_STATUS{#MessageCountDetails_STATUS}
+-------------------------------------------------------
 
 Message Count Details.
 
@@ -870,8 +870,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | transferDeadLetterMessageCount | Number of messages transferred into dead letters.                        | int<br/><small>Optional</small> |
 | transferMessageCount           | Number of messages transferred to another queue, topic, or subscription. | int<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -883,8 +883,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -894,8 +894,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -905,8 +905,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -918,8 +918,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesQueueOperatorSpec"></a>NamespacesQueueOperatorSpec
--------------------------------------------------------------------
+NamespacesQueueOperatorSpec{#NamespacesQueueOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -930,8 +930,8 @@ Used by: [NamespacesQueue_Spec](#NamespacesQueue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicOperatorSpec"></a>NamespacesTopicOperatorSpec
--------------------------------------------------------------------
+NamespacesTopicOperatorSpec{#NamespacesTopicOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -942,8 +942,8 @@ Used by: [NamespacesTopic_Spec](#NamespacesTopic_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionOperatorSpec"></a>NamespacesTopicsSubscriptionOperatorSpec
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionOperatorSpec{#NamespacesTopicsSubscriptionOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -954,8 +954,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRuleOperatorSpec"></a>NamespacesTopicsSubscriptionsRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleOperatorSpec{#NamespacesTopicsSubscriptionsRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -966,8 +966,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -977,8 +977,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="SBClientAffineProperties"></a>SBClientAffineProperties
--------------------------------------------------------------
+SBClientAffineProperties{#SBClientAffineProperties}
+---------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -990,8 +990,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBClientAffineProperties_STATUS"></a>SBClientAffineProperties_STATUS
----------------------------------------------------------------------------
+SBClientAffineProperties_STATUS{#SBClientAffineProperties_STATUS}
+-----------------------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -1003,8 +1003,8 @@ Used by: [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STA
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBNamespaceProperties_MinimumTlsVersion"></a>SBNamespaceProperties_MinimumTlsVersion
--------------------------------------------------------------------------------------------
+SBNamespaceProperties_MinimumTlsVersion{#SBNamespaceProperties_MinimumTlsVersion}
+---------------------------------------------------------------------------------
 
 Used by: [Namespace_Spec](#Namespace_Spec).
 
@@ -1014,20 +1014,20 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="SBNamespaceProperties_MinimumTlsVersion_STATUS"></a>SBNamespaceProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [Namespace_STATUS](#Namespace_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SBNamespaceProperties_PublicNetworkAccess"></a>SBNamespaceProperties_PublicNetworkAccess
+SBNamespaceProperties_MinimumTlsVersion_STATUS{#SBNamespaceProperties_MinimumTlsVersion_STATUS}
 -----------------------------------------------------------------------------------------------
 
+Used by: [Namespace_STATUS](#Namespace_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SBNamespaceProperties_PublicNetworkAccess{#SBNamespaceProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
+
 Used by: [Namespace_Spec](#Namespace_Spec).
 
 | Value                | Description |
@@ -1036,8 +1036,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="SBNamespaceProperties_PublicNetworkAccess_STATUS"></a>SBNamespaceProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------
+SBNamespaceProperties_PublicNetworkAccess_STATUS{#SBNamespaceProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [Namespace_STATUS](#Namespace_STATUS).
 
@@ -1047,8 +1047,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="SBSku"></a>SBSku
------------------------
+SBSku{#SBSku}
+-------------
 
 SKU of the namespace.
 
@@ -1060,8 +1060,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                                                                                                                                                                                                                                                                                                                   | [SBSku_Name](#SBSku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                                                                                                                                                                                            | [SBSku_Tier](#SBSku_Tier)<br/><small>Optional</small> |
 
-<a id="SBSku_STATUS"></a>SBSku_STATUS
--------------------------------------
+SBSku_STATUS{#SBSku_STATUS}
+---------------------------
 
 SKU of the namespace.
 
@@ -1073,8 +1073,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                                                                                                                                                                                                                                                                                                                   | [SBSku_Name_STATUS](#SBSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                                                                                                                                                                                            | [SBSku_Tier_STATUS](#SBSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlFilter"></a>SqlFilter
--------------------------------
+SqlFilter{#SqlFilter}
+---------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1086,8 +1086,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SqlFilter_STATUS"></a>SqlFilter_STATUS
----------------------------------------------
+SqlFilter_STATUS{#SqlFilter_STATUS}
+-----------------------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1099,8 +1099,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -1115,8 +1115,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -1124,8 +1124,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -1133,8 +1133,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -1145,8 +1145,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -1157,8 +1157,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1171,8 +1171,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1185,8 +1185,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -1198,8 +1198,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -1210,8 +1210,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SBSku_Name"></a>SBSku_Name
----------------------------------
+SBSku_Name{#SBSku_Name}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1221,8 +1221,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Name_STATUS"></a>SBSku_Name_STATUS
------------------------------------------------
+SBSku_Name_STATUS{#SBSku_Name_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1232,8 +1232,8 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier"></a>SBSku_Tier
----------------------------------
+SBSku_Tier{#SBSku_Tier}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1243,8 +1243,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier_STATUS"></a>SBSku_Tier_STATUS
------------------------------------------------
+SBSku_Tier_STATUS{#SBSku_Tier_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1254,7 +1254,19 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1266,20 +1278,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Recognized Dictionary value.
 
@@ -1290,8 +1290,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1301,8 +1301,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -1310,8 +1310,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 

--- a/docs/hugo/content/reference/servicebus/v1api20240101.md
+++ b/docs/hugo/content/reference/servicebus/v1api20240101.md
@@ -5,15 +5,15 @@ title: servicebus.azure.com/v1api20240101
 linktitle: v1api20240101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-01-01" |             |
 
-<a id="Namespace"></a>Namespace
--------------------------------
+Namespace{#Namespace}
+---------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -26,7 +26,7 @@ Used by: [NamespaceList](#NamespaceList).
 | spec                                                                                    |             | [Namespace_Spec](#Namespace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Namespace_STATUS](#Namespace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Namespace_Spec"></a>Namespace_Spec
+### Namespace_Spec {#Namespace_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -45,7 +45,7 @@ Used by: [NamespaceList](#NamespaceList).
 | tags                       | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Namespace_STATUS"></a>Namespace_STATUS
+### Namespace_STATUS{#Namespace_STATUS}
 
 | Property                   | Description                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -73,8 +73,8 @@ Used by: [NamespaceList](#NamespaceList).
 | updatedAt                  | The time the namespace was updated.                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                    | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespaceList"></a>NamespaceList
----------------------------------------
+NamespaceList{#NamespaceList}
+-----------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/namespace-preview.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}
 
@@ -84,8 +84,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Namespace[]](#Namespace)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRule"></a>NamespacesAuthorizationRule
--------------------------------------------------------------------
+NamespacesAuthorizationRule{#NamespacesAuthorizationRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -98,7 +98,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | spec                                                                                    |             | [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
+### NamespacesAuthorizationRule_Spec {#NamespacesAuthorizationRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -107,7 +107,7 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-### <a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
+### NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -119,8 +119,8 @@ Used by: [NamespacesAuthorizationRuleList](#NamespacesAuthorizationRuleList).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesAuthorizationRuleList"></a>NamespacesAuthorizationRuleList
----------------------------------------------------------------------------
+NamespacesAuthorizationRuleList{#NamespacesAuthorizationRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/AuthorizationRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/AuthorizationRules/{authorizationRuleName}
 
@@ -130,8 +130,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [NamespacesAuthorizationRule[]](#NamespacesAuthorizationRule)<br/><small>Optional</small> |
 
-<a id="NamespacesQueue"></a>NamespacesQueue
--------------------------------------------
+NamespacesQueue{#NamespacesQueue}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -144,7 +144,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | spec                                                                                    |             | [NamespacesQueue_Spec](#NamespacesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesQueue_STATUS](#NamespacesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
+### NamespacesQueue_Spec {#NamespacesQueue_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
+### NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -200,8 +200,8 @@ Used by: [NamespacesQueueList](#NamespacesQueueList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueueList"></a>NamespacesQueueList
----------------------------------------------------
+NamespacesQueueList{#NamespacesQueueList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/Queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
 
@@ -211,8 +211,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesQueue[]](#NamespacesQueue)<br/><small>Optional</small> |
 
-<a id="NamespacesTopic"></a>NamespacesTopic
--------------------------------------------
+NamespacesTopic{#NamespacesTopic}
+---------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -225,7 +225,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | spec                                                                                    |             | [NamespacesTopic_Spec](#NamespacesTopic_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopic_STATUS](#NamespacesTopic_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
+### NamespacesTopic_Spec {#NamespacesTopic_Spec}
 
 | Property                            | Description                                                                                                                                                                                                                                                                               | Type                                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -243,7 +243,7 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
+### NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
 
 | Property                            | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -271,8 +271,8 @@ Used by: [NamespacesTopicList](#NamespacesTopicList).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicList"></a>NamespacesTopicList
----------------------------------------------------
+NamespacesTopicList{#NamespacesTopicList}
+-----------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/topics.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
 
@@ -282,8 +282,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [NamespacesTopic[]](#NamespacesTopic)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscription"></a>NamespacesTopicsSubscription
----------------------------------------------------------------------
+NamespacesTopicsSubscription{#NamespacesTopicsSubscription}
+-----------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -296,7 +296,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | spec                                                                                    |             | [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
+### NamespacesTopicsSubscription_Spec {#NamespacesTopicsSubscription_Spec}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -317,7 +317,7 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
+### NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
 
 | Property                                  | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -347,8 +347,8 @@ Used by: [NamespacesTopicsSubscriptionList](#NamespacesTopicsSubscriptionList).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionList"></a>NamespacesTopicsSubscriptionList
------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionList{#NamespacesTopicsSubscriptionList}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/subscriptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}
 
@@ -358,8 +358,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                             |
 | items                                                                               |             | [NamespacesTopicsSubscription[]](#NamespacesTopicsSubscription)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRule"></a>NamespacesTopicsSubscriptionsRule
--------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule{#NamespacesTopicsSubscriptionsRule}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -372,7 +372,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | spec                                                                                    |             | [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptionsRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptionsRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
+### NamespacesTopicsSubscriptionsRule_Spec {#NamespacesTopicsSubscriptionsRule_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -384,7 +384,7 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-### <a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
+### NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -399,8 +399,8 @@ Used by: [NamespacesTopicsSubscriptionsRuleList](#NamespacesTopicsSubscriptionsR
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRuleList"></a>NamespacesTopicsSubscriptionsRuleList
----------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleList{#NamespacesTopicsSubscriptionsRuleList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /servicebus/resource-manager/Microsoft.ServiceBus/stable/2024-01-01/Rules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionName}/&ZeroWidthSpace;rules/&ZeroWidthSpace;{ruleName}
 
@@ -410,8 +410,8 @@ Generator information: - Generated from: /servicebus/resource-manager/Microsoft.
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [NamespacesTopicsSubscriptionsRule[]](#NamespacesTopicsSubscriptionsRule)<br/><small>Optional</small> |
 
-<a id="Namespace_Spec"></a>Namespace_Spec
------------------------------------------
+Namespace_Spec{#Namespace_Spec}
+-------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -432,8 +432,8 @@ Used by: [Namespace](#Namespace).
 | tags                       | Resource tags                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                                                                                                                                      | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Namespace_STATUS"></a>Namespace_STATUS
----------------------------------------------
+Namespace_STATUS{#Namespace_STATUS}
+-----------------------------------
 
 Used by: [Namespace](#Namespace).
 
@@ -463,8 +463,8 @@ Used by: [Namespace](#Namespace).
 | updatedAt                  | The time the namespace was updated.                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant              | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones.                                                                    | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="NamespacesAuthorizationRule_Spec"></a>NamespacesAuthorizationRule_Spec
------------------------------------------------------------------------------
+NamespacesAuthorizationRule_Spec{#NamespacesAuthorizationRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -475,8 +475,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/Namespace resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | rights       | The rights associated with the rule.                                                                                                                                                                                                                                                      | [Namespaces_AuthorizationRule_Properties_Rights_Spec[]](#Namespaces_AuthorizationRule_Properties_Rights_Spec)<br/><small>Required</small>                            |
 
-<a id="NamespacesAuthorizationRule_STATUS"></a>NamespacesAuthorizationRule_STATUS
----------------------------------------------------------------------------------
+NamespacesAuthorizationRule_STATUS{#NamespacesAuthorizationRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 
@@ -490,8 +490,8 @@ Used by: [NamespacesAuthorizationRule](#NamespacesAuthorizationRule).
 | systemData | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesQueue_Spec"></a>NamespacesQueue_Spec
------------------------------------------------------
+NamespacesQueue_Spec{#NamespacesQueue_Spec}
+-------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -516,8 +516,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | requiresDuplicateDetection          | A value indicating if this queue requires duplicate detection.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 | requiresSession                     | A value that indicates whether the queue supports the concept of sessions.                                                                                                                                                                                                                | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesQueue_STATUS"></a>NamespacesQueue_STATUS
----------------------------------------------------------
+NamespacesQueue_STATUS{#NamespacesQueue_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesQueue](#NamespacesQueue).
 
@@ -552,8 +552,8 @@ Used by: [NamespacesQueue](#NamespacesQueue).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopic_Spec"></a>NamespacesTopic_Spec
------------------------------------------------------
+NamespacesTopic_Spec{#NamespacesTopic_Spec}
+-------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -573,8 +573,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | requiresDuplicateDetection          | Value indicating if this topic requires duplicate detection.                                                                                                                                                                                                                              | bool<br/><small>Optional</small>                                                                                                                                     |
 | supportOrdering                     | Value that indicates whether the topic supports ordering.                                                                                                                                                                                                                                 | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopic_STATUS"></a>NamespacesTopic_STATUS
----------------------------------------------------------
+NamespacesTopic_STATUS{#NamespacesTopic_STATUS}
+-----------------------------------------------
 
 Used by: [NamespacesTopic](#NamespacesTopic).
 
@@ -604,8 +604,8 @@ Used by: [NamespacesTopic](#NamespacesTopic).
 | type                                | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                           | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscription_Spec"></a>NamespacesTopicsSubscription_Spec
--------------------------------------------------------------------------------
+NamespacesTopicsSubscription_Spec{#NamespacesTopicsSubscription_Spec}
+---------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -628,8 +628,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | owner                                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopic resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | requiresSession                           | Value indicating if a subscription supports the concept of sessions.                                                                                                                                                                                                                            | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="NamespacesTopicsSubscription_STATUS"></a>NamespacesTopicsSubscription_STATUS
------------------------------------------------------------------------------------
+NamespacesTopicsSubscription_STATUS{#NamespacesTopicsSubscription_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 
@@ -661,8 +661,8 @@ Used by: [NamespacesTopicsSubscription](#NamespacesTopicsSubscription).
 | type                                      | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 | updatedAt                                 | The exact time the message was updated.                                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="NamespacesTopicsSubscriptionsRule_Spec"></a>NamespacesTopicsSubscriptionsRule_Spec
------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_Spec{#NamespacesTopicsSubscriptionsRule_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -676,8 +676,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a servicebus.azure.com/NamespacesTopicsSubscription resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | sqlFilter         | Properties of sqlFilter                                                                                                                                                                                                                                                                                      | [SqlFilter](#SqlFilter)<br/><small>Optional</small>                                                                                                                  |
 
-<a id="NamespacesTopicsSubscriptionsRule_STATUS"></a>NamespacesTopicsSubscriptionsRule_STATUS
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRule_STATUS{#NamespacesTopicsSubscriptionsRule_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule).
 
@@ -694,8 +694,8 @@ Used by: [NamespacesTopicsSubscriptionsRule](#NamespacesTopicsSubscriptionsRule)
 | systemData        | The system meta data relating to this resource.                                                                                                                                                                                                                                                                           | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.EventHub/Namespaces" or "Microsoft.EventHub/Namespaces/EventHubs"                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Action"></a>Action
--------------------------
+Action{#Action}
+---------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -707,8 +707,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="Action_STATUS"></a>Action_STATUS
----------------------------------------
+Action_STATUS{#Action_STATUS}
+-----------------------------
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
@@ -720,8 +720,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | SQL expression. e.g. MyProperty='ABC'                                                                                   | string<br/><small>Optional</small> |
 
-<a id="CorrelationFilter"></a>CorrelationFilter
------------------------------------------------
+CorrelationFilter{#CorrelationFilter}
+-------------------------------------
 
 Represents the correlation filter expression.
 
@@ -740,8 +740,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="CorrelationFilter_STATUS"></a>CorrelationFilter_STATUS
--------------------------------------------------------------
+CorrelationFilter_STATUS{#CorrelationFilter_STATUS}
+---------------------------------------------------
 
 Represents the correlation filter expression.
 
@@ -760,8 +760,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | sessionId             | Session identifier.                                                  | string<br/><small>Optional</small>            |
 | to                    | Address to send to.                                                  | string<br/><small>Optional</small>            |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 Properties to configure Encryption
 
@@ -773,8 +773,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties[]](#KeyVaultProperties)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                          |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 Properties to configure Encryption
 
@@ -786,8 +786,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | keyVaultProperties              | Properties of KeyVault                                    | [KeyVaultProperties_STATUS[]](#KeyVaultProperties_STATUS)<br/><small>Optional</small>   |
 | requireInfrastructureEncryption | Enable Infrastructure Encryption (Double Encryption)      | bool<br/><small>Optional</small>                                                        |
 
-<a id="EntityStatus_STATUS"></a>EntityStatus_STATUS
----------------------------------------------------
+EntityStatus_STATUS{#EntityStatus_STATUS}
+-----------------------------------------
 
 Entity status.
 
@@ -805,8 +805,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | "SendDisabled"    |             |
 | "Unknown"         |             |
 
-<a id="FilterType"></a>FilterType
----------------------------------
+FilterType{#FilterType}
+-----------------------
 
 Rule filter types
 
@@ -817,8 +817,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="FilterType_STATUS"></a>FilterType_STATUS
------------------------------------------------
+FilterType_STATUS{#FilterType_STATUS}
+-------------------------------------
 
 Rule filter types
 
@@ -829,8 +829,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | "CorrelationFilter" |             |
 | "SqlFilter"         |             |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -841,8 +841,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | type                   | Type of managed service identity.       | [Identity_Type](#Identity_Type)<br/><small>Optional</small>                               |
 | userAssignedIdentities | Properties for User Assigned Identities | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Properties to configure User Assigned Identities for Bring your Own Keys
 
@@ -855,8 +855,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | type                   | Type of managed service identity.       | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Properties for User Assigned Identities | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="MessageCountDetails_STATUS"></a>MessageCountDetails_STATUS
------------------------------------------------------------------
+MessageCountDetails_STATUS{#MessageCountDetails_STATUS}
+-------------------------------------------------------
 
 Message Count Details.
 
@@ -870,8 +870,8 @@ Used by: [NamespacesQueue_STATUS](#NamespacesQueue_STATUS), [NamespacesTopic_STA
 | transferDeadLetterMessageCount | Number of messages transferred into dead letters.                        | int<br/><small>Optional</small> |
 | transferMessageCount           | Number of messages transferred to another queue, topic, or subscription. | int<br/><small>Optional</small> |
 
-<a id="NamespaceOperatorSpec"></a>NamespaceOperatorSpec
--------------------------------------------------------
+NamespaceOperatorSpec{#NamespaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -883,8 +883,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespaceOperatorSecrets](#NamespaceOperatorSecrets)<br/><small>Optional</small>                                                                                   |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_Spec"></a>Namespaces_AuthorizationRule_Properties_Rights_Spec
--------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_Spec{#Namespaces_AuthorizationRule_Properties_Rights_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 
@@ -894,8 +894,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="Namespaces_AuthorizationRule_Properties_Rights_STATUS"></a>Namespaces_AuthorizationRule_Properties_Rights_STATUS
------------------------------------------------------------------------------------------------------------------------
+Namespaces_AuthorizationRule_Properties_Rights_STATUS{#Namespaces_AuthorizationRule_Properties_Rights_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATUS).
 
@@ -905,8 +905,8 @@ Used by: [NamespacesAuthorizationRule_STATUS](#NamespacesAuthorizationRule_STATU
 | "Manage" |             |
 | "Send"   |             |
 
-<a id="NamespacesAuthorizationRuleOperatorSpec"></a>NamespacesAuthorizationRuleOperatorSpec
--------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSpec{#NamespacesAuthorizationRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -918,8 +918,8 @@ Used by: [NamespacesAuthorizationRule_Spec](#NamespacesAuthorizationRule_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [NamespacesAuthorizationRuleOperatorSecrets](#NamespacesAuthorizationRuleOperatorSecrets)<br/><small>Optional</small>                                               |
 
-<a id="NamespacesQueueOperatorSpec"></a>NamespacesQueueOperatorSpec
--------------------------------------------------------------------
+NamespacesQueueOperatorSpec{#NamespacesQueueOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -930,8 +930,8 @@ Used by: [NamespacesQueue_Spec](#NamespacesQueue_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicOperatorSpec"></a>NamespacesTopicOperatorSpec
--------------------------------------------------------------------
+NamespacesTopicOperatorSpec{#NamespacesTopicOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -942,8 +942,8 @@ Used by: [NamespacesTopic_Spec](#NamespacesTopic_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionOperatorSpec"></a>NamespacesTopicsSubscriptionOperatorSpec
----------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionOperatorSpec{#NamespacesTopicsSubscriptionOperatorSpec}
+-----------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -954,8 +954,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="NamespacesTopicsSubscriptionsRuleOperatorSpec"></a>NamespacesTopicsSubscriptionsRuleOperatorSpec
--------------------------------------------------------------------------------------------------------
+NamespacesTopicsSubscriptionsRuleOperatorSpec{#NamespacesTopicsSubscriptionsRuleOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -966,8 +966,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 Properties of the PrivateEndpointConnection.
 
@@ -977,8 +977,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="SBClientAffineProperties"></a>SBClientAffineProperties
--------------------------------------------------------------
+SBClientAffineProperties{#SBClientAffineProperties}
+---------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -990,8 +990,8 @@ Used by: [NamespacesTopicsSubscription_Spec](#NamespacesTopicsSubscription_Spec)
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBClientAffineProperties_STATUS"></a>SBClientAffineProperties_STATUS
----------------------------------------------------------------------------
+SBClientAffineProperties_STATUS{#SBClientAffineProperties_STATUS}
+-----------------------------------------------------------------
 
 Properties specific to client affine subscriptions.
 
@@ -1003,8 +1003,8 @@ Used by: [NamespacesTopicsSubscription_STATUS](#NamespacesTopicsSubscription_STA
 | isDurable | For client-affine subscriptions, this value indicates whether the subscription is durable or not. | bool<br/><small>Optional</small>   |
 | isShared  | For client-affine subscriptions, this value indicates whether the subscription is shared or not.  | bool<br/><small>Optional</small>   |
 
-<a id="SBNamespaceProperties_MinimumTlsVersion"></a>SBNamespaceProperties_MinimumTlsVersion
--------------------------------------------------------------------------------------------
+SBNamespaceProperties_MinimumTlsVersion{#SBNamespaceProperties_MinimumTlsVersion}
+---------------------------------------------------------------------------------
 
 Used by: [Namespace_Spec](#Namespace_Spec).
 
@@ -1014,20 +1014,20 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "1.1" |             |
 | "1.2" |             |
 
-<a id="SBNamespaceProperties_MinimumTlsVersion_STATUS"></a>SBNamespaceProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------
-
-Used by: [Namespace_STATUS](#Namespace_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SBNamespaceProperties_PublicNetworkAccess"></a>SBNamespaceProperties_PublicNetworkAccess
+SBNamespaceProperties_MinimumTlsVersion_STATUS{#SBNamespaceProperties_MinimumTlsVersion_STATUS}
 -----------------------------------------------------------------------------------------------
 
+Used by: [Namespace_STATUS](#Namespace_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SBNamespaceProperties_PublicNetworkAccess{#SBNamespaceProperties_PublicNetworkAccess}
+-------------------------------------------------------------------------------------
+
 Used by: [Namespace_Spec](#Namespace_Spec).
 
 | Value                | Description |
@@ -1036,8 +1036,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="SBNamespaceProperties_PublicNetworkAccess_STATUS"></a>SBNamespaceProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------
+SBNamespaceProperties_PublicNetworkAccess_STATUS{#SBNamespaceProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [Namespace_STATUS](#Namespace_STATUS).
 
@@ -1047,8 +1047,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | "Enabled"            |             |
 | "SecuredByPerimeter" |             |
 
-<a id="SBSku"></a>SBSku
------------------------
+SBSku{#SBSku}
+-------------
 
 SKU of the namespace.
 
@@ -1060,8 +1060,8 @@ Used by: [Namespace_Spec](#Namespace_Spec).
 | name     | Name of this SKU.                                                                                                                                                                                                                                                                                                                                                                   | [SBSku_Name](#SBSku_Name)<br/><small>Required</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                                                                                                                                                                                            | [SBSku_Tier](#SBSku_Tier)<br/><small>Optional</small> |
 
-<a id="SBSku_STATUS"></a>SBSku_STATUS
--------------------------------------
+SBSku_STATUS{#SBSku_STATUS}
+---------------------------
 
 SKU of the namespace.
 
@@ -1073,8 +1073,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS).
 | name     | Name of this SKU.                                                                                                                                                                                                                                                                                                                                                                   | [SBSku_Name_STATUS](#SBSku_Name_STATUS)<br/><small>Optional</small> |
 | tier     | The billing tier of this particular SKU.                                                                                                                                                                                                                                                                                                                                            | [SBSku_Tier_STATUS](#SBSku_Tier_STATUS)<br/><small>Optional</small> |
 
-<a id="SqlFilter"></a>SqlFilter
--------------------------------
+SqlFilter{#SqlFilter}
+---------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1086,8 +1086,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_Spec](#NamespacesTopicsSubscriptions
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SqlFilter_STATUS"></a>SqlFilter_STATUS
----------------------------------------------
+SqlFilter_STATUS{#SqlFilter_STATUS}
+-----------------------------------
 
 Represents a filter which is a composition of an expression and an action that is executed in the pub/sub pipeline.
 
@@ -1099,8 +1099,8 @@ Used by: [NamespacesTopicsSubscriptionsRule_STATUS](#NamespacesTopicsSubscriptio
 | requiresPreprocessing | Value that indicates whether the rule action requires preprocessing.                                                    | bool<br/><small>Optional</small>   |
 | sqlExpression         | The SQL expression. e.g. MyProperty='ABC'                                                                               | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -1115,8 +1115,8 @@ Used by: [Namespace_STATUS](#Namespace_STATUS), [NamespacesAuthorizationRule_STA
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -1124,8 +1124,8 @@ Used by: [Encryption](#Encryption).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -1133,8 +1133,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-------------|
 | "Microsoft.KeyVault" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -1145,8 +1145,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -1157,8 +1157,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1171,8 +1171,8 @@ Used by: [Encryption](#Encryption).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                            |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                            |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties to configure keyVault Properties
 
@@ -1185,8 +1185,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyVaultUri | Uri of KeyVault               | string<br/><small>Optional</small>                                                                          |
 | keyVersion  | Version of KeyVault           | string<br/><small>Optional</small>                                                                          |
 
-<a id="NamespaceOperatorSecrets"></a>NamespaceOperatorSecrets
--------------------------------------------------------------
+NamespaceOperatorSecrets{#NamespaceOperatorSecrets}
+---------------------------------------------------
 
 Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 
@@ -1198,8 +1198,8 @@ Used by: [NamespaceOperatorSpec](#NamespaceOperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="NamespacesAuthorizationRuleOperatorSecrets"></a>NamespacesAuthorizationRuleOperatorSecrets
--------------------------------------------------------------------------------------------------
+NamespacesAuthorizationRuleOperatorSecrets{#NamespacesAuthorizationRuleOperatorSecrets}
+---------------------------------------------------------------------------------------
 
 Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleOperatorSpec).
 
@@ -1210,8 +1210,8 @@ Used by: [NamespacesAuthorizationRuleOperatorSpec](#NamespacesAuthorizationRuleO
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SBSku_Name"></a>SBSku_Name
----------------------------------
+SBSku_Name{#SBSku_Name}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1221,8 +1221,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Name_STATUS"></a>SBSku_Name_STATUS
------------------------------------------------
+SBSku_Name_STATUS{#SBSku_Name_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1232,8 +1232,8 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier"></a>SBSku_Tier
----------------------------------
+SBSku_Tier{#SBSku_Tier}
+-----------------------
 
 Used by: [SBSku](#SBSku).
 
@@ -1243,8 +1243,8 @@ Used by: [SBSku](#SBSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SBSku_Tier_STATUS"></a>SBSku_Tier_STATUS
------------------------------------------------
+SBSku_Tier_STATUS{#SBSku_Tier_STATUS}
+-------------------------------------
 
 Used by: [SBSku_STATUS](#SBSku_STATUS).
 
@@ -1254,7 +1254,19 @@ Used by: [SBSku_STATUS](#SBSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1266,20 +1278,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 Recognized Dictionary value.
 
@@ -1290,8 +1290,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1301,8 +1301,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties"></a>UserAssignedIdentityProperties
--------------------------------------------------------------------------
+UserAssignedIdentityProperties{#UserAssignedIdentityProperties}
+---------------------------------------------------------------
 
 Used by: [KeyVaultProperties](#KeyVaultProperties).
 
@@ -1310,8 +1310,8 @@ Used by: [KeyVaultProperties](#KeyVaultProperties).
 |-------------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | ARM ID of user Identity selected for encryption | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperties_STATUS"></a>UserAssignedIdentityProperties_STATUS
----------------------------------------------------------------------------------------
+UserAssignedIdentityProperties_STATUS{#UserAssignedIdentityProperties_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [KeyVaultProperties_STATUS](#KeyVaultProperties_STATUS).
 

--- a/docs/hugo/content/reference/signalrservice/v1api20211001.md
+++ b/docs/hugo/content/reference/signalrservice/v1api20211001.md
@@ -5,15 +5,15 @@ title: signalrservice.azure.com/v1api20211001
 linktitle: v1api20211001
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-10-01" |             |
 
-<a id="SignalR"></a>SignalR
----------------------------
+SignalR{#SignalR}
+-----------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2021-10-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}
 
@@ -26,7 +26,7 @@ Used by: [SignalRList](#SignalRList).
 | spec                                                                                    |             | [SignalR_Spec](#SignalR_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SignalR_STATUS](#SignalR_STATUS)<br/><small>Optional</small> |
 
-### <a id="SignalR_Spec"></a>SignalR_Spec
+### SignalR_Spec {#SignalR_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -48,7 +48,7 @@ Used by: [SignalRList](#SignalRList).
 | tls                      | TLS settings for the resource                                                                                                                                                                                                                                                                                                                                                                    | [SignalRTlsSettings](#SignalRTlsSettings)<br/><small>Optional</small>                                                                                                |
 | upstream                 | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings](#ServerlessUpstreamSettings)<br/><small>Optional</small>                                                                                |
 
-### <a id="SignalR_STATUS"></a>SignalR_STATUS
+### SignalR_STATUS{#SignalR_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                        |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -81,8 +81,8 @@ Used by: [SignalRList](#SignalRList).
 | upstream                   | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)<br/><small>Optional</small>                                                         |
 | version                    | Version of the resource. Probably you need the same or higher version of client SDKs.                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                          |
 
-<a id="SignalRList"></a>SignalRList
------------------------------------
+SignalRList{#SignalRList}
+-------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2021-10-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}
 
@@ -92,8 +92,8 @@ Generator information: - Generated from: /signalr/resource-manager/Microsoft.Sig
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [SignalR[]](#SignalR)<br/><small>Optional</small> |
 
-<a id="SignalR_Spec"></a>SignalR_Spec
--------------------------------------
+SignalR_Spec{#SignalR_Spec}
+---------------------------
 
 Used by: [SignalR](#SignalR).
 
@@ -117,8 +117,8 @@ Used by: [SignalR](#SignalR).
 | tls                      | TLS settings for the resource                                                                                                                                                                                                                                                                                                                                                                    | [SignalRTlsSettings](#SignalRTlsSettings)<br/><small>Optional</small>                                                                                                |
 | upstream                 | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings](#ServerlessUpstreamSettings)<br/><small>Optional</small>                                                                                |
 
-<a id="SignalR_STATUS"></a>SignalR_STATUS
------------------------------------------
+SignalR_STATUS{#SignalR_STATUS}
+-------------------------------
 
 Used by: [SignalR](#SignalR).
 
@@ -153,8 +153,8 @@ Used by: [SignalR](#SignalR).
 | upstream                   | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)<br/><small>Optional</small>                                                         |
 | version                    | Version of the resource. Probably you need the same or higher version of client SDKs.                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                          |
 
-<a id="ManagedIdentity"></a>ManagedIdentity
--------------------------------------------
+ManagedIdentity{#ManagedIdentity}
+---------------------------------
 
 A class represent managed identities used for request and response
 
@@ -165,8 +165,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | type                   | Represents the identity type: systemAssigned, userAssigned, None | [ManagedIdentityType](#ManagedIdentityType)<br/><small>Optional</small>                   |
 | userAssignedIdentities | Get or set the user assigned identities                          | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedIdentity_STATUS"></a>ManagedIdentity_STATUS
----------------------------------------------------------
+ManagedIdentity_STATUS{#ManagedIdentity_STATUS}
+-----------------------------------------------
 
 A class represent managed identities used for request and response
 
@@ -179,8 +179,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | type                   | Represents the identity type: systemAssigned, userAssigned, None                 | [ManagedIdentityType_STATUS](#ManagedIdentityType_STATUS)<br/><small>Optional</small>                              |
 | userAssignedIdentities | Get or set the user assigned identities                                          | [map[string]UserAssignedIdentityProperty_STATUS](#UserAssignedIdentityProperty_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded"></a>PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded{#PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 A private endpoint connection to an azure resource
 
@@ -190,8 +190,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------|-----------------------------------------------|------------------------------------|
 | id       | Fully qualified resource Id for the resource. | string<br/><small>Optional</small> |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 Provisioning state of the resource.
 
@@ -209,8 +209,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="ResourceLogConfiguration"></a>ResourceLogConfiguration
--------------------------------------------------------------
+ResourceLogConfiguration{#ResourceLogConfiguration}
+---------------------------------------------------
 
 Resource log configuration of a Microsoft.SignalRService resource.
 
@@ -220,8 +220,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |------------|---------------------------------------------------|---------------------------------------------------------------------------|
 | categories | Gets or sets the list of category configurations. | [ResourceLogCategory[]](#ResourceLogCategory)<br/><small>Optional</small> |
 
-<a id="ResourceLogConfiguration_STATUS"></a>ResourceLogConfiguration_STATUS
----------------------------------------------------------------------------
+ResourceLogConfiguration_STATUS{#ResourceLogConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Resource log configuration of a Microsoft.SignalRService resource.
 
@@ -231,8 +231,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |------------|---------------------------------------------------|-----------------------------------------------------------------------------------------|
 | categories | Gets or sets the list of category configurations. | [ResourceLogCategory_STATUS[]](#ResourceLogCategory_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceSku"></a>ResourceSku
------------------------------------
+ResourceSku{#ResourceSku}
+-------------------------
 
 The billing information of the resource.
 
@@ -244,8 +244,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | name     | The name of the SKU. Required. Allowed values: Standard_S1, Free_F1                                                                             | string<br/><small>Required</small>                            |
 | tier     | Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.                                      | [SignalRSkuTier](#SignalRSkuTier)<br/><small>Optional</small> |
 
-<a id="ResourceSku_STATUS"></a>ResourceSku_STATUS
--------------------------------------------------
+ResourceSku_STATUS{#ResourceSku_STATUS}
+---------------------------------------
 
 The billing information of the resource.
 
@@ -259,8 +259,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | size     | Not used. Retained for future use.                                                                                                              | string<br/><small>Optional</small>                                          |
 | tier     | Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.                                      | [SignalRSkuTier_STATUS](#SignalRSkuTier_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerlessUpstreamSettings"></a>ServerlessUpstreamSettings
------------------------------------------------------------------
+ServerlessUpstreamSettings{#ServerlessUpstreamSettings}
+-------------------------------------------------------
 
 The settings for the Upstream when the service is in server-less mode.
 
@@ -270,8 +270,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |-----------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 | templates | Gets or sets the list of Upstream URL templates. Order matters, and the first matching template takes effects. | [UpstreamTemplate[]](#UpstreamTemplate)<br/><small>Optional</small> |
 
-<a id="ServerlessUpstreamSettings_STATUS"></a>ServerlessUpstreamSettings_STATUS
--------------------------------------------------------------------------------
+ServerlessUpstreamSettings_STATUS{#ServerlessUpstreamSettings_STATUS}
+---------------------------------------------------------------------
 
 The settings for the Upstream when the service is in server-less mode.
 
@@ -281,8 +281,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |-----------|----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | templates | Gets or sets the list of Upstream URL templates. Order matters, and the first matching template takes effects. | [UpstreamTemplate_STATUS[]](#UpstreamTemplate_STATUS)<br/><small>Optional</small> |
 
-<a id="ServiceKind"></a>ServiceKind
------------------------------------
+ServiceKind{#ServiceKind}
+-------------------------
 
 The kind of the service, it can be SignalR or RawWebSockets
 
@@ -293,8 +293,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | "RawWebSockets" |             |
 | "SignalR"       |             |
 
-<a id="ServiceKind_STATUS"></a>ServiceKind_STATUS
--------------------------------------------------
+ServiceKind_STATUS{#ServiceKind_STATUS}
+---------------------------------------
 
 The kind of the service, it can be SignalR or RawWebSockets
 
@@ -305,8 +305,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | "RawWebSockets" |             |
 | "SignalR"       |             |
 
-<a id="SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded"></a>SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded{#SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 Describes a Shared Private Link Resource
 
@@ -316,8 +316,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------|-----------------------------------------------|------------------------------------|
 | id       | Fully qualified resource Id for the resource. | string<br/><small>Optional</small> |
 
-<a id="SignalRCorsSettings"></a>SignalRCorsSettings
----------------------------------------------------
+SignalRCorsSettings{#SignalRCorsSettings}
+-----------------------------------------
 
 Cross-Origin Resource Sharing (CORS) settings.
 
@@ -327,8 +327,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedOrigins | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all. If omitted, allow all by default. | string[]<br/><small>Optional</small> |
 
-<a id="SignalRCorsSettings_STATUS"></a>SignalRCorsSettings_STATUS
------------------------------------------------------------------
+SignalRCorsSettings_STATUS{#SignalRCorsSettings_STATUS}
+-------------------------------------------------------
 
 Cross-Origin Resource Sharing (CORS) settings.
 
@@ -338,8 +338,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedOrigins | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all. If omitted, allow all by default. | string[]<br/><small>Optional</small> |
 
-<a id="SignalRFeature"></a>SignalRFeature
------------------------------------------
+SignalRFeature{#SignalRFeature}
+-------------------------------
 
 Feature of a resource, which controls the runtime behavior.
 
@@ -351,8 +351,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | properties | Optional properties related to this feature.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | map[string]string<br/><small>Optional</small>             |
 | value      | Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/azure/azure-signalr/ for allowed values.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string<br/><small>Required</small>                        |
 
-<a id="SignalRFeature_STATUS"></a>SignalRFeature_STATUS
--------------------------------------------------------
+SignalRFeature_STATUS{#SignalRFeature_STATUS}
+---------------------------------------------
 
 Feature of a resource, which controls the runtime behavior.
 
@@ -364,8 +364,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | properties | Optional properties related to this feature.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | map[string]string<br/><small>Optional</small>                           |
 | value      | Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/azure/azure-signalr/ for allowed values.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                      |
 
-<a id="SignalRNetworkACLs"></a>SignalRNetworkACLs
--------------------------------------------------
+SignalRNetworkACLs{#SignalRNetworkACLs}
+---------------------------------------
 
 Network ACLs for the resource
 
@@ -377,8 +377,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | privateEndpoints | ACLs for requests from private endpoints | [PrivateEndpointACL[]](#PrivateEndpointACL)<br/><small>Optional</small> |
 | publicNetwork    | Network ACL                              | [NetworkACL](#NetworkACL)<br/><small>Optional</small>                   |
 
-<a id="SignalRNetworkACLs_STATUS"></a>SignalRNetworkACLs_STATUS
----------------------------------------------------------------
+SignalRNetworkACLs_STATUS{#SignalRNetworkACLs_STATUS}
+-----------------------------------------------------
 
 Network ACLs for the resource
 
@@ -390,8 +390,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | privateEndpoints | ACLs for requests from private endpoints | [PrivateEndpointACL_STATUS[]](#PrivateEndpointACL_STATUS)<br/><small>Optional</small> |
 | publicNetwork    | Network ACL                              | [NetworkACL_STATUS](#NetworkACL_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SignalROperatorSpec"></a>SignalROperatorSpec
----------------------------------------------------
+SignalROperatorSpec{#SignalROperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -403,8 +403,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [SignalROperatorSecrets](#SignalROperatorSecrets)<br/><small>Optional</small>                                                                                       |
 
-<a id="SignalRTlsSettings"></a>SignalRTlsSettings
--------------------------------------------------
+SignalRTlsSettings{#SignalRTlsSettings}
+---------------------------------------
 
 TLS settings for the resource
 
@@ -414,8 +414,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |-------------------|------------------------------------------------------------|----------------------------------|
 | clientCertEnabled | Request client certificate during TLS handshake if enabled | bool<br/><small>Optional</small> |
 
-<a id="SignalRTlsSettings_STATUS"></a>SignalRTlsSettings_STATUS
----------------------------------------------------------------
+SignalRTlsSettings_STATUS{#SignalRTlsSettings_STATUS}
+-----------------------------------------------------
 
 TLS settings for the resource
 
@@ -425,8 +425,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |-------------------|------------------------------------------------------------|----------------------------------|
 | clientCertEnabled | Request client certificate during TLS handshake if enabled | bool<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -441,8 +441,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ACLAction"></a>ACLAction
--------------------------------
+ACLAction{#ACLAction}
+---------------------
 
 Azure Networking ACL Action.
 
@@ -453,8 +453,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ACLAction_STATUS"></a>ACLAction_STATUS
----------------------------------------------
+ACLAction_STATUS{#ACLAction_STATUS}
+-----------------------------------
 
 Azure Networking ACL Action.
 
@@ -465,8 +465,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="FeatureFlags"></a>FeatureFlags
--------------------------------------
+FeatureFlags{#FeatureFlags}
+---------------------------
 
 FeatureFlags is the supported features of Azure SignalR service. - ServiceMode: Flag for backend server for SignalR service. Values allowed: "Default": have your own backend server; "Serverless": your application doesn't have a backend server; "Classic": for backward compatibility. Support both Default and Serverless mode but not recommended; "PredefinedOnly": for future use. - EnableConnectivityLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableMessagingLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableLiveTrace: Live Trace allows you to know what's happening inside Azure SignalR service, it will give you live traces in real time, it will be helpful when you developing your own Azure SignalR based web application or self-troubleshooting some issues. Please note that live traces are counted as outbound messages that will be charged. Values allowed: "true"/"false", to enable/disable live trace feature.
 
@@ -479,8 +479,8 @@ Used by: [SignalRFeature](#SignalRFeature).
 | "EnableMessagingLogs"    |             |
 | "ServiceMode"            |             |
 
-<a id="FeatureFlags_STATUS"></a>FeatureFlags_STATUS
----------------------------------------------------
+FeatureFlags_STATUS{#FeatureFlags_STATUS}
+-----------------------------------------
 
 FeatureFlags is the supported features of Azure SignalR service. - ServiceMode: Flag for backend server for SignalR service. Values allowed: "Default": have your own backend server; "Serverless": your application doesn't have a backend server; "Classic": for backward compatibility. Support both Default and Serverless mode but not recommended; "PredefinedOnly": for future use. - EnableConnectivityLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableMessagingLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableLiveTrace: Live Trace allows you to know what's happening inside Azure SignalR service, it will give you live traces in real time, it will be helpful when you developing your own Azure SignalR based web application or self-troubleshooting some issues. Please note that live traces are counted as outbound messages that will be charged. Values allowed: "true"/"false", to enable/disable live trace feature.
 
@@ -493,8 +493,8 @@ Used by: [SignalRFeature_STATUS](#SignalRFeature_STATUS).
 | "EnableMessagingLogs"    |             |
 | "ServiceMode"            |             |
 
-<a id="ManagedIdentityType"></a>ManagedIdentityType
----------------------------------------------------
+ManagedIdentityType{#ManagedIdentityType}
+-----------------------------------------
 
 Represents the identity type: systemAssigned, userAssigned, None
 
@@ -506,8 +506,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedIdentityType_STATUS"></a>ManagedIdentityType_STATUS
------------------------------------------------------------------
+ManagedIdentityType_STATUS{#ManagedIdentityType_STATUS}
+-------------------------------------------------------
 
 Represents the identity type: systemAssigned, userAssigned, None
 
@@ -519,8 +519,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="NetworkACL"></a>NetworkACL
----------------------------------
+NetworkACL{#NetworkACL}
+-----------------------
 
 Network ACL
 
@@ -531,8 +531,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | allow    | Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI. | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 
-<a id="NetworkACL_STATUS"></a>NetworkACL_STATUS
------------------------------------------------
+NetworkACL_STATUS{#NetworkACL_STATUS}
+-------------------------------------
 
 Network ACL
 
@@ -543,8 +543,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | allow    | Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI. | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointACL"></a>PrivateEndpointACL
--------------------------------------------------
+PrivateEndpointACL{#PrivateEndpointACL}
+---------------------------------------
 
 ACL for a private endpoint
 
@@ -556,8 +556,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 | name     | Name of the private endpoint connection                                                              | string<br/><small>Required</small>                                      |
 
-<a id="PrivateEndpointACL_STATUS"></a>PrivateEndpointACL_STATUS
----------------------------------------------------------------
+PrivateEndpointACL_STATUS{#PrivateEndpointACL_STATUS}
+-----------------------------------------------------
 
 ACL for a private endpoint
 
@@ -569,8 +569,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 | name     | Name of the private endpoint connection                                                              | string<br/><small>Optional</small>                                                    |
 
-<a id="ResourceLogCategory"></a>ResourceLogCategory
----------------------------------------------------
+ResourceLogCategory{#ResourceLogCategory}
+-----------------------------------------
 
 Resource log category configuration of a Microsoft.SignalRService resource.
 
@@ -581,8 +581,8 @@ Used by: [ResourceLogConfiguration](#ResourceLogConfiguration).
 | enabled  | Indicates whether or the resource log category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the resource log category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="ResourceLogCategory_STATUS"></a>ResourceLogCategory_STATUS
------------------------------------------------------------------
+ResourceLogCategory_STATUS{#ResourceLogCategory_STATUS}
+-------------------------------------------------------
 
 Resource log category configuration of a Microsoft.SignalRService resource.
 
@@ -593,8 +593,8 @@ Used by: [ResourceLogConfiguration_STATUS](#ResourceLogConfiguration_STATUS).
 | enabled  | Indicates whether or the resource log category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the resource log category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="SignalROperatorSecrets"></a>SignalROperatorSecrets
----------------------------------------------------------
+SignalROperatorSecrets{#SignalROperatorSecrets}
+-----------------------------------------------
 
 Used by: [SignalROperatorSpec](#SignalROperatorSpec).
 
@@ -605,8 +605,8 @@ Used by: [SignalROperatorSpec](#SignalROperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SignalRSkuTier"></a>SignalRSkuTier
------------------------------------------
+SignalRSkuTier{#SignalRSkuTier}
+-------------------------------
 
 Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.
 
@@ -619,8 +619,8 @@ Used by: [ResourceSku](#ResourceSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SignalRSkuTier_STATUS"></a>SignalRSkuTier_STATUS
--------------------------------------------------------
+SignalRSkuTier_STATUS{#SignalRSkuTier_STATUS}
+---------------------------------------------
 
 Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.
 
@@ -633,7 +633,19 @@ Used by: [ResourceSku_STATUS](#ResourceSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -645,20 +657,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpstreamTemplate"></a>UpstreamTemplate
----------------------------------------------
+UpstreamTemplate{#UpstreamTemplate}
+-----------------------------------
 
 Upstream template item settings. It defines the Upstream URL of the incoming requests. The template defines the pattern of the event, the hub or the category of the incoming request that matches current URL template.
 
@@ -672,8 +672,8 @@ Used by: [ServerlessUpstreamSettings](#ServerlessUpstreamSettings).
 | hubPattern      | Gets or sets the matching pattern for hub names. If not set, it matches any hub. There are 3 kind of patterns supported: 1. "*", it to matches any hub name 2. Combine multiple hubs with ",", for example "hub1,hub2", it matches "hub1" and "hub2" 3. The single hub name, for example, "hub1", it matches "hub1"                                                                                                    | string<br/><small>Optional</small>                                        |
 | urlTemplate     | Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in. For example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`. | string<br/><small>Required</small>                                        |
 
-<a id="UpstreamTemplate_STATUS"></a>UpstreamTemplate_STATUS
------------------------------------------------------------
+UpstreamTemplate_STATUS{#UpstreamTemplate_STATUS}
+-------------------------------------------------
 
 Upstream template item settings. It defines the Upstream URL of the incoming requests. The template defines the pattern of the event, the hub or the category of the incoming request that matches current URL template.
 
@@ -687,8 +687,8 @@ Used by: [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)
 | hubPattern      | Gets or sets the matching pattern for hub names. If not set, it matches any hub. There are 3 kind of patterns supported: 1. "*", it to matches any hub name 2. Combine multiple hubs with ",", for example "hub1,hub2", it matches "hub1" and "hub2" 3. The single hub name, for example, "hub1", it matches "hub1"                                                                                                    | string<br/><small>Optional</small>                                                      |
 | urlTemplate     | Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in. For example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`. | string<br/><small>Optional</small>                                                      |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -698,8 +698,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperty_STATUS"></a>UserAssignedIdentityProperty_STATUS
------------------------------------------------------------------------------------
+UserAssignedIdentityProperty_STATUS{#UserAssignedIdentityProperty_STATUS}
+-------------------------------------------------------------------------
 
 Properties of user assigned identity.
 
@@ -710,8 +710,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | clientId    | Get the client id for the user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Get the principal id for the user assigned identity | string<br/><small>Optional</small> |
 
-<a id="SignalRRequestType"></a>SignalRRequestType
--------------------------------------------------
+SignalRRequestType{#SignalRRequestType}
+---------------------------------------
 
 The incoming request type to the service
 
@@ -724,8 +724,8 @@ Used by: [NetworkACL](#NetworkACL), [NetworkACL](#NetworkACL), [PrivateEndpointA
 | "ServerConnection" |             |
 | "Trace"            |             |
 
-<a id="SignalRRequestType_STATUS"></a>SignalRRequestType_STATUS
----------------------------------------------------------------
+SignalRRequestType_STATUS{#SignalRRequestType_STATUS}
+-----------------------------------------------------
 
 The incoming request type to the service
 
@@ -738,8 +738,8 @@ Used by: [NetworkACL_STATUS](#NetworkACL_STATUS), [NetworkACL_STATUS](#NetworkAC
 | "ServerConnection" |             |
 | "Trace"            |             |
 
-<a id="UpstreamAuthSettings"></a>UpstreamAuthSettings
------------------------------------------------------
+UpstreamAuthSettings{#UpstreamAuthSettings}
+-------------------------------------------
 
 Upstream auth settings. If not set, no auth is used for upstream messages.
 
@@ -750,8 +750,8 @@ Used by: [UpstreamTemplate](#UpstreamTemplate).
 | managedIdentity | Managed identity settings for upstream. | [ManagedIdentitySettings](#ManagedIdentitySettings)<br/><small>Optional</small> |
 | type            | Upstream auth type enum.                | [UpstreamAuthType](#UpstreamAuthType)<br/><small>Optional</small>               |
 
-<a id="UpstreamAuthSettings_STATUS"></a>UpstreamAuthSettings_STATUS
--------------------------------------------------------------------
+UpstreamAuthSettings_STATUS{#UpstreamAuthSettings_STATUS}
+---------------------------------------------------------
 
 Upstream auth settings. If not set, no auth is used for upstream messages.
 
@@ -762,8 +762,8 @@ Used by: [UpstreamTemplate_STATUS](#UpstreamTemplate_STATUS).
 | managedIdentity | Managed identity settings for upstream. | [ManagedIdentitySettings_STATUS](#ManagedIdentitySettings_STATUS)<br/><small>Optional</small> |
 | type            | Upstream auth type enum.                | [UpstreamAuthType_STATUS](#UpstreamAuthType_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedIdentitySettings"></a>ManagedIdentitySettings
------------------------------------------------------------
+ManagedIdentitySettings{#ManagedIdentitySettings}
+-------------------------------------------------
 
 Managed identity settings for upstream.
 
@@ -773,8 +773,8 @@ Used by: [UpstreamAuthSettings](#UpstreamAuthSettings).
 |----------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | resource | The Resource indicating the App ID URI of the target resource. It also appears in the aud (audience) claim of the issued token. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentitySettings_STATUS"></a>ManagedIdentitySettings_STATUS
--------------------------------------------------------------------------
+ManagedIdentitySettings_STATUS{#ManagedIdentitySettings_STATUS}
+---------------------------------------------------------------
 
 Managed identity settings for upstream.
 
@@ -784,8 +784,8 @@ Used by: [UpstreamAuthSettings_STATUS](#UpstreamAuthSettings_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | resource | The Resource indicating the App ID URI of the target resource. It also appears in the aud (audience) claim of the issued token. | string<br/><small>Optional</small> |
 
-<a id="UpstreamAuthType"></a>UpstreamAuthType
----------------------------------------------
+UpstreamAuthType{#UpstreamAuthType}
+-----------------------------------
 
 Upstream auth type enum.
 
@@ -796,8 +796,8 @@ Used by: [UpstreamAuthSettings](#UpstreamAuthSettings).
 | "ManagedIdentity" |             |
 | "None"            |             |
 
-<a id="UpstreamAuthType_STATUS"></a>UpstreamAuthType_STATUS
------------------------------------------------------------
+UpstreamAuthType_STATUS{#UpstreamAuthType_STATUS}
+-------------------------------------------------
 
 Upstream auth type enum.
 

--- a/docs/hugo/content/reference/signalrservice/v1api20240301.md
+++ b/docs/hugo/content/reference/signalrservice/v1api20240301.md
@@ -5,15 +5,15 @@ title: signalrservice.azure.com/v1api20240301
 linktitle: v1api20240301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2024-03-01" |             |
 
-<a id="CustomCertificate"></a>CustomCertificate
------------------------------------------------
+CustomCertificate{#CustomCertificate}
+-------------------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/customCertificates/{certificateName}
 
@@ -26,7 +26,7 @@ Used by: [CustomCertificateList](#CustomCertificateList).
 | spec                                                                                    |             | [CustomCertificate_Spec](#CustomCertificate_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [CustomCertificate_STATUS](#CustomCertificate_STATUS)<br/><small>Optional</small> |
 
-### <a id="CustomCertificate_Spec"></a>CustomCertificate_Spec
+### CustomCertificate_Spec {#CustomCertificate_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,7 +38,7 @@ Used by: [CustomCertificateList](#CustomCertificateList).
 | operatorSpec              | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [CustomCertificateOperatorSpec](#CustomCertificateOperatorSpec)<br/><small>Optional</small>                                                                          |
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a signalrservice.azure.com/SignalR resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="CustomCertificate_STATUS"></a>CustomCertificate_STATUS
+### CustomCertificate_STATUS{#CustomCertificate_STATUS}
 
 | Property              | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -52,8 +52,8 @@ Used by: [CustomCertificateList](#CustomCertificateList).
 | systemData            | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CustomCertificateList"></a>CustomCertificateList
--------------------------------------------------------
+CustomCertificateList{#CustomCertificateList}
+---------------------------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/customCertificates/{certificateName}
 
@@ -63,8 +63,8 @@ Generator information: - Generated from: /signalr/resource-manager/Microsoft.Sig
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                       |
 | items                                                                               |             | [CustomCertificate[]](#CustomCertificate)<br/><small>Optional</small> |
 
-<a id="CustomDomain"></a>CustomDomain
--------------------------------------
+CustomDomain{#CustomDomain}
+---------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/customDomains/{name}
 
@@ -77,7 +77,7 @@ Used by: [CustomDomainList](#CustomDomainList).
 | spec                                                                                    |             | [CustomDomain_Spec](#CustomDomain_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [CustomDomain_STATUS](#CustomDomain_STATUS)<br/><small>Optional</small> |
 
-### <a id="CustomDomain_Spec"></a>CustomDomain_Spec
+### CustomDomain_Spec {#CustomDomain_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -87,7 +87,7 @@ Used by: [CustomDomainList](#CustomDomainList).
 | operatorSpec      | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [CustomDomainOperatorSpec](#CustomDomainOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a signalrservice.azure.com/SignalR resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
+### CustomDomain_STATUS{#CustomDomain_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -100,8 +100,8 @@ Used by: [CustomDomainList](#CustomDomainList).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CustomDomainList"></a>CustomDomainList
----------------------------------------------
+CustomDomainList{#CustomDomainList}
+-----------------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/customDomains/{name}
 
@@ -111,8 +111,8 @@ Generator information: - Generated from: /signalr/resource-manager/Microsoft.Sig
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                             |
 | items                                                                               |             | [CustomDomain[]](#CustomDomain)<br/><small>Optional</small> |
 
-<a id="Replica"></a>Replica
----------------------------
+Replica{#Replica}
+-----------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}
 
@@ -125,7 +125,7 @@ Used by: [ReplicaList](#ReplicaList).
 | spec                                                                                    |             | [Replica_Spec](#Replica_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Replica_STATUS](#Replica_STATUS)<br/><small>Optional</small> |
 
-### <a id="Replica_Spec"></a>Replica_Spec
+### Replica_Spec {#Replica_Spec}
 
 | Property              | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -138,7 +138,7 @@ Used by: [ReplicaList](#ReplicaList).
 | sku                   | The billing information of the resource.                                                                                                                                                                                                                                                    | [ResourceSku](#ResourceSku)<br/><small>Optional</small>                                                                                                              |
 | tags                  | Resource tags.                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="Replica_STATUS"></a>Replica_STATUS
+### Replica_STATUS{#Replica_STATUS}
 
 | Property              | Description                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -154,8 +154,8 @@ Used by: [ReplicaList](#ReplicaList).
 | tags                  | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ReplicaList"></a>ReplicaList
------------------------------------
+ReplicaList{#ReplicaList}
+-------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}
 
@@ -165,8 +165,8 @@ Generator information: - Generated from: /signalr/resource-manager/Microsoft.Sig
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [Replica[]](#Replica)<br/><small>Optional</small> |
 
-<a id="SignalR"></a>SignalR
----------------------------
+SignalR{#SignalR}
+-----------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}
 
@@ -179,7 +179,7 @@ Used by: [SignalRList](#SignalRList).
 | spec                                                                                    |             | [SignalR_Spec](#SignalR_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SignalR_STATUS](#SignalR_STATUS)<br/><small>Optional</small> |
 
-### <a id="SignalR_Spec"></a>SignalR_Spec
+### SignalR_Spec {#SignalR_Spec}
 
 | Property                 | Description                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -205,7 +205,7 @@ Used by: [SignalRList](#SignalRList).
 | tls                      | TLS settings for the resource                                                                                                                                                                                                                                                                                                                                                                    | [SignalRTlsSettings](#SignalRTlsSettings)<br/><small>Optional</small>                                                                                                |
 | upstream                 | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings](#ServerlessUpstreamSettings)<br/><small>Optional</small>                                                                                |
 
-### <a id="SignalR_STATUS"></a>SignalR_STATUS
+### SignalR_STATUS{#SignalR_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                        |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -242,8 +242,8 @@ Used by: [SignalRList](#SignalRList).
 | upstream                   | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)<br/><small>Optional</small>                                                         |
 | version                    | Version of the resource. Probably you need the same or higher version of client SDKs.                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                          |
 
-<a id="SignalRList"></a>SignalRList
------------------------------------
+SignalRList{#SignalRList}
+-------------------------
 
 Generator information: - Generated from: /signalr/resource-manager/Microsoft.SignalRService/stable/2024-03-01/signalr.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.SignalRService/signalR/{resourceName}
 
@@ -253,8 +253,8 @@ Generator information: - Generated from: /signalr/resource-manager/Microsoft.Sig
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                   |
 | items                                                                               |             | [SignalR[]](#SignalR)<br/><small>Optional</small> |
 
-<a id="CustomCertificate_Spec"></a>CustomCertificate_Spec
----------------------------------------------------------
+CustomCertificate_Spec{#CustomCertificate_Spec}
+-----------------------------------------------
 
 Used by: [CustomCertificate](#CustomCertificate).
 
@@ -268,8 +268,8 @@ Used by: [CustomCertificate](#CustomCertificate).
 | operatorSpec              | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [CustomCertificateOperatorSpec](#CustomCertificateOperatorSpec)<br/><small>Optional</small>                                                                          |
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a signalrservice.azure.com/SignalR resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="CustomCertificate_STATUS"></a>CustomCertificate_STATUS
--------------------------------------------------------------
+CustomCertificate_STATUS{#CustomCertificate_STATUS}
+---------------------------------------------------
 
 Used by: [CustomCertificate](#CustomCertificate).
 
@@ -285,8 +285,8 @@ Used by: [CustomCertificate](#CustomCertificate).
 | systemData            | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CustomDomain_Spec"></a>CustomDomain_Spec
------------------------------------------------
+CustomDomain_Spec{#CustomDomain_Spec}
+-------------------------------------
 
 Used by: [CustomDomain](#CustomDomain).
 
@@ -298,8 +298,8 @@ Used by: [CustomDomain](#CustomDomain).
 | operatorSpec      | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [CustomDomainOperatorSpec](#CustomDomainOperatorSpec)<br/><small>Optional</small>                                                                                    |
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a signalrservice.azure.com/SignalR resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
----------------------------------------------------
+CustomDomain_STATUS{#CustomDomain_STATUS}
+-----------------------------------------
 
 Used by: [CustomDomain](#CustomDomain).
 
@@ -314,8 +314,8 @@ Used by: [CustomDomain](#CustomDomain).
 | systemData        | Azure Resource Manager metadata containing createdBy and modifiedBy information.                                                                                                                                                                                                                                            | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="Replica_Spec"></a>Replica_Spec
--------------------------------------
+Replica_Spec{#Replica_Spec}
+---------------------------
 
 Used by: [Replica](#Replica).
 
@@ -330,8 +330,8 @@ Used by: [Replica](#Replica).
 | sku                   | The billing information of the resource.                                                                                                                                                                                                                                                    | [ResourceSku](#ResourceSku)<br/><small>Optional</small>                                                                                                              |
 | tags                  | Resource tags.                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Replica_STATUS"></a>Replica_STATUS
------------------------------------------
+Replica_STATUS{#Replica_STATUS}
+-------------------------------
 
 Used by: [Replica](#Replica).
 
@@ -349,8 +349,8 @@ Used by: [Replica](#Replica).
 | tags                  | Resource tags.                                                                                                                                                                                                                                                                                                              | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SignalR_Spec"></a>SignalR_Spec
--------------------------------------
+SignalR_Spec{#SignalR_Spec}
+---------------------------
 
 Used by: [SignalR](#SignalR).
 
@@ -378,8 +378,8 @@ Used by: [SignalR](#SignalR).
 | tls                      | TLS settings for the resource                                                                                                                                                                                                                                                                                                                                                                    | [SignalRTlsSettings](#SignalRTlsSettings)<br/><small>Optional</small>                                                                                                |
 | upstream                 | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings](#ServerlessUpstreamSettings)<br/><small>Optional</small>                                                                                |
 
-<a id="SignalR_STATUS"></a>SignalR_STATUS
------------------------------------------
+SignalR_STATUS{#SignalR_STATUS}
+-------------------------------
 
 Used by: [SignalR](#SignalR).
 
@@ -418,8 +418,8 @@ Used by: [SignalR](#SignalR).
 | upstream                   | The settings for the Upstream when the service is in server-less mode.                                                                                                                                                                                                                                                                                                                           | [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)<br/><small>Optional</small>                                                         |
 | version                    | Version of the resource. Probably you need the same or higher version of client SDKs.                                                                                                                                                                                                                                                                                                            | string<br/><small>Optional</small>                                                                                                                          |
 
-<a id="CustomCertificateOperatorSpec"></a>CustomCertificateOperatorSpec
------------------------------------------------------------------------
+CustomCertificateOperatorSpec{#CustomCertificateOperatorSpec}
+-------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -430,8 +430,8 @@ Used by: [CustomCertificate_Spec](#CustomCertificate_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="CustomDomainOperatorSpec"></a>CustomDomainOperatorSpec
--------------------------------------------------------------
+CustomDomainOperatorSpec{#CustomDomainOperatorSpec}
+---------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -442,8 +442,8 @@ Used by: [CustomDomain_Spec](#CustomDomain_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="LiveTraceConfiguration"></a>LiveTraceConfiguration
----------------------------------------------------------
+LiveTraceConfiguration{#LiveTraceConfiguration}
+-----------------------------------------------
 
 Live trace configuration of a Microsoft.SignalRService resource.
 
@@ -454,8 +454,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | categories | Gets or sets the list of category configurations.                                                                                                                                                                                                                                                                     | [LiveTraceCategory[]](#LiveTraceCategory)<br/><small>Optional</small> |
 | enabled    | Indicates whether or not enable live trace. When it's set to true, live trace client can connect to the service. Otherwise, live trace client can't connect to the service, so that you are unable to receive any log, no matter what you configure in "categories". Available values: true, false. Case insensitive. | string<br/><small>Optional</small>                                    |
 
-<a id="LiveTraceConfiguration_STATUS"></a>LiveTraceConfiguration_STATUS
------------------------------------------------------------------------
+LiveTraceConfiguration_STATUS{#LiveTraceConfiguration_STATUS}
+-------------------------------------------------------------
 
 Live trace configuration of a Microsoft.SignalRService resource.
 
@@ -466,8 +466,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | categories | Gets or sets the list of category configurations.                                                                                                                                                                                                                                                                     | [LiveTraceCategory_STATUS[]](#LiveTraceCategory_STATUS)<br/><small>Optional</small> |
 | enabled    | Indicates whether or not enable live trace. When it's set to true, live trace client can connect to the service. Otherwise, live trace client can't connect to the service, so that you are unable to receive any log, no matter what you configure in "categories". Available values: true, false. Case insensitive. | string<br/><small>Optional</small>                                                  |
 
-<a id="ManagedIdentity"></a>ManagedIdentity
--------------------------------------------
+ManagedIdentity{#ManagedIdentity}
+---------------------------------
 
 A class represent managed identities used for request and response
 
@@ -478,8 +478,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | type                   | Represents the identity type: systemAssigned, userAssigned, None | [ManagedIdentityType](#ManagedIdentityType)<br/><small>Optional</small>                   |
 | userAssignedIdentities | Get or set the user assigned identities                          | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedIdentity_STATUS"></a>ManagedIdentity_STATUS
----------------------------------------------------------
+ManagedIdentity_STATUS{#ManagedIdentity_STATUS}
+-----------------------------------------------
 
 A class represent managed identities used for request and response
 
@@ -492,8 +492,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | type                   | Represents the identity type: systemAssigned, userAssigned, None                 | [ManagedIdentityType_STATUS](#ManagedIdentityType_STATUS)<br/><small>Optional</small>                              |
 | userAssignedIdentities | Get or set the user assigned identities                                          | [map[string]UserAssignedIdentityProperty_STATUS](#UserAssignedIdentityProperty_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded"></a>PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded{#PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 A private endpoint connection to an azure resource
 
@@ -503,8 +503,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="ProvisioningState_STATUS"></a>ProvisioningState_STATUS
--------------------------------------------------------------
+ProvisioningState_STATUS{#ProvisioningState_STATUS}
+---------------------------------------------------
 
 Provisioning state of the resource.
 
@@ -522,8 +522,8 @@ Used by: [CustomCertificate_STATUS](#CustomCertificate_STATUS), [CustomDomain_ST
 | "Unknown"   |             |
 | "Updating"  |             |
 
-<a id="ReplicaOperatorSpec"></a>ReplicaOperatorSpec
----------------------------------------------------
+ReplicaOperatorSpec{#ReplicaOperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -534,8 +534,8 @@ Used by: [Replica_Spec](#Replica_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ResourceLogConfiguration"></a>ResourceLogConfiguration
--------------------------------------------------------------
+ResourceLogConfiguration{#ResourceLogConfiguration}
+---------------------------------------------------
 
 Resource log configuration of a Microsoft.SignalRService resource.
 
@@ -545,8 +545,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |------------|---------------------------------------------------|---------------------------------------------------------------------------|
 | categories | Gets or sets the list of category configurations. | [ResourceLogCategory[]](#ResourceLogCategory)<br/><small>Optional</small> |
 
-<a id="ResourceLogConfiguration_STATUS"></a>ResourceLogConfiguration_STATUS
----------------------------------------------------------------------------
+ResourceLogConfiguration_STATUS{#ResourceLogConfiguration_STATUS}
+-----------------------------------------------------------------
 
 Resource log configuration of a Microsoft.SignalRService resource.
 
@@ -556,8 +556,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |------------|---------------------------------------------------|-----------------------------------------------------------------------------------------|
 | categories | Gets or sets the list of category configurations. | [ResourceLogCategory_STATUS[]](#ResourceLogCategory_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceReference"></a>ResourceReference
------------------------------------------------
+ResourceReference{#ResourceReference}
+-------------------------------------
 
 Reference to a resource.
 
@@ -567,8 +567,8 @@ Used by: [CustomDomain_Spec](#CustomDomain_Spec).
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ResourceReference_STATUS"></a>ResourceReference_STATUS
--------------------------------------------------------------
+ResourceReference_STATUS{#ResourceReference_STATUS}
+---------------------------------------------------
 
 Reference to a resource.
 
@@ -578,8 +578,8 @@ Used by: [CustomDomain_STATUS](#CustomDomain_STATUS).
 |----------|--------------|------------------------------------|
 | id       | Resource ID. | string<br/><small>Optional</small> |
 
-<a id="ResourceSku"></a>ResourceSku
------------------------------------
+ResourceSku{#ResourceSku}
+-------------------------
 
 The billing information of the resource.
 
@@ -591,8 +591,8 @@ Used by: [Replica_Spec](#Replica_Spec), and [SignalR_Spec](#SignalR_Spec).
 | name     | The name of the SKU. Required. Allowed values: Standard_S1, Free_F1, Premium_P1, Premium_P2                                                                                                                                                                                                                                                                      | string<br/><small>Required</small>                            |
 | tier     | Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.                                                                                                                                                                                                                                                       | [SignalRSkuTier](#SignalRSkuTier)<br/><small>Optional</small> |
 
-<a id="ResourceSku_STATUS"></a>ResourceSku_STATUS
--------------------------------------------------
+ResourceSku_STATUS{#ResourceSku_STATUS}
+---------------------------------------
 
 The billing information of the resource.
 
@@ -606,8 +606,8 @@ Used by: [Replica_STATUS](#Replica_STATUS), and [SignalR_STATUS](#SignalR_STATUS
 | size     | Not used. Retained for future use.                                                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                          |
 | tier     | Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.                                                                                                                                                                                                                                                       | [SignalRSkuTier_STATUS](#SignalRSkuTier_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerlessSettings"></a>ServerlessSettings
--------------------------------------------------
+ServerlessSettings{#ServerlessSettings}
+---------------------------------------
 
 Serverless settings.
 
@@ -617,8 +617,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | connectionTimeoutInSeconds | Gets or sets Client Connection Timeout. Optional to be set. Value in seconds. Default value is 30 seconds. Customer should set the timeout to a shorter period if messages are expected to be sent in shorter intervals, and want the client to disconnect more quickly after the last message is sent. You can set the timeout to a longer period if messages are expected to be sent in longer intervals, and they want to keep the same client connection alive during this session. The service considers the client disconnected if it hasn't received a message (including keep-alive) in this interval. | int<br/><small>Optional</small> |
 
-<a id="ServerlessSettings_STATUS"></a>ServerlessSettings_STATUS
----------------------------------------------------------------
+ServerlessSettings_STATUS{#ServerlessSettings_STATUS}
+-----------------------------------------------------
 
 Serverless settings.
 
@@ -628,8 +628,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | connectionTimeoutInSeconds | Gets or sets Client Connection Timeout. Optional to be set. Value in seconds. Default value is 30 seconds. Customer should set the timeout to a shorter period if messages are expected to be sent in shorter intervals, and want the client to disconnect more quickly after the last message is sent. You can set the timeout to a longer period if messages are expected to be sent in longer intervals, and they want to keep the same client connection alive during this session. The service considers the client disconnected if it hasn't received a message (including keep-alive) in this interval. | int<br/><small>Optional</small> |
 
-<a id="ServerlessUpstreamSettings"></a>ServerlessUpstreamSettings
------------------------------------------------------------------
+ServerlessUpstreamSettings{#ServerlessUpstreamSettings}
+-------------------------------------------------------
 
 The settings for the Upstream when the service is in server-less mode.
 
@@ -639,8 +639,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |-----------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 | templates | Gets or sets the list of Upstream URL templates. Order matters, and the first matching template takes effects. | [UpstreamTemplate[]](#UpstreamTemplate)<br/><small>Optional</small> |
 
-<a id="ServerlessUpstreamSettings_STATUS"></a>ServerlessUpstreamSettings_STATUS
--------------------------------------------------------------------------------
+ServerlessUpstreamSettings_STATUS{#ServerlessUpstreamSettings_STATUS}
+---------------------------------------------------------------------
 
 The settings for the Upstream when the service is in server-less mode.
 
@@ -650,8 +650,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |-----------|----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | templates | Gets or sets the list of Upstream URL templates. Order matters, and the first matching template takes effects. | [UpstreamTemplate_STATUS[]](#UpstreamTemplate_STATUS)<br/><small>Optional</small> |
 
-<a id="SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded"></a>SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded
--------------------------------------------------------------------------------------------------------------------------------------
+SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded{#SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded}
+---------------------------------------------------------------------------------------------------------------------------
 
 Describes a Shared Private Link Resource
 
@@ -661,8 +661,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. E.g. "/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName}" | string<br/><small>Optional</small> |
 
-<a id="SignalRCorsSettings"></a>SignalRCorsSettings
----------------------------------------------------
+SignalRCorsSettings{#SignalRCorsSettings}
+-----------------------------------------
 
 Cross-Origin Resource Sharing (CORS) settings.
 
@@ -672,8 +672,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedOrigins | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all. If omitted, allow all by default. | string[]<br/><small>Optional</small> |
 
-<a id="SignalRCorsSettings_STATUS"></a>SignalRCorsSettings_STATUS
------------------------------------------------------------------
+SignalRCorsSettings_STATUS{#SignalRCorsSettings_STATUS}
+-------------------------------------------------------
 
 Cross-Origin Resource Sharing (CORS) settings.
 
@@ -683,8 +683,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | allowedOrigins | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all. If omitted, allow all by default. | string[]<br/><small>Optional</small> |
 
-<a id="SignalRFeature"></a>SignalRFeature
------------------------------------------
+SignalRFeature{#SignalRFeature}
+-------------------------------
 
 Feature of a resource, which controls the runtime behavior.
 
@@ -696,8 +696,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | properties | Optional properties related to this feature.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | map[string]string<br/><small>Optional</small>             |
 | value      | Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/azure/azure-signalr/ for allowed values.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string<br/><small>Required</small>                        |
 
-<a id="SignalRFeature_STATUS"></a>SignalRFeature_STATUS
--------------------------------------------------------
+SignalRFeature_STATUS{#SignalRFeature_STATUS}
+---------------------------------------------
 
 Feature of a resource, which controls the runtime behavior.
 
@@ -709,8 +709,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | properties | Optional properties related to this feature.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | map[string]string<br/><small>Optional</small>                           |
 | value      | Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/azure/azure-signalr/ for allowed values.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                      |
 
-<a id="SignalRNetworkACLs"></a>SignalRNetworkACLs
--------------------------------------------------
+SignalRNetworkACLs{#SignalRNetworkACLs}
+---------------------------------------
 
 Network ACLs for the resource
 
@@ -723,8 +723,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | privateEndpoints | ACLs for requests from private endpoints | [PrivateEndpointACL[]](#PrivateEndpointACL)<br/><small>Optional</small> |
 | publicNetwork    | Network ACL                              | [NetworkACL](#NetworkACL)<br/><small>Optional</small>                   |
 
-<a id="SignalRNetworkACLs_STATUS"></a>SignalRNetworkACLs_STATUS
----------------------------------------------------------------
+SignalRNetworkACLs_STATUS{#SignalRNetworkACLs_STATUS}
+-----------------------------------------------------
 
 Network ACLs for the resource
 
@@ -737,8 +737,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | privateEndpoints | ACLs for requests from private endpoints | [PrivateEndpointACL_STATUS[]](#PrivateEndpointACL_STATUS)<br/><small>Optional</small> |
 | publicNetwork    | Network ACL                              | [NetworkACL_STATUS](#NetworkACL_STATUS)<br/><small>Optional</small>                   |
 
-<a id="SignalROperatorSpec"></a>SignalROperatorSpec
----------------------------------------------------
+SignalROperatorSpec{#SignalROperatorSpec}
+-----------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -750,8 +750,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [SignalROperatorSecrets](#SignalROperatorSecrets)<br/><small>Optional</small>                                                                                       |
 
-<a id="SignalrServiceKind"></a>SignalrServiceKind
--------------------------------------------------
+SignalrServiceKind{#SignalrServiceKind}
+---------------------------------------
 
 The kind of the service
 
@@ -762,8 +762,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 | "RawWebSockets" |             |
 | "SignalR"       |             |
 
-<a id="SignalrServiceKind_STATUS"></a>SignalrServiceKind_STATUS
----------------------------------------------------------------
+SignalrServiceKind_STATUS{#SignalrServiceKind_STATUS}
+-----------------------------------------------------
 
 The kind of the service
 
@@ -774,8 +774,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 | "RawWebSockets" |             |
 | "SignalR"       |             |
 
-<a id="SignalRTlsSettings"></a>SignalRTlsSettings
--------------------------------------------------
+SignalRTlsSettings{#SignalRTlsSettings}
+---------------------------------------
 
 TLS settings for the resource
 
@@ -785,8 +785,8 @@ Used by: [SignalR_Spec](#SignalR_Spec).
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | clientCertEnabled | Request client certificate during TLS handshake if enabled. Not supported for free tier. Any input will be ignored for free tier. | bool<br/><small>Optional</small> |
 
-<a id="SignalRTlsSettings_STATUS"></a>SignalRTlsSettings_STATUS
----------------------------------------------------------------
+SignalRTlsSettings_STATUS{#SignalRTlsSettings_STATUS}
+-----------------------------------------------------
 
 TLS settings for the resource
 
@@ -796,8 +796,8 @@ Used by: [SignalR_STATUS](#SignalR_STATUS).
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
 | clientCertEnabled | Request client certificate during TLS handshake if enabled. Not supported for free tier. Any input will be ignored for free tier. | bool<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -812,8 +812,8 @@ Used by: [CustomCertificate_STATUS](#CustomCertificate_STATUS), [CustomDomain_ST
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="ACLAction"></a>ACLAction
--------------------------------
+ACLAction{#ACLAction}
+---------------------
 
 Azure Networking ACL Action.
 
@@ -824,8 +824,8 @@ Used by: [IPRule](#IPRule), and [SignalRNetworkACLs](#SignalRNetworkACLs).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ACLAction_STATUS"></a>ACLAction_STATUS
----------------------------------------------
+ACLAction_STATUS{#ACLAction_STATUS}
+-----------------------------------
 
 Azure Networking ACL Action.
 
@@ -836,8 +836,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS), and [SignalRNetworkACLs_STATUS](#Signa
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="FeatureFlags"></a>FeatureFlags
--------------------------------------
+FeatureFlags{#FeatureFlags}
+---------------------------
 
 FeatureFlags is the supported features of Azure SignalR service. - ServiceMode: Flag for backend server for SignalR service. Values allowed: "Default": have your own backend server; "Serverless": your application doesn't have a backend server; "Classic": for backward compatibility. Support both Default and Serverless mode but not recommended; "PredefinedOnly": for future use. - EnableConnectivityLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableMessagingLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableLiveTrace: Live Trace allows you to know what's happening inside Azure SignalR service, it will give you live traces in real time, it will be helpful when you developing your own Azure SignalR based web application or self-troubleshooting some issues. Please note that live traces are counted as outbound messages that will be charged. Values allowed: "true"/"false", to enable/disable live trace feature.
 
@@ -850,8 +850,8 @@ Used by: [SignalRFeature](#SignalRFeature).
 | "EnableMessagingLogs"    |             |
 | "ServiceMode"            |             |
 
-<a id="FeatureFlags_STATUS"></a>FeatureFlags_STATUS
----------------------------------------------------
+FeatureFlags_STATUS{#FeatureFlags_STATUS}
+-----------------------------------------
 
 FeatureFlags is the supported features of Azure SignalR service. - ServiceMode: Flag for backend server for SignalR service. Values allowed: "Default": have your own backend server; "Serverless": your application doesn't have a backend server; "Classic": for backward compatibility. Support both Default and Serverless mode but not recommended; "PredefinedOnly": for future use. - EnableConnectivityLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableMessagingLogs: "true"/"false", to enable/disable the connectivity log category respectively. - EnableLiveTrace: Live Trace allows you to know what's happening inside Azure SignalR service, it will give you live traces in real time, it will be helpful when you developing your own Azure SignalR based web application or self-troubleshooting some issues. Please note that live traces are counted as outbound messages that will be charged. Values allowed: "true"/"false", to enable/disable live trace feature.
 
@@ -864,8 +864,8 @@ Used by: [SignalRFeature_STATUS](#SignalRFeature_STATUS).
 | "EnableMessagingLogs"    |             |
 | "ServiceMode"            |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 An IP rule
 
@@ -876,8 +876,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | action   | Azure Networking ACL Action. | [ACLAction](#ACLAction)<br/><small>Optional</small> |
 | value    | An IP or CIDR or ServiceTag  | string<br/><small>Optional</small>                  |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 An IP rule
 
@@ -888,8 +888,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | action   | Azure Networking ACL Action. | [ACLAction_STATUS](#ACLAction_STATUS)<br/><small>Optional</small> |
 | value    | An IP or CIDR or ServiceTag  | string<br/><small>Optional</small>                                |
 
-<a id="LiveTraceCategory"></a>LiveTraceCategory
------------------------------------------------
+LiveTraceCategory{#LiveTraceCategory}
+-------------------------------------
 
 Live trace category configuration of a Microsoft.SignalRService resource.
 
@@ -900,8 +900,8 @@ Used by: [LiveTraceConfiguration](#LiveTraceConfiguration).
 | enabled  | Indicates whether or the live trace category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the live trace category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="LiveTraceCategory_STATUS"></a>LiveTraceCategory_STATUS
--------------------------------------------------------------
+LiveTraceCategory_STATUS{#LiveTraceCategory_STATUS}
+---------------------------------------------------
 
 Live trace category configuration of a Microsoft.SignalRService resource.
 
@@ -912,8 +912,8 @@ Used by: [LiveTraceConfiguration_STATUS](#LiveTraceConfiguration_STATUS).
 | enabled  | Indicates whether or the live trace category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the live trace category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentityType"></a>ManagedIdentityType
----------------------------------------------------
+ManagedIdentityType{#ManagedIdentityType}
+-----------------------------------------
 
 Represents the identity type: systemAssigned, userAssigned, None
 
@@ -925,8 +925,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="ManagedIdentityType_STATUS"></a>ManagedIdentityType_STATUS
------------------------------------------------------------------
+ManagedIdentityType_STATUS{#ManagedIdentityType_STATUS}
+-------------------------------------------------------
 
 Represents the identity type: systemAssigned, userAssigned, None
 
@@ -938,8 +938,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | "SystemAssigned" |             |
 | "UserAssigned"   |             |
 
-<a id="NetworkACL"></a>NetworkACL
----------------------------------
+NetworkACL{#NetworkACL}
+-----------------------
 
 Network ACL
 
@@ -950,8 +950,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | allow    | Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI. | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 
-<a id="NetworkACL_STATUS"></a>NetworkACL_STATUS
------------------------------------------------
+NetworkACL_STATUS{#NetworkACL_STATUS}
+-------------------------------------
 
 Network ACL
 
@@ -962,8 +962,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | allow    | Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI. | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 
-<a id="PrivateEndpointACL"></a>PrivateEndpointACL
--------------------------------------------------
+PrivateEndpointACL{#PrivateEndpointACL}
+---------------------------------------
 
 ACL for a private endpoint
 
@@ -975,8 +975,8 @@ Used by: [SignalRNetworkACLs](#SignalRNetworkACLs).
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType[]](#SignalRRequestType)<br/><small>Optional</small> |
 | name     | Name of the private endpoint connection                                                              | string<br/><small>Required</small>                                      |
 
-<a id="PrivateEndpointACL_STATUS"></a>PrivateEndpointACL_STATUS
----------------------------------------------------------------
+PrivateEndpointACL_STATUS{#PrivateEndpointACL_STATUS}
+-----------------------------------------------------
 
 ACL for a private endpoint
 
@@ -988,8 +988,8 @@ Used by: [SignalRNetworkACLs_STATUS](#SignalRNetworkACLs_STATUS).
 | deny     | Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.  | [SignalRRequestType_STATUS[]](#SignalRRequestType_STATUS)<br/><small>Optional</small> |
 | name     | Name of the private endpoint connection                                                              | string<br/><small>Optional</small>                                                    |
 
-<a id="ResourceLogCategory"></a>ResourceLogCategory
----------------------------------------------------
+ResourceLogCategory{#ResourceLogCategory}
+-----------------------------------------
 
 Resource log category configuration of a Microsoft.SignalRService resource.
 
@@ -1000,8 +1000,8 @@ Used by: [ResourceLogConfiguration](#ResourceLogConfiguration).
 | enabled  | Indicates whether or the resource log category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the resource log category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="ResourceLogCategory_STATUS"></a>ResourceLogCategory_STATUS
------------------------------------------------------------------
+ResourceLogCategory_STATUS{#ResourceLogCategory_STATUS}
+-------------------------------------------------------
 
 Resource log category configuration of a Microsoft.SignalRService resource.
 
@@ -1012,8 +1012,8 @@ Used by: [ResourceLogConfiguration_STATUS](#ResourceLogConfiguration_STATUS).
 | enabled  | Indicates whether or the resource log category is enabled. Available values: true, false. Case insensitive.         | string<br/><small>Optional</small> |
 | name     | Gets or sets the resource log category's name. Available values: ConnectivityLogs, MessagingLogs. Case insensitive. | string<br/><small>Optional</small> |
 
-<a id="SignalROperatorSecrets"></a>SignalROperatorSecrets
----------------------------------------------------------
+SignalROperatorSecrets{#SignalROperatorSecrets}
+-----------------------------------------------
 
 Used by: [SignalROperatorSpec](#SignalROperatorSpec).
 
@@ -1024,8 +1024,8 @@ Used by: [SignalROperatorSpec](#SignalROperatorSpec).
 | secondaryConnectionString | indicates where the SecondaryConnectionString secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | secondaryKey              | indicates where the SecondaryKey secret should be placed. If omitted, the secret will not be retrieved from Azure.              | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="SignalRSkuTier"></a>SignalRSkuTier
------------------------------------------
+SignalRSkuTier{#SignalRSkuTier}
+-------------------------------
 
 Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.
 
@@ -1038,8 +1038,8 @@ Used by: [ResourceSku](#ResourceSku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SignalRSkuTier_STATUS"></a>SignalRSkuTier_STATUS
--------------------------------------------------------
+SignalRSkuTier_STATUS{#SignalRSkuTier_STATUS}
+---------------------------------------------
 
 Optional tier of this particular SKU. 'Standard' or 'Free'. `Basic` is deprecated, use `Standard` instead.
 
@@ -1052,7 +1052,19 @@ Used by: [ResourceSku_STATUS](#ResourceSku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -1064,20 +1076,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UpstreamTemplate"></a>UpstreamTemplate
----------------------------------------------
+UpstreamTemplate{#UpstreamTemplate}
+-----------------------------------
 
 Upstream template item settings. It defines the Upstream URL of the incoming requests. The template defines the pattern of the event, the hub or the category of the incoming request that matches current URL template.
 
@@ -1091,8 +1091,8 @@ Used by: [ServerlessUpstreamSettings](#ServerlessUpstreamSettings).
 | hubPattern      | Gets or sets the matching pattern for hub names. If not set, it matches any hub. There are 3 kind of patterns supported: 1. "*", it to matches any hub name. 2. Combine multiple hubs with ",", for example "hub1,hub2", it matches "hub1" and "hub2". 3. The single hub name, for example, "hub1", it matches "hub1".                                                                                                 | string<br/><small>Optional</small>                                        |
 | urlTemplate     | Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in. For example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`. | string<br/><small>Required</small>                                        |
 
-<a id="UpstreamTemplate_STATUS"></a>UpstreamTemplate_STATUS
------------------------------------------------------------
+UpstreamTemplate_STATUS{#UpstreamTemplate_STATUS}
+-------------------------------------------------
 
 Upstream template item settings. It defines the Upstream URL of the incoming requests. The template defines the pattern of the event, the hub or the category of the incoming request that matches current URL template.
 
@@ -1106,8 +1106,8 @@ Used by: [ServerlessUpstreamSettings_STATUS](#ServerlessUpstreamSettings_STATUS)
 | hubPattern      | Gets or sets the matching pattern for hub names. If not set, it matches any hub. There are 3 kind of patterns supported: 1. "*", it to matches any hub name. 2. Combine multiple hubs with ",", for example "hub1,hub2", it matches "hub1" and "hub2". 3. The single hub name, for example, "hub1", it matches "hub1".                                                                                                 | string<br/><small>Optional</small>                                                      |
 | urlTemplate     | Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in. For example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`. | string<br/><small>Optional</small>                                                      |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1117,8 +1117,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityProperty_STATUS"></a>UserAssignedIdentityProperty_STATUS
------------------------------------------------------------------------------------
+UserAssignedIdentityProperty_STATUS{#UserAssignedIdentityProperty_STATUS}
+-------------------------------------------------------------------------
 
 Properties of user assigned identity.
 
@@ -1129,8 +1129,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | clientId    | Get the client id for the user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Get the principal id for the user assigned identity | string<br/><small>Optional</small> |
 
-<a id="SignalRRequestType"></a>SignalRRequestType
--------------------------------------------------
+SignalRRequestType{#SignalRRequestType}
+---------------------------------------
 
 The incoming request type to the service
 
@@ -1143,8 +1143,8 @@ Used by: [NetworkACL](#NetworkACL), [NetworkACL](#NetworkACL), [PrivateEndpointA
 | "ServerConnection" |             |
 | "Trace"            |             |
 
-<a id="SignalRRequestType_STATUS"></a>SignalRRequestType_STATUS
----------------------------------------------------------------
+SignalRRequestType_STATUS{#SignalRRequestType_STATUS}
+-----------------------------------------------------
 
 The incoming request type to the service
 
@@ -1157,8 +1157,8 @@ Used by: [NetworkACL_STATUS](#NetworkACL_STATUS), [NetworkACL_STATUS](#NetworkAC
 | "ServerConnection" |             |
 | "Trace"            |             |
 
-<a id="UpstreamAuthSettings"></a>UpstreamAuthSettings
------------------------------------------------------
+UpstreamAuthSettings{#UpstreamAuthSettings}
+-------------------------------------------
 
 Upstream auth settings. If not set, no auth is used for upstream messages.
 
@@ -1169,8 +1169,8 @@ Used by: [UpstreamTemplate](#UpstreamTemplate).
 | managedIdentity | Managed identity settings for upstream. | [ManagedIdentitySettings](#ManagedIdentitySettings)<br/><small>Optional</small> |
 | type            | Upstream auth type enum.                | [UpstreamAuthType](#UpstreamAuthType)<br/><small>Optional</small>               |
 
-<a id="UpstreamAuthSettings_STATUS"></a>UpstreamAuthSettings_STATUS
--------------------------------------------------------------------
+UpstreamAuthSettings_STATUS{#UpstreamAuthSettings_STATUS}
+---------------------------------------------------------
 
 Upstream auth settings. If not set, no auth is used for upstream messages.
 
@@ -1181,8 +1181,8 @@ Used by: [UpstreamTemplate_STATUS](#UpstreamTemplate_STATUS).
 | managedIdentity | Managed identity settings for upstream. | [ManagedIdentitySettings_STATUS](#ManagedIdentitySettings_STATUS)<br/><small>Optional</small> |
 | type            | Upstream auth type enum.                | [UpstreamAuthType_STATUS](#UpstreamAuthType_STATUS)<br/><small>Optional</small>               |
 
-<a id="ManagedIdentitySettings"></a>ManagedIdentitySettings
------------------------------------------------------------
+ManagedIdentitySettings{#ManagedIdentitySettings}
+-------------------------------------------------
 
 Managed identity settings for upstream.
 
@@ -1192,8 +1192,8 @@ Used by: [UpstreamAuthSettings](#UpstreamAuthSettings).
 |----------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | resource | The Resource indicating the App ID URI of the target resource. It also appears in the aud (audience) claim of the issued token. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentitySettings_STATUS"></a>ManagedIdentitySettings_STATUS
--------------------------------------------------------------------------
+ManagedIdentitySettings_STATUS{#ManagedIdentitySettings_STATUS}
+---------------------------------------------------------------
 
 Managed identity settings for upstream.
 
@@ -1203,8 +1203,8 @@ Used by: [UpstreamAuthSettings_STATUS](#UpstreamAuthSettings_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | resource | The Resource indicating the App ID URI of the target resource. It also appears in the aud (audience) claim of the issued token. | string<br/><small>Optional</small> |
 
-<a id="UpstreamAuthType"></a>UpstreamAuthType
----------------------------------------------
+UpstreamAuthType{#UpstreamAuthType}
+-----------------------------------
 
 Upstream auth type enum.
 
@@ -1215,8 +1215,8 @@ Used by: [UpstreamAuthSettings](#UpstreamAuthSettings).
 | "ManagedIdentity" |             |
 | "None"            |             |
 
-<a id="UpstreamAuthType_STATUS"></a>UpstreamAuthType_STATUS
------------------------------------------------------------
+UpstreamAuthType_STATUS{#UpstreamAuthType_STATUS}
+-------------------------------------------------
 
 Upstream auth type enum.
 

--- a/docs/hugo/content/reference/sql/v1.md
+++ b/docs/hugo/content/reference/sql/v1.md
@@ -5,8 +5,8 @@ title: sql.azure.com/
 linktitle:
 ----------
 
-<a id="User"></a>User
----------------------
+User{#User}
+-----------
 
 <br/>User is an Azure SQL user
 
@@ -19,7 +19,7 @@ Used by: [UserList](#UserList).
 | spec                                                                                    |             | [UserSpec](#UserSpec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [UserStatus](#UserStatus)<br/><small>Optional</small> |
 
-### <a id="UserSpec"></a>UserSpec
+### UserSpec {#UserSpec}
 
 | Property  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -28,14 +28,14 @@ Used by: [UserList](#UserList).
 | owner     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to an sql.azure.com/ServersDatabase resource                                                                                                                                                                                                                                  | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | roles     | The roles assigned to the user. See https://learn.microsoft.com/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles for the fixed set of roles supported by Azure SQL. Roles include the following: db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin, db_datawriter, db_datareader, db_denydatawriter, and db_denydatareader.                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-### <a id="UserStatus"></a>UserStatus
+### UserStatus{#UserStatus}
 
 | Property   | Description                        | Type                                                                                                                                                    |
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="UserList"></a>UserList
------------------------------
+UserList{#UserList}
+-------------------
 
 | Property                                                                            | Description | Type                                        |
 |-------------------------------------------------------------------------------------|-------------|---------------------------------------------|
@@ -43,8 +43,8 @@ Used by: [UserList](#UserList).
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [User[]](#User)<br/><small>Optional</small> |
 
-<a id="UserSpec"></a>UserSpec
------------------------------
+UserSpec{#UserSpec}
+-------------------
 
 Used by: [User](#User).
 
@@ -55,8 +55,8 @@ Used by: [User](#User).
 | owner     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to an sql.azure.com/ServersDatabase resource                                                                                                                                                                                                                                  | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | roles     | The roles assigned to the user. See https://learn.microsoft.com/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles for the fixed set of roles supported by Azure SQL. Roles include the following: db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin, db_datawriter, db_datareader, db_denydatawriter, and db_denydatareader.                                                                                                | string[]<br/><small>Optional</small>                                                                                                                                 |
 
-<a id="UserStatus"></a>UserStatus
----------------------------------
+UserStatus{#UserStatus}
+-----------------------
 
 Used by: [User](#User).
 
@@ -64,8 +64,8 @@ Used by: [User](#User).
 |------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | conditions | The observed state of the resource | [conditions.Condition[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions#Condition)<br/><small>Optional</small> |
 
-<a id="LocalUserSpec"></a>LocalUserSpec
----------------------------------------
+LocalUserSpec{#LocalUserSpec}
+-----------------------------
 
 var _ genruntime.ConvertibleSpec = &UserSpec{} <br/>ConvertSpecFrom populates our ConfigurationStore_Spec from the provided source func (userSpec *UserSpec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error { if source == userSpec { return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec") } <br/> return source.ConvertSpecTo(userSpec) } <br/>ConvertSpecTo populates the provided destination from our ConfigurationStore_Spec func (userSpec *UserSpec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error { if destination == userSpec { return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec") } <br/> return destination.ConvertSpecFrom(userSpec) } <br/>
 

--- a/docs/hugo/content/reference/sql/v1api20211101.md
+++ b/docs/hugo/content/reference/sql/v1api20211101.md
@@ -5,15 +5,15 @@ title: sql.azure.com/v1api20211101
 linktitle: v1api20211101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-11-01" |             |
 
-<a id="Server"></a>Server
--------------------------
+Server{#Server}
+---------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Servers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}
 
@@ -26,7 +26,7 @@ Used by: [ServerList](#ServerList).
 | spec                                                                                    |             | [Server_Spec](#Server_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Server_STATUS](#Server_STATUS)<br/><small>Optional</small> |
 
-### <a id="Server_Spec"></a>Server_Spec
+### Server_Spec {#Server_Spec}
 
 | Property                             | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -47,7 +47,7 @@ Used by: [ServerList](#ServerList).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                              | The version of the server.                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="Server_STATUS"></a>Server_STATUS
+### Server_STATUS{#Server_STATUS}
 
 | Property                      | Description                                                                                                                             | Type                                                                                                                                                    |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -73,8 +73,8 @@ Used by: [ServerList](#ServerList).
 | version                       | The version of the server.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceFeature              | Whether or not existing server has a workspace created and if it allows connection from workspace                                       | [ServerProperties_WorkspaceFeature_STATUS](#ServerProperties_WorkspaceFeature_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="ServerList"></a>ServerList
----------------------------------
+ServerList{#ServerList}
+-----------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Servers.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}
 
@@ -84,8 +84,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                 |
 | items                                                                               |             | [Server[]](#Server)<br/><small>Optional</small> |
 
-<a id="ServersAdministrator"></a>ServersAdministrator
------------------------------------------------------
+ServersAdministrator{#ServersAdministrator}
+-------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAzureADAdministrators.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/administrators/{administratorName}
 
@@ -98,7 +98,7 @@ Used by: [ServersAdministratorList](#ServersAdministratorList).
 | spec                                                                                    |             | [ServersAdministrator_Spec](#ServersAdministrator_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersAdministrator_STATUS](#ServersAdministrator_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersAdministrator_Spec"></a>ServersAdministrator_Spec
+### ServersAdministrator_Spec {#ServersAdministrator_Spec}
 
 | Property           | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -111,7 +111,7 @@ Used by: [ServersAdministratorList](#ServersAdministratorList).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | Tenant ID of the administrator.                                                                                                                                                                                                                                                 | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-### <a id="ServersAdministrator_STATUS"></a>ServersAdministrator_STATUS
+### ServersAdministrator_STATUS{#ServersAdministrator_STATUS}
 
 | Property                  | Description                                         | Type                                                                                                                                                    |
 |---------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -125,8 +125,8 @@ Used by: [ServersAdministratorList](#ServersAdministratorList).
 | tenantId                  | Tenant ID of the administrator.                     | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAdministratorList"></a>ServersAdministratorList
--------------------------------------------------------------
+ServersAdministratorList{#ServersAdministratorList}
+---------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAzureADAdministrators.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/administrators/{administratorName}
 
@@ -136,8 +136,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [ServersAdministrator[]](#ServersAdministrator)<br/><small>Optional</small> |
 
-<a id="ServersAdvancedThreatProtectionSetting"></a>ServersAdvancedThreatProtectionSetting
------------------------------------------------------------------------------------------
+ServersAdvancedThreatProtectionSetting{#ServersAdvancedThreatProtectionSetting}
+-------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAdvancedThreatProtectionSettings.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/advancedThreatProtectionSettings/Default
 
@@ -150,7 +150,7 @@ Used by: [ServersAdvancedThreatProtectionSettingList](#ServersAdvancedThreatProt
 | spec                                                                                    |             | [ServersAdvancedThreatProtectionSetting_Spec](#ServersAdvancedThreatProtectionSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersAdvancedThreatProtectionSetting_STATUS](#ServersAdvancedThreatProtectionSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersAdvancedThreatProtectionSetting_Spec"></a>ServersAdvancedThreatProtectionSetting_Spec
+### ServersAdvancedThreatProtectionSetting_Spec {#ServersAdvancedThreatProtectionSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -158,7 +158,7 @@ Used by: [ServersAdvancedThreatProtectionSettingList](#ServersAdvancedThreatProt
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the Advanced Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific database or server.                                                                                                                | [AdvancedThreatProtectionProperties_State](#AdvancedThreatProtectionProperties_State)<br/><small>Required</small>                                                    |
 
-### <a id="ServersAdvancedThreatProtectionSetting_STATUS"></a>ServersAdvancedThreatProtectionSetting_STATUS
+### ServersAdvancedThreatProtectionSetting_STATUS{#ServersAdvancedThreatProtectionSetting_STATUS}
 
 | Property     | Description                                                                                                                                                      | Type                                                                                                                                                    |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -170,8 +170,8 @@ Used by: [ServersAdvancedThreatProtectionSettingList](#ServersAdvancedThreatProt
 | systemData   | SystemData of AdvancedThreatProtectionResource.                                                                                                                  | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type         | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAdvancedThreatProtectionSettingList"></a>ServersAdvancedThreatProtectionSettingList
--------------------------------------------------------------------------------------------------
+ServersAdvancedThreatProtectionSettingList{#ServersAdvancedThreatProtectionSettingList}
+---------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAdvancedThreatProtectionSettings.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/advancedThreatProtectionSettings/Default
 
@@ -181,8 +181,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                 |
 | items                                                                               |             | [ServersAdvancedThreatProtectionSetting[]](#ServersAdvancedThreatProtectionSetting)<br/><small>Optional</small> |
 
-<a id="ServersAuditingSetting"></a>ServersAuditingSetting
----------------------------------------------------------
+ServersAuditingSetting{#ServersAuditingSetting}
+-----------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BlobAuditing.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/auditingSettings/default
 
@@ -195,7 +195,7 @@ Used by: [ServersAuditingSettingList](#ServersAuditingSettingList).
 | spec                                                                                    |             | [ServersAuditingSetting_Spec](#ServersAuditingSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersAuditingSetting_STATUS](#ServersAuditingSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersAuditingSetting_Spec"></a>ServersAuditingSetting_Spec
+### ServersAuditingSetting_Spec {#ServersAuditingSetting_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -213,7 +213,7 @@ Used by: [ServersAuditingSettingList](#ServersAuditingSettingList).
 | storageAccountSubscriptionId | Specifies the blob storage subscription Id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersAuditingSetting_STATUS"></a>ServersAuditingSetting_STATUS
+### ServersAuditingSetting_STATUS{#ServersAuditingSetting_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -232,8 +232,8 @@ Used by: [ServersAuditingSettingList](#ServersAuditingSettingList).
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAuditingSettingList"></a>ServersAuditingSettingList
------------------------------------------------------------------
+ServersAuditingSettingList{#ServersAuditingSettingList}
+-------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BlobAuditing.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/auditingSettings/default
 
@@ -243,8 +243,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                 |
 | items                                                                               |             | [ServersAuditingSetting[]](#ServersAuditingSetting)<br/><small>Optional</small> |
 
-<a id="ServersAzureADOnlyAuthentication"></a>ServersAzureADOnlyAuthentication
------------------------------------------------------------------------------
+ServersAzureADOnlyAuthentication{#ServersAzureADOnlyAuthentication}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAzureADOnlyAuthentications.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/azureADOnlyAuthentications/Default
 
@@ -257,7 +257,7 @@ Used by: [ServersAzureADOnlyAuthenticationList](#ServersAzureADOnlyAuthenticatio
 | spec                                                                                    |             | [ServersAzureADOnlyAuthentication_Spec](#ServersAzureADOnlyAuthentication_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersAzureADOnlyAuthentication_STATUS](#ServersAzureADOnlyAuthentication_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersAzureADOnlyAuthentication_Spec"></a>ServersAzureADOnlyAuthentication_Spec
+### ServersAzureADOnlyAuthentication_Spec {#ServersAzureADOnlyAuthentication_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -265,7 +265,7 @@ Used by: [ServersAzureADOnlyAuthenticationList](#ServersAzureADOnlyAuthenticatio
 | operatorSpec              | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersAzureADOnlyAuthenticationOperatorSpec](#ServersAzureADOnlyAuthenticationOperatorSpec)<br/><small>Optional</small>                                            |
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="ServersAzureADOnlyAuthentication_STATUS"></a>ServersAzureADOnlyAuthentication_STATUS
+### ServersAzureADOnlyAuthentication_STATUS{#ServersAzureADOnlyAuthentication_STATUS}
 
 | Property                  | Description                                         | Type                                                                                                                                                    |
 |---------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -275,8 +275,8 @@ Used by: [ServersAzureADOnlyAuthenticationList](#ServersAzureADOnlyAuthenticatio
 | name                      | Resource name.                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAzureADOnlyAuthenticationList"></a>ServersAzureADOnlyAuthenticationList
--------------------------------------------------------------------------------------
+ServersAzureADOnlyAuthenticationList{#ServersAzureADOnlyAuthenticationList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAzureADOnlyAuthentications.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/azureADOnlyAuthentications/Default
 
@@ -286,8 +286,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [ServersAzureADOnlyAuthentication[]](#ServersAzureADOnlyAuthentication)<br/><small>Optional</small> |
 
-<a id="ServersConnectionPolicy"></a>ServersConnectionPolicy
------------------------------------------------------------
+ServersConnectionPolicy{#ServersConnectionPolicy}
+-------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerConnectionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/connectionPolicies/default
 
@@ -300,7 +300,7 @@ Used by: [ServersConnectionPolicyList](#ServersConnectionPolicyList).
 | spec                                                                                    |             | [ServersConnectionPolicy_Spec](#ServersConnectionPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersConnectionPolicy_STATUS](#ServersConnectionPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersConnectionPolicy_Spec"></a>ServersConnectionPolicy_Spec
+### ServersConnectionPolicy_Spec {#ServersConnectionPolicy_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -308,7 +308,7 @@ Used by: [ServersConnectionPolicyList](#ServersConnectionPolicyList).
 | operatorSpec   | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersConnectionPolicyOperatorSpec](#ServersConnectionPolicyOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="ServersConnectionPolicy_STATUS"></a>ServersConnectionPolicy_STATUS
+### ServersConnectionPolicy_STATUS{#ServersConnectionPolicy_STATUS}
 
 | Property       | Description                                    | Type                                                                                                                                                    |
 |----------------|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -320,8 +320,8 @@ Used by: [ServersConnectionPolicyList](#ServersConnectionPolicyList).
 | name           | Resource name.                                 | string<br/><small>Optional</small>                                                                                                                      |
 | type           | Resource type.                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersConnectionPolicyList"></a>ServersConnectionPolicyList
--------------------------------------------------------------------
+ServersConnectionPolicyList{#ServersConnectionPolicyList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerConnectionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/connectionPolicies/default
 
@@ -331,8 +331,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [ServersConnectionPolicy[]](#ServersConnectionPolicy)<br/><small>Optional</small> |
 
-<a id="ServersDatabase"></a>ServersDatabase
--------------------------------------------
+ServersDatabase{#ServersDatabase}
+---------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}
 
@@ -345,7 +345,7 @@ Used by: [ServersDatabaseList](#ServersDatabaseList).
 | spec                                                                                    |             | [ServersDatabase_Spec](#ServersDatabase_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabase_STATUS](#ServersDatabase_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabase_Spec"></a>ServersDatabase_Spec
+### ServersDatabase_Spec {#ServersDatabase_Spec}
 
 | Property                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                                                                                                                                                                 |
 |------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -382,7 +382,7 @@ Used by: [ServersDatabaseList](#ServersDatabaseList).
 | tags                                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant                            | Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="ServersDatabase_STATUS"></a>ServersDatabase_STATUS
+### ServersDatabase_STATUS{#ServersDatabase_STATUS}
 
 | Property                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Type                                                                                                                                                    |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -436,8 +436,8 @@ Used by: [ServersDatabaseList](#ServersDatabaseList).
 | type                              | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant                     | Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServersDatabaseList"></a>ServersDatabaseList
----------------------------------------------------
+ServersDatabaseList{#ServersDatabaseList}
+-----------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Databases.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}
 
@@ -447,8 +447,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                   |
 | items                                                                               |             | [ServersDatabase[]](#ServersDatabase)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesAdvancedThreatProtectionSetting"></a>ServersDatabasesAdvancedThreatProtectionSetting
------------------------------------------------------------------------------------------------------------
+ServersDatabasesAdvancedThreatProtectionSetting{#ServersDatabasesAdvancedThreatProtectionSetting}
+-------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseAdvancedThreatProtectionSettings.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/advancedThreatProtectionSettings/Default
 
@@ -461,7 +461,7 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSettingList](#ServersDatabases
 | spec                                                                                    |             | [ServersDatabasesAdvancedThreatProtectionSetting_Spec](#ServersDatabasesAdvancedThreatProtectionSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesAdvancedThreatProtectionSetting_STATUS](#ServersDatabasesAdvancedThreatProtectionSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesAdvancedThreatProtectionSetting_Spec"></a>ServersDatabasesAdvancedThreatProtectionSetting_Spec
+### ServersDatabasesAdvancedThreatProtectionSetting_Spec {#ServersDatabasesAdvancedThreatProtectionSetting_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -469,7 +469,7 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSettingList](#ServersDatabases
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the Advanced Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific database or server.                                                                                                                         | [AdvancedThreatProtectionProperties_State](#AdvancedThreatProtectionProperties_State)<br/><small>Required</small>                                                    |
 
-### <a id="ServersDatabasesAdvancedThreatProtectionSetting_STATUS"></a>ServersDatabasesAdvancedThreatProtectionSetting_STATUS
+### ServersDatabasesAdvancedThreatProtectionSetting_STATUS{#ServersDatabasesAdvancedThreatProtectionSetting_STATUS}
 
 | Property     | Description                                                                                                                                                      | Type                                                                                                                                                    |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -481,8 +481,8 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSettingList](#ServersDatabases
 | systemData   | SystemData of AdvancedThreatProtectionResource.                                                                                                                  | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type         | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesAdvancedThreatProtectionSettingList"></a>ServersDatabasesAdvancedThreatProtectionSettingList
--------------------------------------------------------------------------------------------------------------------
+ServersDatabasesAdvancedThreatProtectionSettingList{#ServersDatabasesAdvancedThreatProtectionSettingList}
+---------------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseAdvancedThreatProtectionSettings.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/advancedThreatProtectionSettings/Default
 
@@ -492,8 +492,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                                   |
 | items                                                                               |             | [ServersDatabasesAdvancedThreatProtectionSetting[]](#ServersDatabasesAdvancedThreatProtectionSetting)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesAuditingSetting"></a>ServersDatabasesAuditingSetting
----------------------------------------------------------------------------
+ServersDatabasesAuditingSetting{#ServersDatabasesAuditingSetting}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BlobAuditing.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/auditingSettings/default
 
@@ -506,7 +506,7 @@ Used by: [ServersDatabasesAuditingSettingList](#ServersDatabasesAuditingSettingL
 | spec                                                                                    |             | [ServersDatabasesAuditingSetting_Spec](#ServersDatabasesAuditingSetting_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesAuditingSetting_STATUS](#ServersDatabasesAuditingSetting_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesAuditingSetting_Spec"></a>ServersDatabasesAuditingSetting_Spec
+### ServersDatabasesAuditingSetting_Spec {#ServersDatabasesAuditingSetting_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -523,7 +523,7 @@ Used by: [ServersDatabasesAuditingSettingList](#ServersDatabasesAuditingSettingL
 | storageAccountSubscriptionId | Specifies the blob storage subscription Id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersDatabasesAuditingSetting_STATUS"></a>ServersDatabasesAuditingSetting_STATUS
+### ServersDatabasesAuditingSetting_STATUS{#ServersDatabasesAuditingSetting_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                    |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -542,8 +542,8 @@ Used by: [ServersDatabasesAuditingSettingList](#ServersDatabasesAuditingSettingL
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesAuditingSettingList"></a>ServersDatabasesAuditingSettingList
------------------------------------------------------------------------------------
+ServersDatabasesAuditingSettingList{#ServersDatabasesAuditingSettingList}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BlobAuditing.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/auditingSettings/default
 
@@ -553,8 +553,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                   |
 | items                                                                               |             | [ServersDatabasesAuditingSetting[]](#ServersDatabasesAuditingSetting)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesBackupLongTermRetentionPolicy"></a>ServersDatabasesBackupLongTermRetentionPolicy
--------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupLongTermRetentionPolicy{#ServersDatabasesBackupLongTermRetentionPolicy}
+---------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/LongTermRetentionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupLongTermRetentionPolicies/default
 
@@ -567,7 +567,7 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicyList](#ServersDatabasesBa
 | spec                                                                                    |             | [ServersDatabasesBackupLongTermRetentionPolicy_Spec](#ServersDatabasesBackupLongTermRetentionPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesBackupLongTermRetentionPolicy_STATUS](#ServersDatabasesBackupLongTermRetentionPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesBackupLongTermRetentionPolicy_Spec"></a>ServersDatabasesBackupLongTermRetentionPolicy_Spec
+### ServersDatabasesBackupLongTermRetentionPolicy_Spec {#ServersDatabasesBackupLongTermRetentionPolicy_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -578,7 +578,7 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicyList](#ServersDatabasesBa
 | weekOfYear       | The week of year to take the yearly backup in an ISO 8601 format.                                                                                                                                                                                                                        | int<br/><small>Optional</small>                                                                                                                                      |
 | yearlyRetention  | The yearly retention policy for an LTR backup in an ISO 8601 format.                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersDatabasesBackupLongTermRetentionPolicy_STATUS"></a>ServersDatabasesBackupLongTermRetentionPolicy_STATUS
+### ServersDatabasesBackupLongTermRetentionPolicy_STATUS{#ServersDatabasesBackupLongTermRetentionPolicy_STATUS}
 
 | Property         | Description                                                           | Type                                                                                                                                                    |
 |------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -591,8 +591,8 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicyList](#ServersDatabasesBa
 | weekOfYear       | The week of year to take the yearly backup in an ISO 8601 format.     | int<br/><small>Optional</small>                                                                                                                         |
 | yearlyRetention  | The yearly retention policy for an LTR backup in an ISO 8601 format.  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesBackupLongTermRetentionPolicyList"></a>ServersDatabasesBackupLongTermRetentionPolicyList
----------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupLongTermRetentionPolicyList{#ServersDatabasesBackupLongTermRetentionPolicyList}
+-----------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/LongTermRetentionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupLongTermRetentionPolicies/default
 
@@ -602,8 +602,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                               |
 | items                                                                               |             | [ServersDatabasesBackupLongTermRetentionPolicy[]](#ServersDatabasesBackupLongTermRetentionPolicy)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesBackupShortTermRetentionPolicy"></a>ServersDatabasesBackupShortTermRetentionPolicy
----------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupShortTermRetentionPolicy{#ServersDatabasesBackupShortTermRetentionPolicy}
+-----------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BackupShortTermRetentionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupShortTermRetentionPolicies/default
 
@@ -616,7 +616,7 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicyList](#ServersDatabasesB
 | spec                                                                                    |             | [ServersDatabasesBackupShortTermRetentionPolicy_Spec](#ServersDatabasesBackupShortTermRetentionPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesBackupShortTermRetentionPolicy_STATUS](#ServersDatabasesBackupShortTermRetentionPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesBackupShortTermRetentionPolicy_Spec"></a>ServersDatabasesBackupShortTermRetentionPolicy_Spec
+### ServersDatabasesBackupShortTermRetentionPolicy_Spec {#ServersDatabasesBackupShortTermRetentionPolicy_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                  |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -625,7 +625,7 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicyList](#ServersDatabasesB
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small>  |
 | retentionDays             | The backup retention period in days. This is how many days Point-in-Time Restore will be supported.                                                                                                                                                                                      | int<br/><small>Optional</small>                                                                                                                                       |
 
-### <a id="ServersDatabasesBackupShortTermRetentionPolicy_STATUS"></a>ServersDatabasesBackupShortTermRetentionPolicy_STATUS
+### ServersDatabasesBackupShortTermRetentionPolicy_STATUS{#ServersDatabasesBackupShortTermRetentionPolicy_STATUS}
 
 | Property                  | Description                                                                                                                                                                                         | Type                                                                                                                                                                                |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -636,8 +636,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicyList](#ServersDatabasesB
 | retentionDays             | The backup retention period in days. This is how many days Point-in-Time Restore will be supported.                                                                                                 | int<br/><small>Optional</small>                                                                                                                                                     |
 | type                      | Resource type.                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                                  |
 
-<a id="ServersDatabasesBackupShortTermRetentionPolicyList"></a>ServersDatabasesBackupShortTermRetentionPolicyList
------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupShortTermRetentionPolicyList{#ServersDatabasesBackupShortTermRetentionPolicyList}
+-------------------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/BackupShortTermRetentionPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupShortTermRetentionPolicies/default
 
@@ -647,8 +647,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                                 |
 | items                                                                               |             | [ServersDatabasesBackupShortTermRetentionPolicy[]](#ServersDatabasesBackupShortTermRetentionPolicy)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesSecurityAlertPolicy"></a>ServersDatabasesSecurityAlertPolicy
------------------------------------------------------------------------------------
+ServersDatabasesSecurityAlertPolicy{#ServersDatabasesSecurityAlertPolicy}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseSecurityAlertPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/securityAlertPolicies/default
 
@@ -661,7 +661,7 @@ Used by: [ServersDatabasesSecurityAlertPolicyList](#ServersDatabasesSecurityAler
 | spec                                                                                    |             | [ServersDatabasesSecurityAlertPolicy_Spec](#ServersDatabasesSecurityAlertPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesSecurityAlertPolicy_STATUS](#ServersDatabasesSecurityAlertPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesSecurityAlertPolicy_Spec"></a>ServersDatabasesSecurityAlertPolicy_Spec
+### ServersDatabasesSecurityAlertPolicy_Spec {#ServersDatabasesSecurityAlertPolicy_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -675,7 +675,7 @@ Used by: [ServersDatabasesSecurityAlertPolicyList](#ServersDatabasesSecurityAler
 | storageAccountAccessKey | Specifies the identifier key of the Threat Detection audit storage account.                                                                                                                                                                                                              | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | storageEndpoint         | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs.                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersDatabasesSecurityAlertPolicy_STATUS"></a>ServersDatabasesSecurityAlertPolicy_STATUS
+### ServersDatabasesSecurityAlertPolicy_STATUS{#ServersDatabasesSecurityAlertPolicy_STATUS}
 
 | Property           | Description                                                                                                                                                                   | Type                                                                                                                                                                              |
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -692,8 +692,8 @@ Used by: [ServersDatabasesSecurityAlertPolicyList](#ServersDatabasesSecurityAler
 | systemData         | SystemData of SecurityAlertPolicyResource.                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                               |
 | type               | Resource type.                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                                |
 
-<a id="ServersDatabasesSecurityAlertPolicyList"></a>ServersDatabasesSecurityAlertPolicyList
--------------------------------------------------------------------------------------------
+ServersDatabasesSecurityAlertPolicyList{#ServersDatabasesSecurityAlertPolicyList}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseSecurityAlertPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/securityAlertPolicies/default
 
@@ -703,8 +703,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                           |
 | items                                                                               |             | [ServersDatabasesSecurityAlertPolicy[]](#ServersDatabasesSecurityAlertPolicy)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesTransparentDataEncryption"></a>ServersDatabasesTransparentDataEncryption
------------------------------------------------------------------------------------------------
+ServersDatabasesTransparentDataEncryption{#ServersDatabasesTransparentDataEncryption}
+-------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/TransparentDataEncryptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/transparentDataEncryption/{tdeName}
 
@@ -717,7 +717,7 @@ Used by: [ServersDatabasesTransparentDataEncryptionList](#ServersDatabasesTransp
 | spec                                                                                    |             | [ServersDatabasesTransparentDataEncryption_Spec](#ServersDatabasesTransparentDataEncryption_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesTransparentDataEncryption_STATUS](#ServersDatabasesTransparentDataEncryption_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesTransparentDataEncryption_Spec"></a>ServersDatabasesTransparentDataEncryption_Spec
+### ServersDatabasesTransparentDataEncryption_Spec {#ServersDatabasesTransparentDataEncryption_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -725,7 +725,7 @@ Used by: [ServersDatabasesTransparentDataEncryptionList](#ServersDatabasesTransp
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the transparent data encryption.                                                                                                                                                                                                                                  | [TransparentDataEncryptionProperties_State](#TransparentDataEncryptionProperties_State)<br/><small>Required</small>                                                  |
 
-### <a id="ServersDatabasesTransparentDataEncryption_STATUS"></a>ServersDatabasesTransparentDataEncryption_STATUS
+### ServersDatabasesTransparentDataEncryption_STATUS{#ServersDatabasesTransparentDataEncryption_STATUS}
 
 | Property   | Description                                             | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -735,8 +735,8 @@ Used by: [ServersDatabasesTransparentDataEncryptionList](#ServersDatabasesTransp
 | state      | Specifies the state of the transparent data encryption. | [TransparentDataEncryptionProperties_State_STATUS](#TransparentDataEncryptionProperties_State_STATUS)<br/><small>Optional</small>                       |
 | type       | Resource type.                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesTransparentDataEncryptionList"></a>ServersDatabasesTransparentDataEncryptionList
--------------------------------------------------------------------------------------------------------
+ServersDatabasesTransparentDataEncryptionList{#ServersDatabasesTransparentDataEncryptionList}
+---------------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/TransparentDataEncryptions.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/transparentDataEncryption/{tdeName}
 
@@ -746,8 +746,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                       |
 | items                                                                               |             | [ServersDatabasesTransparentDataEncryption[]](#ServersDatabasesTransparentDataEncryption)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesVulnerabilityAssessment"></a>ServersDatabasesVulnerabilityAssessment
--------------------------------------------------------------------------------------------
+ServersDatabasesVulnerabilityAssessment{#ServersDatabasesVulnerabilityAssessment}
+---------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseVulnerabilityAssessments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/vulnerabilityAssessments/default
 
@@ -760,7 +760,7 @@ Used by: [ServersDatabasesVulnerabilityAssessmentList](#ServersDatabasesVulnerab
 | spec                                                                                    |             | [ServersDatabasesVulnerabilityAssessment_Spec](#ServersDatabasesVulnerabilityAssessment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersDatabasesVulnerabilityAssessment_STATUS](#ServersDatabasesVulnerabilityAssessment_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersDatabasesVulnerabilityAssessment_Spec"></a>ServersDatabasesVulnerabilityAssessment_Spec
+### ServersDatabasesVulnerabilityAssessment_Spec {#ServersDatabasesVulnerabilityAssessment_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -772,7 +772,7 @@ Used by: [ServersDatabasesVulnerabilityAssessmentList](#ServersDatabasesVulnerab
 | storageContainerPathFromConfig | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). It is required if server level vulnerability assessment policy doesn't set                                                                                               | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 | storageContainerSasKey         | A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required. Applies only if the storage account is not behind a Vnet or a firewall  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 
-### <a id="ServersDatabasesVulnerabilityAssessment_STATUS"></a>ServersDatabasesVulnerabilityAssessment_STATUS
+### ServersDatabasesVulnerabilityAssessment_STATUS{#ServersDatabasesVulnerabilityAssessment_STATUS}
 
 | Property             | Description                                                                                                                                                                                | Type                                                                                                                                                    |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -783,8 +783,8 @@ Used by: [ServersDatabasesVulnerabilityAssessmentList](#ServersDatabasesVulnerab
 | storageContainerPath | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). It is required if server level vulnerability assessment policy doesn't set | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | Resource type.                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesVulnerabilityAssessmentList"></a>ServersDatabasesVulnerabilityAssessmentList
----------------------------------------------------------------------------------------------------
+ServersDatabasesVulnerabilityAssessmentList{#ServersDatabasesVulnerabilityAssessmentList}
+-----------------------------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/DatabaseVulnerabilityAssessments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/databases/{databaseName}/vulnerabilityAssessments/default
 
@@ -794,8 +794,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                                   |
 | items                                                                               |             | [ServersDatabasesVulnerabilityAssessment[]](#ServersDatabasesVulnerabilityAssessment)<br/><small>Optional</small> |
 
-<a id="ServersElasticPool"></a>ServersElasticPool
--------------------------------------------------
+ServersElasticPool{#ServersElasticPool}
+---------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ElasticPools.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}
 
@@ -808,7 +808,7 @@ Used by: [ServersElasticPoolList](#ServersElasticPoolList).
 | spec                                                                                    |             | [ServersElasticPool_Spec](#ServersElasticPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersElasticPool_STATUS](#ServersElasticPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersElasticPool_Spec"></a>ServersElasticPool_Spec
+### ServersElasticPool_Spec {#ServersElasticPool_Spec}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                                 |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -826,7 +826,7 @@ Used by: [ServersElasticPoolList](#ServersElasticPoolList).
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant                | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.                                                                                                                                                                                                                       | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="ServersElasticPool_STATUS"></a>ServersElasticPool_STATUS
+### ServersElasticPool_STATUS{#ServersElasticPool_STATUS}
 
 | Property                     | Description                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                                                                                    |
 |------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -848,8 +848,8 @@ Used by: [ServersElasticPoolList](#ServersElasticPoolList).
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant                | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.                                                                                                                                                                                                                       | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServersElasticPoolList"></a>ServersElasticPoolList
----------------------------------------------------------
+ServersElasticPoolList{#ServersElasticPoolList}
+-----------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ElasticPools.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}
 
@@ -859,8 +859,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [ServersElasticPool[]](#ServersElasticPool)<br/><small>Optional</small> |
 
-<a id="ServersFailoverGroup"></a>ServersFailoverGroup
------------------------------------------------------
+ServersFailoverGroup{#ServersFailoverGroup}
+-------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/FailoverGroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}
 
@@ -873,7 +873,7 @@ Used by: [ServersFailoverGroupList](#ServersFailoverGroupList).
 | spec                                                                                    |             | [ServersFailoverGroup_Spec](#ServersFailoverGroup_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersFailoverGroup_Spec"></a>ServersFailoverGroup_Spec
+### ServersFailoverGroup_Spec {#ServersFailoverGroup_Spec}
 
 | Property            | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -886,7 +886,7 @@ Used by: [ServersFailoverGroupList](#ServersFailoverGroupList).
 | readWriteEndpoint   | Read-write endpoint of the failover group instance.                                                                                                                                                                                                                             | [FailoverGroupReadWriteEndpoint](#FailoverGroupReadWriteEndpoint)<br/><small>Required</small>                                                                        |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="ServersFailoverGroup_STATUS"></a>ServersFailoverGroup_STATUS
+### ServersFailoverGroup_STATUS{#ServersFailoverGroup_STATUS}
 
 | Property          | Description                                                | Type                                                                                                                                                    |
 |-------------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -903,8 +903,8 @@ Used by: [ServersFailoverGroupList](#ServersFailoverGroupList).
 | tags              | Resource tags.                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | Resource type.                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersFailoverGroupList"></a>ServersFailoverGroupList
--------------------------------------------------------------
+ServersFailoverGroupList{#ServersFailoverGroupList}
+---------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/FailoverGroups.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}
 
@@ -914,8 +914,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                             |
 | items                                                                               |             | [ServersFailoverGroup[]](#ServersFailoverGroup)<br/><small>Optional</small> |
 
-<a id="ServersFirewallRule"></a>ServersFirewallRule
----------------------------------------------------
+ServersFirewallRule{#ServersFirewallRule}
+-----------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -928,7 +928,7 @@ Used by: [ServersFirewallRuleList](#ServersFirewallRuleList).
 | spec                                                                                    |             | [ServersFirewallRule_Spec](#ServersFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersFirewallRule_STATUS](#ServersFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersFirewallRule_Spec"></a>ServersFirewallRule_Spec
+### ServersFirewallRule_Spec {#ServersFirewallRule_Spec}
 
 | Property       | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -938,7 +938,7 @@ Used by: [ServersFirewallRuleList](#ServersFirewallRuleList).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses.                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersFirewallRule_STATUS"></a>ServersFirewallRule_STATUS
+### ServersFirewallRule_STATUS{#ServersFirewallRule_STATUS}
 
 | Property       | Description                                                                                                                                                             | Type                                                                                                                                                    |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -949,8 +949,8 @@ Used by: [ServersFirewallRuleList](#ServersFirewallRuleList).
 | startIpAddress | The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses.                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type           | Resource type.                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersFirewallRuleList"></a>ServersFirewallRuleList
------------------------------------------------------------
+ServersFirewallRuleList{#ServersFirewallRuleList}
+-------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/firewallRules/{firewallRuleName}
 
@@ -960,8 +960,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                           |
 | items                                                                               |             | [ServersFirewallRule[]](#ServersFirewallRule)<br/><small>Optional</small> |
 
-<a id="ServersIPV6FirewallRule"></a>ServersIPV6FirewallRule
------------------------------------------------------------
+ServersIPV6FirewallRule{#ServersIPV6FirewallRule}
+-------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/IPv6FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/ipv6FirewallRules/{firewallRuleName}
 
@@ -974,7 +974,7 @@ Used by: [ServersIPV6FirewallRuleList](#ServersIPV6FirewallRuleList).
 | spec                                                                                    |             | [ServersIPV6FirewallRule_Spec](#ServersIPV6FirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersIPV6FirewallRule_STATUS](#ServersIPV6FirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersIPV6FirewallRule_Spec"></a>ServersIPV6FirewallRule_Spec
+### ServersIPV6FirewallRule_Spec {#ServersIPV6FirewallRule_Spec}
 
 | Property         | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -984,7 +984,7 @@ Used by: [ServersIPV6FirewallRuleList](#ServersIPV6FirewallRuleList).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIPv6Address | The start IP address of the firewall rule. Must be IPv6 format.                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersIPV6FirewallRule_STATUS"></a>ServersIPV6FirewallRule_STATUS
+### ServersIPV6FirewallRule_STATUS{#ServersIPV6FirewallRule_STATUS}
 
 | Property         | Description                                                                                                    | Type                                                                                                                                                    |
 |------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -995,8 +995,8 @@ Used by: [ServersIPV6FirewallRuleList](#ServersIPV6FirewallRuleList).
 | startIPv6Address | The start IP address of the firewall rule. Must be IPv6 format.                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type             | Resource type.                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersIPV6FirewallRuleList"></a>ServersIPV6FirewallRuleList
--------------------------------------------------------------------
+ServersIPV6FirewallRuleList{#ServersIPV6FirewallRuleList}
+---------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/IPv6FirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/ipv6FirewallRules/{firewallRuleName}
 
@@ -1006,8 +1006,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                   |
 | items                                                                               |             | [ServersIPV6FirewallRule[]](#ServersIPV6FirewallRule)<br/><small>Optional</small> |
 
-<a id="ServersOutboundFirewallRule"></a>ServersOutboundFirewallRule
--------------------------------------------------------------------
+ServersOutboundFirewallRule{#ServersOutboundFirewallRule}
+---------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/OutboundFirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/outboundFirewallRules/{outboundRuleFqdn}
 
@@ -1020,7 +1020,7 @@ Used by: [ServersOutboundFirewallRuleList](#ServersOutboundFirewallRuleList).
 | spec                                                                                    |             | [ServersOutboundFirewallRule_Spec](#ServersOutboundFirewallRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersOutboundFirewallRule_STATUS](#ServersOutboundFirewallRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersOutboundFirewallRule_Spec"></a>ServersOutboundFirewallRule_Spec
+### ServersOutboundFirewallRule_Spec {#ServersOutboundFirewallRule_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1028,7 +1028,7 @@ Used by: [ServersOutboundFirewallRuleList](#ServersOutboundFirewallRuleList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersOutboundFirewallRuleOperatorSpec](#ServersOutboundFirewallRuleOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="ServersOutboundFirewallRule_STATUS"></a>ServersOutboundFirewallRule_STATUS
+### ServersOutboundFirewallRule_STATUS{#ServersOutboundFirewallRule_STATUS}
 
 | Property          | Description                        | Type                                                                                                                                                    |
 |-------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1038,8 +1038,8 @@ Used by: [ServersOutboundFirewallRuleList](#ServersOutboundFirewallRuleList).
 | provisioningState | The state of the outbound rule.    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | Resource type.                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersOutboundFirewallRuleList"></a>ServersOutboundFirewallRuleList
----------------------------------------------------------------------------
+ServersOutboundFirewallRuleList{#ServersOutboundFirewallRuleList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/OutboundFirewallRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/outboundFirewallRules/{outboundRuleFqdn}
 
@@ -1049,8 +1049,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [ServersOutboundFirewallRule[]](#ServersOutboundFirewallRule)<br/><small>Optional</small> |
 
-<a id="ServersSecurityAlertPolicy"></a>ServersSecurityAlertPolicy
------------------------------------------------------------------
+ServersSecurityAlertPolicy{#ServersSecurityAlertPolicy}
+-------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerSecurityAlertPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/securityAlertPolicies/Default
 
@@ -1063,7 +1063,7 @@ Used by: [ServersSecurityAlertPolicyList](#ServersSecurityAlertPolicyList).
 | spec                                                                                    |             | [ServersSecurityAlertPolicy_Spec](#ServersSecurityAlertPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersSecurityAlertPolicy_STATUS](#ServersSecurityAlertPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersSecurityAlertPolicy_Spec"></a>ServersSecurityAlertPolicy_Spec
+### ServersSecurityAlertPolicy_Spec {#ServersSecurityAlertPolicy_Spec}
 
 | Property                | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1077,7 +1077,7 @@ Used by: [ServersSecurityAlertPolicyList](#ServersSecurityAlertPolicyList).
 | storageAccountAccessKey | Specifies the identifier key of the Threat Detection audit storage account.                                                                                                                                                                                                     | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | storageEndpoint         | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs.                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="ServersSecurityAlertPolicy_STATUS"></a>ServersSecurityAlertPolicy_STATUS
+### ServersSecurityAlertPolicy_STATUS{#ServersSecurityAlertPolicy_STATUS}
 
 | Property           | Description                                                                                                                                                                   | Type                                                                                                                                                                          |
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1094,8 +1094,8 @@ Used by: [ServersSecurityAlertPolicyList](#ServersSecurityAlertPolicyList).
 | systemData         | SystemData of SecurityAlertPolicyResource.                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                           |
 | type               | Resource type.                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                            |
 
-<a id="ServersSecurityAlertPolicyList"></a>ServersSecurityAlertPolicyList
--------------------------------------------------------------------------
+ServersSecurityAlertPolicyList{#ServersSecurityAlertPolicyList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerSecurityAlertPolicies.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/securityAlertPolicies/Default
 
@@ -1105,8 +1105,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [ServersSecurityAlertPolicy[]](#ServersSecurityAlertPolicy)<br/><small>Optional</small> |
 
-<a id="ServersVirtualNetworkRule"></a>ServersVirtualNetworkRule
----------------------------------------------------------------
+ServersVirtualNetworkRule{#ServersVirtualNetworkRule}
+-----------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/VirtualNetworkRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/virtualNetworkRules/{virtualNetworkRuleName}
 
@@ -1119,7 +1119,7 @@ Used by: [ServersVirtualNetworkRuleList](#ServersVirtualNetworkRuleList).
 | spec                                                                                    |             | [ServersVirtualNetworkRule_Spec](#ServersVirtualNetworkRule_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersVirtualNetworkRule_STATUS](#ServersVirtualNetworkRule_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersVirtualNetworkRule_Spec"></a>ServersVirtualNetworkRule_Spec
+### ServersVirtualNetworkRule_Spec {#ServersVirtualNetworkRule_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1129,7 +1129,7 @@ Used by: [ServersVirtualNetworkRuleList](#ServersVirtualNetworkRuleList).
 | owner                            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | virtualNetworkSubnetReference    | The ARM resource id of the virtual network subnet.                                                                                                                                                                                                                              | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-### <a id="ServersVirtualNetworkRule_STATUS"></a>ServersVirtualNetworkRule_STATUS
+### ServersVirtualNetworkRule_STATUS{#ServersVirtualNetworkRule_STATUS}
 
 | Property                         | Description                                                                        | Type                                                                                                                                                    |
 |----------------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1141,8 +1141,8 @@ Used by: [ServersVirtualNetworkRuleList](#ServersVirtualNetworkRuleList).
 | type                             | Resource type.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetworkSubnetId           | The ARM resource id of the virtual network subnet.                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersVirtualNetworkRuleList"></a>ServersVirtualNetworkRuleList
------------------------------------------------------------------------
+ServersVirtualNetworkRuleList{#ServersVirtualNetworkRuleList}
+-------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/VirtualNetworkRules.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/virtualNetworkRules/{virtualNetworkRuleName}
 
@@ -1152,8 +1152,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                       |
 | items                                                                               |             | [ServersVirtualNetworkRule[]](#ServersVirtualNetworkRule)<br/><small>Optional</small> |
 
-<a id="ServersVulnerabilityAssessment"></a>ServersVulnerabilityAssessment
--------------------------------------------------------------------------
+ServersVulnerabilityAssessment{#ServersVulnerabilityAssessment}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerVulnerabilityAssessments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/vulnerabilityAssessments/default
 
@@ -1166,7 +1166,7 @@ Used by: [ServersVulnerabilityAssessmentList](#ServersVulnerabilityAssessmentLis
 | spec                                                                                    |             | [ServersVulnerabilityAssessment_Spec](#ServersVulnerabilityAssessment_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServersVulnerabilityAssessment_STATUS](#ServersVulnerabilityAssessment_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServersVulnerabilityAssessment_Spec"></a>ServersVulnerabilityAssessment_Spec
+### ServersVulnerabilityAssessment_Spec {#ServersVulnerabilityAssessment_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1178,7 +1178,7 @@ Used by: [ServersVulnerabilityAssessmentList](#ServersVulnerabilityAssessmentLis
 | storageContainerPathFromConfig | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/).                                                                                                                                                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 | storageContainerSasKey         | A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required. Applies only if the storage account is not behind a Vnet or a firewall | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 
-### <a id="ServersVulnerabilityAssessment_STATUS"></a>ServersVulnerabilityAssessment_STATUS
+### ServersVulnerabilityAssessment_STATUS{#ServersVulnerabilityAssessment_STATUS}
 
 | Property             | Description                                                                                                     | Type                                                                                                                                                    |
 |----------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1189,8 +1189,8 @@ Used by: [ServersVulnerabilityAssessmentList](#ServersVulnerabilityAssessmentLis
 | storageContainerPath | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | Resource type.                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersVulnerabilityAssessmentList"></a>ServersVulnerabilityAssessmentList
----------------------------------------------------------------------------------
+ServersVulnerabilityAssessmentList{#ServersVulnerabilityAssessmentList}
+-----------------------------------------------------------------------
 
 Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerVulnerabilityAssessments.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Sql/servers/{serverName}/vulnerabilityAssessments/default
 
@@ -1200,8 +1200,8 @@ Generator information: - Generated from: /sql/resource-manager/Microsoft.Sql/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                 |
 | items                                                                               |             | [ServersVulnerabilityAssessment[]](#ServersVulnerabilityAssessment)<br/><small>Optional</small> |
 
-<a id="Server_Spec"></a>Server_Spec
------------------------------------
+Server_Spec{#Server_Spec}
+-------------------------
 
 Used by: [Server](#Server).
 
@@ -1224,8 +1224,8 @@ Used by: [Server](#Server).
 | tags                                 | Resource tags.                                                                                                                                                                                                                                                                               | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | version                              | The version of the server.                                                                                                                                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="Server_STATUS"></a>Server_STATUS
----------------------------------------
+Server_STATUS{#Server_STATUS}
+-----------------------------
 
 An Azure SQL Database server.
 
@@ -1255,8 +1255,8 @@ Used by: [Server](#Server).
 | version                       | The version of the server.                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 | workspaceFeature              | Whether or not existing server has a workspace created and if it allows connection from workspace                                       | [ServerProperties_WorkspaceFeature_STATUS](#ServerProperties_WorkspaceFeature_STATUS)<br/><small>Optional</small>                                       |
 
-<a id="ServersAdministrator_Spec"></a>ServersAdministrator_Spec
----------------------------------------------------------------
+ServersAdministrator_Spec{#ServersAdministrator_Spec}
+-----------------------------------------------------
 
 Used by: [ServersAdministrator](#ServersAdministrator).
 
@@ -1271,8 +1271,8 @@ Used by: [ServersAdministrator](#ServersAdministrator).
 | tenantId           | Tenant ID of the administrator.                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | tenantIdFromConfig | Tenant ID of the administrator.                                                                                                                                                                                                                                                 | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 
-<a id="ServersAdministrator_STATUS"></a>ServersAdministrator_STATUS
--------------------------------------------------------------------
+ServersAdministrator_STATUS{#ServersAdministrator_STATUS}
+---------------------------------------------------------
 
 Used by: [ServersAdministrator](#ServersAdministrator).
 
@@ -1288,8 +1288,8 @@ Used by: [ServersAdministrator](#ServersAdministrator).
 | tenantId                  | Tenant ID of the administrator.                     | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAdvancedThreatProtectionSetting_Spec"></a>ServersAdvancedThreatProtectionSetting_Spec
----------------------------------------------------------------------------------------------------
+ServersAdvancedThreatProtectionSetting_Spec{#ServersAdvancedThreatProtectionSetting_Spec}
+-----------------------------------------------------------------------------------------
 
 Used by: [ServersAdvancedThreatProtectionSetting](#ServersAdvancedThreatProtectionSetting).
 
@@ -1299,8 +1299,8 @@ Used by: [ServersAdvancedThreatProtectionSetting](#ServersAdvancedThreatProtecti
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the Advanced Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific database or server.                                                                                                                | [AdvancedThreatProtectionProperties_State](#AdvancedThreatProtectionProperties_State)<br/><small>Required</small>                                                    |
 
-<a id="ServersAdvancedThreatProtectionSetting_STATUS"></a>ServersAdvancedThreatProtectionSetting_STATUS
--------------------------------------------------------------------------------------------------------
+ServersAdvancedThreatProtectionSetting_STATUS{#ServersAdvancedThreatProtectionSetting_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [ServersAdvancedThreatProtectionSetting](#ServersAdvancedThreatProtectionSetting).
 
@@ -1314,8 +1314,8 @@ Used by: [ServersAdvancedThreatProtectionSetting](#ServersAdvancedThreatProtecti
 | systemData   | SystemData of AdvancedThreatProtectionResource.                                                                                                                  | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type         | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAuditingSetting_Spec"></a>ServersAuditingSetting_Spec
--------------------------------------------------------------------
+ServersAuditingSetting_Spec{#ServersAuditingSetting_Spec}
+---------------------------------------------------------
 
 Used by: [ServersAuditingSetting](#ServersAuditingSetting).
 
@@ -1335,8 +1335,8 @@ Used by: [ServersAuditingSetting](#ServersAuditingSetting).
 | storageAccountSubscriptionId | Specifies the blob storage subscription Id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersAuditingSetting_STATUS"></a>ServersAuditingSetting_STATUS
------------------------------------------------------------------------
+ServersAuditingSetting_STATUS{#ServersAuditingSetting_STATUS}
+-------------------------------------------------------------
 
 Used by: [ServersAuditingSetting](#ServersAuditingSetting).
 
@@ -1357,8 +1357,8 @@ Used by: [ServersAuditingSetting](#ServersAuditingSetting).
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersAzureADOnlyAuthentication_Spec"></a>ServersAzureADOnlyAuthentication_Spec
----------------------------------------------------------------------------------------
+ServersAzureADOnlyAuthentication_Spec{#ServersAzureADOnlyAuthentication_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [ServersAzureADOnlyAuthentication](#ServersAzureADOnlyAuthentication).
 
@@ -1368,8 +1368,8 @@ Used by: [ServersAzureADOnlyAuthentication](#ServersAzureADOnlyAuthentication).
 | operatorSpec              | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersAzureADOnlyAuthenticationOperatorSpec](#ServersAzureADOnlyAuthenticationOperatorSpec)<br/><small>Optional</small>                                            |
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="ServersAzureADOnlyAuthentication_STATUS"></a>ServersAzureADOnlyAuthentication_STATUS
--------------------------------------------------------------------------------------------
+ServersAzureADOnlyAuthentication_STATUS{#ServersAzureADOnlyAuthentication_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ServersAzureADOnlyAuthentication](#ServersAzureADOnlyAuthentication).
 
@@ -1381,8 +1381,8 @@ Used by: [ServersAzureADOnlyAuthentication](#ServersAzureADOnlyAuthentication).
 | name                      | Resource name.                                      | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                      | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersConnectionPolicy_Spec"></a>ServersConnectionPolicy_Spec
----------------------------------------------------------------------
+ServersConnectionPolicy_Spec{#ServersConnectionPolicy_Spec}
+-----------------------------------------------------------
 
 Used by: [ServersConnectionPolicy](#ServersConnectionPolicy).
 
@@ -1392,8 +1392,8 @@ Used by: [ServersConnectionPolicy](#ServersConnectionPolicy).
 | operatorSpec   | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersConnectionPolicyOperatorSpec](#ServersConnectionPolicyOperatorSpec)<br/><small>Optional</small>                                                              |
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="ServersConnectionPolicy_STATUS"></a>ServersConnectionPolicy_STATUS
--------------------------------------------------------------------------
+ServersConnectionPolicy_STATUS{#ServersConnectionPolicy_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServersConnectionPolicy](#ServersConnectionPolicy).
 
@@ -1407,8 +1407,8 @@ Used by: [ServersConnectionPolicy](#ServersConnectionPolicy).
 | name           | Resource name.                                 | string<br/><small>Optional</small>                                                                                                                      |
 | type           | Resource type.                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabase_Spec"></a>ServersDatabase_Spec
------------------------------------------------------
+ServersDatabase_Spec{#ServersDatabase_Spec}
+-------------------------------------------
 
 Used by: [ServersDatabase](#ServersDatabase).
 
@@ -1447,8 +1447,8 @@ Used by: [ServersDatabase](#ServersDatabase).
 | tags                                     | Resource tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant                            | Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="ServersDatabase_STATUS"></a>ServersDatabase_STATUS
----------------------------------------------------------
+ServersDatabase_STATUS{#ServersDatabase_STATUS}
+-----------------------------------------------
 
 Used by: [ServersDatabase](#ServersDatabase).
 
@@ -1504,8 +1504,8 @@ Used by: [ServersDatabase](#ServersDatabase).
 | type                              | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant                     | Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServersDatabasesAdvancedThreatProtectionSetting_Spec"></a>ServersDatabasesAdvancedThreatProtectionSetting_Spec
----------------------------------------------------------------------------------------------------------------------
+ServersDatabasesAdvancedThreatProtectionSetting_Spec{#ServersDatabasesAdvancedThreatProtectionSetting_Spec}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAdvancedThreatProtectionSetting](#ServersDatabasesAdvancedThreatProtectionSetting).
 
@@ -1515,8 +1515,8 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSetting](#ServersDatabasesAdva
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the Advanced Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific database or server.                                                                                                                         | [AdvancedThreatProtectionProperties_State](#AdvancedThreatProtectionProperties_State)<br/><small>Required</small>                                                    |
 
-<a id="ServersDatabasesAdvancedThreatProtectionSetting_STATUS"></a>ServersDatabasesAdvancedThreatProtectionSetting_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesAdvancedThreatProtectionSetting_STATUS{#ServersDatabasesAdvancedThreatProtectionSetting_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAdvancedThreatProtectionSetting](#ServersDatabasesAdvancedThreatProtectionSetting).
 
@@ -1530,8 +1530,8 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSetting](#ServersDatabasesAdva
 | systemData   | SystemData of AdvancedThreatProtectionResource.                                                                                                                  | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type         | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesAuditingSetting_Spec"></a>ServersDatabasesAuditingSetting_Spec
--------------------------------------------------------------------------------------
+ServersDatabasesAuditingSetting_Spec{#ServersDatabasesAuditingSetting_Spec}
+---------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAuditingSetting](#ServersDatabasesAuditingSetting).
 
@@ -1550,8 +1550,8 @@ Used by: [ServersDatabasesAuditingSetting](#ServersDatabasesAuditingSetting).
 | storageAccountSubscriptionId | Specifies the blob storage subscription Id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersDatabasesAuditingSetting_STATUS"></a>ServersDatabasesAuditingSetting_STATUS
------------------------------------------------------------------------------------------
+ServersDatabasesAuditingSetting_STATUS{#ServersDatabasesAuditingSetting_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAuditingSetting](#ServersDatabasesAuditingSetting).
 
@@ -1572,8 +1572,8 @@ Used by: [ServersDatabasesAuditingSetting](#ServersDatabasesAuditingSetting).
 | storageEndpoint              | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesBackupLongTermRetentionPolicy_Spec"></a>ServersDatabasesBackupLongTermRetentionPolicy_Spec
------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupLongTermRetentionPolicy_Spec{#ServersDatabasesBackupLongTermRetentionPolicy_Spec}
+-------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupLongTermRetentionPolicy](#ServersDatabasesBackupLongTermRetentionPolicy).
 
@@ -1586,8 +1586,8 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicy](#ServersDatabasesBackup
 | weekOfYear       | The week of year to take the yearly backup in an ISO 8601 format.                                                                                                                                                                                                                        | int<br/><small>Optional</small>                                                                                                                                      |
 | yearlyRetention  | The yearly retention policy for an LTR backup in an ISO 8601 format.                                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersDatabasesBackupLongTermRetentionPolicy_STATUS"></a>ServersDatabasesBackupLongTermRetentionPolicy_STATUS
----------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupLongTermRetentionPolicy_STATUS{#ServersDatabasesBackupLongTermRetentionPolicy_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupLongTermRetentionPolicy](#ServersDatabasesBackupLongTermRetentionPolicy).
 
@@ -1602,8 +1602,8 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicy](#ServersDatabasesBackup
 | weekOfYear       | The week of year to take the yearly backup in an ISO 8601 format.     | int<br/><small>Optional</small>                                                                                                                         |
 | yearlyRetention  | The yearly retention policy for an LTR backup in an ISO 8601 format.  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesBackupShortTermRetentionPolicy_Spec"></a>ServersDatabasesBackupShortTermRetentionPolicy_Spec
--------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupShortTermRetentionPolicy_Spec{#ServersDatabasesBackupShortTermRetentionPolicy_Spec}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupShortTermRetentionPolicy](#ServersDatabasesBackupShortTermRetentionPolicy).
 
@@ -1614,8 +1614,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicy](#ServersDatabasesBacku
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small>  |
 | retentionDays             | The backup retention period in days. This is how many days Point-in-Time Restore will be supported.                                                                                                                                                                                      | int<br/><small>Optional</small>                                                                                                                                       |
 
-<a id="ServersDatabasesBackupShortTermRetentionPolicy_STATUS"></a>ServersDatabasesBackupShortTermRetentionPolicy_STATUS
------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupShortTermRetentionPolicy_STATUS{#ServersDatabasesBackupShortTermRetentionPolicy_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupShortTermRetentionPolicy](#ServersDatabasesBackupShortTermRetentionPolicy).
 
@@ -1628,8 +1628,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicy](#ServersDatabasesBacku
 | retentionDays             | The backup retention period in days. This is how many days Point-in-Time Restore will be supported.                                                                                                 | int<br/><small>Optional</small>                                                                                                                                                     |
 | type                      | Resource type.                                                                                                                                                                                      | string<br/><small>Optional</small>                                                                                                                                                  |
 
-<a id="ServersDatabasesSecurityAlertPolicy_Spec"></a>ServersDatabasesSecurityAlertPolicy_Spec
----------------------------------------------------------------------------------------------
+ServersDatabasesSecurityAlertPolicy_Spec{#ServersDatabasesSecurityAlertPolicy_Spec}
+-----------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesSecurityAlertPolicy](#ServersDatabasesSecurityAlertPolicy).
 
@@ -1645,8 +1645,8 @@ Used by: [ServersDatabasesSecurityAlertPolicy](#ServersDatabasesSecurityAlertPol
 | storageAccountAccessKey | Specifies the identifier key of the Threat Detection audit storage account.                                                                                                                                                                                                              | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | storageEndpoint         | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs.                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersDatabasesSecurityAlertPolicy_STATUS"></a>ServersDatabasesSecurityAlertPolicy_STATUS
--------------------------------------------------------------------------------------------------
+ServersDatabasesSecurityAlertPolicy_STATUS{#ServersDatabasesSecurityAlertPolicy_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesSecurityAlertPolicy](#ServersDatabasesSecurityAlertPolicy).
 
@@ -1665,8 +1665,8 @@ Used by: [ServersDatabasesSecurityAlertPolicy](#ServersDatabasesSecurityAlertPol
 | systemData         | SystemData of SecurityAlertPolicyResource.                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                               |
 | type               | Resource type.                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                                |
 
-<a id="ServersDatabasesTransparentDataEncryption_Spec"></a>ServersDatabasesTransparentDataEncryption_Spec
----------------------------------------------------------------------------------------------------------
+ServersDatabasesTransparentDataEncryption_Spec{#ServersDatabasesTransparentDataEncryption_Spec}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesTransparentDataEncryption](#ServersDatabasesTransparentDataEncryption).
 
@@ -1676,8 +1676,8 @@ Used by: [ServersDatabasesTransparentDataEncryption](#ServersDatabasesTransparen
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/ServersDatabase resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | state        | Specifies the state of the transparent data encryption.                                                                                                                                                                                                                                  | [TransparentDataEncryptionProperties_State](#TransparentDataEncryptionProperties_State)<br/><small>Required</small>                                                  |
 
-<a id="ServersDatabasesTransparentDataEncryption_STATUS"></a>ServersDatabasesTransparentDataEncryption_STATUS
--------------------------------------------------------------------------------------------------------------
+ServersDatabasesTransparentDataEncryption_STATUS{#ServersDatabasesTransparentDataEncryption_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesTransparentDataEncryption](#ServersDatabasesTransparentDataEncryption).
 
@@ -1689,8 +1689,8 @@ Used by: [ServersDatabasesTransparentDataEncryption](#ServersDatabasesTransparen
 | state      | Specifies the state of the transparent data encryption. | [TransparentDataEncryptionProperties_State_STATUS](#TransparentDataEncryptionProperties_State_STATUS)<br/><small>Optional</small>                       |
 | type       | Resource type.                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersDatabasesVulnerabilityAssessment_Spec"></a>ServersDatabasesVulnerabilityAssessment_Spec
------------------------------------------------------------------------------------------------------
+ServersDatabasesVulnerabilityAssessment_Spec{#ServersDatabasesVulnerabilityAssessment_Spec}
+-------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesVulnerabilityAssessment](#ServersDatabasesVulnerabilityAssessment).
 
@@ -1704,8 +1704,8 @@ Used by: [ServersDatabasesVulnerabilityAssessment](#ServersDatabasesVulnerabilit
 | storageContainerPathFromConfig | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). It is required if server level vulnerability assessment policy doesn't set                                                                                               | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 | storageContainerSasKey         | A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required. Applies only if the storage account is not behind a Vnet or a firewall  | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 
-<a id="ServersDatabasesVulnerabilityAssessment_STATUS"></a>ServersDatabasesVulnerabilityAssessment_STATUS
----------------------------------------------------------------------------------------------------------
+ServersDatabasesVulnerabilityAssessment_STATUS{#ServersDatabasesVulnerabilityAssessment_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesVulnerabilityAssessment](#ServersDatabasesVulnerabilityAssessment).
 
@@ -1718,8 +1718,8 @@ Used by: [ServersDatabasesVulnerabilityAssessment](#ServersDatabasesVulnerabilit
 | storageContainerPath | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). It is required if server level vulnerability assessment policy doesn't set | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | Resource type.                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersElasticPool_Spec"></a>ServersElasticPool_Spec
------------------------------------------------------------
+ServersElasticPool_Spec{#ServersElasticPool_Spec}
+-------------------------------------------------
 
 Used by: [ServersElasticPool](#ServersElasticPool).
 
@@ -1739,8 +1739,8 @@ Used by: [ServersElasticPool](#ServersElasticPool).
 | tags                         | Resource tags.                                                                                                                                                                                                                                                                                                                                                             | map[string]string<br/><small>Optional</small>                                                                                                                        |
 | zoneRedundant                | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.                                                                                                                                                                                                                       | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="ServersElasticPool_STATUS"></a>ServersElasticPool_STATUS
----------------------------------------------------------------
+ServersElasticPool_STATUS{#ServersElasticPool_STATUS}
+-----------------------------------------------------
 
 Used by: [ServersElasticPool](#ServersElasticPool).
 
@@ -1764,8 +1764,8 @@ Used by: [ServersElasticPool](#ServersElasticPool).
 | type                         | Resource type.                                                                                                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant                | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.                                                                                                                                                                                                                       | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServersFailoverGroup_Spec"></a>ServersFailoverGroup_Spec
----------------------------------------------------------------
+ServersFailoverGroup_Spec{#ServersFailoverGroup_Spec}
+-----------------------------------------------------
 
 Used by: [ServersFailoverGroup](#ServersFailoverGroup).
 
@@ -1780,8 +1780,8 @@ Used by: [ServersFailoverGroup](#ServersFailoverGroup).
 | readWriteEndpoint   | Read-write endpoint of the failover group instance.                                                                                                                                                                                                                             | [FailoverGroupReadWriteEndpoint](#FailoverGroupReadWriteEndpoint)<br/><small>Required</small>                                                                        |
 | tags                | Resource tags.                                                                                                                                                                                                                                                                  | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServersFailoverGroup_STATUS"></a>ServersFailoverGroup_STATUS
--------------------------------------------------------------------
+ServersFailoverGroup_STATUS{#ServersFailoverGroup_STATUS}
+---------------------------------------------------------
 
 Used by: [ServersFailoverGroup](#ServersFailoverGroup).
 
@@ -1800,8 +1800,8 @@ Used by: [ServersFailoverGroup](#ServersFailoverGroup).
 | tags              | Resource tags.                                             | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type              | Resource type.                                             | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersFirewallRule_Spec"></a>ServersFirewallRule_Spec
--------------------------------------------------------------
+ServersFirewallRule_Spec{#ServersFirewallRule_Spec}
+---------------------------------------------------
 
 Used by: [ServersFirewallRule](#ServersFirewallRule).
 
@@ -1813,8 +1813,8 @@ Used by: [ServersFirewallRule](#ServersFirewallRule).
 | owner          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIpAddress | The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses.                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersFirewallRule_STATUS"></a>ServersFirewallRule_STATUS
------------------------------------------------------------------
+ServersFirewallRule_STATUS{#ServersFirewallRule_STATUS}
+-------------------------------------------------------
 
 Used by: [ServersFirewallRule](#ServersFirewallRule).
 
@@ -1827,8 +1827,8 @@ Used by: [ServersFirewallRule](#ServersFirewallRule).
 | startIpAddress | The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses.                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type           | Resource type.                                                                                                                                                          | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersIPV6FirewallRule_Spec"></a>ServersIPV6FirewallRule_Spec
----------------------------------------------------------------------
+ServersIPV6FirewallRule_Spec{#ServersIPV6FirewallRule_Spec}
+-----------------------------------------------------------
 
 Used by: [ServersIPV6FirewallRule](#ServersIPV6FirewallRule).
 
@@ -1840,8 +1840,8 @@ Used by: [ServersIPV6FirewallRule](#ServersIPV6FirewallRule).
 | owner            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | startIPv6Address | The start IP address of the firewall rule. Must be IPv6 format.                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersIPV6FirewallRule_STATUS"></a>ServersIPV6FirewallRule_STATUS
--------------------------------------------------------------------------
+ServersIPV6FirewallRule_STATUS{#ServersIPV6FirewallRule_STATUS}
+---------------------------------------------------------------
 
 Used by: [ServersIPV6FirewallRule](#ServersIPV6FirewallRule).
 
@@ -1854,8 +1854,8 @@ Used by: [ServersIPV6FirewallRule](#ServersIPV6FirewallRule).
 | startIPv6Address | The start IP address of the firewall rule. Must be IPv6 format.                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type             | Resource type.                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersOutboundFirewallRule_Spec"></a>ServersOutboundFirewallRule_Spec
------------------------------------------------------------------------------
+ServersOutboundFirewallRule_Spec{#ServersOutboundFirewallRule_Spec}
+-------------------------------------------------------------------
 
 Used by: [ServersOutboundFirewallRule](#ServersOutboundFirewallRule).
 
@@ -1865,8 +1865,8 @@ Used by: [ServersOutboundFirewallRule](#ServersOutboundFirewallRule).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                 | [ServersOutboundFirewallRuleOperatorSpec](#ServersOutboundFirewallRuleOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="ServersOutboundFirewallRule_STATUS"></a>ServersOutboundFirewallRule_STATUS
----------------------------------------------------------------------------------
+ServersOutboundFirewallRule_STATUS{#ServersOutboundFirewallRule_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ServersOutboundFirewallRule](#ServersOutboundFirewallRule).
 
@@ -1878,8 +1878,8 @@ Used by: [ServersOutboundFirewallRule](#ServersOutboundFirewallRule).
 | provisioningState | The state of the outbound rule.    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | Resource type.                     | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersSecurityAlertPolicy_Spec"></a>ServersSecurityAlertPolicy_Spec
----------------------------------------------------------------------------
+ServersSecurityAlertPolicy_Spec{#ServersSecurityAlertPolicy_Spec}
+-----------------------------------------------------------------
 
 Used by: [ServersSecurityAlertPolicy](#ServersSecurityAlertPolicy).
 
@@ -1895,8 +1895,8 @@ Used by: [ServersSecurityAlertPolicy](#ServersSecurityAlertPolicy).
 | storageAccountAccessKey | Specifies the identifier key of the Threat Detection audit storage account.                                                                                                                                                                                                     | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 | storageEndpoint         | Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs.                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="ServersSecurityAlertPolicy_STATUS"></a>ServersSecurityAlertPolicy_STATUS
--------------------------------------------------------------------------------
+ServersSecurityAlertPolicy_STATUS{#ServersSecurityAlertPolicy_STATUS}
+---------------------------------------------------------------------
 
 Used by: [ServersSecurityAlertPolicy](#ServersSecurityAlertPolicy).
 
@@ -1915,8 +1915,8 @@ Used by: [ServersSecurityAlertPolicy](#ServersSecurityAlertPolicy).
 | systemData         | SystemData of SecurityAlertPolicyResource.                                                                                                                                    | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                                           |
 | type               | Resource type.                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                                            |
 
-<a id="ServersVirtualNetworkRule_Spec"></a>ServersVirtualNetworkRule_Spec
--------------------------------------------------------------------------
+ServersVirtualNetworkRule_Spec{#ServersVirtualNetworkRule_Spec}
+---------------------------------------------------------------
 
 Used by: [ServersVirtualNetworkRule](#ServersVirtualNetworkRule).
 
@@ -1928,8 +1928,8 @@ Used by: [ServersVirtualNetworkRule](#ServersVirtualNetworkRule).
 | owner                            | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a sql.azure.com/Server resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | virtualNetworkSubnetReference    | The ARM resource id of the virtual network subnet.                                                                                                                                                                                                                              | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small>           |
 
-<a id="ServersVirtualNetworkRule_STATUS"></a>ServersVirtualNetworkRule_STATUS
------------------------------------------------------------------------------
+ServersVirtualNetworkRule_STATUS{#ServersVirtualNetworkRule_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ServersVirtualNetworkRule](#ServersVirtualNetworkRule).
 
@@ -1943,8 +1943,8 @@ Used by: [ServersVirtualNetworkRule](#ServersVirtualNetworkRule).
 | type                             | Resource type.                                                                     | string<br/><small>Optional</small>                                                                                                                      |
 | virtualNetworkSubnetId           | The ARM resource id of the virtual network subnet.                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="ServersVulnerabilityAssessment_Spec"></a>ServersVulnerabilityAssessment_Spec
------------------------------------------------------------------------------------
+ServersVulnerabilityAssessment_Spec{#ServersVulnerabilityAssessment_Spec}
+-------------------------------------------------------------------------
 
 Used by: [ServersVulnerabilityAssessment](#ServersVulnerabilityAssessment).
 
@@ -1958,8 +1958,8 @@ Used by: [ServersVulnerabilityAssessment](#ServersVulnerabilityAssessment).
 | storageContainerPathFromConfig | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/).                                                                                                                                                                         | [genruntime.ConfigMapReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapReference)<br/><small>Optional</small>         |
 | storageContainerSasKey         | A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required. Applies only if the storage account is not behind a Vnet or a firewall | [genruntime.SecretReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretReference)<br/><small>Optional</small>               |
 
-<a id="ServersVulnerabilityAssessment_STATUS"></a>ServersVulnerabilityAssessment_STATUS
----------------------------------------------------------------------------------------
+ServersVulnerabilityAssessment_STATUS{#ServersVulnerabilityAssessment_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [ServersVulnerabilityAssessment](#ServersVulnerabilityAssessment).
 
@@ -1972,8 +1972,8 @@ Used by: [ServersVulnerabilityAssessment](#ServersVulnerabilityAssessment).
 | storageContainerPath | A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/). | string<br/><small>Optional</small>                                                                                                                      |
 | type                 | Resource type.                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AdministratorProperties_AdministratorType"></a>AdministratorProperties_AdministratorType
------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType{#AdministratorProperties_AdministratorType}
+-------------------------------------------------------------------------------------
 
 Used by: [ServersAdministrator_Spec](#ServersAdministrator_Spec).
 
@@ -1981,8 +1981,8 @@ Used by: [ServersAdministrator_Spec](#ServersAdministrator_Spec).
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="AdministratorProperties_AdministratorType_STATUS"></a>AdministratorProperties_AdministratorType_STATUS
--------------------------------------------------------------------------------------------------------------
+AdministratorProperties_AdministratorType_STATUS{#AdministratorProperties_AdministratorType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ServersAdministrator_STATUS](#ServersAdministrator_STATUS).
 
@@ -1990,8 +1990,8 @@ Used by: [ServersAdministrator_STATUS](#ServersAdministrator_STATUS).
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="AdvancedThreatProtectionProperties_State"></a>AdvancedThreatProtectionProperties_State
----------------------------------------------------------------------------------------------
+AdvancedThreatProtectionProperties_State{#AdvancedThreatProtectionProperties_State}
+-----------------------------------------------------------------------------------
 
 Used by: [ServersAdvancedThreatProtectionSetting_Spec](#ServersAdvancedThreatProtectionSetting_Spec), and [ServersDatabasesAdvancedThreatProtectionSetting_Spec](#ServersDatabasesAdvancedThreatProtectionSetting_Spec).
 
@@ -2001,8 +2001,8 @@ Used by: [ServersAdvancedThreatProtectionSetting_Spec](#ServersAdvancedThreatPro
 | "Enabled"  |             |
 | "New"      |             |
 
-<a id="AdvancedThreatProtectionProperties_State_STATUS"></a>AdvancedThreatProtectionProperties_State_STATUS
------------------------------------------------------------------------------------------------------------
+AdvancedThreatProtectionProperties_State_STATUS{#AdvancedThreatProtectionProperties_State_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ServersAdvancedThreatProtectionSetting_STATUS](#ServersAdvancedThreatProtectionSetting_STATUS), and [ServersDatabasesAdvancedThreatProtectionSetting_STATUS](#ServersDatabasesAdvancedThreatProtectionSetting_STATUS).
 
@@ -2012,8 +2012,8 @@ Used by: [ServersAdvancedThreatProtectionSetting_STATUS](#ServersAdvancedThreatP
 | "Enabled"  |             |
 | "New"      |             |
 
-<a id="BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours"></a>BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours
--------------------------------------------------------------------------------------------------------------------------------------------------
+BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours{#BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours}
+---------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupShortTermRetentionPolicy_Spec](#ServersDatabasesBackupShortTermRetentionPolicy_Spec).
 
@@ -2022,8 +2022,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicy_Spec](#ServersDatabases
 | 12    |             |
 | 24    |             |
 
-<a id="BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours_STATUS"></a>BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours_STATUS{#BackupShortTermRetentionPolicyProperties_DiffBackupIntervalInHours_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesBackupShortTermRetentionPolicy_STATUS](#ServersDatabasesBackupShortTermRetentionPolicy_STATUS).
 
@@ -2032,8 +2032,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicy_STATUS](#ServersDatabas
 | 12    |             |
 | 24    |             |
 
-<a id="DatabaseBlobAuditingPolicyProperties_State"></a>DatabaseBlobAuditingPolicyProperties_State
--------------------------------------------------------------------------------------------------
+DatabaseBlobAuditingPolicyProperties_State{#DatabaseBlobAuditingPolicyProperties_State}
+---------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAuditingSetting_Spec](#ServersDatabasesAuditingSetting_Spec).
 
@@ -2042,8 +2042,8 @@ Used by: [ServersDatabasesAuditingSetting_Spec](#ServersDatabasesAuditingSetting
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DatabaseBlobAuditingPolicyProperties_State_STATUS"></a>DatabaseBlobAuditingPolicyProperties_State_STATUS
----------------------------------------------------------------------------------------------------------------
+DatabaseBlobAuditingPolicyProperties_State_STATUS{#DatabaseBlobAuditingPolicyProperties_State_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesAuditingSetting_STATUS](#ServersDatabasesAuditingSetting_STATUS).
 
@@ -2052,8 +2052,8 @@ Used by: [ServersDatabasesAuditingSetting_STATUS](#ServersDatabasesAuditingSetti
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DatabaseIdentity"></a>DatabaseIdentity
----------------------------------------------
+DatabaseIdentity{#DatabaseIdentity}
+-----------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -2064,8 +2064,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | type                   | The identity type                                       | [DatabaseIdentity_Type](#DatabaseIdentity_Type)<br/><small>Optional</small>               |
 | userAssignedIdentities | The resource ids of the user assigned identities to use | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="DatabaseIdentity_STATUS"></a>DatabaseIdentity_STATUS
------------------------------------------------------------
+DatabaseIdentity_STATUS{#DatabaseIdentity_STATUS}
+-------------------------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -2077,96 +2077,96 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | type                   | The identity type                                       | [DatabaseIdentity_Type_STATUS](#DatabaseIdentity_Type_STATUS)<br/><small>Optional</small>          |
 | userAssignedIdentities | The resource ids of the user assigned identities to use | [map[string]DatabaseUserIdentity_STATUS](#DatabaseUserIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="DatabaseProperties_CatalogCollation"></a>DatabaseProperties_CatalogCollation
------------------------------------------------------------------------------------
-
-Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
-
-| Value                          | Description |
-|--------------------------------|-------------|
-| "DATABASE_DEFAULT"             |             |
-| "SQL_Latin1_General_CP1_CI_AS" |             |
-
-<a id="DatabaseProperties_CatalogCollation_STATUS"></a>DatabaseProperties_CatalogCollation_STATUS
--------------------------------------------------------------------------------------------------
-
-Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
-
-| Value                          | Description |
-|--------------------------------|-------------|
-| "DATABASE_DEFAULT"             |             |
-| "SQL_Latin1_General_CP1_CI_AS" |             |
-
-<a id="DatabaseProperties_CreateMode"></a>DatabaseProperties_CreateMode
------------------------------------------------------------------------
-
-Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
-
-| Value                            | Description |
-|----------------------------------|-------------|
-| "Copy"                           |             |
-| "Default"                        |             |
-| "OnlineSecondary"                |             |
-| "PointInTimeRestore"             |             |
-| "Recovery"                       |             |
-| "Restore"                        |             |
-| "RestoreExternalBackup"          |             |
-| "RestoreExternalBackupSecondary" |             |
-| "RestoreLongTermRetentionBackup" |             |
-| "Secondary"                      |             |
-
-<a id="DatabaseProperties_CreateMode_STATUS"></a>DatabaseProperties_CreateMode_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
-
-| Value                            | Description |
-|----------------------------------|-------------|
-| "Copy"                           |             |
-| "Default"                        |             |
-| "OnlineSecondary"                |             |
-| "PointInTimeRestore"             |             |
-| "Recovery"                       |             |
-| "Restore"                        |             |
-| "RestoreExternalBackup"          |             |
-| "RestoreExternalBackupSecondary" |             |
-| "RestoreLongTermRetentionBackup" |             |
-| "Secondary"                      |             |
-
-<a id="DatabaseProperties_CurrentBackupStorageRedundancy_STATUS"></a>DatabaseProperties_CurrentBackupStorageRedundancy_STATUS
------------------------------------------------------------------------------------------------------------------------------
-
-Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
-
-| Value     | Description |
-|-----------|-------------|
-| "Geo"     |             |
-| "GeoZone" |             |
-| "Local"   |             |
-| "Zone"    |             |
-
-<a id="DatabaseProperties_LicenseType"></a>DatabaseProperties_LicenseType
+DatabaseProperties_CatalogCollation{#DatabaseProperties_CatalogCollation}
 -------------------------------------------------------------------------
 
 Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 
-| Value             | Description |
-|-------------------|-------------|
-| "BasePrice"       |             |
-| "LicenseIncluded" |             |
+| Value                          | Description |
+|--------------------------------|-------------|
+| "DATABASE_DEFAULT"             |             |
+| "SQL_Latin1_General_CP1_CI_AS" |             |
 
-<a id="DatabaseProperties_LicenseType_STATUS"></a>DatabaseProperties_LicenseType_STATUS
+DatabaseProperties_CatalogCollation_STATUS{#DatabaseProperties_CatalogCollation_STATUS}
 ---------------------------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
+| Value                          | Description |
+|--------------------------------|-------------|
+| "DATABASE_DEFAULT"             |             |
+| "SQL_Latin1_General_CP1_CI_AS" |             |
+
+DatabaseProperties_CreateMode{#DatabaseProperties_CreateMode}
+-------------------------------------------------------------
+
+Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
+
+| Value                            | Description |
+|----------------------------------|-------------|
+| "Copy"                           |             |
+| "Default"                        |             |
+| "OnlineSecondary"                |             |
+| "PointInTimeRestore"             |             |
+| "Recovery"                       |             |
+| "Restore"                        |             |
+| "RestoreExternalBackup"          |             |
+| "RestoreExternalBackupSecondary" |             |
+| "RestoreLongTermRetentionBackup" |             |
+| "Secondary"                      |             |
+
+DatabaseProperties_CreateMode_STATUS{#DatabaseProperties_CreateMode_STATUS}
+---------------------------------------------------------------------------
+
+Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
+
+| Value                            | Description |
+|----------------------------------|-------------|
+| "Copy"                           |             |
+| "Default"                        |             |
+| "OnlineSecondary"                |             |
+| "PointInTimeRestore"             |             |
+| "Recovery"                       |             |
+| "Restore"                        |             |
+| "RestoreExternalBackup"          |             |
+| "RestoreExternalBackupSecondary" |             |
+| "RestoreLongTermRetentionBackup" |             |
+| "Secondary"                      |             |
+
+DatabaseProperties_CurrentBackupStorageRedundancy_STATUS{#DatabaseProperties_CurrentBackupStorageRedundancy_STATUS}
+-------------------------------------------------------------------------------------------------------------------
+
+Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
+
+| Value     | Description |
+|-----------|-------------|
+| "Geo"     |             |
+| "GeoZone" |             |
+| "Local"   |             |
+| "Zone"    |             |
+
+DatabaseProperties_LicenseType{#DatabaseProperties_LicenseType}
+---------------------------------------------------------------
+
+Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
+
 | Value             | Description |
 |-------------------|-------------|
 | "BasePrice"       |             |
 | "LicenseIncluded" |             |
 
-<a id="DatabaseProperties_ReadScale"></a>DatabaseProperties_ReadScale
----------------------------------------------------------------------
+DatabaseProperties_LicenseType_STATUS{#DatabaseProperties_LicenseType_STATUS}
+-----------------------------------------------------------------------------
+
+Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "BasePrice"       |             |
+| "LicenseIncluded" |             |
+
+DatabaseProperties_ReadScale{#DatabaseProperties_ReadScale}
+-----------------------------------------------------------
 
 Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 
@@ -2175,8 +2175,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DatabaseProperties_ReadScale_STATUS"></a>DatabaseProperties_ReadScale_STATUS
------------------------------------------------------------------------------------
+DatabaseProperties_ReadScale_STATUS{#DatabaseProperties_ReadScale_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
@@ -2185,8 +2185,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DatabaseProperties_RequestedBackupStorageRedundancy"></a>DatabaseProperties_RequestedBackupStorageRedundancy
--------------------------------------------------------------------------------------------------------------------
+DatabaseProperties_RequestedBackupStorageRedundancy{#DatabaseProperties_RequestedBackupStorageRedundancy}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 
@@ -2197,8 +2197,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | "Local"   |             |
 | "Zone"    |             |
 
-<a id="DatabaseProperties_RequestedBackupStorageRedundancy_STATUS"></a>DatabaseProperties_RequestedBackupStorageRedundancy_STATUS
----------------------------------------------------------------------------------------------------------------------------------
+DatabaseProperties_RequestedBackupStorageRedundancy_STATUS{#DatabaseProperties_RequestedBackupStorageRedundancy_STATUS}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
@@ -2209,8 +2209,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | "Local"   |             |
 | "Zone"    |             |
 
-<a id="DatabaseProperties_SampleName"></a>DatabaseProperties_SampleName
------------------------------------------------------------------------
+DatabaseProperties_SampleName{#DatabaseProperties_SampleName}
+-------------------------------------------------------------
 
 Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 
@@ -2220,8 +2220,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | "WideWorldImportersFull" |             |
 | "WideWorldImportersStd"  |             |
 
-<a id="DatabaseProperties_SampleName_STATUS"></a>DatabaseProperties_SampleName_STATUS
--------------------------------------------------------------------------------------
+DatabaseProperties_SampleName_STATUS{#DatabaseProperties_SampleName_STATUS}
+---------------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
@@ -2231,8 +2231,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | "WideWorldImportersFull" |             |
 | "WideWorldImportersStd"  |             |
 
-<a id="DatabaseProperties_SecondaryType"></a>DatabaseProperties_SecondaryType
------------------------------------------------------------------------------
+DatabaseProperties_SecondaryType{#DatabaseProperties_SecondaryType}
+-------------------------------------------------------------------
 
 Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 
@@ -2241,8 +2241,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | "Geo"   |             |
 | "Named" |             |
 
-<a id="DatabaseProperties_SecondaryType_STATUS"></a>DatabaseProperties_SecondaryType_STATUS
--------------------------------------------------------------------------------------------
+DatabaseProperties_SecondaryType_STATUS{#DatabaseProperties_SecondaryType_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
@@ -2251,8 +2251,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | "Geo"   |             |
 | "Named" |             |
 
-<a id="DatabaseProperties_Status_STATUS"></a>DatabaseProperties_Status_STATUS
------------------------------------------------------------------------------
+DatabaseProperties_Status_STATUS{#DatabaseProperties_Status_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 
@@ -2283,8 +2283,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS).
 | "Stopping"                          |             |
 | "Suspect"                           |             |
 
-<a id="DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State"></a>DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State
------------------------------------------------------------------------------------------------------------------------------------------------
+DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State{#DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State}
+-------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesSecurityAlertPolicy_Spec](#ServersDatabasesSecurityAlertPolicy_Spec).
 
@@ -2293,8 +2293,8 @@ Used by: [ServersDatabasesSecurityAlertPolicy_Spec](#ServersDatabasesSecurityAle
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS"></a>DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS{#DatabaseSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS}
+---------------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesSecurityAlertPolicy_STATUS](#ServersDatabasesSecurityAlertPolicy_STATUS).
 
@@ -2303,8 +2303,8 @@ Used by: [ServersDatabasesSecurityAlertPolicy_STATUS](#ServersDatabasesSecurityA
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ElasticPoolPerDatabaseSettings"></a>ElasticPoolPerDatabaseSettings
--------------------------------------------------------------------------
+ElasticPoolPerDatabaseSettings{#ElasticPoolPerDatabaseSettings}
+---------------------------------------------------------------
 
 Per database settings of an elastic pool.
 
@@ -2315,8 +2315,8 @@ Used by: [ServersElasticPool_Spec](#ServersElasticPool_Spec).
 | maxCapacity | The maximum capacity any one database can consume. | float64<br/><small>Optional</small> |
 | minCapacity | The minimum capacity all databases are guaranteed. | float64<br/><small>Optional</small> |
 
-<a id="ElasticPoolPerDatabaseSettings_STATUS"></a>ElasticPoolPerDatabaseSettings_STATUS
----------------------------------------------------------------------------------------
+ElasticPoolPerDatabaseSettings_STATUS{#ElasticPoolPerDatabaseSettings_STATUS}
+-----------------------------------------------------------------------------
 
 Per database settings of an elastic pool.
 
@@ -2327,8 +2327,8 @@ Used by: [ServersElasticPool_STATUS](#ServersElasticPool_STATUS).
 | maxCapacity | The maximum capacity any one database can consume. | float64<br/><small>Optional</small> |
 | minCapacity | The minimum capacity all databases are guaranteed. | float64<br/><small>Optional</small> |
 
-<a id="ElasticPoolProperties_LicenseType"></a>ElasticPoolProperties_LicenseType
--------------------------------------------------------------------------------
+ElasticPoolProperties_LicenseType{#ElasticPoolProperties_LicenseType}
+---------------------------------------------------------------------
 
 Used by: [ServersElasticPool_Spec](#ServersElasticPool_Spec).
 
@@ -2337,8 +2337,8 @@ Used by: [ServersElasticPool_Spec](#ServersElasticPool_Spec).
 | "BasePrice"       |             |
 | "LicenseIncluded" |             |
 
-<a id="ElasticPoolProperties_LicenseType_STATUS"></a>ElasticPoolProperties_LicenseType_STATUS
----------------------------------------------------------------------------------------------
+ElasticPoolProperties_LicenseType_STATUS{#ElasticPoolProperties_LicenseType_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [ServersElasticPool_STATUS](#ServersElasticPool_STATUS).
 
@@ -2347,8 +2347,8 @@ Used by: [ServersElasticPool_STATUS](#ServersElasticPool_STATUS).
 | "BasePrice"       |             |
 | "LicenseIncluded" |             |
 
-<a id="ElasticPoolProperties_State_STATUS"></a>ElasticPoolProperties_State_STATUS
----------------------------------------------------------------------------------
+ElasticPoolProperties_State_STATUS{#ElasticPoolProperties_State_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ServersElasticPool_STATUS](#ServersElasticPool_STATUS).
 
@@ -2358,8 +2358,8 @@ Used by: [ServersElasticPool_STATUS](#ServersElasticPool_STATUS).
 | "Disabled" |             |
 | "Ready"    |             |
 
-<a id="FailoverGroupProperties_ReplicationRole_STATUS"></a>FailoverGroupProperties_ReplicationRole_STATUS
----------------------------------------------------------------------------------------------------------
+FailoverGroupProperties_ReplicationRole_STATUS{#FailoverGroupProperties_ReplicationRole_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS).
 
@@ -2368,8 +2368,8 @@ Used by: [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="FailoverGroupReadOnlyEndpoint"></a>FailoverGroupReadOnlyEndpoint
------------------------------------------------------------------------
+FailoverGroupReadOnlyEndpoint{#FailoverGroupReadOnlyEndpoint}
+-------------------------------------------------------------
 
 Read-only endpoint of the failover group instance.
 
@@ -2379,8 +2379,8 @@ Used by: [ServersFailoverGroup_Spec](#ServersFailoverGroup_Spec).
 |----------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | failoverPolicy | Failover policy of the read-only endpoint for the failover group. | [FailoverGroupReadOnlyEndpoint_FailoverPolicy](#FailoverGroupReadOnlyEndpoint_FailoverPolicy)<br/><small>Optional</small> |
 
-<a id="FailoverGroupReadOnlyEndpoint_STATUS"></a>FailoverGroupReadOnlyEndpoint_STATUS
--------------------------------------------------------------------------------------
+FailoverGroupReadOnlyEndpoint_STATUS{#FailoverGroupReadOnlyEndpoint_STATUS}
+---------------------------------------------------------------------------
 
 Read-only endpoint of the failover group instance.
 
@@ -2390,8 +2390,8 @@ Used by: [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS).
 |----------------|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | failoverPolicy | Failover policy of the read-only endpoint for the failover group. | [FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS](#FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS)<br/><small>Optional</small> |
 
-<a id="FailoverGroupReadWriteEndpoint"></a>FailoverGroupReadWriteEndpoint
--------------------------------------------------------------------------
+FailoverGroupReadWriteEndpoint{#FailoverGroupReadWriteEndpoint}
+---------------------------------------------------------------
 
 Read-write endpoint of the failover group instance.
 
@@ -2402,8 +2402,8 @@ Used by: [ServersFailoverGroup_Spec](#ServersFailoverGroup_Spec).
 | failoverPolicy                         | Failover policy of the read-write endpoint for the failover group. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required.                    | [FailoverGroupReadWriteEndpoint_FailoverPolicy](#FailoverGroupReadWriteEndpoint_FailoverPolicy)<br/><small>Required</small> |
 | failoverWithDataLossGracePeriodMinutes | Grace period before failover with data loss is attempted for the read-write endpoint. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required. | int<br/><small>Optional</small>                                                                                             |
 
-<a id="FailoverGroupReadWriteEndpoint_STATUS"></a>FailoverGroupReadWriteEndpoint_STATUS
----------------------------------------------------------------------------------------
+FailoverGroupReadWriteEndpoint_STATUS{#FailoverGroupReadWriteEndpoint_STATUS}
+-----------------------------------------------------------------------------
 
 Read-write endpoint of the failover group instance.
 
@@ -2414,8 +2414,8 @@ Used by: [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS).
 | failoverPolicy                         | Failover policy of the read-write endpoint for the failover group. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required.                    | [FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS](#FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS)<br/><small>Optional</small> |
 | failoverWithDataLossGracePeriodMinutes | Grace period before failover with data loss is attempted for the read-write endpoint. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required. | int<br/><small>Optional</small>                                                                                                           |
 
-<a id="PartnerInfo"></a>PartnerInfo
------------------------------------
+PartnerInfo{#PartnerInfo}
+-------------------------
 
 Partner server information for the failover group.
 
@@ -2425,8 +2425,8 @@ Used by: [ServersFailoverGroup_Spec](#ServersFailoverGroup_Spec).
 |-----------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource identifier of the partner server. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="PartnerInfo_STATUS"></a>PartnerInfo_STATUS
--------------------------------------------------
+PartnerInfo_STATUS{#PartnerInfo_STATUS}
+---------------------------------------
 
 Partner server information for the failover group.
 
@@ -2438,8 +2438,8 @@ Used by: [ServersFailoverGroup_STATUS](#ServersFailoverGroup_STATUS).
 | location        | Geo location of the partner server.        | string<br/><small>Optional</small>                                                                    |
 | replicationRole | Replication role of the partner server.    | [PartnerInfo_ReplicationRole_STATUS](#PartnerInfo_ReplicationRole_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceIdentity"></a>ResourceIdentity
----------------------------------------------
+ResourceIdentity{#ResourceIdentity}
+-----------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -2450,8 +2450,8 @@ Used by: [Server_Spec](#Server_Spec).
 | type                   | The identity type. Set this to 'SystemAssigned' in order to automatically create and assign an Azure Active Directory principal for the resource. | [ResourceIdentity_Type](#ResourceIdentity_Type)<br/><small>Optional</small>               |
 | userAssignedIdentities | The resource ids of the user assigned identities to use                                                                                           | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ResourceIdentity_STATUS"></a>ResourceIdentity_STATUS
------------------------------------------------------------
+ResourceIdentity_STATUS{#ResourceIdentity_STATUS}
+-------------------------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -2464,8 +2464,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | type                   | The identity type. Set this to 'SystemAssigned' in order to automatically create and assign an Azure Active Directory principal for the resource. | [ResourceIdentity_Type_STATUS](#ResourceIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | The resource ids of the user assigned identities to use                                                                                           | [map[string]UserIdentity_STATUS](#UserIdentity_STATUS)<br/><small>Optional</small>        |
 
-<a id="ServerBlobAuditingPolicyProperties_State"></a>ServerBlobAuditingPolicyProperties_State
----------------------------------------------------------------------------------------------
+ServerBlobAuditingPolicyProperties_State{#ServerBlobAuditingPolicyProperties_State}
+-----------------------------------------------------------------------------------
 
 Used by: [ServersAuditingSetting_Spec](#ServersAuditingSetting_Spec).
 
@@ -2474,8 +2474,8 @@ Used by: [ServersAuditingSetting_Spec](#ServersAuditingSetting_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerBlobAuditingPolicyProperties_State_STATUS"></a>ServerBlobAuditingPolicyProperties_State_STATUS
------------------------------------------------------------------------------------------------------------
+ServerBlobAuditingPolicyProperties_State_STATUS{#ServerBlobAuditingPolicyProperties_State_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ServersAuditingSetting_STATUS](#ServersAuditingSetting_STATUS).
 
@@ -2484,8 +2484,8 @@ Used by: [ServersAuditingSetting_STATUS](#ServersAuditingSetting_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerConnectionPolicyProperties_ConnectionType"></a>ServerConnectionPolicyProperties_ConnectionType
------------------------------------------------------------------------------------------------------------
+ServerConnectionPolicyProperties_ConnectionType{#ServerConnectionPolicyProperties_ConnectionType}
+-------------------------------------------------------------------------------------------------
 
 Used by: [ServersConnectionPolicy_Spec](#ServersConnectionPolicy_Spec).
 
@@ -2495,8 +2495,8 @@ Used by: [ServersConnectionPolicy_Spec](#ServersConnectionPolicy_Spec).
 | "Proxy"    |             |
 | "Redirect" |             |
 
-<a id="ServerConnectionPolicyProperties_ConnectionType_STATUS"></a>ServerConnectionPolicyProperties_ConnectionType_STATUS
--------------------------------------------------------------------------------------------------------------------------
+ServerConnectionPolicyProperties_ConnectionType_STATUS{#ServerConnectionPolicyProperties_ConnectionType_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersConnectionPolicy_STATUS](#ServersConnectionPolicy_STATUS).
 
@@ -2506,8 +2506,8 @@ Used by: [ServersConnectionPolicy_STATUS](#ServersConnectionPolicy_STATUS).
 | "Proxy"    |             |
 | "Redirect" |             |
 
-<a id="ServerExternalAdministrator"></a>ServerExternalAdministrator
--------------------------------------------------------------------
+ServerExternalAdministrator{#ServerExternalAdministrator}
+---------------------------------------------------------
 
 Properties of a active directory administrator.
 
@@ -2522,8 +2522,8 @@ Used by: [Server_Spec](#Server_Spec).
 | sid                       | SID (object ID) of the server administrator.        | string<br/><small>Optional</small>                                                                                          |
 | tenantId                  | Tenant ID of the administrator.                     | string<br/><small>Optional</small>                                                                                          |
 
-<a id="ServerExternalAdministrator_STATUS"></a>ServerExternalAdministrator_STATUS
----------------------------------------------------------------------------------
+ServerExternalAdministrator_STATUS{#ServerExternalAdministrator_STATUS}
+-----------------------------------------------------------------------
 
 Properties of a active directory administrator.
 
@@ -2538,8 +2538,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | sid                       | SID (object ID) of the server administrator.        | string<br/><small>Optional</small>                                                                                                        |
 | tenantId                  | Tenant ID of the administrator.                     | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="ServerOperatorSpec"></a>ServerOperatorSpec
--------------------------------------------------
+ServerOperatorSpec{#ServerOperatorSpec}
+---------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2551,8 +2551,8 @@ Used by: [Server_Spec](#Server_Spec).
 | configMaps           | configures where to place operator written ConfigMaps.                                        | [ServerOperatorConfigMaps](#ServerOperatorConfigMaps)<br/><small>Optional</small>                                                                                   |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServerPrivateEndpointConnection_STATUS"></a>ServerPrivateEndpointConnection_STATUS
------------------------------------------------------------------------------------------
+ServerPrivateEndpointConnection_STATUS{#ServerPrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------------------
 
 A private endpoint connection under a server
 
@@ -2563,8 +2563,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | id         | Resource ID.                           | string<br/><small>Optional</small>                                                                                    |
 | properties | Private endpoint connection properties | [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnectionProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="ServerProperties_PublicNetworkAccess"></a>ServerProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------
+ServerProperties_PublicNetworkAccess{#ServerProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------
 
 Used by: [Server_Spec](#Server_Spec).
 
@@ -2573,8 +2573,8 @@ Used by: [Server_Spec](#Server_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerProperties_PublicNetworkAccess_STATUS"></a>ServerProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------
+ServerProperties_PublicNetworkAccess_STATUS{#ServerProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [Server_STATUS](#Server_STATUS).
 
@@ -2583,8 +2583,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerProperties_RestrictOutboundNetworkAccess"></a>ServerProperties_RestrictOutboundNetworkAccess
----------------------------------------------------------------------------------------------------------
+ServerProperties_RestrictOutboundNetworkAccess{#ServerProperties_RestrictOutboundNetworkAccess}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Server_Spec](#Server_Spec).
 
@@ -2593,8 +2593,8 @@ Used by: [Server_Spec](#Server_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerProperties_RestrictOutboundNetworkAccess_STATUS"></a>ServerProperties_RestrictOutboundNetworkAccess_STATUS
------------------------------------------------------------------------------------------------------------------------
+ServerProperties_RestrictOutboundNetworkAccess_STATUS{#ServerProperties_RestrictOutboundNetworkAccess_STATUS}
+-------------------------------------------------------------------------------------------------------------
 
 Used by: [Server_STATUS](#Server_STATUS).
 
@@ -2603,8 +2603,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerProperties_WorkspaceFeature_STATUS"></a>ServerProperties_WorkspaceFeature_STATUS
----------------------------------------------------------------------------------------------
+ServerProperties_WorkspaceFeature_STATUS{#ServerProperties_WorkspaceFeature_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Server_STATUS](#Server_STATUS).
 
@@ -2613,8 +2613,8 @@ Used by: [Server_STATUS](#Server_STATUS).
 | "Connected"    |             |
 | "Disconnected" |             |
 
-<a id="ServersAdministratorOperatorSpec"></a>ServersAdministratorOperatorSpec
------------------------------------------------------------------------------
+ServersAdministratorOperatorSpec{#ServersAdministratorOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2625,8 +2625,8 @@ Used by: [ServersAdministrator_Spec](#ServersAdministrator_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersAdvancedThreatProtectionSettingOperatorSpec"></a>ServersAdvancedThreatProtectionSettingOperatorSpec
------------------------------------------------------------------------------------------------------------------
+ServersAdvancedThreatProtectionSettingOperatorSpec{#ServersAdvancedThreatProtectionSettingOperatorSpec}
+-------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2637,8 +2637,8 @@ Used by: [ServersAdvancedThreatProtectionSetting_Spec](#ServersAdvancedThreatPro
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersAuditingSettingOperatorSpec"></a>ServersAuditingSettingOperatorSpec
----------------------------------------------------------------------------------
+ServersAuditingSettingOperatorSpec{#ServersAuditingSettingOperatorSpec}
+-----------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2649,8 +2649,8 @@ Used by: [ServersAuditingSetting_Spec](#ServersAuditingSetting_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersAzureADOnlyAuthenticationOperatorSpec"></a>ServersAzureADOnlyAuthenticationOperatorSpec
------------------------------------------------------------------------------------------------------
+ServersAzureADOnlyAuthenticationOperatorSpec{#ServersAzureADOnlyAuthenticationOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2661,8 +2661,8 @@ Used by: [ServersAzureADOnlyAuthentication_Spec](#ServersAzureADOnlyAuthenticati
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersConnectionPolicyOperatorSpec"></a>ServersConnectionPolicyOperatorSpec
------------------------------------------------------------------------------------
+ServersConnectionPolicyOperatorSpec{#ServersConnectionPolicyOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2673,8 +2673,8 @@ Used by: [ServersConnectionPolicy_Spec](#ServersConnectionPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabaseOperatorSpec"></a>ServersDatabaseOperatorSpec
--------------------------------------------------------------------
+ServersDatabaseOperatorSpec{#ServersDatabaseOperatorSpec}
+---------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2685,8 +2685,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesAdvancedThreatProtectionSettingOperatorSpec"></a>ServersDatabasesAdvancedThreatProtectionSettingOperatorSpec
------------------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesAdvancedThreatProtectionSettingOperatorSpec{#ServersDatabasesAdvancedThreatProtectionSettingOperatorSpec}
+-------------------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2697,8 +2697,8 @@ Used by: [ServersDatabasesAdvancedThreatProtectionSetting_Spec](#ServersDatabase
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesAuditingSettingOperatorSpec"></a>ServersDatabasesAuditingSettingOperatorSpec
----------------------------------------------------------------------------------------------------
+ServersDatabasesAuditingSettingOperatorSpec{#ServersDatabasesAuditingSettingOperatorSpec}
+-----------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2709,8 +2709,8 @@ Used by: [ServersDatabasesAuditingSetting_Spec](#ServersDatabasesAuditingSetting
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesBackupLongTermRetentionPolicyOperatorSpec"></a>ServersDatabasesBackupLongTermRetentionPolicyOperatorSpec
--------------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupLongTermRetentionPolicyOperatorSpec{#ServersDatabasesBackupLongTermRetentionPolicyOperatorSpec}
+---------------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2721,8 +2721,8 @@ Used by: [ServersDatabasesBackupLongTermRetentionPolicy_Spec](#ServersDatabasesB
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesBackupShortTermRetentionPolicyOperatorSpec"></a>ServersDatabasesBackupShortTermRetentionPolicyOperatorSpec
----------------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesBackupShortTermRetentionPolicyOperatorSpec{#ServersDatabasesBackupShortTermRetentionPolicyOperatorSpec}
+-----------------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2733,8 +2733,8 @@ Used by: [ServersDatabasesBackupShortTermRetentionPolicy_Spec](#ServersDatabases
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesSecurityAlertPolicyOperatorSpec"></a>ServersDatabasesSecurityAlertPolicyOperatorSpec
------------------------------------------------------------------------------------------------------------
+ServersDatabasesSecurityAlertPolicyOperatorSpec{#ServersDatabasesSecurityAlertPolicyOperatorSpec}
+-------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2745,8 +2745,8 @@ Used by: [ServersDatabasesSecurityAlertPolicy_Spec](#ServersDatabasesSecurityAle
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesTransparentDataEncryptionOperatorSpec"></a>ServersDatabasesTransparentDataEncryptionOperatorSpec
------------------------------------------------------------------------------------------------------------------------
+ServersDatabasesTransparentDataEncryptionOperatorSpec{#ServersDatabasesTransparentDataEncryptionOperatorSpec}
+-------------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2757,8 +2757,8 @@ Used by: [ServersDatabasesTransparentDataEncryption_Spec](#ServersDatabasesTrans
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersDatabasesVulnerabilityAssessmentOperatorSpec"></a>ServersDatabasesVulnerabilityAssessmentOperatorSpec
--------------------------------------------------------------------------------------------------------------------
+ServersDatabasesVulnerabilityAssessmentOperatorSpec{#ServersDatabasesVulnerabilityAssessmentOperatorSpec}
+---------------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2769,8 +2769,8 @@ Used by: [ServersDatabasesVulnerabilityAssessment_Spec](#ServersDatabasesVulnera
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State"></a>ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State
--------------------------------------------------------------------------------------------------------------------------------------------
+ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State{#ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State}
+---------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersSecurityAlertPolicy_Spec](#ServersSecurityAlertPolicy_Spec).
 
@@ -2779,8 +2779,8 @@ Used by: [ServersSecurityAlertPolicy_Spec](#ServersSecurityAlertPolicy_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS"></a>ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------------
+ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS{#ServerSecurityAlertPoliciesSecurityAlertsPolicyProperties_State_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [ServersSecurityAlertPolicy_STATUS](#ServersSecurityAlertPolicy_STATUS).
 
@@ -2789,8 +2789,8 @@ Used by: [ServersSecurityAlertPolicy_STATUS](#ServersSecurityAlertPolicy_STATUS)
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="ServersElasticPoolOperatorSpec"></a>ServersElasticPoolOperatorSpec
--------------------------------------------------------------------------
+ServersElasticPoolOperatorSpec{#ServersElasticPoolOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2801,8 +2801,8 @@ Used by: [ServersElasticPool_Spec](#ServersElasticPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersFailoverGroupOperatorSpec"></a>ServersFailoverGroupOperatorSpec
------------------------------------------------------------------------------
+ServersFailoverGroupOperatorSpec{#ServersFailoverGroupOperatorSpec}
+-------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2813,8 +2813,8 @@ Used by: [ServersFailoverGroup_Spec](#ServersFailoverGroup_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersFirewallRuleOperatorSpec"></a>ServersFirewallRuleOperatorSpec
----------------------------------------------------------------------------
+ServersFirewallRuleOperatorSpec{#ServersFirewallRuleOperatorSpec}
+-----------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2825,8 +2825,8 @@ Used by: [ServersFirewallRule_Spec](#ServersFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersIPV6FirewallRuleOperatorSpec"></a>ServersIPV6FirewallRuleOperatorSpec
------------------------------------------------------------------------------------
+ServersIPV6FirewallRuleOperatorSpec{#ServersIPV6FirewallRuleOperatorSpec}
+-------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2837,8 +2837,8 @@ Used by: [ServersIPV6FirewallRule_Spec](#ServersIPV6FirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersOutboundFirewallRuleOperatorSpec"></a>ServersOutboundFirewallRuleOperatorSpec
--------------------------------------------------------------------------------------------
+ServersOutboundFirewallRuleOperatorSpec{#ServersOutboundFirewallRuleOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2849,8 +2849,8 @@ Used by: [ServersOutboundFirewallRule_Spec](#ServersOutboundFirewallRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersSecurityAlertPolicyOperatorSpec"></a>ServersSecurityAlertPolicyOperatorSpec
------------------------------------------------------------------------------------------
+ServersSecurityAlertPolicyOperatorSpec{#ServersSecurityAlertPolicyOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2861,8 +2861,8 @@ Used by: [ServersSecurityAlertPolicy_Spec](#ServersSecurityAlertPolicy_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersVirtualNetworkRuleOperatorSpec"></a>ServersVirtualNetworkRuleOperatorSpec
----------------------------------------------------------------------------------------
+ServersVirtualNetworkRuleOperatorSpec{#ServersVirtualNetworkRuleOperatorSpec}
+-----------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2873,8 +2873,8 @@ Used by: [ServersVirtualNetworkRule_Spec](#ServersVirtualNetworkRule_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ServersVulnerabilityAssessmentOperatorSpec"></a>ServersVulnerabilityAssessmentOperatorSpec
--------------------------------------------------------------------------------------------------
+ServersVulnerabilityAssessmentOperatorSpec{#ServersVulnerabilityAssessmentOperatorSpec}
+---------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2885,8 +2885,8 @@ Used by: [ServersVulnerabilityAssessment_Spec](#ServersVulnerabilityAssessment_S
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 An ARM Resource SKU.
 
@@ -2900,8 +2900,8 @@ Used by: [ServersDatabase_Spec](#ServersDatabase_Spec), and [ServersElasticPool_
 | size     | Size of the particular SKU                                                                              | string<br/><small>Optional</small> |
 | tier     | The tier or edition of the particular SKU, e.g. Basic, Premium.                                         | string<br/><small>Optional</small> |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 An ARM Resource SKU.
 
@@ -2915,8 +2915,8 @@ Used by: [ServersDatabase_STATUS](#ServersDatabase_STATUS), [ServersDatabase_STA
 | size     | Size of the particular SKU                                                                              | string<br/><small>Optional</small> |
 | tier     | The tier or edition of the particular SKU, e.g. Basic, Premium.                                         | string<br/><small>Optional</small> |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -2931,8 +2931,8 @@ Used by: [ServersAdvancedThreatProtectionSetting_STATUS](#ServersAdvancedThreatP
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="TransparentDataEncryptionProperties_State"></a>TransparentDataEncryptionProperties_State
------------------------------------------------------------------------------------------------
+TransparentDataEncryptionProperties_State{#TransparentDataEncryptionProperties_State}
+-------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesTransparentDataEncryption_Spec](#ServersDatabasesTransparentDataEncryption_Spec).
 
@@ -2941,8 +2941,8 @@ Used by: [ServersDatabasesTransparentDataEncryption_Spec](#ServersDatabasesTrans
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="TransparentDataEncryptionProperties_State_STATUS"></a>TransparentDataEncryptionProperties_State_STATUS
--------------------------------------------------------------------------------------------------------------
+TransparentDataEncryptionProperties_State_STATUS{#TransparentDataEncryptionProperties_State_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ServersDatabasesTransparentDataEncryption_STATUS](#ServersDatabasesTransparentDataEncryption_STATUS).
 
@@ -2951,8 +2951,8 @@ Used by: [ServersDatabasesTransparentDataEncryption_STATUS](#ServersDatabasesTra
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="VirtualNetworkRuleProperties_State_STATUS"></a>VirtualNetworkRuleProperties_State_STATUS
------------------------------------------------------------------------------------------------
+VirtualNetworkRuleProperties_State_STATUS{#VirtualNetworkRuleProperties_State_STATUS}
+-------------------------------------------------------------------------------------
 
 Used by: [ServersVirtualNetworkRule_STATUS](#ServersVirtualNetworkRule_STATUS).
 
@@ -2965,8 +2965,8 @@ Used by: [ServersVirtualNetworkRule_STATUS](#ServersVirtualNetworkRule_STATUS).
 | "Ready"        |             |
 | "Unknown"      |             |
 
-<a id="VulnerabilityAssessmentRecurringScansProperties"></a>VulnerabilityAssessmentRecurringScansProperties
------------------------------------------------------------------------------------------------------------
+VulnerabilityAssessmentRecurringScansProperties{#VulnerabilityAssessmentRecurringScansProperties}
+-------------------------------------------------------------------------------------------------
 
 Properties of a Vulnerability Assessment recurring scans.
 
@@ -2978,8 +2978,8 @@ Used by: [ServersDatabasesVulnerabilityAssessment_Spec](#ServersDatabasesVulnera
 | emailSubscriptionAdmins | Specifies that the schedule scan notification will be is sent to the subscription administrators. | bool<br/><small>Optional</small>     |
 | isEnabled               | Recurring scans state.                                                                            | bool<br/><small>Optional</small>     |
 
-<a id="VulnerabilityAssessmentRecurringScansProperties_STATUS"></a>VulnerabilityAssessmentRecurringScansProperties_STATUS
--------------------------------------------------------------------------------------------------------------------------
+VulnerabilityAssessmentRecurringScansProperties_STATUS{#VulnerabilityAssessmentRecurringScansProperties_STATUS}
+---------------------------------------------------------------------------------------------------------------
 
 Properties of a Vulnerability Assessment recurring scans.
 
@@ -2991,8 +2991,8 @@ Used by: [ServersDatabasesVulnerabilityAssessment_STATUS](#ServersDatabasesVulne
 | emailSubscriptionAdmins | Specifies that the schedule scan notification will be is sent to the subscription administrators. | bool<br/><small>Optional</small>     |
 | isEnabled               | Recurring scans state.                                                                            | bool<br/><small>Optional</small>     |
 
-<a id="DatabaseIdentity_Type"></a>DatabaseIdentity_Type
--------------------------------------------------------
+DatabaseIdentity_Type{#DatabaseIdentity_Type}
+---------------------------------------------
 
 Used by: [DatabaseIdentity](#DatabaseIdentity).
 
@@ -3001,8 +3001,8 @@ Used by: [DatabaseIdentity](#DatabaseIdentity).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="DatabaseIdentity_Type_STATUS"></a>DatabaseIdentity_Type_STATUS
----------------------------------------------------------------------
+DatabaseIdentity_Type_STATUS{#DatabaseIdentity_Type_STATUS}
+-----------------------------------------------------------
 
 Used by: [DatabaseIdentity_STATUS](#DatabaseIdentity_STATUS).
 
@@ -3011,8 +3011,8 @@ Used by: [DatabaseIdentity_STATUS](#DatabaseIdentity_STATUS).
 | "None"         |             |
 | "UserAssigned" |             |
 
-<a id="DatabaseUserIdentity_STATUS"></a>DatabaseUserIdentity_STATUS
--------------------------------------------------------------------
+DatabaseUserIdentity_STATUS{#DatabaseUserIdentity_STATUS}
+---------------------------------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -3023,8 +3023,8 @@ Used by: [DatabaseIdentity_STATUS](#DatabaseIdentity_STATUS).
 | clientId    | The Azure Active Directory client id.    | string<br/><small>Optional</small> |
 | principalId | The Azure Active Directory principal id. | string<br/><small>Optional</small> |
 
-<a id="FailoverGroupReadOnlyEndpoint_FailoverPolicy"></a>FailoverGroupReadOnlyEndpoint_FailoverPolicy
------------------------------------------------------------------------------------------------------
+FailoverGroupReadOnlyEndpoint_FailoverPolicy{#FailoverGroupReadOnlyEndpoint_FailoverPolicy}
+-------------------------------------------------------------------------------------------
 
 Used by: [FailoverGroupReadOnlyEndpoint](#FailoverGroupReadOnlyEndpoint).
 
@@ -3033,8 +3033,8 @@ Used by: [FailoverGroupReadOnlyEndpoint](#FailoverGroupReadOnlyEndpoint).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS"></a>FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS
--------------------------------------------------------------------------------------------------------------------
+FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS{#FailoverGroupReadOnlyEndpoint_FailoverPolicy_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [FailoverGroupReadOnlyEndpoint_STATUS](#FailoverGroupReadOnlyEndpoint_STATUS).
 
@@ -3043,8 +3043,8 @@ Used by: [FailoverGroupReadOnlyEndpoint_STATUS](#FailoverGroupReadOnlyEndpoint_S
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="FailoverGroupReadWriteEndpoint_FailoverPolicy"></a>FailoverGroupReadWriteEndpoint_FailoverPolicy
--------------------------------------------------------------------------------------------------------
+FailoverGroupReadWriteEndpoint_FailoverPolicy{#FailoverGroupReadWriteEndpoint_FailoverPolicy}
+---------------------------------------------------------------------------------------------
 
 Used by: [FailoverGroupReadWriteEndpoint](#FailoverGroupReadWriteEndpoint).
 
@@ -3053,8 +3053,8 @@ Used by: [FailoverGroupReadWriteEndpoint](#FailoverGroupReadWriteEndpoint).
 | "Automatic" |             |
 | "Manual"    |             |
 
-<a id="FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS"></a>FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS
----------------------------------------------------------------------------------------------------------------------
+FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS{#FailoverGroupReadWriteEndpoint_FailoverPolicy_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [FailoverGroupReadWriteEndpoint_STATUS](#FailoverGroupReadWriteEndpoint_STATUS).
 
@@ -3063,8 +3063,8 @@ Used by: [FailoverGroupReadWriteEndpoint_STATUS](#FailoverGroupReadWriteEndpoint
 | "Automatic" |             |
 | "Manual"    |             |
 
-<a id="PartnerInfo_ReplicationRole_STATUS"></a>PartnerInfo_ReplicationRole_STATUS
----------------------------------------------------------------------------------
+PartnerInfo_ReplicationRole_STATUS{#PartnerInfo_ReplicationRole_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [PartnerInfo_STATUS](#PartnerInfo_STATUS).
 
@@ -3073,8 +3073,8 @@ Used by: [PartnerInfo_STATUS](#PartnerInfo_STATUS).
 | "Primary"   |             |
 | "Secondary" |             |
 
-<a id="PrivateEndpointConnectionProperties_STATUS"></a>PrivateEndpointConnectionProperties_STATUS
--------------------------------------------------------------------------------------------------
+PrivateEndpointConnectionProperties_STATUS{#PrivateEndpointConnectionProperties_STATUS}
+---------------------------------------------------------------------------------------
 
 Properties of a private endpoint connection.
 
@@ -3087,8 +3087,8 @@ Used by: [ServerPrivateEndpointConnection_STATUS](#ServerPrivateEndpointConnecti
 | privateLinkServiceConnectionState | Connection state of the private endpoint connection. | [PrivateLinkServiceConnectionStateProperty_STATUS](#PrivateLinkServiceConnectionStateProperty_STATUS)<br/><small>Optional</small>                         |
 | provisioningState                 | State of the private endpoint connection.            | [PrivateEndpointConnectionProperties_ProvisioningState_STATUS](#PrivateEndpointConnectionProperties_ProvisioningState_STATUS)<br/><small>Optional</small> |
 
-<a id="ResourceIdentity_Type"></a>ResourceIdentity_Type
--------------------------------------------------------
+ResourceIdentity_Type{#ResourceIdentity_Type}
+---------------------------------------------
 
 Used by: [ResourceIdentity](#ResourceIdentity).
 
@@ -3099,8 +3099,8 @@ Used by: [ResourceIdentity](#ResourceIdentity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ResourceIdentity_Type_STATUS"></a>ResourceIdentity_Type_STATUS
----------------------------------------------------------------------
+ResourceIdentity_Type_STATUS{#ResourceIdentity_Type_STATUS}
+-----------------------------------------------------------
 
 Used by: [ResourceIdentity_STATUS](#ResourceIdentity_STATUS).
 
@@ -3111,8 +3111,8 @@ Used by: [ResourceIdentity_STATUS](#ResourceIdentity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ServerExternalAdministrator_AdministratorType"></a>ServerExternalAdministrator_AdministratorType
--------------------------------------------------------------------------------------------------------
+ServerExternalAdministrator_AdministratorType{#ServerExternalAdministrator_AdministratorType}
+---------------------------------------------------------------------------------------------
 
 Used by: [ServerExternalAdministrator](#ServerExternalAdministrator).
 
@@ -3120,8 +3120,8 @@ Used by: [ServerExternalAdministrator](#ServerExternalAdministrator).
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="ServerExternalAdministrator_AdministratorType_STATUS"></a>ServerExternalAdministrator_AdministratorType_STATUS
----------------------------------------------------------------------------------------------------------------------
+ServerExternalAdministrator_AdministratorType_STATUS{#ServerExternalAdministrator_AdministratorType_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ServerExternalAdministrator_STATUS](#ServerExternalAdministrator_STATUS).
 
@@ -3129,8 +3129,8 @@ Used by: [ServerExternalAdministrator_STATUS](#ServerExternalAdministrator_STATU
 |-------------------|-------------|
 | "ActiveDirectory" |             |
 
-<a id="ServerExternalAdministrator_PrincipalType"></a>ServerExternalAdministrator_PrincipalType
------------------------------------------------------------------------------------------------
+ServerExternalAdministrator_PrincipalType{#ServerExternalAdministrator_PrincipalType}
+-------------------------------------------------------------------------------------
 
 Used by: [ServerExternalAdministrator](#ServerExternalAdministrator).
 
@@ -3140,8 +3140,8 @@ Used by: [ServerExternalAdministrator](#ServerExternalAdministrator).
 | "Group"       |             |
 | "User"        |             |
 
-<a id="ServerExternalAdministrator_PrincipalType_STATUS"></a>ServerExternalAdministrator_PrincipalType_STATUS
--------------------------------------------------------------------------------------------------------------
+ServerExternalAdministrator_PrincipalType_STATUS{#ServerExternalAdministrator_PrincipalType_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [ServerExternalAdministrator_STATUS](#ServerExternalAdministrator_STATUS).
 
@@ -3151,8 +3151,8 @@ Used by: [ServerExternalAdministrator_STATUS](#ServerExternalAdministrator_STATU
 | "Group"       |             |
 | "User"        |             |
 
-<a id="ServerOperatorConfigMaps"></a>ServerOperatorConfigMaps
--------------------------------------------------------------
+ServerOperatorConfigMaps{#ServerOperatorConfigMaps}
+---------------------------------------------------
 
 Used by: [ServerOperatorSpec](#ServerOperatorSpec).
 
@@ -3160,7 +3160,19 @@ Used by: [ServerOperatorSpec](#ServerOperatorSpec).
 |--------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fullyQualifiedDomainName | indicates where the FullyQualifiedDomainName config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -3172,20 +3184,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -3195,8 +3195,8 @@ Used by: [DatabaseIdentity](#DatabaseIdentity), and [ResourceIdentity](#Resource
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserIdentity_STATUS"></a>UserIdentity_STATUS
----------------------------------------------------
+UserIdentity_STATUS{#UserIdentity_STATUS}
+-----------------------------------------
 
 Azure Active Directory identity configuration for a resource.
 
@@ -3207,8 +3207,8 @@ Used by: [ResourceIdentity_STATUS](#ResourceIdentity_STATUS).
 | clientId    | The Azure Active Directory client id.    | string<br/><small>Optional</small> |
 | principalId | The Azure Active Directory principal id. | string<br/><small>Optional</small> |
 
-<a id="PrivateEndpointConnectionProperties_ProvisioningState_STATUS"></a>PrivateEndpointConnectionProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+PrivateEndpointConnectionProperties_ProvisioningState_STATUS{#PrivateEndpointConnectionProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnectionProperties_STATUS).
 
@@ -3220,8 +3220,8 @@ Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnection
 | "Ready"     |             |
 | "Rejecting" |             |
 
-<a id="PrivateEndpointProperty_STATUS"></a>PrivateEndpointProperty_STATUS
--------------------------------------------------------------------------
+PrivateEndpointProperty_STATUS{#PrivateEndpointProperty_STATUS}
+---------------------------------------------------------------
 
 Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnectionProperties_STATUS).
 
@@ -3229,8 +3229,8 @@ Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnection
 |----------|--------------------------------------|------------------------------------|
 | id       | Resource id of the private endpoint. | string<br/><small>Optional</small> |
 
-<a id="PrivateLinkServiceConnectionStateProperty_STATUS"></a>PrivateLinkServiceConnectionStateProperty_STATUS
--------------------------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionStateProperty_STATUS{#PrivateLinkServiceConnectionStateProperty_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnectionProperties_STATUS).
 
@@ -3240,8 +3240,8 @@ Used by: [PrivateEndpointConnectionProperties_STATUS](#PrivateEndpointConnection
 | description     | The private link service connection description.          | string<br/><small>Optional</small>                                                                                                                                |
 | status          | The private link service connection status.               | [PrivateLinkServiceConnectionStateProperty_Status_STATUS](#PrivateLinkServiceConnectionStateProperty_Status_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS"></a>PrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS{#PrivateLinkServiceConnectionStateProperty_ActionsRequired_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceConnectionStateProperty_STATUS](#PrivateLinkServiceConnectionStateProperty_STATUS).
 
@@ -3249,8 +3249,8 @@ Used by: [PrivateLinkServiceConnectionStateProperty_STATUS](#PrivateLinkServiceC
 |--------|-------------|
 | "None" |             |
 
-<a id="PrivateLinkServiceConnectionStateProperty_Status_STATUS"></a>PrivateLinkServiceConnectionStateProperty_Status_STATUS
----------------------------------------------------------------------------------------------------------------------------
+PrivateLinkServiceConnectionStateProperty_Status_STATUS{#PrivateLinkServiceConnectionStateProperty_Status_STATUS}
+-----------------------------------------------------------------------------------------------------------------
 
 Used by: [PrivateLinkServiceConnectionStateProperty_STATUS](#PrivateLinkServiceConnectionStateProperty_STATUS).
 

--- a/docs/hugo/content/reference/storage/v1api20210401.md
+++ b/docs/hugo/content/reference/storage/v1api20210401.md
@@ -5,15 +5,15 @@ title: storage.azure.com/v1api20210401
 linktitle: v1api20210401
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-04-01" |             |
 
-<a id="StorageAccount"></a>StorageAccount
------------------------------------------
+StorageAccount{#StorageAccount}
+-------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | spec                                                                                    |             | [StorageAccount_Spec](#StorageAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccount_STATUS](#StorageAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccount_Spec"></a>StorageAccount_Spec
+### StorageAccount_Spec {#StorageAccount_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -56,7 +56,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
+### StorageAccount_STATUS{#StorageAccount_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -101,8 +101,8 @@ Used by: [StorageAccountList](#StorageAccountList).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountList"></a>StorageAccountList
--------------------------------------------------
+StorageAccountList{#StorageAccountList}
+---------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -112,8 +112,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [StorageAccount[]](#StorageAccount)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobService"></a>StorageAccountsBlobService
------------------------------------------------------------------
+StorageAccountsBlobService{#StorageAccountsBlobService}
+-------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -126,7 +126,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | spec                                                                                    |             | [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
+### StorageAccountsBlobService_Spec {#StorageAccountsBlobService_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -142,7 +142,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-### <a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
+### StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -161,8 +161,8 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServiceList"></a>StorageAccountsBlobServiceList
--------------------------------------------------------------------------
+StorageAccountsBlobServiceList{#StorageAccountsBlobServiceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -172,8 +172,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [StorageAccountsBlobService[]](#StorageAccountsBlobService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainer"></a>StorageAccountsBlobServicesContainer
--------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer{#StorageAccountsBlobServicesContainer}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -186,7 +186,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | spec                                                                                    |             | [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
+### StorageAccountsBlobServicesContainer_Spec {#StorageAccountsBlobServicesContainer_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -199,7 +199,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-### <a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
+### StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -226,8 +226,8 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainerList"></a>StorageAccountsBlobServicesContainerList
----------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerList{#StorageAccountsBlobServicesContainerList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -237,8 +237,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [StorageAccountsBlobServicesContainer[]](#StorageAccountsBlobServicesContainer)<br/><small>Optional</small> |
 
-<a id="StorageAccountsManagementPolicy"></a>StorageAccountsManagementPolicy
----------------------------------------------------------------------------
+StorageAccountsManagementPolicy{#StorageAccountsManagementPolicy}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -251,7 +251,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | spec                                                                                    |             | [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
+### StorageAccountsManagementPolicy_Spec {#StorageAccountsManagementPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -259,7 +259,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-### <a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
+### StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -270,8 +270,8 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicyList"></a>StorageAccountsManagementPolicyList
------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyList{#StorageAccountsManagementPolicyList}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -281,8 +281,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                   |
 | items                                                                               |             | [StorageAccountsManagementPolicy[]](#StorageAccountsManagementPolicy)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueService"></a>StorageAccountsQueueService
--------------------------------------------------------------------
+StorageAccountsQueueService{#StorageAccountsQueueService}
+---------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -295,7 +295,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | spec                                                                                    |             | [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueService_STATUS](#StorageAccountsQueueService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
+### StorageAccountsQueueService_Spec {#StorageAccountsQueueService_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -303,7 +303,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
+### StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -313,8 +313,8 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServiceList"></a>StorageAccountsQueueServiceList
----------------------------------------------------------------------------
+StorageAccountsQueueServiceList{#StorageAccountsQueueServiceList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -324,8 +324,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [StorageAccountsQueueService[]](#StorageAccountsQueueService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueue"></a>StorageAccountsQueueServicesQueue
--------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue{#StorageAccountsQueueServicesQueue}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -338,7 +338,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | spec                                                                                    |             | [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueServicesQueue_STATUS](#StorageAccountsQueueServicesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
+### StorageAccountsQueueServicesQueue_Spec {#StorageAccountsQueueServicesQueue_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -347,7 +347,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
+### StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -358,8 +358,8 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueueList"></a>StorageAccountsQueueServicesQueueList
----------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueList{#StorageAccountsQueueServicesQueueList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2021-04-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -369,8 +369,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [StorageAccountsQueueServicesQueue[]](#StorageAccountsQueueServicesQueue)<br/><small>Optional</small> |
 
-<a id="StorageAccount_Spec"></a>StorageAccount_Spec
----------------------------------------------------
+StorageAccount_Spec{#StorageAccount_Spec}
+-----------------------------------------
 
 Used by: [StorageAccount](#StorageAccount).
 
@@ -402,8 +402,8 @@ Used by: [StorageAccount](#StorageAccount).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
--------------------------------------------------------
+StorageAccount_STATUS{#StorageAccount_STATUS}
+---------------------------------------------
 
 The storage account.
 
@@ -452,8 +452,8 @@ Used by: [StorageAccount](#StorageAccount).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
----------------------------------------------------------------------------
+StorageAccountsBlobService_Spec{#StorageAccountsBlobService_Spec}
+-----------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -471,8 +471,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-<a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
--------------------------------------------------------------------------------
+StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
+---------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -493,8 +493,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_Spec{#StorageAccountsBlobServicesContainer_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -509,8 +509,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-<a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
----------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -539,8 +539,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
--------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_Spec{#StorageAccountsManagementPolicy_Spec}
+---------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -550,8 +550,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-<a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -564,8 +564,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
------------------------------------------------------------------------------
+StorageAccountsQueueService_Spec{#StorageAccountsQueueService_Spec}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -575,8 +575,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
----------------------------------------------------------------------------------
+StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -588,8 +588,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_Spec{#StorageAccountsQueueServicesQueue_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -600,8 +600,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -614,8 +614,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AzureFilesIdentityBasedAuthentication"></a>AzureFilesIdentityBasedAuthentication
----------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication{#AzureFilesIdentityBasedAuthentication}
+-----------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -627,8 +627,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used.                                                          | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions)<br/><small>Required</small> |
 
-<a id="AzureFilesIdentityBasedAuthentication_STATUS"></a>AzureFilesIdentityBasedAuthentication_STATUS
------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_STATUS{#AzureFilesIdentityBasedAuthentication_STATUS}
+-------------------------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -640,8 +640,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used.                                                          | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="BlobRestoreStatus_STATUS"></a>BlobRestoreStatus_STATUS
--------------------------------------------------------------
+BlobRestoreStatus_STATUS{#BlobRestoreStatus_STATUS}
+---------------------------------------------------
 
 Blob restore status.
 
@@ -654,8 +654,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | restoreId     | Id for tracking blob restore request.                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                              |
 | status        | The status of blob restore progress. Possible values are: - InProgress: Indicates that blob restore is ongoing. - Complete: Indicates that blob restore has been completed successfully. - Failed: Indicates that blob restore is failed. | [BlobRestoreStatus_Status_STATUS](#BlobRestoreStatus_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="ChangeFeed"></a>ChangeFeed
----------------------------------
+ChangeFeed{#ChangeFeed}
+-----------------------
 
 The blob service properties for change feed events.
 
@@ -666,8 +666,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ChangeFeed_STATUS"></a>ChangeFeed_STATUS
------------------------------------------------
+ChangeFeed_STATUS{#ChangeFeed_STATUS}
+-------------------------------------
 
 The blob service properties for change feed events.
 
@@ -678,8 +678,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ContainerProperties_LeaseDuration_STATUS"></a>ContainerProperties_LeaseDuration_STATUS
----------------------------------------------------------------------------------------------
+ContainerProperties_LeaseDuration_STATUS{#ContainerProperties_LeaseDuration_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -688,8 +688,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Fixed"    |             |
 | "Infinite" |             |
 
-<a id="ContainerProperties_LeaseState_STATUS"></a>ContainerProperties_LeaseState_STATUS
----------------------------------------------------------------------------------------
+ContainerProperties_LeaseState_STATUS{#ContainerProperties_LeaseState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -701,8 +701,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Expired"   |             |
 | "Leased"    |             |
 
-<a id="ContainerProperties_LeaseStatus_STATUS"></a>ContainerProperties_LeaseStatus_STATUS
------------------------------------------------------------------------------------------
+ContainerProperties_LeaseStatus_STATUS{#ContainerProperties_LeaseStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -711,8 +711,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ContainerProperties_PublicAccess"></a>ContainerProperties_PublicAccess
------------------------------------------------------------------------------
+ContainerProperties_PublicAccess{#ContainerProperties_PublicAccess}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec).
 
@@ -722,8 +722,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | "Container" |             |
 | "None"      |             |
 
-<a id="ContainerProperties_PublicAccess_STATUS"></a>ContainerProperties_PublicAccess_STATUS
--------------------------------------------------------------------------------------------
+ContainerProperties_PublicAccess_STATUS{#ContainerProperties_PublicAccess_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -733,8 +733,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Container" |             |
 | "None"      |             |
 
-<a id="CorsRules"></a>CorsRules
--------------------------------
+CorsRules{#CorsRules}
+---------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -744,8 +744,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), an
 |-----------|--------------------------------------------------------------------------------------|-----------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule[]](#CorsRule)<br/><small>Optional</small> |
 
-<a id="CorsRules_STATUS"></a>CorsRules_STATUS
----------------------------------------------
+CorsRules_STATUS{#CorsRules_STATUS}
+-----------------------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -755,8 +755,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 |-----------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule_STATUS[]](#CorsRule_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomDomain"></a>CustomDomain
--------------------------------------
+CustomDomain{#CustomDomain}
+---------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -767,8 +767,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Required</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
----------------------------------------------------
+CustomDomain_STATUS{#CustomDomain_STATUS}
+-----------------------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -779,8 +779,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Optional</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="DeleteRetentionPolicy"></a>DeleteRetentionPolicy
--------------------------------------------------------
+DeleteRetentionPolicy{#DeleteRetentionPolicy}
+---------------------------------------------
 
 The service properties for soft delete.
 
@@ -791,8 +791,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), an
 | days     | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365. | int<br/><small>Optional</small>  |
 | enabled  | Indicates whether DeleteRetentionPolicy is enabled.                                                                                           | bool<br/><small>Optional</small> |
 
-<a id="DeleteRetentionPolicy_STATUS"></a>DeleteRetentionPolicy_STATUS
----------------------------------------------------------------------
+DeleteRetentionPolicy_STATUS{#DeleteRetentionPolicy_STATUS}
+-----------------------------------------------------------
 
 The service properties for soft delete.
 
@@ -803,8 +803,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | days     | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365. | int<br/><small>Optional</small>  |
 | enabled  | Indicates whether DeleteRetentionPolicy is enabled.                                                                                           | bool<br/><small>Optional</small> |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 The encryption settings on the storage account.
 
@@ -818,8 +818,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                          |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices](#EncryptionServices)<br/><small>Optional</small>     |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 The encryption settings on the storage account.
 
@@ -833,8 +833,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                                        |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices_STATUS](#EncryptionServices_STATUS)<br/><small>Optional</small>     |
 
-<a id="Endpoints_STATUS"></a>Endpoints_STATUS
----------------------------------------------
+Endpoints_STATUS{#Endpoints_STATUS}
+-----------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object.
 
@@ -851,8 +851,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), and [StorageAccount_ST
 | table              | Gets the table endpoint.                      | string<br/><small>Optional</small>                                                                              |
 | web                | Gets the web endpoint.                        | string<br/><small>Optional</small>                                                                              |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -863,8 +863,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -875,8 +875,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="GeoReplicationStats_STATUS"></a>GeoReplicationStats_STATUS
------------------------------------------------------------------
+GeoReplicationStats_STATUS{#GeoReplicationStats_STATUS}
+-------------------------------------------------------
 
 Statistics related to replication for storage account's Blob, Table, Queue and File services. It is only available when geo-redundant replication is enabled for the storage account.
 
@@ -888,8 +888,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | lastSyncTime | All primary writes preceding this UTC date/time value are guaranteed to be available for read operations. Primary writes following this point in time may or may not be available for reads. Element may be default value if value of LastSyncTime is not available, this can happen if secondary is offline or we are in bootstrap.                                                            | string<br/><small>Optional</small>                                                                  |
 | status       | The status of the secondary location. Possible values are: - Live: Indicates that the secondary location is active and operational. - Bootstrap: Indicates initial synchronization from the primary location to the secondary location is in progress.This typically occurs when replication is first enabled. - Unavailable: Indicates that the secondary location is temporarily unavailable. | [GeoReplicationStats_Status_STATUS](#GeoReplicationStats_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -900,8 +900,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type](#Identity_Type)<br/><small>Required</small>                               |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -914,8 +914,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilityPolicyProperties_STATUS"></a>ImmutabilityPolicyProperties_STATUS
------------------------------------------------------------------------------------
+ImmutabilityPolicyProperties_STATUS{#ImmutabilityPolicyProperties_STATUS}
+-------------------------------------------------------------------------
 
 The properties of an ImmutabilityPolicy of a blob container.
 
@@ -929,8 +929,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | state                                 | The ImmutabilityPolicy state of a blob container, possible values include: Locked and Unlocked.                                                                                                                                                                                                                                                         | [ImmutabilityPolicyProperty_State_STATUS](#ImmutabilityPolicyProperty_State_STATUS)<br/><small>Optional</small> |
 | updateHistory                         | The ImmutabilityPolicy update history of the blob container.                                                                                                                                                                                                                                                                                            | [UpdateHistoryProperty_STATUS[]](#UpdateHistoryProperty_STATUS)<br/><small>Optional</small>                     |
 
-<a id="ImmutableStorageWithVersioning"></a>ImmutableStorageWithVersioning
--------------------------------------------------------------------------
+ImmutableStorageWithVersioning{#ImmutableStorageWithVersioning}
+---------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -940,8 +940,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 |----------|--------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | This is an immutable property, when set to true it enables object level immutability at the container level. | bool<br/><small>Optional</small> |
 
-<a id="ImmutableStorageWithVersioning_STATUS"></a>ImmutableStorageWithVersioning_STATUS
----------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_STATUS{#ImmutableStorageWithVersioning_STATUS}
+-----------------------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -953,8 +953,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | migrationState | This property denotes the container level immutability to object level immutability migration state.         | [ImmutableStorageWithVersioning_MigrationState_STATUS](#ImmutableStorageWithVersioning_MigrationState_STATUS)<br/><small>Optional</small> |
 | timeStamp      | Returns the date and time the object level immutability was enabled.                                         | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="KeyCreationTime_STATUS"></a>KeyCreationTime_STATUS
----------------------------------------------------------
+KeyCreationTime_STATUS{#KeyCreationTime_STATUS}
+-----------------------------------------------
 
 Storage account keys creation time.
 
@@ -965,8 +965,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | key1     |             | string<br/><small>Optional</small> |
 | key2     |             | string<br/><small>Optional</small> |
 
-<a id="KeyPolicy"></a>KeyPolicy
--------------------------------
+KeyPolicy{#KeyPolicy}
+---------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -976,8 +976,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Required</small> |
 
-<a id="KeyPolicy_STATUS"></a>KeyPolicy_STATUS
----------------------------------------------
+KeyPolicy_STATUS{#KeyPolicy_STATUS}
+-----------------------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -987,8 +987,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy"></a>LastAccessTimeTrackingPolicy
----------------------------------------------------------------------
+LastAccessTimeTrackingPolicy{#LastAccessTimeTrackingPolicy}
+-----------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1001,8 +1001,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name](#LastAccessTimeTrackingPolicy_Name)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                     |
 
-<a id="LastAccessTimeTrackingPolicy_STATUS"></a>LastAccessTimeTrackingPolicy_STATUS
------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_STATUS{#LastAccessTimeTrackingPolicy_STATUS}
+-------------------------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1015,8 +1015,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name_STATUS](#LastAccessTimeTrackingPolicy_Name_STATUS)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                                   |
 
-<a id="LegalHoldProperties_STATUS"></a>LegalHoldProperties_STATUS
------------------------------------------------------------------
+LegalHoldProperties_STATUS{#LegalHoldProperties_STATUS}
+-------------------------------------------------------
 
 The LegalHold property of a blob container.
 
@@ -1027,8 +1027,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | hasLegalHold | The hasLegalHold public property is set to true by SRP if there are at least one existing tag. The hasLegalHold public property is set to false by SRP if all existing legal hold tags are cleared out. There can be a maximum of 1000 blob containers with hasLegalHold=true for a given account. | bool<br/><small>Optional</small>                                        |
 | tags         | The list of LegalHold tags of a blob container.                                                                                                                                                                                                                                                    | [TagProperty_STATUS[]](#TagProperty_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySchema"></a>ManagementPolicySchema
----------------------------------------------------------
+ManagementPolicySchema{#ManagementPolicySchema}
+-----------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1038,8 +1038,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule[]](#ManagementPolicyRule)<br/><small>Required</small> |
 
-<a id="ManagementPolicySchema_STATUS"></a>ManagementPolicySchema_STATUS
------------------------------------------------------------------------
+ManagementPolicySchema_STATUS{#ManagementPolicySchema_STATUS}
+-------------------------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1049,8 +1049,8 @@ Used by: [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPoli
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule_STATUS[]](#ManagementPolicyRule_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 Network rule set
 
@@ -1064,8 +1064,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule[]](#ResourceAccessRule)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                   |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 Network rule set
 
@@ -1079,8 +1079,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule_STATUS[]](#ResourceAccessRule_STATUS)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -1090,8 +1090,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="RestorePolicyProperties"></a>RestorePolicyProperties
------------------------------------------------------------
+RestorePolicyProperties{#RestorePolicyProperties}
+-------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1102,8 +1102,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | days     | how long this blob can be restored. It should be great than zero and less than DeleteRetentionPolicy.days. | int<br/><small>Optional</small>  |
 | enabled  | Blob restore is enabled if set to true.                                                                    | bool<br/><small>Required</small> |
 
-<a id="RestorePolicyProperties_STATUS"></a>RestorePolicyProperties_STATUS
--------------------------------------------------------------------------
+RestorePolicyProperties_STATUS{#RestorePolicyProperties_STATUS}
+---------------------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1116,8 +1116,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | lastEnabledTime | Deprecated in favor of minRestoreTime property.                                                            | string<br/><small>Optional</small> |
 | minRestoreTime  | Returns the minimum date and time that the restore can be started.                                         | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference"></a>RoutingPreference
------------------------------------------------
+RoutingPreference{#RoutingPreference}
+-------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1129,8 +1129,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice](#RoutingPreference_RoutingChoice)<br/><small>Optional</small> |
 
-<a id="RoutingPreference_STATUS"></a>RoutingPreference_STATUS
--------------------------------------------------------------
+RoutingPreference_STATUS{#RoutingPreference_STATUS}
+---------------------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1142,8 +1142,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                              |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice_STATUS](#RoutingPreference_RoutingChoice_STATUS)<br/><small>Optional</small> |
 
-<a id="SasPolicy"></a>SasPolicy
--------------------------------
+SasPolicy{#SasPolicy}
+---------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1154,8 +1154,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction](#SasPolicy_ExpirationAction)<br/><small>Required</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Required</small>                                                    |
 
-<a id="SasPolicy_STATUS"></a>SasPolicy_STATUS
----------------------------------------------
+SasPolicy_STATUS{#SasPolicy_STATUS}
+-----------------------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1166,8 +1166,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction_STATUS](#SasPolicy_ExpirationAction_STATUS)<br/><small>Optional</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Optional</small>                                                                  |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The SKU of the storage account.
 
@@ -1178,8 +1178,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName](#SkuName)<br/><small>Required</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier](#Tier)<br/><small>Optional</small>       |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The SKU of the storage account.
 
@@ -1190,8 +1190,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), and [StorageAccountsBl
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName_STATUS](#SkuName_STATUS)<br/><small>Optional</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier_STATUS](#Tier_STATUS)<br/><small>Optional</small>       |
 
-<a id="StorageAccount_Kind_Spec"></a>StorageAccount_Kind_Spec
--------------------------------------------------------------
+StorageAccount_Kind_Spec{#StorageAccount_Kind_Spec}
+---------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1203,8 +1203,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccount_Kind_STATUS"></a>StorageAccount_Kind_STATUS
------------------------------------------------------------------
+StorageAccount_Kind_STATUS{#StorageAccount_Kind_STATUS}
+-------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1216,8 +1216,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccountOperatorSpec"></a>StorageAccountOperatorSpec
------------------------------------------------------------------
+StorageAccountOperatorSpec{#StorageAccountOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1230,8 +1230,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [StorageAccountOperatorSecrets](#StorageAccountOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="StorageAccountProperties_AccessTier_STATUS"></a>StorageAccountProperties_AccessTier_STATUS
--------------------------------------------------------------------------------------------------
+StorageAccountProperties_AccessTier_STATUS{#StorageAccountProperties_AccessTier_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1240,8 +1240,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Cool" |             |
 | "Hot"  |             |
 
-<a id="StorageAccountProperties_LargeFileSharesState_STATUS"></a>StorageAccountProperties_LargeFileSharesState_STATUS
----------------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_LargeFileSharesState_STATUS{#StorageAccountProperties_LargeFileSharesState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1250,8 +1250,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountProperties_MinimumTlsVersion_STATUS"></a>StorageAccountProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_MinimumTlsVersion_STATUS{#StorageAccountProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1261,8 +1261,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountProperties_ProvisioningState_STATUS"></a>StorageAccountProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_ProvisioningState_STATUS{#StorageAccountProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1272,8 +1272,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "ResolvingDNS" |             |
 | "Succeeded"    |             |
 
-<a id="StorageAccountProperties_StatusOfPrimary_STATUS"></a>StorageAccountProperties_StatusOfPrimary_STATUS
------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfPrimary_STATUS{#StorageAccountProperties_StatusOfPrimary_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1282,8 +1282,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountProperties_StatusOfSecondary_STATUS"></a>StorageAccountProperties_StatusOfSecondary_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfSecondary_STATUS{#StorageAccountProperties_StatusOfSecondary_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1292,8 +1292,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_AccessTier"></a>StorageAccountPropertiesCreateParameters_AccessTier
--------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_AccessTier{#StorageAccountPropertiesCreateParameters_AccessTier}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1302,8 +1302,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Cool" |             |
 | "Hot"  |             |
 
-<a id="StorageAccountPropertiesCreateParameters_LargeFileSharesState"></a>StorageAccountPropertiesCreateParameters_LargeFileSharesState
----------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_LargeFileSharesState{#StorageAccountPropertiesCreateParameters_LargeFileSharesState}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1312,8 +1312,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountPropertiesCreateParameters_MinimumTlsVersion"></a>StorageAccountPropertiesCreateParameters_MinimumTlsVersion
----------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_MinimumTlsVersion{#StorageAccountPropertiesCreateParameters_MinimumTlsVersion}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1323,8 +1323,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountsBlobServiceOperatorSpec"></a>StorageAccountsBlobServiceOperatorSpec
------------------------------------------------------------------------------------------
+StorageAccountsBlobServiceOperatorSpec{#StorageAccountsBlobServiceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1335,8 +1335,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainerOperatorSpec"></a>StorageAccountsBlobServicesContainerOperatorSpec
--------------------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerOperatorSpec{#StorageAccountsBlobServicesContainerOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1347,8 +1347,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsManagementPolicyOperatorSpec"></a>StorageAccountsManagementPolicyOperatorSpec
----------------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyOperatorSpec{#StorageAccountsManagementPolicyOperatorSpec}
+-----------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1359,8 +1359,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServiceOperatorSpec"></a>StorageAccountsQueueServiceOperatorSpec
--------------------------------------------------------------------------------------------
+StorageAccountsQueueServiceOperatorSpec{#StorageAccountsQueueServiceOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1371,8 +1371,8 @@ Used by: [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueueOperatorSpec"></a>StorageAccountsQueueServicesQueueOperatorSpec
--------------------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueOperatorSpec{#StorageAccountsQueueServicesQueueOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1383,8 +1383,8 @@ Used by: [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQ
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="ActiveDirectoryProperties"></a>ActiveDirectoryProperties
----------------------------------------------------------------
+ActiveDirectoryProperties{#ActiveDirectoryProperties}
+-----------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -1399,8 +1399,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | forestName        | Specifies the Active Directory forest to get.                             | string<br/><small>Required</small> |
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Required</small> |
 
-<a id="ActiveDirectoryProperties_STATUS"></a>ActiveDirectoryProperties_STATUS
------------------------------------------------------------------------------
+ActiveDirectoryProperties_STATUS{#ActiveDirectoryProperties_STATUS}
+-------------------------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -1415,8 +1415,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | forestName        | Specifies the Active Directory forest to get.                             | string<br/><small>Optional</small> |
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Optional</small> |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission
--------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -1428,8 +1428,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "StorageFileDataSmbShareOwner"               |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -1441,8 +1441,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "StorageFileDataSmbShareOwner"               |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions
----------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -1452,8 +1452,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "AD"    |             |
 | "None"  |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -1463,8 +1463,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "AD"    |             |
 | "None"  |             |
 
-<a id="BlobRestoreParameters_STATUS"></a>BlobRestoreParameters_STATUS
----------------------------------------------------------------------
+BlobRestoreParameters_STATUS{#BlobRestoreParameters_STATUS}
+-----------------------------------------------------------
 
 Blob restore parameters
 
@@ -1475,8 +1475,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | blobRanges    | Blob ranges to restore.             | [BlobRestoreRange_STATUS[]](#BlobRestoreRange_STATUS)<br/><small>Optional</small> |
 | timeToRestore | Restore blob to the specified time. | string<br/><small>Optional</small>                                                |
 
-<a id="BlobRestoreStatus_Status_STATUS"></a>BlobRestoreStatus_Status_STATUS
----------------------------------------------------------------------------
+BlobRestoreStatus_Status_STATUS{#BlobRestoreStatus_Status_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 
@@ -1486,8 +1486,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="CorsRule"></a>CorsRule
------------------------------
+CorsRule{#CorsRule}
+-------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -1501,8 +1501,8 @@ Used by: [CorsRules](#CorsRules).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Required</small>                                              |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Required</small>                                                   |
 
-<a id="CorsRule_STATUS"></a>CorsRule_STATUS
--------------------------------------------
+CorsRule_STATUS{#CorsRule_STATUS}
+---------------------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -1516,8 +1516,8 @@ Used by: [CorsRules_STATUS](#CorsRules_STATUS).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Optional</small>                                                            |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Optional</small>                                                                 |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -1526,8 +1526,8 @@ Used by: [Encryption](#Encryption).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -1536,8 +1536,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="EncryptionIdentity"></a>EncryptionIdentity
--------------------------------------------------
+EncryptionIdentity{#EncryptionIdentity}
+---------------------------------------
 
 Encryption identity for the storage account.
 
@@ -1547,8 +1547,8 @@ Used by: [Encryption](#Encryption).
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | userAssignedIdentityReference | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EncryptionIdentity_STATUS"></a>EncryptionIdentity_STATUS
----------------------------------------------------------------
+EncryptionIdentity_STATUS{#EncryptionIdentity_STATUS}
+-----------------------------------------------------
 
 Encryption identity for the storage account.
 
@@ -1558,8 +1558,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 |----------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | userAssignedIdentity | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account. | string<br/><small>Optional</small> |
 
-<a id="EncryptionServices"></a>EncryptionServices
--------------------------------------------------
+EncryptionServices{#EncryptionServices}
+---------------------------------------
 
 A list of services that support encryption.
 
@@ -1572,8 +1572,8 @@ Used by: [Encryption](#Encryption).
 | queue    | The encryption function of the queue storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 
-<a id="EncryptionServices_STATUS"></a>EncryptionServices_STATUS
----------------------------------------------------------------
+EncryptionServices_STATUS{#EncryptionServices_STATUS}
+-----------------------------------------------------
 
 A list of services that support encryption.
 
@@ -1586,8 +1586,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | queue    | The encryption function of the queue storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -1597,8 +1597,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -1608,8 +1608,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="GeoReplicationStats_Status_STATUS"></a>GeoReplicationStats_Status_STATUS
--------------------------------------------------------------------------------
+GeoReplicationStats_Status_STATUS{#GeoReplicationStats_Status_STATUS}
+---------------------------------------------------------------------
 
 Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 
@@ -1619,8 +1619,8 @@ Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 | "Live"        |             |
 | "Unavailable" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -1631,8 +1631,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -1643,8 +1643,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ImmutabilityPolicyProperty_State_STATUS"></a>ImmutabilityPolicyProperty_State_STATUS
--------------------------------------------------------------------------------------------
+ImmutabilityPolicyProperty_State_STATUS{#ImmutabilityPolicyProperty_State_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STATUS).
 
@@ -1653,8 +1653,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ImmutableStorageWithVersioning_MigrationState_STATUS"></a>ImmutableStorageWithVersioning_MigrationState_STATUS
----------------------------------------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_MigrationState_STATUS{#ImmutableStorageWithVersioning_MigrationState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning_STATUS).
 
@@ -1663,8 +1663,8 @@ Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning
 | "Completed"  |             |
 | "InProgress" |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -1675,8 +1675,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action](#IPRule_Action)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Required</small>                          |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -1687,8 +1687,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action_STATUS](#IPRule_Action_STATUS)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small>                                        |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties of key vault.
 
@@ -1700,8 +1700,8 @@ Used by: [Encryption](#Encryption).
 | keyvaulturi | The Uri of KeyVault.         | string<br/><small>Optional</small> |
 | keyversion  | The version of KeyVault key. | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties of key vault.
 
@@ -1715,8 +1715,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyversion                    | The version of KeyVault key.                                         | string<br/><small>Optional</small> |
 | lastKeyRotationTimestamp      | Timestamp of last rotation of the Key Vault Key.                     | string<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy_Name"></a>LastAccessTimeTrackingPolicy_Name
--------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name{#LastAccessTimeTrackingPolicy_Name}
+---------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 
@@ -1724,8 +1724,8 @@ Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="LastAccessTimeTrackingPolicy_Name_STATUS"></a>LastAccessTimeTrackingPolicy_Name_STATUS
----------------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name_STATUS{#LastAccessTimeTrackingPolicy_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STATUS).
 
@@ -1733,8 +1733,8 @@ Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STA
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="ManagementPolicyRule"></a>ManagementPolicyRule
------------------------------------------------------
+ManagementPolicyRule{#ManagementPolicyRule}
+-------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -1747,8 +1747,8 @@ Used by: [ManagementPolicySchema](#ManagementPolicySchema).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Required</small>                                                    |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type](#ManagementPolicyRule_Type)<br/><small>Required</small>   |
 
-<a id="ManagementPolicyRule_STATUS"></a>ManagementPolicyRule_STATUS
--------------------------------------------------------------------
+ManagementPolicyRule_STATUS{#ManagementPolicyRule_STATUS}
+---------------------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -1761,8 +1761,8 @@ Used by: [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Optional</small>                                                                  |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type_STATUS](#ManagementPolicyRule_Type_STATUS)<br/><small>Optional</small>   |
 
-<a id="NetworkRuleSet_Bypass_STATUS"></a>NetworkRuleSet_Bypass_STATUS
----------------------------------------------------------------------
+NetworkRuleSet_Bypass_STATUS{#NetworkRuleSet_Bypass_STATUS}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -1773,8 +1773,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Metrics"       |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -1783,8 +1783,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -1793,8 +1793,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ResourceAccessRule"></a>ResourceAccessRule
--------------------------------------------------
+ResourceAccessRule{#ResourceAccessRule}
+---------------------------------------
 
 Resource Access Rule.
 
@@ -1805,8 +1805,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | resourceReference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | Tenant Id   | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ResourceAccessRule_STATUS"></a>ResourceAccessRule_STATUS
----------------------------------------------------------------
+ResourceAccessRule_STATUS{#ResourceAccessRule_STATUS}
+-----------------------------------------------------
 
 Resource Access Rule.
 
@@ -1817,8 +1817,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | resourceId | Resource Id | string<br/><small>Optional</small> |
 | tenantId   | Tenant Id   | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference_RoutingChoice"></a>RoutingPreference_RoutingChoice
----------------------------------------------------------------------------
+RoutingPreference_RoutingChoice{#RoutingPreference_RoutingChoice}
+-----------------------------------------------------------------
 
 Used by: [RoutingPreference](#RoutingPreference).
 
@@ -1827,8 +1827,8 @@ Used by: [RoutingPreference](#RoutingPreference).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="RoutingPreference_RoutingChoice_STATUS"></a>RoutingPreference_RoutingChoice_STATUS
------------------------------------------------------------------------------------------
+RoutingPreference_RoutingChoice_STATUS{#RoutingPreference_RoutingChoice_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 
@@ -1837,8 +1837,8 @@ Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="SasPolicy_ExpirationAction"></a>SasPolicy_ExpirationAction
------------------------------------------------------------------
+SasPolicy_ExpirationAction{#SasPolicy_ExpirationAction}
+-------------------------------------------------------
 
 Used by: [SasPolicy](#SasPolicy).
 
@@ -1846,8 +1846,8 @@ Used by: [SasPolicy](#SasPolicy).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SasPolicy_ExpirationAction_STATUS"></a>SasPolicy_ExpirationAction_STATUS
--------------------------------------------------------------------------------
+SasPolicy_ExpirationAction_STATUS{#SasPolicy_ExpirationAction_STATUS}
+---------------------------------------------------------------------
 
 Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 
@@ -1855,8 +1855,8 @@ Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SkuName"></a>SkuName
----------------------------
+SkuName{#SkuName}
+-----------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -1873,8 +1873,8 @@ Used by: [Sku](#Sku).
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="SkuName_STATUS"></a>SkuName_STATUS
------------------------------------------
+SkuName_STATUS{#SkuName_STATUS}
+-------------------------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -1891,8 +1891,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="StorageAccountInternetEndpoints_STATUS"></a>StorageAccountInternetEndpoints_STATUS
------------------------------------------------------------------------------------------
+StorageAccountInternetEndpoints_STATUS{#StorageAccountInternetEndpoints_STATUS}
+-------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, file, web or dfs object via a internet routing endpoint.
 
@@ -1905,8 +1905,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | file     | Gets the file endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.  | string<br/><small>Optional</small> |
 
-<a id="StorageAccountMicrosoftEndpoints_STATUS"></a>StorageAccountMicrosoftEndpoints_STATUS
--------------------------------------------------------------------------------------------
+StorageAccountMicrosoftEndpoints_STATUS{#StorageAccountMicrosoftEndpoints_STATUS}
+---------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object via a microsoft routing endpoint.
 
@@ -1921,8 +1921,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | table    | Gets the table endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.   | string<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorConfigMaps"></a>StorageAccountOperatorConfigMaps
------------------------------------------------------------------------------
+StorageAccountOperatorConfigMaps{#StorageAccountOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -1935,8 +1935,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint config map should be placed. If omitted, no config map will be created.   | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorSecrets"></a>StorageAccountOperatorSecrets
------------------------------------------------------------------------
+StorageAccountOperatorSecrets{#StorageAccountOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -1951,8 +1951,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure.   | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="TagProperty_STATUS"></a>TagProperty_STATUS
--------------------------------------------------
+TagProperty_STATUS{#TagProperty_STATUS}
+---------------------------------------
 
 A tag of the LegalHold of a blob container.
 
@@ -1966,8 +1966,8 @@ Used by: [LegalHoldProperties_STATUS](#LegalHoldProperties_STATUS).
 | timestamp        | Returns the date and time the tag was added.                                | string<br/><small>Optional</small> |
 | upn              | Returns the User Principal Name of the user who added the tag.              | string<br/><small>Optional</small> |
 
-<a id="Tier"></a>Tier
----------------------
+Tier{#Tier}
+-----------
 
 The SKU tier. This is based on the SKU name.
 
@@ -1978,8 +1978,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Tier_STATUS"></a>Tier_STATUS
------------------------------------
+Tier_STATUS{#Tier_STATUS}
+-------------------------
 
 The SKU tier. This is based on the SKU name.
 
@@ -1990,8 +1990,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="UpdateHistoryProperty_STATUS"></a>UpdateHistoryProperty_STATUS
----------------------------------------------------------------------
+UpdateHistoryProperty_STATUS{#UpdateHistoryProperty_STATUS}
+-----------------------------------------------------------
 
 An update history of the ImmutabilityPolicy of a blob container.
 
@@ -2006,8 +2006,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | update                                | The ImmutabilityPolicy update type of a blob container, possible values include: put, lock and extend. | [UpdateHistoryProperty_Update_STATUS](#UpdateHistoryProperty_Update_STATUS)<br/><small>Optional</small> |
 | upn                                   | Returns the User Principal Name of the user who updated the ImmutabilityPolicy.                        | string<br/><small>Optional</small>                                                                      |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 UserAssignedIdentity for the resource.
 
@@ -2018,8 +2018,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | The client ID of the identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2029,8 +2029,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network rule.
 
@@ -2042,8 +2042,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | reference | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 | state     | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State](#VirtualNetworkRule_State)<br/><small>Optional</small>                                                                          |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network rule.
 
@@ -2055,8 +2055,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | id       | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | string<br/><small>Optional</small>                                                                |
 | state    | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State_STATUS](#VirtualNetworkRule_State_STATUS)<br/><small>Optional</small>   |
 
-<a id="BlobRestoreRange_STATUS"></a>BlobRestoreRange_STATUS
------------------------------------------------------------
+BlobRestoreRange_STATUS{#BlobRestoreRange_STATUS}
+-------------------------------------------------
 
 Blob range
 
@@ -2067,8 +2067,8 @@ Used by: [BlobRestoreParameters_STATUS](#BlobRestoreParameters_STATUS).
 | endRange   | Blob end range. This is exclusive. Empty means account end.     | string<br/><small>Optional</small> |
 | startRange | Blob start range. This is inclusive. Empty means account start. | string<br/><small>Optional</small> |
 
-<a id="CorsRule_AllowedMethods"></a>CorsRule_AllowedMethods
------------------------------------------------------------
+CorsRule_AllowedMethods{#CorsRule_AllowedMethods}
+-------------------------------------------------
 
 Used by: [CorsRule](#CorsRule).
 
@@ -2082,8 +2082,8 @@ Used by: [CorsRule](#CorsRule).
 | "POST"    |             |
 | "PUT"     |             |
 
-<a id="CorsRule_AllowedMethods_STATUS"></a>CorsRule_AllowedMethods_STATUS
--------------------------------------------------------------------------
+CorsRule_AllowedMethods_STATUS{#CorsRule_AllowedMethods_STATUS}
+---------------------------------------------------------------
 
 Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 
@@ -2097,8 +2097,8 @@ Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 | "POST"    |             |
 | "PUT"     |             |
 
-<a id="EncryptionService"></a>EncryptionService
------------------------------------------------
+EncryptionService{#EncryptionService}
+-------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -2109,8 +2109,8 @@ Used by: [EncryptionServices](#EncryptionServices), [EncryptionServices](#Encryp
 | enabled  | A boolean indicating whether or not the service encrypts the data as it is stored.                                                                                                                       | bool<br/><small>Optional</small>                                                    |
 | keyType  | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used. | [EncryptionService_KeyType](#EncryptionService_KeyType)<br/><small>Optional</small> |
 
-<a id="EncryptionService_STATUS"></a>EncryptionService_STATUS
--------------------------------------------------------------
+EncryptionService_STATUS{#EncryptionService_STATUS}
+---------------------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -2122,8 +2122,8 @@ Used by: [EncryptionServices_STATUS](#EncryptionServices_STATUS), [EncryptionSer
 | keyType         | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used.                                     | [EncryptionService_KeyType_STATUS](#EncryptionService_KeyType_STATUS)<br/><small>Optional</small> |
 | lastEnabledTime | Gets a rough estimate of the date/time when the encryption was last enabled by the user. Only returned when encryption is enabled. There might be some unencrypted blobs which were written after this time, as it is just a rough estimate. | string<br/><small>Optional</small>                                                                |
 
-<a id="IPRule_Action"></a>IPRule_Action
----------------------------------------
+IPRule_Action{#IPRule_Action}
+-----------------------------
 
 Used by: [IPRule](#IPRule).
 
@@ -2131,8 +2131,8 @@ Used by: [IPRule](#IPRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="IPRule_Action_STATUS"></a>IPRule_Action_STATUS
------------------------------------------------------
+IPRule_Action_STATUS{#IPRule_Action_STATUS}
+-------------------------------------------
 
 Used by: [IPRule_STATUS](#IPRule_STATUS).
 
@@ -2140,8 +2140,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="ManagementPolicyDefinition"></a>ManagementPolicyDefinition
------------------------------------------------------------------
+ManagementPolicyDefinition{#ManagementPolicyDefinition}
+-------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -2152,8 +2152,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 | actions  | An object that defines the action set. | [ManagementPolicyAction](#ManagementPolicyAction)<br/><small>Required</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter](#ManagementPolicyFilter)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyDefinition_STATUS"></a>ManagementPolicyDefinition_STATUS
--------------------------------------------------------------------------------
+ManagementPolicyDefinition_STATUS{#ManagementPolicyDefinition_STATUS}
+---------------------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -2164,8 +2164,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 | actions  | An object that defines the action set. | [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS)<br/><small>Optional</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyRule_Type"></a>ManagementPolicyRule_Type
----------------------------------------------------------------
+ManagementPolicyRule_Type{#ManagementPolicyRule_Type}
+-----------------------------------------------------
 
 Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 
@@ -2173,8 +2173,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="ManagementPolicyRule_Type_STATUS"></a>ManagementPolicyRule_Type_STATUS
------------------------------------------------------------------------------
+ManagementPolicyRule_Type_STATUS{#ManagementPolicyRule_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 
@@ -2182,8 +2182,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="UpdateHistoryProperty_Update_STATUS"></a>UpdateHistoryProperty_Update_STATUS
------------------------------------------------------------------------------------
+UpdateHistoryProperty_Update_STATUS{#UpdateHistoryProperty_Update_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 
@@ -2193,8 +2193,8 @@ Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 | "lock"   |             |
 | "put"    |             |
 
-<a id="VirtualNetworkRule_Action"></a>VirtualNetworkRule_Action
----------------------------------------------------------------
+VirtualNetworkRule_Action{#VirtualNetworkRule_Action}
+-----------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -2202,8 +2202,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_Action_STATUS"></a>VirtualNetworkRule_Action_STATUS
------------------------------------------------------------------------------
+VirtualNetworkRule_Action_STATUS{#VirtualNetworkRule_Action_STATUS}
+-------------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -2211,8 +2211,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_State"></a>VirtualNetworkRule_State
--------------------------------------------------------------
+VirtualNetworkRule_State{#VirtualNetworkRule_State}
+---------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -2224,8 +2224,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="VirtualNetworkRule_State_STATUS"></a>VirtualNetworkRule_State_STATUS
----------------------------------------------------------------------------
+VirtualNetworkRule_State_STATUS{#VirtualNetworkRule_State_STATUS}
+-----------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -2237,8 +2237,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="EncryptionService_KeyType"></a>EncryptionService_KeyType
----------------------------------------------------------------
+EncryptionService_KeyType{#EncryptionService_KeyType}
+-----------------------------------------------------
 
 Used by: [EncryptionService](#EncryptionService).
 
@@ -2247,8 +2247,8 @@ Used by: [EncryptionService](#EncryptionService).
 | "Account" |             |
 | "Service" |             |
 
-<a id="EncryptionService_KeyType_STATUS"></a>EncryptionService_KeyType_STATUS
------------------------------------------------------------------------------
+EncryptionService_KeyType_STATUS{#EncryptionService_KeyType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 
@@ -2257,8 +2257,8 @@ Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 | "Account" |             |
 | "Service" |             |
 
-<a id="ManagementPolicyAction"></a>ManagementPolicyAction
----------------------------------------------------------
+ManagementPolicyAction{#ManagementPolicyAction}
+-----------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -2270,8 +2270,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot](#ManagementPolicySnapShot)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion](#ManagementPolicyVersion)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyAction_STATUS"></a>ManagementPolicyAction_STATUS
------------------------------------------------------------------------
+ManagementPolicyAction_STATUS{#ManagementPolicyAction_STATUS}
+-------------------------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -2283,8 +2283,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion_STATUS](#ManagementPolicyVersion_STATUS)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyFilter"></a>ManagementPolicyFilter
----------------------------------------------------------
+ManagementPolicyFilter{#ManagementPolicyFilter}
+-----------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -2296,8 +2296,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Required</small>                  |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                  |
 
-<a id="ManagementPolicyFilter_STATUS"></a>ManagementPolicyFilter_STATUS
------------------------------------------------------------------------
+ManagementPolicyFilter_STATUS{#ManagementPolicyFilter_STATUS}
+-------------------------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -2309,8 +2309,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Optional</small>                                |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                                |
 
-<a id="ManagementPolicyBaseBlob"></a>ManagementPolicyBaseBlob
--------------------------------------------------------------
+ManagementPolicyBaseBlob{#ManagementPolicyBaseBlob}
+---------------------------------------------------
 
 Management policy action for base blob.
 
@@ -2323,8 +2323,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToArchive               | The function to tier blobs to archive storage. Support blobs currently at Hot or Cool tier                                                            | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 | tierToCool                  | The function to tier blobs to cool storage. Support blobs currently at Hot tier                                                                       | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyBaseBlob_STATUS"></a>ManagementPolicyBaseBlob_STATUS
----------------------------------------------------------------------------
+ManagementPolicyBaseBlob_STATUS{#ManagementPolicyBaseBlob_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for base blob.
 
@@ -2337,8 +2337,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToArchive               | The function to tier blobs to archive storage. Support blobs currently at Hot or Cool tier                                                            | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 | tierToCool                  | The function to tier blobs to cool storage. Support blobs currently at Hot tier                                                                       | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot"></a>ManagementPolicySnapShot
--------------------------------------------------------------
+ManagementPolicySnapShot{#ManagementPolicySnapShot}
+---------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -2350,8 +2350,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToArchive | The function to tier blob snapshot to archive storage. Support blob snapshot currently at Hot or Cool tier | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToCool    | The function to tier blob snapshot to cool storage. Support blob snapshot currently at Hot tier            | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot_STATUS"></a>ManagementPolicySnapShot_STATUS
----------------------------------------------------------------------------
+ManagementPolicySnapShot_STATUS{#ManagementPolicySnapShot_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -2363,8 +2363,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToArchive | The function to tier blob snapshot to archive storage. Support blob snapshot currently at Hot or Cool tier | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToCool    | The function to tier blob snapshot to cool storage. Support blob snapshot currently at Hot tier            | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion"></a>ManagementPolicyVersion
------------------------------------------------------------
+ManagementPolicyVersion{#ManagementPolicyVersion}
+-------------------------------------------------
 
 Management policy action for blob version.
 
@@ -2376,8 +2376,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToArchive | The function to tier blob version to archive storage. Support blob version currently at Hot or Cool tier | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToCool    | The function to tier blob version to cool storage. Support blob version currently at Hot tier            | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion_STATUS"></a>ManagementPolicyVersion_STATUS
--------------------------------------------------------------------------
+ManagementPolicyVersion_STATUS{#ManagementPolicyVersion_STATUS}
+---------------------------------------------------------------
 
 Management policy action for blob version.
 
@@ -2389,8 +2389,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToArchive | The function to tier blob version to archive storage. Support blob version currently at Hot or Cool tier | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToCool    | The function to tier blob version to cool storage. Support blob version currently at Hot tier            | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="TagFilter"></a>TagFilter
--------------------------------
+TagFilter{#TagFilter}
+---------------------
 
 Blob index tag based filtering for blob objects
 
@@ -2402,8 +2402,8 @@ Used by: [ManagementPolicyFilter](#ManagementPolicyFilter).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Required</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Required</small> |
 
-<a id="TagFilter_STATUS"></a>TagFilter_STATUS
----------------------------------------------
+TagFilter_STATUS{#TagFilter_STATUS}
+-----------------------------------
 
 Blob index tag based filtering for blob objects
 
@@ -2415,8 +2415,8 @@ Used by: [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Optional</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Optional</small> |
 
-<a id="DateAfterCreation"></a>DateAfterCreation
------------------------------------------------
+DateAfterCreation{#DateAfterCreation}
+-------------------------------------
 
 Object to define the number of days after creation.
 
@@ -2426,8 +2426,8 @@ Used by: [ManagementPolicySnapShot](#ManagementPolicySnapShot), [ManagementPolic
 |------------------------------|-------------------------------------------------|---------------------------------|
 | daysAfterCreationGreaterThan | Value indicating the age in days after creation | int<br/><small>Required</small> |
 
-<a id="DateAfterCreation_STATUS"></a>DateAfterCreation_STATUS
--------------------------------------------------------------
+DateAfterCreation_STATUS{#DateAfterCreation_STATUS}
+---------------------------------------------------
 
 Object to define the number of days after creation.
 
@@ -2437,8 +2437,8 @@ Used by: [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS), [M
 |------------------------------|-------------------------------------------------|-------------------------------------|
 | daysAfterCreationGreaterThan | Value indicating the age in days after creation | float64<br/><small>Optional</small> |
 
-<a id="DateAfterModification"></a>DateAfterModification
--------------------------------------------------------
+DateAfterModification{#DateAfterModification}
+---------------------------------------------
 
 Object to define the number of days after object last modification Or last access. Properties daysAfterModificationGreaterThan and daysAfterLastAccessTimeGreaterThan are mutually exclusive.
 
@@ -2449,8 +2449,8 @@ Used by: [ManagementPolicyBaseBlob](#ManagementPolicyBaseBlob), [ManagementPolic
 | daysAfterLastAccessTimeGreaterThan | Value indicating the age in days after last blob access. This property can only be used in conjunction with last access time tracking policy | int<br/><small>Optional</small> |
 | daysAfterModificationGreaterThan   | Value indicating the age in days after last modification                                                                                     | int<br/><small>Optional</small> |
 
-<a id="DateAfterModification_STATUS"></a>DateAfterModification_STATUS
----------------------------------------------------------------------
+DateAfterModification_STATUS{#DateAfterModification_STATUS}
+-----------------------------------------------------------
 
 Object to define the number of days after object last modification Or last access. Properties daysAfterModificationGreaterThan and daysAfterLastAccessTimeGreaterThan are mutually exclusive.
 

--- a/docs/hugo/content/reference/storage/v1api20220901.md
+++ b/docs/hugo/content/reference/storage/v1api20220901.md
@@ -5,15 +5,15 @@ title: storage.azure.com/v1api20220901
 linktitle: v1api20220901
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-09-01" |             |
 
-<a id="StorageAccount"></a>StorageAccount
------------------------------------------
+StorageAccount{#StorageAccount}
+-------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | spec                                                                                    |             | [StorageAccount_Spec](#StorageAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccount_STATUS](#StorageAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccount_Spec"></a>StorageAccount_Spec
+### StorageAccount_Spec {#StorageAccount_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,7 +63,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
+### StorageAccount_STATUS{#StorageAccount_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -116,8 +116,8 @@ Used by: [StorageAccountList](#StorageAccountList).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountList"></a>StorageAccountList
--------------------------------------------------
+StorageAccountList{#StorageAccountList}
+---------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -127,8 +127,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [StorageAccount[]](#StorageAccount)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobService"></a>StorageAccountsBlobService
------------------------------------------------------------------
+StorageAccountsBlobService{#StorageAccountsBlobService}
+-------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -141,7 +141,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | spec                                                                                    |             | [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
+### StorageAccountsBlobService_Spec {#StorageAccountsBlobService_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -157,7 +157,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-### <a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
+### StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,8 +176,8 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServiceList"></a>StorageAccountsBlobServiceList
--------------------------------------------------------------------------
+StorageAccountsBlobServiceList{#StorageAccountsBlobServiceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -187,8 +187,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [StorageAccountsBlobService[]](#StorageAccountsBlobService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainer"></a>StorageAccountsBlobServicesContainer
--------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer{#StorageAccountsBlobServicesContainer}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -201,7 +201,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | spec                                                                                    |             | [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
+### StorageAccountsBlobServicesContainer_Spec {#StorageAccountsBlobServicesContainer_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -216,7 +216,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-### <a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
+### StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -245,8 +245,8 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainerList"></a>StorageAccountsBlobServicesContainerList
----------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerList{#StorageAccountsBlobServicesContainerList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -256,8 +256,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [StorageAccountsBlobServicesContainer[]](#StorageAccountsBlobServicesContainer)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileService"></a>StorageAccountsFileService
------------------------------------------------------------------
+StorageAccountsFileService{#StorageAccountsFileService}
+-------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default
 
@@ -270,7 +270,7 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | spec                                                                                    |             | [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsFileService_STATUS](#StorageAccountsFileService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsFileService_Spec"></a>StorageAccountsFileService_Spec
+### StorageAccountsFileService_Spec {#StorageAccountsFileService_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -280,7 +280,7 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | protocolSettings           | Protocol settings for file service                                                                                                                                                                                                                                                          | [ProtocolSettings](#ProtocolSettings)<br/><small>Optional</small>                                                                                                    |
 | shareDeleteRetentionPolicy | The file service properties for share soft delete.                                                                                                                                                                                                                                          | [DeleteRetentionPolicy](#DeleteRetentionPolicy)<br/><small>Optional</small>                                                                                          |
 
-### <a id="StorageAccountsFileService_STATUS"></a>StorageAccountsFileService_STATUS
+### StorageAccountsFileService_STATUS{#StorageAccountsFileService_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -293,8 +293,8 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | sku                        | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServiceList"></a>StorageAccountsFileServiceList
--------------------------------------------------------------------------
+StorageAccountsFileServiceList{#StorageAccountsFileServiceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default
 
@@ -304,8 +304,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [StorageAccountsFileService[]](#StorageAccountsFileService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServicesShare"></a>StorageAccountsFileServicesShare
------------------------------------------------------------------------------
+StorageAccountsFileServicesShare{#StorageAccountsFileServicesShare}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}
 
@@ -318,7 +318,7 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | spec                                                                                    |             | [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsFileServicesShare_Spec"></a>StorageAccountsFileServicesShare_Spec
+### StorageAccountsFileServicesShare_Spec {#StorageAccountsFileServicesShare_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -332,7 +332,7 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | shareQuota        | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.                                                                                                                                           | int<br/><small>Optional</small>                                                                                                                                      |
 | signedIdentifiers | List of stored access policies specified on the share.                                                                                                                                                                                                                                                  | [SignedIdentifier[]](#SignedIdentifier)<br/><small>Optional</small>                                                                                                  |
 
-### <a id="StorageAccountsFileServicesShare_STATUS"></a>StorageAccountsFileServicesShare_STATUS
+### StorageAccountsFileServicesShare_STATUS{#StorageAccountsFileServicesShare_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -360,8 +360,8 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                | The version of the share.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServicesShareList"></a>StorageAccountsFileServicesShareList
--------------------------------------------------------------------------------------
+StorageAccountsFileServicesShareList{#StorageAccountsFileServicesShareList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}
 
@@ -371,8 +371,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [StorageAccountsFileServicesShare[]](#StorageAccountsFileServicesShare)<br/><small>Optional</small> |
 
-<a id="StorageAccountsManagementPolicy"></a>StorageAccountsManagementPolicy
----------------------------------------------------------------------------
+StorageAccountsManagementPolicy{#StorageAccountsManagementPolicy}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -385,7 +385,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | spec                                                                                    |             | [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
+### StorageAccountsManagementPolicy_Spec {#StorageAccountsManagementPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -393,7 +393,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-### <a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
+### StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -404,8 +404,8 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicyList"></a>StorageAccountsManagementPolicyList
------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyList{#StorageAccountsManagementPolicyList}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -415,8 +415,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                   |
 | items                                                                               |             | [StorageAccountsManagementPolicy[]](#StorageAccountsManagementPolicy)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueService"></a>StorageAccountsQueueService
--------------------------------------------------------------------
+StorageAccountsQueueService{#StorageAccountsQueueService}
+---------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -429,7 +429,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | spec                                                                                    |             | [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueService_STATUS](#StorageAccountsQueueService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
+### StorageAccountsQueueService_Spec {#StorageAccountsQueueService_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -437,7 +437,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
+### StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -447,8 +447,8 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServiceList"></a>StorageAccountsQueueServiceList
----------------------------------------------------------------------------
+StorageAccountsQueueServiceList{#StorageAccountsQueueServiceList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -458,8 +458,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [StorageAccountsQueueService[]](#StorageAccountsQueueService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueue"></a>StorageAccountsQueueServicesQueue
--------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue{#StorageAccountsQueueServicesQueue}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -472,7 +472,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | spec                                                                                    |             | [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueServicesQueue_STATUS](#StorageAccountsQueueServicesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
+### StorageAccountsQueueServicesQueue_Spec {#StorageAccountsQueueServicesQueue_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -481,7 +481,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
+### StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -492,8 +492,8 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueueList"></a>StorageAccountsQueueServicesQueueList
----------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueList{#StorageAccountsQueueServicesQueueList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -503,8 +503,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [StorageAccountsQueueServicesQueue[]](#StorageAccountsQueueServicesQueue)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableService"></a>StorageAccountsTableService
--------------------------------------------------------------------
+StorageAccountsTableService{#StorageAccountsTableService}
+---------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default
 
@@ -517,7 +517,7 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | spec                                                                                    |             | [StorageAccountsTableService_Spec](#StorageAccountsTableService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsTableService_STATUS](#StorageAccountsTableService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsTableService_Spec"></a>StorageAccountsTableService_Spec
+### StorageAccountsTableService_Spec {#StorageAccountsTableService_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -525,7 +525,7 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsTableServiceOperatorSpec](#StorageAccountsTableServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsTableService_STATUS"></a>StorageAccountsTableService_STATUS
+### StorageAccountsTableService_STATUS{#StorageAccountsTableService_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -535,8 +535,8 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServiceList"></a>StorageAccountsTableServiceList
----------------------------------------------------------------------------
+StorageAccountsTableServiceList{#StorageAccountsTableServiceList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default
 
@@ -546,8 +546,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [StorageAccountsTableService[]](#StorageAccountsTableService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServicesTable"></a>StorageAccountsTableServicesTable
--------------------------------------------------------------------------------
+StorageAccountsTableServicesTable{#StorageAccountsTableServicesTable}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}
 
@@ -560,7 +560,7 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | spec                                                                                    |             | [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesTable_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsTableServicesTable_STATUS](#StorageAccountsTableServicesTable_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsTableServicesTable_Spec"></a>StorageAccountsTableServicesTable_Spec
+### StorageAccountsTableServicesTable_Spec {#StorageAccountsTableServicesTable_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -569,7 +569,7 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsTableService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | signedIdentifiers | List of stored access policies specified on the table.                                                                                                                                                                                                                                                   | [TableSignedIdentifier[]](#TableSignedIdentifier)<br/><small>Optional</small>                                                                                        |
 
-### <a id="StorageAccountsTableServicesTable_STATUS"></a>StorageAccountsTableServicesTable_STATUS
+### StorageAccountsTableServicesTable_STATUS{#StorageAccountsTableServicesTable_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -580,8 +580,8 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | tableName         | Table name under the specified account                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServicesTableList"></a>StorageAccountsTableServicesTableList
----------------------------------------------------------------------------------------
+StorageAccountsTableServicesTableList{#StorageAccountsTableServicesTableList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2022-09-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}
 
@@ -591,8 +591,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [StorageAccountsTableServicesTable[]](#StorageAccountsTableServicesTable)<br/><small>Optional</small> |
 
-<a id="StorageAccount_Spec"></a>StorageAccount_Spec
----------------------------------------------------
+StorageAccount_Spec{#StorageAccount_Spec}
+-----------------------------------------
 
 Used by: [StorageAccount](#StorageAccount).
 
@@ -631,8 +631,8 @@ Used by: [StorageAccount](#StorageAccount).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
--------------------------------------------------------
+StorageAccount_STATUS{#StorageAccount_STATUS}
+---------------------------------------------
 
 The storage account.
 
@@ -689,8 +689,8 @@ Used by: [StorageAccount](#StorageAccount).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
----------------------------------------------------------------------------
+StorageAccountsBlobService_Spec{#StorageAccountsBlobService_Spec}
+-----------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -708,8 +708,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-<a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
--------------------------------------------------------------------------------
+StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
+---------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -730,8 +730,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_Spec{#StorageAccountsBlobServicesContainer_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -748,8 +748,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-<a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
----------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -780,8 +780,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileService_Spec"></a>StorageAccountsFileService_Spec
----------------------------------------------------------------------------
+StorageAccountsFileService_Spec{#StorageAccountsFileService_Spec}
+-----------------------------------------------------------------
 
 Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 
@@ -793,8 +793,8 @@ Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 | protocolSettings           | Protocol settings for file service                                                                                                                                                                                                                                                          | [ProtocolSettings](#ProtocolSettings)<br/><small>Optional</small>                                                                                                    |
 | shareDeleteRetentionPolicy | The file service properties for share soft delete.                                                                                                                                                                                                                                          | [DeleteRetentionPolicy](#DeleteRetentionPolicy)<br/><small>Optional</small>                                                                                          |
 
-<a id="StorageAccountsFileService_STATUS"></a>StorageAccountsFileService_STATUS
--------------------------------------------------------------------------------
+StorageAccountsFileService_STATUS{#StorageAccountsFileService_STATUS}
+---------------------------------------------------------------------
 
 Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 
@@ -809,8 +809,8 @@ Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 | sku                        | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServicesShare_Spec"></a>StorageAccountsFileServicesShare_Spec
----------------------------------------------------------------------------------------
+StorageAccountsFileServicesShare_Spec{#StorageAccountsFileServicesShare_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 
@@ -826,8 +826,8 @@ Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 | shareQuota        | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.                                                                                                                                           | int<br/><small>Optional</small>                                                                                                                                      |
 | signedIdentifiers | List of stored access policies specified on the share.                                                                                                                                                                                                                                                  | [SignedIdentifier[]](#SignedIdentifier)<br/><small>Optional</small>                                                                                                  |
 
-<a id="StorageAccountsFileServicesShare_STATUS"></a>StorageAccountsFileServicesShare_STATUS
--------------------------------------------------------------------------------------------
+StorageAccountsFileServicesShare_STATUS{#StorageAccountsFileServicesShare_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 
@@ -857,8 +857,8 @@ Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                | The version of the share.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
--------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_Spec{#StorageAccountsManagementPolicy_Spec}
+---------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -868,8 +868,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-<a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -882,8 +882,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
------------------------------------------------------------------------------
+StorageAccountsQueueService_Spec{#StorageAccountsQueueService_Spec}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -893,8 +893,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
----------------------------------------------------------------------------------
+StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -906,8 +906,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_Spec{#StorageAccountsQueueServicesQueue_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -918,8 +918,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -932,8 +932,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableService_Spec"></a>StorageAccountsTableService_Spec
------------------------------------------------------------------------------
+StorageAccountsTableService_Spec{#StorageAccountsTableService_Spec}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 
@@ -943,8 +943,8 @@ Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsTableServiceOperatorSpec](#StorageAccountsTableServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsTableService_STATUS"></a>StorageAccountsTableService_STATUS
----------------------------------------------------------------------------------
+StorageAccountsTableService_STATUS{#StorageAccountsTableService_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 
@@ -956,8 +956,8 @@ Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServicesTable_Spec"></a>StorageAccountsTableServicesTable_Spec
------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTable_Spec{#StorageAccountsTableServicesTable_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable).
 
@@ -968,8 +968,8 @@ Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsTableService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | signedIdentifiers | List of stored access policies specified on the table.                                                                                                                                                                                                                                                   | [TableSignedIdentifier[]](#TableSignedIdentifier)<br/><small>Optional</small>                                                                                        |
 
-<a id="StorageAccountsTableServicesTable_STATUS"></a>StorageAccountsTableServicesTable_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTable_STATUS{#StorageAccountsTableServicesTable_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable).
 
@@ -982,8 +982,8 @@ Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable)
 | tableName         | Table name under the specified account                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AzureFilesIdentityBasedAuthentication"></a>AzureFilesIdentityBasedAuthentication
----------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication{#AzureFilesIdentityBasedAuthentication}
+-----------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -995,8 +995,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used. Note that this enum may be extended in the future.       | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions)<br/><small>Required</small> |
 
-<a id="AzureFilesIdentityBasedAuthentication_STATUS"></a>AzureFilesIdentityBasedAuthentication_STATUS
------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_STATUS{#AzureFilesIdentityBasedAuthentication_STATUS}
+-------------------------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -1008,8 +1008,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used. Note that this enum may be extended in the future.       | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="BlobRestoreStatus_STATUS"></a>BlobRestoreStatus_STATUS
--------------------------------------------------------------
+BlobRestoreStatus_STATUS{#BlobRestoreStatus_STATUS}
+---------------------------------------------------
 
 Blob restore status.
 
@@ -1022,8 +1022,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | restoreId     | Id for tracking blob restore request.                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                              |
 | status        | The status of blob restore progress. Possible values are: - InProgress: Indicates that blob restore is ongoing. - Complete: Indicates that blob restore has been completed successfully. - Failed: Indicates that blob restore is failed. | [BlobRestoreStatus_Status_STATUS](#BlobRestoreStatus_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="ChangeFeed"></a>ChangeFeed
----------------------------------
+ChangeFeed{#ChangeFeed}
+-----------------------
 
 The blob service properties for change feed events.
 
@@ -1034,8 +1034,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ChangeFeed_STATUS"></a>ChangeFeed_STATUS
------------------------------------------------
+ChangeFeed_STATUS{#ChangeFeed_STATUS}
+-------------------------------------
 
 The blob service properties for change feed events.
 
@@ -1046,8 +1046,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ContainerProperties_LeaseDuration_STATUS"></a>ContainerProperties_LeaseDuration_STATUS
----------------------------------------------------------------------------------------------
+ContainerProperties_LeaseDuration_STATUS{#ContainerProperties_LeaseDuration_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1056,8 +1056,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Fixed"    |             |
 | "Infinite" |             |
 
-<a id="ContainerProperties_LeaseState_STATUS"></a>ContainerProperties_LeaseState_STATUS
----------------------------------------------------------------------------------------
+ContainerProperties_LeaseState_STATUS{#ContainerProperties_LeaseState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1069,8 +1069,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Expired"   |             |
 | "Leased"    |             |
 
-<a id="ContainerProperties_LeaseStatus_STATUS"></a>ContainerProperties_LeaseStatus_STATUS
------------------------------------------------------------------------------------------
+ContainerProperties_LeaseStatus_STATUS{#ContainerProperties_LeaseStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1079,8 +1079,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ContainerProperties_PublicAccess"></a>ContainerProperties_PublicAccess
------------------------------------------------------------------------------
+ContainerProperties_PublicAccess{#ContainerProperties_PublicAccess}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec).
 
@@ -1090,8 +1090,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | "Container" |             |
 | "None"      |             |
 
-<a id="ContainerProperties_PublicAccess_STATUS"></a>ContainerProperties_PublicAccess_STATUS
--------------------------------------------------------------------------------------------
+ContainerProperties_PublicAccess_STATUS{#ContainerProperties_PublicAccess_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1101,8 +1101,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Container" |             |
 | "None"      |             |
 
-<a id="CorsRules"></a>CorsRules
--------------------------------
+CorsRules{#CorsRules}
+---------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -1112,8 +1112,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), [S
 |-----------|--------------------------------------------------------------------------------------|-----------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule[]](#CorsRule)<br/><small>Optional</small> |
 
-<a id="CorsRules_STATUS"></a>CorsRules_STATUS
----------------------------------------------
+CorsRules_STATUS{#CorsRules_STATUS}
+-----------------------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -1123,8 +1123,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 |-----------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule_STATUS[]](#CorsRule_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomDomain"></a>CustomDomain
--------------------------------------
+CustomDomain{#CustomDomain}
+---------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -1135,8 +1135,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Required</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
----------------------------------------------------
+CustomDomain_STATUS{#CustomDomain_STATUS}
+-----------------------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -1147,8 +1147,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Optional</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="DeleteRetentionPolicy"></a>DeleteRetentionPolicy
--------------------------------------------------------
+DeleteRetentionPolicy{#DeleteRetentionPolicy}
+---------------------------------------------
 
 The service properties for soft delete.
 
@@ -1160,8 +1160,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), [S
 | days                 | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365.                                                                                                | int<br/><small>Optional</small>  |
 | enabled              | Indicates whether DeleteRetentionPolicy is enabled.                                                                                                                                                                                          | bool<br/><small>Optional</small> |
 
-<a id="DeleteRetentionPolicy_STATUS"></a>DeleteRetentionPolicy_STATUS
----------------------------------------------------------------------
+DeleteRetentionPolicy_STATUS{#DeleteRetentionPolicy_STATUS}
+-----------------------------------------------------------
 
 The service properties for soft delete.
 
@@ -1173,8 +1173,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | days                 | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365.                                                                                                | int<br/><small>Optional</small>  |
 | enabled              | Indicates whether DeleteRetentionPolicy is enabled.                                                                                                                                                                                          | bool<br/><small>Optional</small> |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 The encryption settings on the storage account.
 
@@ -1188,8 +1188,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                          |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices](#EncryptionServices)<br/><small>Optional</small>     |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 The encryption settings on the storage account.
 
@@ -1203,8 +1203,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                                        |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices_STATUS](#EncryptionServices_STATUS)<br/><small>Optional</small>     |
 
-<a id="Endpoints_STATUS"></a>Endpoints_STATUS
----------------------------------------------
+Endpoints_STATUS{#Endpoints_STATUS}
+-----------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object.
 
@@ -1221,8 +1221,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), and [StorageAccount_ST
 | table              | Gets the table endpoint.                      | string<br/><small>Optional</small>                                                                              |
 | web                | Gets the web endpoint.                        | string<br/><small>Optional</small>                                                                              |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -1233,8 +1233,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -1245,8 +1245,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="FileShareProperties_AccessTier"></a>FileShareProperties_AccessTier
--------------------------------------------------------------------------
+FileShareProperties_AccessTier{#FileShareProperties_AccessTier}
+---------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1257,8 +1257,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "Premium"              |             |
 | "TransactionOptimized" |             |
 
-<a id="FileShareProperties_AccessTier_STATUS"></a>FileShareProperties_AccessTier_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_AccessTier_STATUS{#FileShareProperties_AccessTier_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1269,8 +1269,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Premium"              |             |
 | "TransactionOptimized" |             |
 
-<a id="FileShareProperties_EnabledProtocols"></a>FileShareProperties_EnabledProtocols
--------------------------------------------------------------------------------------
+FileShareProperties_EnabledProtocols{#FileShareProperties_EnabledProtocols}
+---------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1279,8 +1279,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "NFS" |             |
 | "SMB" |             |
 
-<a id="FileShareProperties_EnabledProtocols_STATUS"></a>FileShareProperties_EnabledProtocols_STATUS
----------------------------------------------------------------------------------------------------
+FileShareProperties_EnabledProtocols_STATUS{#FileShareProperties_EnabledProtocols_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1289,8 +1289,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "NFS" |             |
 | "SMB" |             |
 
-<a id="FileShareProperties_LeaseDuration_STATUS"></a>FileShareProperties_LeaseDuration_STATUS
----------------------------------------------------------------------------------------------
+FileShareProperties_LeaseDuration_STATUS{#FileShareProperties_LeaseDuration_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1299,8 +1299,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Fixed"    |             |
 | "Infinite" |             |
 
-<a id="FileShareProperties_LeaseState_STATUS"></a>FileShareProperties_LeaseState_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_LeaseState_STATUS{#FileShareProperties_LeaseState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1312,8 +1312,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Expired"   |             |
 | "Leased"    |             |
 
-<a id="FileShareProperties_LeaseStatus_STATUS"></a>FileShareProperties_LeaseStatus_STATUS
------------------------------------------------------------------------------------------
+FileShareProperties_LeaseStatus_STATUS{#FileShareProperties_LeaseStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1322,8 +1322,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="FileShareProperties_RootSquash"></a>FileShareProperties_RootSquash
--------------------------------------------------------------------------
+FileShareProperties_RootSquash{#FileShareProperties_RootSquash}
+---------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1333,8 +1333,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "NoRootSquash" |             |
 | "RootSquash"   |             |
 
-<a id="FileShareProperties_RootSquash_STATUS"></a>FileShareProperties_RootSquash_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_RootSquash_STATUS{#FileShareProperties_RootSquash_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1344,8 +1344,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "NoRootSquash" |             |
 | "RootSquash"   |             |
 
-<a id="GeoReplicationStats_STATUS"></a>GeoReplicationStats_STATUS
------------------------------------------------------------------
+GeoReplicationStats_STATUS{#GeoReplicationStats_STATUS}
+-------------------------------------------------------
 
 Statistics related to replication for storage account's Blob, Table, Queue and File services. It is only available when geo-redundant replication is enabled for the storage account.
 
@@ -1357,8 +1357,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | lastSyncTime | All primary writes preceding this UTC date/time value are guaranteed to be available for read operations. Primary writes following this point in time may or may not be available for reads. Element may be default value if value of LastSyncTime is not available, this can happen if secondary is offline or we are in bootstrap.                                                            | string<br/><small>Optional</small>                                                                  |
 | status       | The status of the secondary location. Possible values are: - Live: Indicates that the secondary location is active and operational. - Bootstrap: Indicates initial synchronization from the primary location to the secondary location is in progress.This typically occurs when replication is first enabled. - Unavailable: Indicates that the secondary location is temporarily unavailable. | [GeoReplicationStats_Status_STATUS](#GeoReplicationStats_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -1369,8 +1369,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type](#Identity_Type)<br/><small>Required</small>                               |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -1383,8 +1383,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilityPolicyProperties_STATUS"></a>ImmutabilityPolicyProperties_STATUS
------------------------------------------------------------------------------------
+ImmutabilityPolicyProperties_STATUS{#ImmutabilityPolicyProperties_STATUS}
+-------------------------------------------------------------------------
 
 The properties of an ImmutabilityPolicy of a blob container.
 
@@ -1399,8 +1399,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | state                                 | The ImmutabilityPolicy state of a blob container, possible values include: Locked and Unlocked.                                                                                                                                                                                                                                                                                                                                                                                | [ImmutabilityPolicyProperty_State_STATUS](#ImmutabilityPolicyProperty_State_STATUS)<br/><small>Optional</small> |
 | updateHistory                         | The ImmutabilityPolicy update history of the blob container.                                                                                                                                                                                                                                                                                                                                                                                                                   | [UpdateHistoryProperty_STATUS[]](#UpdateHistoryProperty_STATUS)<br/><small>Optional</small>                     |
 
-<a id="ImmutableStorageAccount"></a>ImmutableStorageAccount
------------------------------------------------------------
+ImmutableStorageAccount{#ImmutableStorageAccount}
+-------------------------------------------------
 
 This property enables and defines account-level immutability. Enabling the feature auto-enables Blob Versioning.
 
@@ -1411,8 +1411,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | enabled            | A boolean flag which enables account-level immutability. All the containers under such an account have object-level immutability enabled by default.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                        |
 | immutabilityPolicy | Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy. | [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyProperties)<br/><small>Optional</small> |
 
-<a id="ImmutableStorageAccount_STATUS"></a>ImmutableStorageAccount_STATUS
--------------------------------------------------------------------------
+ImmutableStorageAccount_STATUS{#ImmutableStorageAccount_STATUS}
+---------------------------------------------------------------
 
 This property enables and defines account-level immutability. Enabling the feature auto-enables Blob Versioning.
 
@@ -1423,8 +1423,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | enabled            | A boolean flag which enables account-level immutability. All the containers under such an account have object-level immutability enabled by default.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                      |
 | immutabilityPolicy | Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy. | [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicyProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutableStorageWithVersioning"></a>ImmutableStorageWithVersioning
--------------------------------------------------------------------------
+ImmutableStorageWithVersioning{#ImmutableStorageWithVersioning}
+---------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -1434,8 +1434,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 |----------|--------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | This is an immutable property, when set to true it enables object level immutability at the container level. | bool<br/><small>Optional</small> |
 
-<a id="ImmutableStorageWithVersioning_STATUS"></a>ImmutableStorageWithVersioning_STATUS
----------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_STATUS{#ImmutableStorageWithVersioning_STATUS}
+-----------------------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -1447,8 +1447,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | migrationState | This property denotes the container level immutability to object level immutability migration state.         | [ImmutableStorageWithVersioning_MigrationState_STATUS](#ImmutableStorageWithVersioning_MigrationState_STATUS)<br/><small>Optional</small> |
 | timeStamp      | Returns the date and time the object level immutability was enabled.                                         | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="KeyCreationTime_STATUS"></a>KeyCreationTime_STATUS
----------------------------------------------------------
+KeyCreationTime_STATUS{#KeyCreationTime_STATUS}
+-----------------------------------------------
 
 Storage account keys creation time.
 
@@ -1459,8 +1459,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | key1     |             | string<br/><small>Optional</small> |
 | key2     |             | string<br/><small>Optional</small> |
 
-<a id="KeyPolicy"></a>KeyPolicy
--------------------------------
+KeyPolicy{#KeyPolicy}
+---------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -1470,8 +1470,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Required</small> |
 
-<a id="KeyPolicy_STATUS"></a>KeyPolicy_STATUS
----------------------------------------------
+KeyPolicy_STATUS{#KeyPolicy_STATUS}
+-----------------------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -1481,8 +1481,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy"></a>LastAccessTimeTrackingPolicy
----------------------------------------------------------------------
+LastAccessTimeTrackingPolicy{#LastAccessTimeTrackingPolicy}
+-----------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1495,8 +1495,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name](#LastAccessTimeTrackingPolicy_Name)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                     |
 
-<a id="LastAccessTimeTrackingPolicy_STATUS"></a>LastAccessTimeTrackingPolicy_STATUS
------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_STATUS{#LastAccessTimeTrackingPolicy_STATUS}
+-------------------------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1509,8 +1509,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name_STATUS](#LastAccessTimeTrackingPolicy_Name_STATUS)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                                   |
 
-<a id="LegalHoldProperties_STATUS"></a>LegalHoldProperties_STATUS
------------------------------------------------------------------
+LegalHoldProperties_STATUS{#LegalHoldProperties_STATUS}
+-------------------------------------------------------
 
 The LegalHold property of a blob container.
 
@@ -1522,8 +1522,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | protectedAppendWritesHistory | Protected append blob writes history.                                                                                                                                                                                                                                                              | [ProtectedAppendWritesHistory_STATUS](#ProtectedAppendWritesHistory_STATUS)<br/><small>Optional</small> |
 | tags                         | The list of LegalHold tags of a blob container.                                                                                                                                                                                                                                                    | [TagProperty_STATUS[]](#TagProperty_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="ManagementPolicySchema"></a>ManagementPolicySchema
----------------------------------------------------------
+ManagementPolicySchema{#ManagementPolicySchema}
+-----------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1533,8 +1533,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule[]](#ManagementPolicyRule)<br/><small>Required</small> |
 
-<a id="ManagementPolicySchema_STATUS"></a>ManagementPolicySchema_STATUS
------------------------------------------------------------------------
+ManagementPolicySchema_STATUS{#ManagementPolicySchema_STATUS}
+-------------------------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1544,8 +1544,8 @@ Used by: [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPoli
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule_STATUS[]](#ManagementPolicyRule_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 Network rule set
 
@@ -1559,8 +1559,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule[]](#ResourceAccessRule)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                   |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 Network rule set
 
@@ -1574,8 +1574,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule_STATUS[]](#ResourceAccessRule_STATUS)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -1585,8 +1585,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="ProtocolSettings"></a>ProtocolSettings
----------------------------------------------
+ProtocolSettings{#ProtocolSettings}
+-----------------------------------
 
 Protocol settings for file service
 
@@ -1596,8 +1596,8 @@ Used by: [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec).
 |----------|--------------------------|-------------------------------------------------------|
 | smb      | Setting for SMB protocol | [SmbSetting](#SmbSetting)<br/><small>Optional</small> |
 
-<a id="ProtocolSettings_STATUS"></a>ProtocolSettings_STATUS
------------------------------------------------------------
+ProtocolSettings_STATUS{#ProtocolSettings_STATUS}
+-------------------------------------------------
 
 Protocol settings for file service
 
@@ -1607,8 +1607,8 @@ Used by: [StorageAccountsFileService_STATUS](#StorageAccountsFileService_STATUS)
 |----------|--------------------------|---------------------------------------------------------------------|
 | smb      | Setting for SMB protocol | [SmbSetting_STATUS](#SmbSetting_STATUS)<br/><small>Optional</small> |
 
-<a id="RestorePolicyProperties"></a>RestorePolicyProperties
------------------------------------------------------------
+RestorePolicyProperties{#RestorePolicyProperties}
+-------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1619,8 +1619,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | days     | how long this blob can be restored. It should be great than zero and less than DeleteRetentionPolicy.days. | int<br/><small>Optional</small>  |
 | enabled  | Blob restore is enabled if set to true.                                                                    | bool<br/><small>Required</small> |
 
-<a id="RestorePolicyProperties_STATUS"></a>RestorePolicyProperties_STATUS
--------------------------------------------------------------------------
+RestorePolicyProperties_STATUS{#RestorePolicyProperties_STATUS}
+---------------------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1633,8 +1633,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | lastEnabledTime | Deprecated in favor of minRestoreTime property.                                                            | string<br/><small>Optional</small> |
 | minRestoreTime  | Returns the minimum date and time that the restore can be started.                                         | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference"></a>RoutingPreference
------------------------------------------------
+RoutingPreference{#RoutingPreference}
+-------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1646,8 +1646,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice](#RoutingPreference_RoutingChoice)<br/><small>Optional</small> |
 
-<a id="RoutingPreference_STATUS"></a>RoutingPreference_STATUS
--------------------------------------------------------------
+RoutingPreference_STATUS{#RoutingPreference_STATUS}
+---------------------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1659,8 +1659,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                              |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice_STATUS](#RoutingPreference_RoutingChoice_STATUS)<br/><small>Optional</small> |
 
-<a id="SasPolicy"></a>SasPolicy
--------------------------------
+SasPolicy{#SasPolicy}
+---------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1671,8 +1671,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction](#SasPolicy_ExpirationAction)<br/><small>Required</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Required</small>                                                    |
 
-<a id="SasPolicy_STATUS"></a>SasPolicy_STATUS
----------------------------------------------
+SasPolicy_STATUS{#SasPolicy_STATUS}
+-----------------------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1683,8 +1683,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction_STATUS](#SasPolicy_ExpirationAction_STATUS)<br/><small>Optional</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Optional</small>                                                                  |
 
-<a id="SignedIdentifier"></a>SignedIdentifier
----------------------------------------------
+SignedIdentifier{#SignedIdentifier}
+-----------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1693,8 +1693,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | accessPolicy | Access policy                                     | [AccessPolicy](#AccessPolicy)<br/><small>Optional</small>                                                                                                  |
 | reference    | An unique identifier of the stored access policy. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SignedIdentifier_STATUS"></a>SignedIdentifier_STATUS
------------------------------------------------------------
+SignedIdentifier_STATUS{#SignedIdentifier_STATUS}
+-------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1703,8 +1703,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | accessPolicy | Access policy                                     | [AccessPolicy_STATUS](#AccessPolicy_STATUS)<br/><small>Optional</small> |
 | id           | An unique identifier of the stored access policy. | string<br/><small>Optional</small>                                      |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The SKU of the storage account.
 
@@ -1715,8 +1715,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName](#SkuName)<br/><small>Required</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier](#Tier)<br/><small>Optional</small>       |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The SKU of the storage account.
 
@@ -1727,8 +1727,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), [StorageAccountsBlobSe
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName_STATUS](#SkuName_STATUS)<br/><small>Optional</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier_STATUS](#Tier_STATUS)<br/><small>Optional</small>       |
 
-<a id="StorageAccount_Kind_Spec"></a>StorageAccount_Kind_Spec
--------------------------------------------------------------
+StorageAccount_Kind_Spec{#StorageAccount_Kind_Spec}
+---------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1740,8 +1740,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccount_Kind_STATUS"></a>StorageAccount_Kind_STATUS
------------------------------------------------------------------
+StorageAccount_Kind_STATUS{#StorageAccount_Kind_STATUS}
+-------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1753,8 +1753,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccountOperatorSpec"></a>StorageAccountOperatorSpec
------------------------------------------------------------------
+StorageAccountOperatorSpec{#StorageAccountOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1767,8 +1767,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [StorageAccountOperatorSecrets](#StorageAccountOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="StorageAccountProperties_AccessTier_STATUS"></a>StorageAccountProperties_AccessTier_STATUS
--------------------------------------------------------------------------------------------------
+StorageAccountProperties_AccessTier_STATUS{#StorageAccountProperties_AccessTier_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1778,8 +1778,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Hot"     |             |
 | "Premium" |             |
 
-<a id="StorageAccountProperties_AllowedCopyScope_STATUS"></a>StorageAccountProperties_AllowedCopyScope_STATUS
--------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_AllowedCopyScope_STATUS{#StorageAccountProperties_AllowedCopyScope_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1788,8 +1788,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "AAD"         |             |
 | "PrivateLink" |             |
 
-<a id="StorageAccountProperties_DnsEndpointType_STATUS"></a>StorageAccountProperties_DnsEndpointType_STATUS
------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_DnsEndpointType_STATUS{#StorageAccountProperties_DnsEndpointType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1798,8 +1798,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "AzureDnsZone" |             |
 | "Standard"     |             |
 
-<a id="StorageAccountProperties_LargeFileSharesState_STATUS"></a>StorageAccountProperties_LargeFileSharesState_STATUS
----------------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_LargeFileSharesState_STATUS{#StorageAccountProperties_LargeFileSharesState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1808,8 +1808,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountProperties_MinimumTlsVersion_STATUS"></a>StorageAccountProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_MinimumTlsVersion_STATUS{#StorageAccountProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1819,8 +1819,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountProperties_ProvisioningState_STATUS"></a>StorageAccountProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_ProvisioningState_STATUS{#StorageAccountProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1830,8 +1830,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "ResolvingDNS" |             |
 | "Succeeded"    |             |
 
-<a id="StorageAccountProperties_PublicNetworkAccess_STATUS"></a>StorageAccountProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_PublicNetworkAccess_STATUS{#StorageAccountProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1840,8 +1840,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountProperties_StatusOfPrimary_STATUS"></a>StorageAccountProperties_StatusOfPrimary_STATUS
------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfPrimary_STATUS{#StorageAccountProperties_StatusOfPrimary_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1850,8 +1850,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountProperties_StatusOfSecondary_STATUS"></a>StorageAccountProperties_StatusOfSecondary_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfSecondary_STATUS{#StorageAccountProperties_StatusOfSecondary_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1860,8 +1860,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_AccessTier"></a>StorageAccountPropertiesCreateParameters_AccessTier
--------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_AccessTier{#StorageAccountPropertiesCreateParameters_AccessTier}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1871,8 +1871,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Hot"     |             |
 | "Premium" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_AllowedCopyScope"></a>StorageAccountPropertiesCreateParameters_AllowedCopyScope
--------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_AllowedCopyScope{#StorageAccountPropertiesCreateParameters_AllowedCopyScope}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1881,8 +1881,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "AAD"         |             |
 | "PrivateLink" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_DnsEndpointType"></a>StorageAccountPropertiesCreateParameters_DnsEndpointType
------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_DnsEndpointType{#StorageAccountPropertiesCreateParameters_DnsEndpointType}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1891,8 +1891,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "AzureDnsZone" |             |
 | "Standard"     |             |
 
-<a id="StorageAccountPropertiesCreateParameters_LargeFileSharesState"></a>StorageAccountPropertiesCreateParameters_LargeFileSharesState
----------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_LargeFileSharesState{#StorageAccountPropertiesCreateParameters_LargeFileSharesState}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1901,8 +1901,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountPropertiesCreateParameters_MinimumTlsVersion"></a>StorageAccountPropertiesCreateParameters_MinimumTlsVersion
----------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_MinimumTlsVersion{#StorageAccountPropertiesCreateParameters_MinimumTlsVersion}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1912,8 +1912,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_PublicNetworkAccess"></a>StorageAccountPropertiesCreateParameters_PublicNetworkAccess
--------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_PublicNetworkAccess{#StorageAccountPropertiesCreateParameters_PublicNetworkAccess}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1922,8 +1922,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountsBlobServiceOperatorSpec"></a>StorageAccountsBlobServiceOperatorSpec
------------------------------------------------------------------------------------------
+StorageAccountsBlobServiceOperatorSpec{#StorageAccountsBlobServiceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1934,8 +1934,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainerOperatorSpec"></a>StorageAccountsBlobServicesContainerOperatorSpec
--------------------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerOperatorSpec{#StorageAccountsBlobServicesContainerOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1946,8 +1946,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServiceOperatorSpec"></a>StorageAccountsFileServiceOperatorSpec
------------------------------------------------------------------------------------------
+StorageAccountsFileServiceOperatorSpec{#StorageAccountsFileServiceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1958,8 +1958,8 @@ Used by: [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServicesShareOperatorSpec"></a>StorageAccountsFileServicesShareOperatorSpec
------------------------------------------------------------------------------------------------------
+StorageAccountsFileServicesShareOperatorSpec{#StorageAccountsFileServicesShareOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1970,8 +1970,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountSkuConversionStatus_STATUS"></a>StorageAccountSkuConversionStatus_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountSkuConversionStatus_STATUS{#StorageAccountSkuConversionStatus_STATUS}
+-----------------------------------------------------------------------------------
 
 This defines the sku conversion status object for asynchronous sku conversions.
 
@@ -1984,8 +1984,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | startTime           | This property represents the sku conversion start time.                                                  | string<br/><small>Optional</small>                                                                                                                        |
 | targetSkuName       | This property represents the target sku name to which the account sku is being converted asynchronously. | [SkuName_STATUS](#SkuName_STATUS)<br/><small>Optional</small>                                                                                             |
 
-<a id="StorageAccountsManagementPolicyOperatorSpec"></a>StorageAccountsManagementPolicyOperatorSpec
----------------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyOperatorSpec{#StorageAccountsManagementPolicyOperatorSpec}
+-----------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1996,8 +1996,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServiceOperatorSpec"></a>StorageAccountsQueueServiceOperatorSpec
--------------------------------------------------------------------------------------------
+StorageAccountsQueueServiceOperatorSpec{#StorageAccountsQueueServiceOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2008,8 +2008,8 @@ Used by: [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueueOperatorSpec"></a>StorageAccountsQueueServicesQueueOperatorSpec
--------------------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueOperatorSpec{#StorageAccountsQueueServicesQueueOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2020,8 +2020,8 @@ Used by: [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQ
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServiceOperatorSpec"></a>StorageAccountsTableServiceOperatorSpec
--------------------------------------------------------------------------------------------
+StorageAccountsTableServiceOperatorSpec{#StorageAccountsTableServiceOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2032,8 +2032,8 @@ Used by: [StorageAccountsTableService_Spec](#StorageAccountsTableService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServicesTableOperatorSpec"></a>StorageAccountsTableServicesTableOperatorSpec
--------------------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTableOperatorSpec{#StorageAccountsTableServicesTableOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2044,8 +2044,8 @@ Used by: [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesT
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TableSignedIdentifier"></a>TableSignedIdentifier
--------------------------------------------------------
+TableSignedIdentifier{#TableSignedIdentifier}
+---------------------------------------------
 
 Object to set Table Access Policy.
 
@@ -2056,8 +2056,8 @@ Used by: [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesT
 | accessPolicy | Access policy                                          | [TableAccessPolicy](#TableAccessPolicy)<br/><small>Optional</small>                                                                                        |
 | reference    | unique-64-character-value of the stored access policy. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="TableSignedIdentifier_STATUS"></a>TableSignedIdentifier_STATUS
----------------------------------------------------------------------
+TableSignedIdentifier_STATUS{#TableSignedIdentifier_STATUS}
+-----------------------------------------------------------
 
 Object to set Table Access Policy.
 
@@ -2068,8 +2068,8 @@ Used by: [StorageAccountsTableServicesTable_STATUS](#StorageAccountsTableService
 | accessPolicy | Access policy                                          | [TableAccessPolicy_STATUS](#TableAccessPolicy_STATUS)<br/><small>Optional</small> |
 | id           | unique-64-character-value of the stored access policy. | string<br/><small>Optional</small>                                                |
 
-<a id="AccessPolicy"></a>AccessPolicy
--------------------------------------
+AccessPolicy{#AccessPolicy}
+---------------------------
 
 Used by: [SignedIdentifier](#SignedIdentifier).
 
@@ -2079,8 +2079,8 @@ Used by: [SignedIdentifier](#SignedIdentifier).
 | permission | List of abbreviated permissions. | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy  | string<br/><small>Optional</small> |
 
-<a id="AccessPolicy_STATUS"></a>AccessPolicy_STATUS
----------------------------------------------------
+AccessPolicy_STATUS{#AccessPolicy_STATUS}
+-----------------------------------------
 
 Used by: [SignedIdentifier_STATUS](#SignedIdentifier_STATUS).
 
@@ -2090,8 +2090,8 @@ Used by: [SignedIdentifier_STATUS](#SignedIdentifier_STATUS).
 | permission | List of abbreviated permissions. | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy  | string<br/><small>Optional</small> |
 
-<a id="AccountImmutabilityPolicyProperties"></a>AccountImmutabilityPolicyProperties
------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties{#AccountImmutabilityPolicyProperties}
+-------------------------------------------------------------------------
 
 This defines account-level immutability policy properties.
 
@@ -2103,8 +2103,8 @@ Used by: [ImmutableStorageAccount](#ImmutableStorageAccount).
 | immutabilityPeriodSinceCreationInDays | The immutability period for the blobs in the container since the policy creation, in days.                                                                                                                                                                                                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                     |
 | state                                 | The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted. | [AccountImmutabilityPolicyProperties_State](#AccountImmutabilityPolicyProperties_State)<br/><small>Optional</small> |
 
-<a id="AccountImmutabilityPolicyProperties_STATUS"></a>AccountImmutabilityPolicyProperties_STATUS
--------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_STATUS{#AccountImmutabilityPolicyProperties_STATUS}
+---------------------------------------------------------------------------------------
 
 This defines account-level immutability policy properties.
 
@@ -2116,8 +2116,8 @@ Used by: [ImmutableStorageAccount_STATUS](#ImmutableStorageAccount_STATUS).
 | immutabilityPeriodSinceCreationInDays | The immutability period for the blobs in the container since the policy creation, in days.                                                                                                                                                                                                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                   |
 | state                                 | The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted. | [AccountImmutabilityPolicyProperties_State_STATUS](#AccountImmutabilityPolicyProperties_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ActiveDirectoryProperties"></a>ActiveDirectoryProperties
----------------------------------------------------------------
+ActiveDirectoryProperties{#ActiveDirectoryProperties}
+-----------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -2134,8 +2134,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Optional</small>                                                                          |
 | samAccountName    | Specifies the Active Directory SAMAccountName for Azure Storage.          | string<br/><small>Optional</small>                                                                          |
 
-<a id="ActiveDirectoryProperties_STATUS"></a>ActiveDirectoryProperties_STATUS
------------------------------------------------------------------------------
+ActiveDirectoryProperties_STATUS{#ActiveDirectoryProperties_STATUS}
+-------------------------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -2152,8 +2152,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Optional</small>                                                                                        |
 | samAccountName    | Specifies the Active Directory SAMAccountName for Azure Storage.          | string<br/><small>Optional</small>                                                                                        |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission
--------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -2164,8 +2164,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "StorageFileDataSmbShareElevatedContributor" |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -2176,8 +2176,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "StorageFileDataSmbShareElevatedContributor" |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions
----------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -2188,8 +2188,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "AD"      |             |
 | "None"    |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -2200,8 +2200,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "AD"      |             |
 | "None"    |             |
 
-<a id="BlobRestoreParameters_STATUS"></a>BlobRestoreParameters_STATUS
----------------------------------------------------------------------
+BlobRestoreParameters_STATUS{#BlobRestoreParameters_STATUS}
+-----------------------------------------------------------
 
 Blob restore parameters
 
@@ -2212,8 +2212,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | blobRanges    | Blob ranges to restore.             | [BlobRestoreRange_STATUS[]](#BlobRestoreRange_STATUS)<br/><small>Optional</small> |
 | timeToRestore | Restore blob to the specified time. | string<br/><small>Optional</small>                                                |
 
-<a id="BlobRestoreStatus_Status_STATUS"></a>BlobRestoreStatus_Status_STATUS
----------------------------------------------------------------------------
+BlobRestoreStatus_Status_STATUS{#BlobRestoreStatus_Status_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 
@@ -2223,8 +2223,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="CorsRule"></a>CorsRule
------------------------------
+CorsRule{#CorsRule}
+-------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -2238,8 +2238,8 @@ Used by: [CorsRules](#CorsRules).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Required</small>                                              |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Required</small>                                                   |
 
-<a id="CorsRule_STATUS"></a>CorsRule_STATUS
--------------------------------------------
+CorsRule_STATUS{#CorsRule_STATUS}
+---------------------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -2253,8 +2253,8 @@ Used by: [CorsRules_STATUS](#CorsRules_STATUS).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Optional</small>                                                            |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Optional</small>                                                                 |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -2263,8 +2263,8 @@ Used by: [Encryption](#Encryption).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -2273,8 +2273,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="EncryptionIdentity"></a>EncryptionIdentity
--------------------------------------------------
+EncryptionIdentity{#EncryptionIdentity}
+---------------------------------------
 
 Encryption identity for the storage account.
 
@@ -2285,8 +2285,8 @@ Used by: [Encryption](#Encryption).
 | federatedIdentityClientId     | ClientId of the multi-tenant application to be used in conjunction with the user-assigned identity for cross-tenant customer-managed-keys server-side encryption on the storage account. | string<br/><small>Optional</small>                                                                                                                         |
 | userAssignedIdentityReference | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.                                                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EncryptionIdentity_STATUS"></a>EncryptionIdentity_STATUS
----------------------------------------------------------------
+EncryptionIdentity_STATUS{#EncryptionIdentity_STATUS}
+-----------------------------------------------------
 
 Encryption identity for the storage account.
 
@@ -2297,8 +2297,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | federatedIdentityClientId | ClientId of the multi-tenant application to be used in conjunction with the user-assigned identity for cross-tenant customer-managed-keys server-side encryption on the storage account. | string<br/><small>Optional</small> |
 | userAssignedIdentity      | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.                                                                    | string<br/><small>Optional</small> |
 
-<a id="EncryptionServices"></a>EncryptionServices
--------------------------------------------------
+EncryptionServices{#EncryptionServices}
+---------------------------------------
 
 A list of services that support encryption.
 
@@ -2311,8 +2311,8 @@ Used by: [Encryption](#Encryption).
 | queue    | The encryption function of the queue storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 
-<a id="EncryptionServices_STATUS"></a>EncryptionServices_STATUS
----------------------------------------------------------------
+EncryptionServices_STATUS{#EncryptionServices_STATUS}
+-----------------------------------------------------
 
 A list of services that support encryption.
 
@@ -2325,8 +2325,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | queue    | The encryption function of the queue storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -2336,8 +2336,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -2347,8 +2347,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="GeoReplicationStats_Status_STATUS"></a>GeoReplicationStats_Status_STATUS
--------------------------------------------------------------------------------
+GeoReplicationStats_Status_STATUS{#GeoReplicationStats_Status_STATUS}
+---------------------------------------------------------------------
 
 Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 
@@ -2358,8 +2358,8 @@ Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 | "Live"        |             |
 | "Unavailable" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -2370,8 +2370,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -2382,8 +2382,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ImmutabilityPolicyProperty_State_STATUS"></a>ImmutabilityPolicyProperty_State_STATUS
--------------------------------------------------------------------------------------------
+ImmutabilityPolicyProperty_State_STATUS{#ImmutabilityPolicyProperty_State_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STATUS).
 
@@ -2392,8 +2392,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ImmutableStorageWithVersioning_MigrationState_STATUS"></a>ImmutableStorageWithVersioning_MigrationState_STATUS
----------------------------------------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_MigrationState_STATUS{#ImmutableStorageWithVersioning_MigrationState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning_STATUS).
 
@@ -2402,8 +2402,8 @@ Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning
 | "Completed"  |             |
 | "InProgress" |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -2414,8 +2414,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action](#IPRule_Action)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Required</small>                          |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -2426,8 +2426,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action_STATUS](#IPRule_Action_STATUS)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small>                                        |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties of key vault.
 
@@ -2439,8 +2439,8 @@ Used by: [Encryption](#Encryption).
 | keyvaulturi | The Uri of KeyVault.         | string<br/><small>Optional</small> |
 | keyversion  | The version of KeyVault key. | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties of key vault.
 
@@ -2455,8 +2455,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyversion                             | The version of KeyVault key.                                                                                                             | string<br/><small>Optional</small> |
 | lastKeyRotationTimestamp               | Timestamp of last rotation of the Key Vault Key.                                                                                         | string<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy_Name"></a>LastAccessTimeTrackingPolicy_Name
--------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name{#LastAccessTimeTrackingPolicy_Name}
+---------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 
@@ -2464,8 +2464,8 @@ Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="LastAccessTimeTrackingPolicy_Name_STATUS"></a>LastAccessTimeTrackingPolicy_Name_STATUS
----------------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name_STATUS{#LastAccessTimeTrackingPolicy_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STATUS).
 
@@ -2473,8 +2473,8 @@ Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STA
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="ManagementPolicyRule"></a>ManagementPolicyRule
------------------------------------------------------
+ManagementPolicyRule{#ManagementPolicyRule}
+-------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -2487,8 +2487,8 @@ Used by: [ManagementPolicySchema](#ManagementPolicySchema).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Required</small>                                                    |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type](#ManagementPolicyRule_Type)<br/><small>Required</small>   |
 
-<a id="ManagementPolicyRule_STATUS"></a>ManagementPolicyRule_STATUS
--------------------------------------------------------------------
+ManagementPolicyRule_STATUS{#ManagementPolicyRule_STATUS}
+---------------------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -2501,8 +2501,8 @@ Used by: [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Optional</small>                                                                  |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type_STATUS](#ManagementPolicyRule_Type_STATUS)<br/><small>Optional</small>   |
 
-<a id="NetworkRuleSet_Bypass_STATUS"></a>NetworkRuleSet_Bypass_STATUS
----------------------------------------------------------------------
+NetworkRuleSet_Bypass_STATUS{#NetworkRuleSet_Bypass_STATUS}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -2513,8 +2513,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Metrics"       |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -2523,8 +2523,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -2533,8 +2533,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ProtectedAppendWritesHistory_STATUS"></a>ProtectedAppendWritesHistory_STATUS
------------------------------------------------------------------------------------
+ProtectedAppendWritesHistory_STATUS{#ProtectedAppendWritesHistory_STATUS}
+-------------------------------------------------------------------------
 
 Protected append writes history setting for the blob container with Legal holds.
 
@@ -2545,8 +2545,8 @@ Used by: [LegalHoldProperties_STATUS](#LegalHoldProperties_STATUS).
 | allowProtectedAppendWritesAll | When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining legal hold protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. | bool<br/><small>Optional</small>   |
 | timestamp                     | Returns the date and time the tag was added.                                                                                                                                                                        | string<br/><small>Optional</small> |
 
-<a id="ResourceAccessRule"></a>ResourceAccessRule
--------------------------------------------------
+ResourceAccessRule{#ResourceAccessRule}
+---------------------------------------
 
 Resource Access Rule.
 
@@ -2557,8 +2557,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | resourceReference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | Tenant Id   | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ResourceAccessRule_STATUS"></a>ResourceAccessRule_STATUS
----------------------------------------------------------------
+ResourceAccessRule_STATUS{#ResourceAccessRule_STATUS}
+-----------------------------------------------------
 
 Resource Access Rule.
 
@@ -2569,8 +2569,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | resourceId | Resource Id | string<br/><small>Optional</small> |
 | tenantId   | Tenant Id   | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference_RoutingChoice"></a>RoutingPreference_RoutingChoice
----------------------------------------------------------------------------
+RoutingPreference_RoutingChoice{#RoutingPreference_RoutingChoice}
+-----------------------------------------------------------------
 
 Used by: [RoutingPreference](#RoutingPreference).
 
@@ -2579,8 +2579,8 @@ Used by: [RoutingPreference](#RoutingPreference).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="RoutingPreference_RoutingChoice_STATUS"></a>RoutingPreference_RoutingChoice_STATUS
------------------------------------------------------------------------------------------
+RoutingPreference_RoutingChoice_STATUS{#RoutingPreference_RoutingChoice_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 
@@ -2589,8 +2589,8 @@ Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="SasPolicy_ExpirationAction"></a>SasPolicy_ExpirationAction
------------------------------------------------------------------
+SasPolicy_ExpirationAction{#SasPolicy_ExpirationAction}
+-------------------------------------------------------
 
 Used by: [SasPolicy](#SasPolicy).
 
@@ -2598,8 +2598,8 @@ Used by: [SasPolicy](#SasPolicy).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SasPolicy_ExpirationAction_STATUS"></a>SasPolicy_ExpirationAction_STATUS
--------------------------------------------------------------------------------
+SasPolicy_ExpirationAction_STATUS{#SasPolicy_ExpirationAction_STATUS}
+---------------------------------------------------------------------
 
 Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 
@@ -2607,8 +2607,8 @@ Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SkuName"></a>SkuName
----------------------------
+SkuName{#SkuName}
+-----------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -2625,8 +2625,8 @@ Used by: [Sku](#Sku).
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="SkuName_STATUS"></a>SkuName_STATUS
------------------------------------------
+SkuName_STATUS{#SkuName_STATUS}
+-------------------------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -2643,8 +2643,8 @@ Used by: [Sku_STATUS](#Sku_STATUS), and [StorageAccountSkuConversionStatus_STATU
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="SmbSetting"></a>SmbSetting
----------------------------------
+SmbSetting{#SmbSetting}
+-----------------------
 
 Setting for SMB protocol
 
@@ -2658,8 +2658,8 @@ Used by: [ProtocolSettings](#ProtocolSettings).
 | multichannel             | Multichannel setting. Applies to Premium FileStorage only.                                                                                           | [Multichannel](#Multichannel)<br/><small>Optional</small> |
 | versions                 | SMB protocol versions supported by server. Valid values are SMB2.1, SMB3.0, SMB3.1.1. Should be passed as a string with delimiter ';'.               | string<br/><small>Optional</small>                        |
 
-<a id="SmbSetting_STATUS"></a>SmbSetting_STATUS
------------------------------------------------
+SmbSetting_STATUS{#SmbSetting_STATUS}
+-------------------------------------
 
 Setting for SMB protocol
 
@@ -2673,8 +2673,8 @@ Used by: [ProtocolSettings_STATUS](#ProtocolSettings_STATUS).
 | multichannel             | Multichannel setting. Applies to Premium FileStorage only.                                                                                           | [Multichannel_STATUS](#Multichannel_STATUS)<br/><small>Optional</small> |
 | versions                 | SMB protocol versions supported by server. Valid values are SMB2.1, SMB3.0, SMB3.1.1. Should be passed as a string with delimiter ';'.               | string<br/><small>Optional</small>                                      |
 
-<a id="StorageAccountInternetEndpoints_STATUS"></a>StorageAccountInternetEndpoints_STATUS
------------------------------------------------------------------------------------------
+StorageAccountInternetEndpoints_STATUS{#StorageAccountInternetEndpoints_STATUS}
+-------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, file, web or dfs object via a internet routing endpoint.
 
@@ -2687,8 +2687,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | file     | Gets the file endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.  | string<br/><small>Optional</small> |
 
-<a id="StorageAccountMicrosoftEndpoints_STATUS"></a>StorageAccountMicrosoftEndpoints_STATUS
--------------------------------------------------------------------------------------------
+StorageAccountMicrosoftEndpoints_STATUS{#StorageAccountMicrosoftEndpoints_STATUS}
+---------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object via a microsoft routing endpoint.
 
@@ -2703,8 +2703,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | table    | Gets the table endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.   | string<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorConfigMaps"></a>StorageAccountOperatorConfigMaps
------------------------------------------------------------------------------
+StorageAccountOperatorConfigMaps{#StorageAccountOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -2717,8 +2717,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint config map should be placed. If omitted, no config map will be created.   | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorSecrets"></a>StorageAccountOperatorSecrets
------------------------------------------------------------------------
+StorageAccountOperatorSecrets{#StorageAccountOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -2733,8 +2733,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure.   | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS"></a>StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS{#StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccountSkuConversionStatus_STATUS](#StorageAccountSkuConversionStatus_STATUS).
 
@@ -2744,8 +2744,8 @@ Used by: [StorageAccountSkuConversionStatus_STATUS](#StorageAccountSkuConversion
 | "InProgress" |             |
 | "Succeeded"  |             |
 
-<a id="TableAccessPolicy"></a>TableAccessPolicy
------------------------------------------------
+TableAccessPolicy{#TableAccessPolicy}
+-------------------------------------
 
 Table Access Policy Properties Object.
 
@@ -2757,8 +2757,8 @@ Used by: [TableSignedIdentifier](#TableSignedIdentifier).
 | permission | Required. List of abbreviated permissions. Supported permission values include 'r','a','u','d' | string<br/><small>Required</small> |
 | startTime  | Start time of the access policy                                                                | string<br/><small>Optional</small> |
 
-<a id="TableAccessPolicy_STATUS"></a>TableAccessPolicy_STATUS
--------------------------------------------------------------
+TableAccessPolicy_STATUS{#TableAccessPolicy_STATUS}
+---------------------------------------------------
 
 Table Access Policy Properties Object.
 
@@ -2770,8 +2770,8 @@ Used by: [TableSignedIdentifier_STATUS](#TableSignedIdentifier_STATUS).
 | permission | Required. List of abbreviated permissions. Supported permission values include 'r','a','u','d' | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy                                                                | string<br/><small>Optional</small> |
 
-<a id="TagProperty_STATUS"></a>TagProperty_STATUS
--------------------------------------------------
+TagProperty_STATUS{#TagProperty_STATUS}
+---------------------------------------
 
 A tag of the LegalHold of a blob container.
 
@@ -2785,8 +2785,8 @@ Used by: [LegalHoldProperties_STATUS](#LegalHoldProperties_STATUS).
 | timestamp        | Returns the date and time the tag was added.                                | string<br/><small>Optional</small> |
 | upn              | Returns the User Principal Name of the user who added the tag.              | string<br/><small>Optional</small> |
 
-<a id="Tier"></a>Tier
----------------------
+Tier{#Tier}
+-----------
 
 The SKU tier. This is based on the SKU name.
 
@@ -2797,8 +2797,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Tier_STATUS"></a>Tier_STATUS
------------------------------------
+Tier_STATUS{#Tier_STATUS}
+-------------------------
 
 The SKU tier. This is based on the SKU name.
 
@@ -2809,8 +2809,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="UpdateHistoryProperty_STATUS"></a>UpdateHistoryProperty_STATUS
----------------------------------------------------------------------
+UpdateHistoryProperty_STATUS{#UpdateHistoryProperty_STATUS}
+-----------------------------------------------------------
 
 An update history of the ImmutabilityPolicy of a blob container.
 
@@ -2827,8 +2827,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | update                                | The ImmutabilityPolicy update type of a blob container, possible values include: put, lock and extend.                                                                                                                                                                                                                                                                                                                                                                         | [UpdateHistoryProperty_Update_STATUS](#UpdateHistoryProperty_Update_STATUS)<br/><small>Optional</small> |
 | upn                                   | Returns the User Principal Name of the user who updated the ImmutabilityPolicy.                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                      |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 UserAssignedIdentity for the resource.
 
@@ -2839,8 +2839,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | The client ID of the identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2850,8 +2850,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network rule.
 
@@ -2863,8 +2863,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | reference | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 | state     | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State](#VirtualNetworkRule_State)<br/><small>Optional</small>                                                                          |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network rule.
 
@@ -2876,8 +2876,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | id       | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | string<br/><small>Optional</small>                                                                |
 | state    | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State_STATUS](#VirtualNetworkRule_State_STATUS)<br/><small>Optional</small>   |
 
-<a id="AccountImmutabilityPolicyProperties_State"></a>AccountImmutabilityPolicyProperties_State
------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_State{#AccountImmutabilityPolicyProperties_State}
+-------------------------------------------------------------------------------------
 
 Used by: [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyProperties).
 
@@ -2887,8 +2887,8 @@ Used by: [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyPropert
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="AccountImmutabilityPolicyProperties_State_STATUS"></a>AccountImmutabilityPolicyProperties_State_STATUS
--------------------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_State_STATUS{#AccountImmutabilityPolicyProperties_State_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicyProperties_STATUS).
 
@@ -2898,8 +2898,8 @@ Used by: [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicy
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ActiveDirectoryProperties_AccountType"></a>ActiveDirectoryProperties_AccountType
----------------------------------------------------------------------------------------
+ActiveDirectoryProperties_AccountType{#ActiveDirectoryProperties_AccountType}
+-----------------------------------------------------------------------------
 
 Used by: [ActiveDirectoryProperties](#ActiveDirectoryProperties).
 
@@ -2908,8 +2908,8 @@ Used by: [ActiveDirectoryProperties](#ActiveDirectoryProperties).
 | "Computer" |             |
 | "User"     |             |
 
-<a id="ActiveDirectoryProperties_AccountType_STATUS"></a>ActiveDirectoryProperties_AccountType_STATUS
------------------------------------------------------------------------------------------------------
+ActiveDirectoryProperties_AccountType_STATUS{#ActiveDirectoryProperties_AccountType_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ActiveDirectoryProperties_STATUS](#ActiveDirectoryProperties_STATUS).
 
@@ -2918,8 +2918,8 @@ Used by: [ActiveDirectoryProperties_STATUS](#ActiveDirectoryProperties_STATUS).
 | "Computer" |             |
 | "User"     |             |
 
-<a id="BlobRestoreRange_STATUS"></a>BlobRestoreRange_STATUS
------------------------------------------------------------
+BlobRestoreRange_STATUS{#BlobRestoreRange_STATUS}
+-------------------------------------------------
 
 Blob range
 
@@ -2930,8 +2930,8 @@ Used by: [BlobRestoreParameters_STATUS](#BlobRestoreParameters_STATUS).
 | endRange   | Blob end range. This is exclusive. Empty means account end.     | string<br/><small>Optional</small> |
 | startRange | Blob start range. This is inclusive. Empty means account start. | string<br/><small>Optional</small> |
 
-<a id="CorsRule_AllowedMethods"></a>CorsRule_AllowedMethods
------------------------------------------------------------
+CorsRule_AllowedMethods{#CorsRule_AllowedMethods}
+-------------------------------------------------
 
 Used by: [CorsRule](#CorsRule).
 
@@ -2946,8 +2946,8 @@ Used by: [CorsRule](#CorsRule).
 | "POST"    |             |
 | "PUT"     |             |
 
-<a id="CorsRule_AllowedMethods_STATUS"></a>CorsRule_AllowedMethods_STATUS
--------------------------------------------------------------------------
+CorsRule_AllowedMethods_STATUS{#CorsRule_AllowedMethods_STATUS}
+---------------------------------------------------------------
 
 Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 
@@ -2962,8 +2962,8 @@ Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 | "POST"    |             |
 | "PUT"     |             |
 
-<a id="EncryptionService"></a>EncryptionService
------------------------------------------------
+EncryptionService{#EncryptionService}
+-------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -2974,8 +2974,8 @@ Used by: [EncryptionServices](#EncryptionServices), [EncryptionServices](#Encryp
 | enabled  | A boolean indicating whether or not the service encrypts the data as it is stored. Encryption at rest is enabled by default today and cannot be disabled.                                                | bool<br/><small>Optional</small>                                                    |
 | keyType  | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used. | [EncryptionService_KeyType](#EncryptionService_KeyType)<br/><small>Optional</small> |
 
-<a id="EncryptionService_STATUS"></a>EncryptionService_STATUS
--------------------------------------------------------------
+EncryptionService_STATUS{#EncryptionService_STATUS}
+---------------------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -2987,8 +2987,8 @@ Used by: [EncryptionServices_STATUS](#EncryptionServices_STATUS), [EncryptionSer
 | keyType         | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used. | [EncryptionService_KeyType_STATUS](#EncryptionService_KeyType_STATUS)<br/><small>Optional</small> |
 | lastEnabledTime | Gets a rough estimate of the date/time when the encryption was last enabled by the user. Data is encrypted at rest by default today and cannot be disabled.                                              | string<br/><small>Optional</small>                                                                |
 
-<a id="IPRule_Action"></a>IPRule_Action
----------------------------------------
+IPRule_Action{#IPRule_Action}
+-----------------------------
 
 Used by: [IPRule](#IPRule).
 
@@ -2996,8 +2996,8 @@ Used by: [IPRule](#IPRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="IPRule_Action_STATUS"></a>IPRule_Action_STATUS
------------------------------------------------------
+IPRule_Action_STATUS{#IPRule_Action_STATUS}
+-------------------------------------------
 
 Used by: [IPRule_STATUS](#IPRule_STATUS).
 
@@ -3005,8 +3005,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="ManagementPolicyDefinition"></a>ManagementPolicyDefinition
------------------------------------------------------------------
+ManagementPolicyDefinition{#ManagementPolicyDefinition}
+-------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -3017,8 +3017,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 | actions  | An object that defines the action set. | [ManagementPolicyAction](#ManagementPolicyAction)<br/><small>Required</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter](#ManagementPolicyFilter)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyDefinition_STATUS"></a>ManagementPolicyDefinition_STATUS
--------------------------------------------------------------------------------
+ManagementPolicyDefinition_STATUS{#ManagementPolicyDefinition_STATUS}
+---------------------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -3029,8 +3029,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 | actions  | An object that defines the action set. | [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS)<br/><small>Optional</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyRule_Type"></a>ManagementPolicyRule_Type
----------------------------------------------------------------
+ManagementPolicyRule_Type{#ManagementPolicyRule_Type}
+-----------------------------------------------------
 
 Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 
@@ -3038,8 +3038,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="ManagementPolicyRule_Type_STATUS"></a>ManagementPolicyRule_Type_STATUS
------------------------------------------------------------------------------
+ManagementPolicyRule_Type_STATUS{#ManagementPolicyRule_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 
@@ -3047,8 +3047,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="Multichannel"></a>Multichannel
--------------------------------------
+Multichannel{#Multichannel}
+---------------------------
 
 Multichannel setting. Applies to Premium FileStorage only.
 
@@ -3058,8 +3058,8 @@ Used by: [SmbSetting](#SmbSetting).
 |----------|-------------------------------------------|----------------------------------|
 | enabled  | Indicates whether multichannel is enabled | bool<br/><small>Optional</small> |
 
-<a id="Multichannel_STATUS"></a>Multichannel_STATUS
----------------------------------------------------
+Multichannel_STATUS{#Multichannel_STATUS}
+-----------------------------------------
 
 Multichannel setting. Applies to Premium FileStorage only.
 
@@ -3069,8 +3069,8 @@ Used by: [SmbSetting_STATUS](#SmbSetting_STATUS).
 |----------|-------------------------------------------|----------------------------------|
 | enabled  | Indicates whether multichannel is enabled | bool<br/><small>Optional</small> |
 
-<a id="UpdateHistoryProperty_Update_STATUS"></a>UpdateHistoryProperty_Update_STATUS
------------------------------------------------------------------------------------
+UpdateHistoryProperty_Update_STATUS{#UpdateHistoryProperty_Update_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 
@@ -3080,8 +3080,8 @@ Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 | "lock"   |             |
 | "put"    |             |
 
-<a id="VirtualNetworkRule_Action"></a>VirtualNetworkRule_Action
----------------------------------------------------------------
+VirtualNetworkRule_Action{#VirtualNetworkRule_Action}
+-----------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -3089,8 +3089,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_Action_STATUS"></a>VirtualNetworkRule_Action_STATUS
------------------------------------------------------------------------------
+VirtualNetworkRule_Action_STATUS{#VirtualNetworkRule_Action_STATUS}
+-------------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -3098,8 +3098,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_State"></a>VirtualNetworkRule_State
--------------------------------------------------------------
+VirtualNetworkRule_State{#VirtualNetworkRule_State}
+---------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -3111,8 +3111,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="VirtualNetworkRule_State_STATUS"></a>VirtualNetworkRule_State_STATUS
----------------------------------------------------------------------------
+VirtualNetworkRule_State_STATUS{#VirtualNetworkRule_State_STATUS}
+-----------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -3124,8 +3124,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="EncryptionService_KeyType"></a>EncryptionService_KeyType
----------------------------------------------------------------
+EncryptionService_KeyType{#EncryptionService_KeyType}
+-----------------------------------------------------
 
 Used by: [EncryptionService](#EncryptionService).
 
@@ -3134,8 +3134,8 @@ Used by: [EncryptionService](#EncryptionService).
 | "Account" |             |
 | "Service" |             |
 
-<a id="EncryptionService_KeyType_STATUS"></a>EncryptionService_KeyType_STATUS
------------------------------------------------------------------------------
+EncryptionService_KeyType_STATUS{#EncryptionService_KeyType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 
@@ -3144,8 +3144,8 @@ Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 | "Account" |             |
 | "Service" |             |
 
-<a id="ManagementPolicyAction"></a>ManagementPolicyAction
----------------------------------------------------------
+ManagementPolicyAction{#ManagementPolicyAction}
+-----------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -3157,8 +3157,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot](#ManagementPolicySnapShot)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion](#ManagementPolicyVersion)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyAction_STATUS"></a>ManagementPolicyAction_STATUS
------------------------------------------------------------------------
+ManagementPolicyAction_STATUS{#ManagementPolicyAction_STATUS}
+-------------------------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -3170,8 +3170,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion_STATUS](#ManagementPolicyVersion_STATUS)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyFilter"></a>ManagementPolicyFilter
----------------------------------------------------------
+ManagementPolicyFilter{#ManagementPolicyFilter}
+-----------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -3183,8 +3183,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Required</small>                  |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                  |
 
-<a id="ManagementPolicyFilter_STATUS"></a>ManagementPolicyFilter_STATUS
------------------------------------------------------------------------
+ManagementPolicyFilter_STATUS{#ManagementPolicyFilter_STATUS}
+-------------------------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -3196,8 +3196,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Optional</small>                                |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                                |
 
-<a id="ManagementPolicyBaseBlob"></a>ManagementPolicyBaseBlob
--------------------------------------------------------------
+ManagementPolicyBaseBlob{#ManagementPolicyBaseBlob}
+---------------------------------------------------
 
 Management policy action for base blob.
 
@@ -3212,8 +3212,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool                  | The function to tier blobs to cool storage.                                                                                                           | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 | tierToHot                   | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts                                      | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyBaseBlob_STATUS"></a>ManagementPolicyBaseBlob_STATUS
----------------------------------------------------------------------------
+ManagementPolicyBaseBlob_STATUS{#ManagementPolicyBaseBlob_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for base blob.
 
@@ -3228,8 +3228,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool                  | The function to tier blobs to cool storage.                                                                                                           | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 | tierToHot                   | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts                                      | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot"></a>ManagementPolicySnapShot
--------------------------------------------------------------
+ManagementPolicySnapShot{#ManagementPolicySnapShot}
+---------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -3243,8 +3243,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool    | The function to tier blob snapshot to cool storage.                                                              | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot_STATUS"></a>ManagementPolicySnapShot_STATUS
----------------------------------------------------------------------------
+ManagementPolicySnapShot_STATUS{#ManagementPolicySnapShot_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -3258,8 +3258,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool    | The function to tier blob snapshot to cool storage.                                                              | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion"></a>ManagementPolicyVersion
------------------------------------------------------------
+ManagementPolicyVersion{#ManagementPolicyVersion}
+-------------------------------------------------
 
 Management policy action for blob version.
 
@@ -3273,8 +3273,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool    | The function to tier blob version to cool storage.                                                               | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion_STATUS"></a>ManagementPolicyVersion_STATUS
--------------------------------------------------------------------------
+ManagementPolicyVersion_STATUS{#ManagementPolicyVersion_STATUS}
+---------------------------------------------------------------
 
 Management policy action for blob version.
 
@@ -3288,8 +3288,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool    | The function to tier blob version to cool storage.                                                               | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="TagFilter"></a>TagFilter
--------------------------------
+TagFilter{#TagFilter}
+---------------------
 
 Blob index tag based filtering for blob objects
 
@@ -3301,8 +3301,8 @@ Used by: [ManagementPolicyFilter](#ManagementPolicyFilter).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Required</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Required</small> |
 
-<a id="TagFilter_STATUS"></a>TagFilter_STATUS
----------------------------------------------
+TagFilter_STATUS{#TagFilter_STATUS}
+-----------------------------------
 
 Blob index tag based filtering for blob objects
 
@@ -3314,8 +3314,8 @@ Used by: [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Optional</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Optional</small> |
 
-<a id="DateAfterCreation"></a>DateAfterCreation
------------------------------------------------
+DateAfterCreation{#DateAfterCreation}
+-------------------------------------
 
 Object to define snapshot and version action conditions.
 
@@ -3326,8 +3326,8 @@ Used by: [ManagementPolicySnapShot](#ManagementPolicySnapShot), [ManagementPolic
 | daysAfterCreationGreaterThan       | Value indicating the age in days after creation                                                                                                                                                                                                                                                 | int<br/><small>Required</small> |
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterCreationGreaterThan to be set for snapshots and blob version based actions. The blob will be archived if both the conditions are satisfied. | int<br/><small>Optional</small> |
 
-<a id="DateAfterCreation_STATUS"></a>DateAfterCreation_STATUS
--------------------------------------------------------------
+DateAfterCreation_STATUS{#DateAfterCreation_STATUS}
+---------------------------------------------------
 
 Object to define snapshot and version action conditions.
 
@@ -3338,8 +3338,8 @@ Used by: [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS), [M
 | daysAfterCreationGreaterThan       | Value indicating the age in days after creation                                                                                                                                                                                                                                                 | float64<br/><small>Optional</small> |
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterCreationGreaterThan to be set for snapshots and blob version based actions. The blob will be archived if both the conditions are satisfied. | float64<br/><small>Optional</small> |
 
-<a id="DateAfterModification"></a>DateAfterModification
--------------------------------------------------------
+DateAfterModification{#DateAfterModification}
+---------------------------------------------
 
 Object to define the base blob action conditions. Properties daysAfterModificationGreaterThan, daysAfterLastAccessTimeGreaterThan and daysAfterCreationGreaterThan are mutually exclusive. The daysAfterLastTierChangeGreaterThan property is only applicable for tierToArchive actions which requires daysAfterModificationGreaterThan to be set, also it cannot be used in conjunction with daysAfterLastAccessTimeGreaterThan or daysAfterCreationGreaterThan.
 
@@ -3352,8 +3352,8 @@ Used by: [ManagementPolicyBaseBlob](#ManagementPolicyBaseBlob), [ManagementPolic
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterModificationGreaterThan to be set for baseBlobs based actions. The blob will be archived if both the conditions are satisfied. | int<br/><small>Optional</small> |
 | daysAfterModificationGreaterThan   | Value indicating the age in days after last modification                                                                                                                                                                                                                           | int<br/><small>Optional</small> |
 
-<a id="DateAfterModification_STATUS"></a>DateAfterModification_STATUS
----------------------------------------------------------------------
+DateAfterModification_STATUS{#DateAfterModification_STATUS}
+-----------------------------------------------------------
 
 Object to define the base blob action conditions. Properties daysAfterModificationGreaterThan, daysAfterLastAccessTimeGreaterThan and daysAfterCreationGreaterThan are mutually exclusive. The daysAfterLastTierChangeGreaterThan property is only applicable for tierToArchive actions which requires daysAfterModificationGreaterThan to be set, also it cannot be used in conjunction with daysAfterLastAccessTimeGreaterThan or daysAfterCreationGreaterThan.
 

--- a/docs/hugo/content/reference/storage/v1api20230101.md
+++ b/docs/hugo/content/reference/storage/v1api20230101.md
@@ -5,15 +5,15 @@ title: storage.azure.com/v1api20230101
 linktitle: v1api20230101
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2023-01-01" |             |
 
-<a id="StorageAccount"></a>StorageAccount
------------------------------------------
+StorageAccount{#StorageAccount}
+-------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -26,7 +26,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | spec                                                                                    |             | [StorageAccount_Spec](#StorageAccount_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccount_STATUS](#StorageAccount_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccount_Spec"></a>StorageAccount_Spec
+### StorageAccount_Spec {#StorageAccount_Spec}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                     | Type                                                                                                                                                                 |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -63,7 +63,7 @@ Used by: [StorageAccountList](#StorageAccountList).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
+### StorageAccount_STATUS{#StorageAccount_STATUS}
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -118,8 +118,8 @@ Used by: [StorageAccountList](#StorageAccountList).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountList"></a>StorageAccountList
--------------------------------------------------
+StorageAccountList{#StorageAccountList}
+---------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}
 
@@ -129,8 +129,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                 |
 | items                                                                               |             | [StorageAccount[]](#StorageAccount)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobService"></a>StorageAccountsBlobService
------------------------------------------------------------------
+StorageAccountsBlobService{#StorageAccountsBlobService}
+-------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -143,7 +143,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | spec                                                                                    |             | [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
+### StorageAccountsBlobService_Spec {#StorageAccountsBlobService_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -159,7 +159,7 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-### <a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
+### StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -178,8 +178,8 @@ Used by: [StorageAccountsBlobServiceList](#StorageAccountsBlobServiceList).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServiceList"></a>StorageAccountsBlobServiceList
--------------------------------------------------------------------------
+StorageAccountsBlobServiceList{#StorageAccountsBlobServiceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default
 
@@ -189,8 +189,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [StorageAccountsBlobService[]](#StorageAccountsBlobService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainer"></a>StorageAccountsBlobServicesContainer
--------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer{#StorageAccountsBlobServicesContainer}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -203,7 +203,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | spec                                                                                    |             | [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
+### StorageAccountsBlobServicesContainer_Spec {#StorageAccountsBlobServicesContainer_Spec}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -218,7 +218,7 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-### <a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
+### StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
 
 | Property                       | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -247,8 +247,8 @@ Used by: [StorageAccountsBlobServicesContainerList](#StorageAccountsBlobServices
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainerList"></a>StorageAccountsBlobServicesContainerList
----------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerList{#StorageAccountsBlobServicesContainerList}
+-----------------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/blob.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}
 
@@ -258,8 +258,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                             |
 | items                                                                               |             | [StorageAccountsBlobServicesContainer[]](#StorageAccountsBlobServicesContainer)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileService"></a>StorageAccountsFileService
------------------------------------------------------------------
+StorageAccountsFileService{#StorageAccountsFileService}
+-------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default
 
@@ -272,7 +272,7 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | spec                                                                                    |             | [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsFileService_STATUS](#StorageAccountsFileService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsFileService_Spec"></a>StorageAccountsFileService_Spec
+### StorageAccountsFileService_Spec {#StorageAccountsFileService_Spec}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -282,7 +282,7 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | protocolSettings           | Protocol settings for file service                                                                                                                                                                                                                                                          | [ProtocolSettings](#ProtocolSettings)<br/><small>Optional</small>                                                                                                    |
 | shareDeleteRetentionPolicy | The file service properties for share soft delete.                                                                                                                                                                                                                                          | [DeleteRetentionPolicy](#DeleteRetentionPolicy)<br/><small>Optional</small>                                                                                          |
 
-### <a id="StorageAccountsFileService_STATUS"></a>StorageAccountsFileService_STATUS
+### StorageAccountsFileService_STATUS{#StorageAccountsFileService_STATUS}
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -295,8 +295,8 @@ Used by: [StorageAccountsFileServiceList](#StorageAccountsFileServiceList).
 | sku                        | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServiceList"></a>StorageAccountsFileServiceList
--------------------------------------------------------------------------
+StorageAccountsFileServiceList{#StorageAccountsFileServiceList}
+---------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default
 
@@ -306,8 +306,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                         |
 | items                                                                               |             | [StorageAccountsFileService[]](#StorageAccountsFileService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServicesShare"></a>StorageAccountsFileServicesShare
------------------------------------------------------------------------------
+StorageAccountsFileServicesShare{#StorageAccountsFileServicesShare}
+-------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}
 
@@ -320,7 +320,7 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | spec                                                                                    |             | [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsFileServicesShare_Spec"></a>StorageAccountsFileServicesShare_Spec
+### StorageAccountsFileServicesShare_Spec {#StorageAccountsFileServicesShare_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                             | Type                                                                                                                                                                 |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -334,7 +334,7 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | shareQuota        | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.                                                                                                                                           | int<br/><small>Optional</small>                                                                                                                                      |
 | signedIdentifiers | List of stored access policies specified on the share.                                                                                                                                                                                                                                                  | [SignedIdentifier[]](#SignedIdentifier)<br/><small>Optional</small>                                                                                                  |
 
-### <a id="StorageAccountsFileServicesShare_STATUS"></a>StorageAccountsFileServicesShare_STATUS
+### StorageAccountsFileServicesShare_STATUS{#StorageAccountsFileServicesShare_STATUS}
 
 | Property               | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -362,8 +362,8 @@ Used by: [StorageAccountsFileServicesShareList](#StorageAccountsFileServicesShar
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                | The version of the share.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServicesShareList"></a>StorageAccountsFileServicesShareList
--------------------------------------------------------------------------------------
+StorageAccountsFileServicesShareList{#StorageAccountsFileServicesShareList}
+---------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/file.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}
 
@@ -373,8 +373,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                     |
 | items                                                                               |             | [StorageAccountsFileServicesShare[]](#StorageAccountsFileServicesShare)<br/><small>Optional</small> |
 
-<a id="StorageAccountsManagementPolicy"></a>StorageAccountsManagementPolicy
----------------------------------------------------------------------------
+StorageAccountsManagementPolicy{#StorageAccountsManagementPolicy}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -387,7 +387,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | spec                                                                                    |             | [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPolicy_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
+### StorageAccountsManagementPolicy_Spec {#StorageAccountsManagementPolicy_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -395,7 +395,7 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-### <a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
+### StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
 
 | Property         | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -406,8 +406,8 @@ Used by: [StorageAccountsManagementPolicyList](#StorageAccountsManagementPolicyL
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicyList"></a>StorageAccountsManagementPolicyList
------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyList{#StorageAccountsManagementPolicyList}
+-------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/storage.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/default
 
@@ -417,8 +417,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                   |
 | items                                                                               |             | [StorageAccountsManagementPolicy[]](#StorageAccountsManagementPolicy)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueService"></a>StorageAccountsQueueService
--------------------------------------------------------------------
+StorageAccountsQueueService{#StorageAccountsQueueService}
+---------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -431,7 +431,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | spec                                                                                    |             | [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueService_STATUS](#StorageAccountsQueueService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
+### StorageAccountsQueueService_Spec {#StorageAccountsQueueService_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -439,7 +439,7 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
+### StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -449,8 +449,8 @@ Used by: [StorageAccountsQueueServiceList](#StorageAccountsQueueServiceList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServiceList"></a>StorageAccountsQueueServiceList
----------------------------------------------------------------------------
+StorageAccountsQueueServiceList{#StorageAccountsQueueServiceList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default
 
@@ -460,8 +460,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [StorageAccountsQueueService[]](#StorageAccountsQueueService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueue"></a>StorageAccountsQueueServicesQueue
--------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue{#StorageAccountsQueueServicesQueue}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -474,7 +474,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | spec                                                                                    |             | [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQueue_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsQueueServicesQueue_STATUS](#StorageAccountsQueueServicesQueue_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
+### StorageAccountsQueueServicesQueue_Spec {#StorageAccountsQueueServicesQueue_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -483,7 +483,7 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
+### StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
 
 | Property                | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -494,8 +494,8 @@ Used by: [StorageAccountsQueueServicesQueueList](#StorageAccountsQueueServicesQu
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueueList"></a>StorageAccountsQueueServicesQueueList
----------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueList{#StorageAccountsQueueServicesQueueList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/queue.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}
 
@@ -505,8 +505,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [StorageAccountsQueueServicesQueue[]](#StorageAccountsQueueServicesQueue)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableService"></a>StorageAccountsTableService
--------------------------------------------------------------------
+StorageAccountsTableService{#StorageAccountsTableService}
+---------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default
 
@@ -519,7 +519,7 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | spec                                                                                    |             | [StorageAccountsTableService_Spec](#StorageAccountsTableService_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsTableService_STATUS](#StorageAccountsTableService_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsTableService_Spec"></a>StorageAccountsTableService_Spec
+### StorageAccountsTableService_Spec {#StorageAccountsTableService_Spec}
 
 | Property     | Description                                                                                                                                                                                                                                                                                 | Type                                                                                                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -527,7 +527,7 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsTableServiceOperatorSpec](#StorageAccountsTableServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-### <a id="StorageAccountsTableService_STATUS"></a>StorageAccountsTableService_STATUS
+### StorageAccountsTableService_STATUS{#StorageAccountsTableService_STATUS}
 
 | Property   | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -537,8 +537,8 @@ Used by: [StorageAccountsTableServiceList](#StorageAccountsTableServiceList).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServiceList"></a>StorageAccountsTableServiceList
----------------------------------------------------------------------------
+StorageAccountsTableServiceList{#StorageAccountsTableServiceList}
+-----------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default
 
@@ -548,8 +548,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                           |
 | items                                                                               |             | [StorageAccountsTableService[]](#StorageAccountsTableService)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServicesTable"></a>StorageAccountsTableServicesTable
--------------------------------------------------------------------------------
+StorageAccountsTableServicesTable{#StorageAccountsTableServicesTable}
+---------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}
 
@@ -562,7 +562,7 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | spec                                                                                    |             | [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesTable_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [StorageAccountsTableServicesTable_STATUS](#StorageAccountsTableServicesTable_STATUS)<br/><small>Optional</small> |
 
-### <a id="StorageAccountsTableServicesTable_Spec"></a>StorageAccountsTableServicesTable_Spec
+### StorageAccountsTableServicesTable_Spec {#StorageAccountsTableServicesTable_Spec}
 
 | Property          | Description                                                                                                                                                                                                                                                                                              | Type                                                                                                                                                                 |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -571,7 +571,7 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsTableService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | signedIdentifiers | List of stored access policies specified on the table.                                                                                                                                                                                                                                                   | [TableSignedIdentifier[]](#TableSignedIdentifier)<br/><small>Optional</small>                                                                                        |
 
-### <a id="StorageAccountsTableServicesTable_STATUS"></a>StorageAccountsTableServicesTable_STATUS
+### StorageAccountsTableServicesTable_STATUS{#StorageAccountsTableServicesTable_STATUS}
 
 | Property          | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -582,8 +582,8 @@ Used by: [StorageAccountsTableServicesTableList](#StorageAccountsTableServicesTa
 | tableName         | Table name under the specified account                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServicesTableList"></a>StorageAccountsTableServicesTableList
----------------------------------------------------------------------------------------
+StorageAccountsTableServicesTableList{#StorageAccountsTableServicesTableList}
+-----------------------------------------------------------------------------
 
 Generator information: - Generated from: /storage/resource-manager/Microsoft.Storage/stable/2023-01-01/table.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}
 
@@ -593,8 +593,8 @@ Generator information: - Generated from: /storage/resource-manager/Microsoft.Sto
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                                                       |
 | items                                                                               |             | [StorageAccountsTableServicesTable[]](#StorageAccountsTableServicesTable)<br/><small>Optional</small> |
 
-<a id="StorageAccount_Spec"></a>StorageAccount_Spec
----------------------------------------------------
+StorageAccount_Spec{#StorageAccount_Spec}
+-----------------------------------------
 
 Used by: [StorageAccount](#StorageAccount).
 
@@ -633,8 +633,8 @@ Used by: [StorageAccount](#StorageAccount).
 | supportsHttpsTrafficOnly              | Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.                                                                                                                                                                                                                           | bool<br/><small>Optional</small>                                                                                                                                     |
 | tags                                  | Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="StorageAccount_STATUS"></a>StorageAccount_STATUS
--------------------------------------------------------
+StorageAccount_STATUS{#StorageAccount_STATUS}
+---------------------------------------------
 
 The storage account.
 
@@ -693,8 +693,8 @@ Used by: [StorageAccount](#StorageAccount).
 | tags                                  | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                                  | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobService_Spec"></a>StorageAccountsBlobService_Spec
----------------------------------------------------------------------------
+StorageAccountsBlobService_Spec{#StorageAccountsBlobService_Spec}
+-----------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -712,8 +712,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | restorePolicy                  | The blob service properties for blob restore policy.                                                                                                                                                                                                                                        | [RestorePolicyProperties](#RestorePolicyProperties)<br/><small>Optional</small>                                                                                      |
 
-<a id="StorageAccountsBlobService_STATUS"></a>StorageAccountsBlobService_STATUS
--------------------------------------------------------------------------------
+StorageAccountsBlobService_STATUS{#StorageAccountsBlobService_STATUS}
+---------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 
@@ -734,8 +734,8 @@ Used by: [StorageAccountsBlobService](#StorageAccountsBlobService).
 | sku                            | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsBlobServicesContainer_Spec"></a>StorageAccountsBlobServicesContainer_Spec
------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_Spec{#StorageAccountsBlobServicesContainer_Spec}
+-------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -752,8 +752,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | owner                          | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsBlobService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | publicAccess                   | Specifies whether data in the container may be accessed publicly and the level of access.                                                                                                                                                                                                               | [ContainerProperties_PublicAccess](#ContainerProperties_PublicAccess)<br/><small>Optional</small>                                                                    |
 
-<a id="StorageAccountsBlobServicesContainer_STATUS"></a>StorageAccountsBlobServicesContainer_STATUS
----------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainer_STATUS{#StorageAccountsBlobServicesContainer_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesContainer).
 
@@ -784,8 +784,8 @@ Used by: [StorageAccountsBlobServicesContainer](#StorageAccountsBlobServicesCont
 | type                           | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                        | The version of the deleted blob container.                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileService_Spec"></a>StorageAccountsFileService_Spec
----------------------------------------------------------------------------
+StorageAccountsFileService_Spec{#StorageAccountsFileService_Spec}
+-----------------------------------------------------------------
 
 Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 
@@ -797,8 +797,8 @@ Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 | protocolSettings           | Protocol settings for file service                                                                                                                                                                                                                                                          | [ProtocolSettings](#ProtocolSettings)<br/><small>Optional</small>                                                                                                    |
 | shareDeleteRetentionPolicy | The file service properties for share soft delete.                                                                                                                                                                                                                                          | [DeleteRetentionPolicy](#DeleteRetentionPolicy)<br/><small>Optional</small>                                                                                          |
 
-<a id="StorageAccountsFileService_STATUS"></a>StorageAccountsFileService_STATUS
--------------------------------------------------------------------------------
+StorageAccountsFileService_STATUS{#StorageAccountsFileService_STATUS}
+---------------------------------------------------------------------
 
 Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 
@@ -813,8 +813,8 @@ Used by: [StorageAccountsFileService](#StorageAccountsFileService).
 | sku                        | Sku name and tier.                                                                                                                                                                                                                                                                                                        | [Sku_STATUS](#Sku_STATUS)<br/><small>Optional</small>                                                                                                   |
 | type                       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsFileServicesShare_Spec"></a>StorageAccountsFileServicesShare_Spec
----------------------------------------------------------------------------------------
+StorageAccountsFileServicesShare_Spec{#StorageAccountsFileServicesShare_Spec}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 
@@ -830,8 +830,8 @@ Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 | shareQuota        | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.                                                                                                                                           | int<br/><small>Optional</small>                                                                                                                                      |
 | signedIdentifiers | List of stored access policies specified on the share.                                                                                                                                                                                                                                                  | [SignedIdentifier[]](#SignedIdentifier)<br/><small>Optional</small>                                                                                                  |
 
-<a id="StorageAccountsFileServicesShare_STATUS"></a>StorageAccountsFileServicesShare_STATUS
--------------------------------------------------------------------------------------------
+StorageAccountsFileServicesShare_STATUS{#StorageAccountsFileServicesShare_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 
@@ -861,8 +861,8 @@ Used by: [StorageAccountsFileServicesShare](#StorageAccountsFileServicesShare).
 | type                   | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 | version                | The version of the share.                                                                                                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsManagementPolicy_Spec"></a>StorageAccountsManagementPolicy_Spec
--------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_Spec{#StorageAccountsManagementPolicy_Spec}
+---------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -872,8 +872,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | policy       | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                      | [ManagementPolicySchema](#ManagementPolicySchema)<br/><small>Required</small>                                                                                        |
 
-<a id="StorageAccountsManagementPolicy_STATUS"></a>StorageAccountsManagementPolicy_STATUS
------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicy_STATUS{#StorageAccountsManagementPolicy_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 
@@ -886,8 +886,8 @@ Used by: [StorageAccountsManagementPolicy](#StorageAccountsManagementPolicy).
 | policy           | The Storage Account ManagementPolicy, in JSON format. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.                                                                                                                                                    | [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS)<br/><small>Optional</small>                                                             |
 | type             | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueService_Spec"></a>StorageAccountsQueueService_Spec
------------------------------------------------------------------------------
+StorageAccountsQueueService_Spec{#StorageAccountsQueueService_Spec}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -897,8 +897,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsQueueServiceOperatorSpec](#StorageAccountsQueueServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueService_STATUS"></a>StorageAccountsQueueService_STATUS
----------------------------------------------------------------------------------
+StorageAccountsQueueService_STATUS{#StorageAccountsQueueService_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 
@@ -910,8 +910,8 @@ Used by: [StorageAccountsQueueService](#StorageAccountsQueueService).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsQueueServicesQueue_Spec"></a>StorageAccountsQueueServicesQueue_Spec
------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_Spec{#StorageAccountsQueueServicesQueue_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -922,8 +922,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                                          | [StorageAccountsQueueServicesQueueOperatorSpec](#StorageAccountsQueueServicesQueueOperatorSpec)<br/><small>Optional</small>                                          |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsQueueService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsQueueServicesQueue_STATUS"></a>StorageAccountsQueueServicesQueue_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueue_STATUS{#StorageAccountsQueueServicesQueue_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue).
 
@@ -936,8 +936,8 @@ Used by: [StorageAccountsQueueServicesQueue](#StorageAccountsQueueServicesQueue)
 | name                    | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type                    | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableService_Spec"></a>StorageAccountsTableService_Spec
------------------------------------------------------------------------------
+StorageAccountsTableService_Spec{#StorageAccountsTableService_Spec}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 
@@ -947,8 +947,8 @@ Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure                                                                                                                                                             | [StorageAccountsTableServiceOperatorSpec](#StorageAccountsTableServiceOperatorSpec)<br/><small>Optional</small>                                                      |
 | owner        | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccount resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 
-<a id="StorageAccountsTableService_STATUS"></a>StorageAccountsTableService_STATUS
----------------------------------------------------------------------------------
+StorageAccountsTableService_STATUS{#StorageAccountsTableService_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 
@@ -960,8 +960,8 @@ Used by: [StorageAccountsTableService](#StorageAccountsTableService).
 | name       | The name of the resource                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                      |
 | type       | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="StorageAccountsTableServicesTable_Spec"></a>StorageAccountsTableServicesTable_Spec
------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTable_Spec{#StorageAccountsTableServicesTable_Spec}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable).
 
@@ -972,8 +972,8 @@ Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable)
 | owner             | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a storage.azure.com/StorageAccountsTableService resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | signedIdentifiers | List of stored access policies specified on the table.                                                                                                                                                                                                                                                   | [TableSignedIdentifier[]](#TableSignedIdentifier)<br/><small>Optional</small>                                                                                        |
 
-<a id="StorageAccountsTableServicesTable_STATUS"></a>StorageAccountsTableServicesTable_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTable_STATUS{#StorageAccountsTableServicesTable_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable).
 
@@ -986,8 +986,8 @@ Used by: [StorageAccountsTableServicesTable](#StorageAccountsTableServicesTable)
 | tableName         | Table name under the specified account                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>                                                                                                                      |
 | type              | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AzureFilesIdentityBasedAuthentication"></a>AzureFilesIdentityBasedAuthentication
----------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication{#AzureFilesIdentityBasedAuthentication}
+-----------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -999,8 +999,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used. Note that this enum may be extended in the future.       | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions)<br/><small>Required</small> |
 
-<a id="AzureFilesIdentityBasedAuthentication_STATUS"></a>AzureFilesIdentityBasedAuthentication_STATUS
------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_STATUS{#AzureFilesIdentityBasedAuthentication_STATUS}
+-------------------------------------------------------------------------------------------
 
 Settings for Azure Files identity based authentication.
 
@@ -1012,8 +1012,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | defaultSharePermission    | Default share permission for users using Kerberos authentication if RBAC role is not assigned. | [AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS](#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS)<br/><small>Optional</small>   |
 | directoryServiceOptions   | Indicates the directory service used. Note that this enum may be extended in the future.       | [AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS](#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS)<br/><small>Optional</small> |
 
-<a id="BlobRestoreStatus_STATUS"></a>BlobRestoreStatus_STATUS
--------------------------------------------------------------
+BlobRestoreStatus_STATUS{#BlobRestoreStatus_STATUS}
+---------------------------------------------------
 
 Blob restore status.
 
@@ -1026,8 +1026,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | restoreId     | Id for tracking blob restore request.                                                                                                                                                                                                     | string<br/><small>Optional</small>                                                              |
 | status        | The status of blob restore progress. Possible values are: - InProgress: Indicates that blob restore is ongoing. - Complete: Indicates that blob restore has been completed successfully. - Failed: Indicates that blob restore is failed. | [BlobRestoreStatus_Status_STATUS](#BlobRestoreStatus_Status_STATUS)<br/><small>Optional</small> |
 
-<a id="ChangeFeed"></a>ChangeFeed
----------------------------------
+ChangeFeed{#ChangeFeed}
+-----------------------
 
 The blob service properties for change feed events.
 
@@ -1038,8 +1038,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ChangeFeed_STATUS"></a>ChangeFeed_STATUS
------------------------------------------------
+ChangeFeed_STATUS{#ChangeFeed_STATUS}
+-------------------------------------
 
 The blob service properties for change feed events.
 
@@ -1050,8 +1050,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | enabled         | Indicates whether change feed event logging is enabled for the Blob service.                                                                                                                  | bool<br/><small>Optional</small> |
 | retentionInDays | Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed. | int<br/><small>Optional</small>  |
 
-<a id="ContainerProperties_LeaseDuration_STATUS"></a>ContainerProperties_LeaseDuration_STATUS
----------------------------------------------------------------------------------------------
+ContainerProperties_LeaseDuration_STATUS{#ContainerProperties_LeaseDuration_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1060,8 +1060,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Fixed"    |             |
 | "Infinite" |             |
 
-<a id="ContainerProperties_LeaseState_STATUS"></a>ContainerProperties_LeaseState_STATUS
----------------------------------------------------------------------------------------
+ContainerProperties_LeaseState_STATUS{#ContainerProperties_LeaseState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1073,8 +1073,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Expired"   |             |
 | "Leased"    |             |
 
-<a id="ContainerProperties_LeaseStatus_STATUS"></a>ContainerProperties_LeaseStatus_STATUS
------------------------------------------------------------------------------------------
+ContainerProperties_LeaseStatus_STATUS{#ContainerProperties_LeaseStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1083,8 +1083,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ContainerProperties_PublicAccess"></a>ContainerProperties_PublicAccess
------------------------------------------------------------------------------
+ContainerProperties_PublicAccess{#ContainerProperties_PublicAccess}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobServicesContainer_Spec).
 
@@ -1094,8 +1094,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | "Container" |             |
 | "None"      |             |
 
-<a id="ContainerProperties_PublicAccess_STATUS"></a>ContainerProperties_PublicAccess_STATUS
--------------------------------------------------------------------------------------------
+ContainerProperties_PublicAccess_STATUS{#ContainerProperties_PublicAccess_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServicesContainer_STATUS).
 
@@ -1105,8 +1105,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | "Container" |             |
 | "None"      |             |
 
-<a id="CorsRules"></a>CorsRules
--------------------------------
+CorsRules{#CorsRules}
+---------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -1116,8 +1116,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), [S
 |-----------|--------------------------------------------------------------------------------------|-----------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule[]](#CorsRule)<br/><small>Optional</small> |
 
-<a id="CorsRules_STATUS"></a>CorsRules_STATUS
----------------------------------------------
+CorsRules_STATUS{#CorsRules_STATUS}
+-----------------------------------
 
 Sets the CORS rules. You can include up to five CorsRule elements in the request.
 
@@ -1127,8 +1127,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 |-----------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | corsRules | The List of CORS rules. You can include up to five CorsRule elements in the request. | [CorsRule_STATUS[]](#CorsRule_STATUS)<br/><small>Optional</small> |
 
-<a id="CustomDomain"></a>CustomDomain
--------------------------------------
+CustomDomain{#CustomDomain}
+---------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -1139,8 +1139,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Required</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="CustomDomain_STATUS"></a>CustomDomain_STATUS
----------------------------------------------------
+CustomDomain_STATUS{#CustomDomain_STATUS}
+-----------------------------------------
 
 The custom domain assigned to this storage account. This can be set via Update.
 
@@ -1151,8 +1151,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name             | Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.                      | string<br/><small>Optional</small> |
 | useSubDomainName | Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates. | bool<br/><small>Optional</small>   |
 
-<a id="DeleteRetentionPolicy"></a>DeleteRetentionPolicy
--------------------------------------------------------
+DeleteRetentionPolicy{#DeleteRetentionPolicy}
+---------------------------------------------
 
 The service properties for soft delete.
 
@@ -1164,8 +1164,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec), [S
 | days                 | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365.                                                                                                | int<br/><small>Optional</small>  |
 | enabled              | Indicates whether DeleteRetentionPolicy is enabled.                                                                                                                                                                                          | bool<br/><small>Optional</small> |
 
-<a id="DeleteRetentionPolicy_STATUS"></a>DeleteRetentionPolicy_STATUS
----------------------------------------------------------------------
+DeleteRetentionPolicy_STATUS{#DeleteRetentionPolicy_STATUS}
+-----------------------------------------------------------
 
 The service properties for soft delete.
 
@@ -1177,8 +1177,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | days                 | Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365.                                                                                                | int<br/><small>Optional</small>  |
 | enabled              | Indicates whether DeleteRetentionPolicy is enabled.                                                                                                                                                                                          | bool<br/><small>Optional</small> |
 
-<a id="Encryption"></a>Encryption
----------------------------------
+Encryption{#Encryption}
+-----------------------
 
 The encryption settings on the storage account.
 
@@ -1192,8 +1192,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                          |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices](#EncryptionServices)<br/><small>Optional</small>     |
 
-<a id="Encryption_STATUS"></a>Encryption_STATUS
------------------------------------------------
+Encryption_STATUS{#Encryption_STATUS}
+-------------------------------------
 
 The encryption settings on the storage account.
 
@@ -1207,8 +1207,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | requireInfrastructureEncryption | A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. | bool<br/><small>Optional</small>                                                        |
 | services                        | List of services which support encryption.                                                                                           | [EncryptionServices_STATUS](#EncryptionServices_STATUS)<br/><small>Optional</small>     |
 
-<a id="Endpoints_STATUS"></a>Endpoints_STATUS
----------------------------------------------
+Endpoints_STATUS{#Endpoints_STATUS}
+-----------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object.
 
@@ -1225,8 +1225,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), and [StorageAccount_ST
 | table              | Gets the table endpoint.                      | string<br/><small>Optional</small>                                                                              |
 | web                | Gets the web endpoint.                        | string<br/><small>Optional</small>                                                                              |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 The complex type of the extended location.
 
@@ -1237,8 +1237,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                        |
 | type     | The type of the extended location. | [ExtendedLocationType](#ExtendedLocationType)<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 The complex type of the extended location.
 
@@ -1249,8 +1249,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | name     | The name of the extended location. | string<br/><small>Optional</small>                                                      |
 | type     | The type of the extended location. | [ExtendedLocationType_STATUS](#ExtendedLocationType_STATUS)<br/><small>Optional</small> |
 
-<a id="FileShareProperties_AccessTier"></a>FileShareProperties_AccessTier
--------------------------------------------------------------------------
+FileShareProperties_AccessTier{#FileShareProperties_AccessTier}
+---------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1261,8 +1261,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "Premium"              |             |
 | "TransactionOptimized" |             |
 
-<a id="FileShareProperties_AccessTier_STATUS"></a>FileShareProperties_AccessTier_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_AccessTier_STATUS{#FileShareProperties_AccessTier_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1273,8 +1273,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Premium"              |             |
 | "TransactionOptimized" |             |
 
-<a id="FileShareProperties_EnabledProtocols"></a>FileShareProperties_EnabledProtocols
--------------------------------------------------------------------------------------
+FileShareProperties_EnabledProtocols{#FileShareProperties_EnabledProtocols}
+---------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1283,8 +1283,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "NFS" |             |
 | "SMB" |             |
 
-<a id="FileShareProperties_EnabledProtocols_STATUS"></a>FileShareProperties_EnabledProtocols_STATUS
----------------------------------------------------------------------------------------------------
+FileShareProperties_EnabledProtocols_STATUS{#FileShareProperties_EnabledProtocols_STATUS}
+-----------------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1293,8 +1293,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "NFS" |             |
 | "SMB" |             |
 
-<a id="FileShareProperties_LeaseDuration_STATUS"></a>FileShareProperties_LeaseDuration_STATUS
----------------------------------------------------------------------------------------------
+FileShareProperties_LeaseDuration_STATUS{#FileShareProperties_LeaseDuration_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1303,8 +1303,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Fixed"    |             |
 | "Infinite" |             |
 
-<a id="FileShareProperties_LeaseState_STATUS"></a>FileShareProperties_LeaseState_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_LeaseState_STATUS{#FileShareProperties_LeaseState_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1316,8 +1316,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Expired"   |             |
 | "Leased"    |             |
 
-<a id="FileShareProperties_LeaseStatus_STATUS"></a>FileShareProperties_LeaseStatus_STATUS
------------------------------------------------------------------------------------------
+FileShareProperties_LeaseStatus_STATUS{#FileShareProperties_LeaseStatus_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1326,8 +1326,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="FileShareProperties_RootSquash"></a>FileShareProperties_RootSquash
--------------------------------------------------------------------------
+FileShareProperties_RootSquash{#FileShareProperties_RootSquash}
+---------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1337,8 +1337,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | "NoRootSquash" |             |
 | "RootSquash"   |             |
 
-<a id="FileShareProperties_RootSquash_STATUS"></a>FileShareProperties_RootSquash_STATUS
----------------------------------------------------------------------------------------
+FileShareProperties_RootSquash_STATUS{#FileShareProperties_RootSquash_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1348,8 +1348,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | "NoRootSquash" |             |
 | "RootSquash"   |             |
 
-<a id="GeoReplicationStats_STATUS"></a>GeoReplicationStats_STATUS
------------------------------------------------------------------
+GeoReplicationStats_STATUS{#GeoReplicationStats_STATUS}
+-------------------------------------------------------
 
 Statistics related to replication for storage account's Blob, Table, Queue and File services. It is only available when geo-redundant replication is enabled for the storage account.
 
@@ -1364,8 +1364,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | postPlannedFailoverRedundancy | The redundancy type of the account after a planned account failover is performed.                                                                                                                                                                                                                                                                                                               | [GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS](#GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS)<br/><small>Optional</small> |
 | status                        | The status of the secondary location. Possible values are: - Live: Indicates that the secondary location is active and operational. - Bootstrap: Indicates initial synchronization from the primary location to the secondary location is in progress.This typically occurs when replication is first enabled. - Unavailable: Indicates that the secondary location is temporarily unavailable. | [GeoReplicationStats_Status_STATUS](#GeoReplicationStats_Status_STATUS)<br/><small>Optional</small>                                               |
 
-<a id="Identity"></a>Identity
------------------------------
+Identity{#Identity}
+-------------------
 
 Identity for the resource.
 
@@ -1376,8 +1376,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type](#Identity_Type)<br/><small>Required</small>                               |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="Identity_STATUS"></a>Identity_STATUS
--------------------------------------------
+Identity_STATUS{#Identity_STATUS}
+---------------------------------
 
 Identity for the resource.
 
@@ -1390,8 +1390,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | type                   | The identity type.                                                                                                                                                                                                                             | [Identity_Type_STATUS](#Identity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here. | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutabilityPolicyProperties_STATUS"></a>ImmutabilityPolicyProperties_STATUS
------------------------------------------------------------------------------------
+ImmutabilityPolicyProperties_STATUS{#ImmutabilityPolicyProperties_STATUS}
+-------------------------------------------------------------------------
 
 The properties of an ImmutabilityPolicy of a blob container.
 
@@ -1406,8 +1406,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | state                                 | The ImmutabilityPolicy state of a blob container, possible values include: Locked and Unlocked.                                                                                                                                                                                                                                                                                                                                                                                | [ImmutabilityPolicyProperty_State_STATUS](#ImmutabilityPolicyProperty_State_STATUS)<br/><small>Optional</small> |
 | updateHistory                         | The ImmutabilityPolicy update history of the blob container.                                                                                                                                                                                                                                                                                                                                                                                                                   | [UpdateHistoryProperty_STATUS[]](#UpdateHistoryProperty_STATUS)<br/><small>Optional</small>                     |
 
-<a id="ImmutableStorageAccount"></a>ImmutableStorageAccount
------------------------------------------------------------
+ImmutableStorageAccount{#ImmutableStorageAccount}
+-------------------------------------------------
 
 This property enables and defines account-level immutability. Enabling the feature auto-enables Blob Versioning.
 
@@ -1418,8 +1418,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | enabled            | A boolean flag which enables account-level immutability. All the containers under such an account have object-level immutability enabled by default.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                        |
 | immutabilityPolicy | Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy. | [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyProperties)<br/><small>Optional</small> |
 
-<a id="ImmutableStorageAccount_STATUS"></a>ImmutableStorageAccount_STATUS
--------------------------------------------------------------------------
+ImmutableStorageAccount_STATUS{#ImmutableStorageAccount_STATUS}
+---------------------------------------------------------------
 
 This property enables and defines account-level immutability. Enabling the feature auto-enables Blob Versioning.
 
@@ -1430,8 +1430,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | enabled            | A boolean flag which enables account-level immutability. All the containers under such an account have object-level immutability enabled by default.                                                                                                                                                                                                          | bool<br/><small>Optional</small>                                                                                      |
 | immutabilityPolicy | Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy. | [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicyProperties_STATUS)<br/><small>Optional</small> |
 
-<a id="ImmutableStorageWithVersioning"></a>ImmutableStorageWithVersioning
--------------------------------------------------------------------------
+ImmutableStorageWithVersioning{#ImmutableStorageWithVersioning}
+---------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -1441,8 +1441,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 |----------|--------------------------------------------------------------------------------------------------------------|----------------------------------|
 | enabled  | This is an immutable property, when set to true it enables object level immutability at the container level. | bool<br/><small>Optional</small> |
 
-<a id="ImmutableStorageWithVersioning_STATUS"></a>ImmutableStorageWithVersioning_STATUS
----------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_STATUS{#ImmutableStorageWithVersioning_STATUS}
+-----------------------------------------------------------------------------
 
 Object level immutability properties of the container.
 
@@ -1454,8 +1454,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | migrationState | This property denotes the container level immutability to object level immutability migration state.         | [ImmutableStorageWithVersioning_MigrationState_STATUS](#ImmutableStorageWithVersioning_MigrationState_STATUS)<br/><small>Optional</small> |
 | timeStamp      | Returns the date and time the object level immutability was enabled.                                         | string<br/><small>Optional</small>                                                                                                        |
 
-<a id="KeyCreationTime_STATUS"></a>KeyCreationTime_STATUS
----------------------------------------------------------
+KeyCreationTime_STATUS{#KeyCreationTime_STATUS}
+-----------------------------------------------
 
 Storage account keys creation time.
 
@@ -1466,8 +1466,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | key1     |             | string<br/><small>Optional</small> |
 | key2     |             | string<br/><small>Optional</small> |
 
-<a id="KeyPolicy"></a>KeyPolicy
--------------------------------
+KeyPolicy{#KeyPolicy}
+---------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -1477,8 +1477,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Required</small> |
 
-<a id="KeyPolicy_STATUS"></a>KeyPolicy_STATUS
----------------------------------------------
+KeyPolicy_STATUS{#KeyPolicy_STATUS}
+-----------------------------------
 
 KeyPolicy assigned to the storage account.
 
@@ -1488,8 +1488,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |---------------------------|------------------------------------|---------------------------------|
 | keyExpirationPeriodInDays | The key expiration period in days. | int<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy"></a>LastAccessTimeTrackingPolicy
----------------------------------------------------------------------
+LastAccessTimeTrackingPolicy{#LastAccessTimeTrackingPolicy}
+-----------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1502,8 +1502,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name](#LastAccessTimeTrackingPolicy_Name)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                     |
 
-<a id="LastAccessTimeTrackingPolicy_STATUS"></a>LastAccessTimeTrackingPolicy_STATUS
------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_STATUS{#LastAccessTimeTrackingPolicy_STATUS}
+-------------------------------------------------------------------------
 
 The blob service properties for Last access time based tracking policy.
 
@@ -1516,8 +1516,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | name                      | Name of the policy. The valid value is AccessTimeTracking. This field is currently read only                                                                          | [LastAccessTimeTrackingPolicy_Name_STATUS](#LastAccessTimeTrackingPolicy_Name_STATUS)<br/><small>Optional</small> |
 | trackingGranularityInDays | The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1 | int<br/><small>Optional</small>                                                                                   |
 
-<a id="LegalHoldProperties_STATUS"></a>LegalHoldProperties_STATUS
------------------------------------------------------------------
+LegalHoldProperties_STATUS{#LegalHoldProperties_STATUS}
+-------------------------------------------------------
 
 The LegalHold property of a blob container.
 
@@ -1529,8 +1529,8 @@ Used by: [StorageAccountsBlobServicesContainer_STATUS](#StorageAccountsBlobServi
 | protectedAppendWritesHistory | Protected append blob writes history.                                                                                                                                                                                                                                                              | [ProtectedAppendWritesHistory_STATUS](#ProtectedAppendWritesHistory_STATUS)<br/><small>Optional</small> |
 | tags                         | The list of LegalHold tags of a blob container.                                                                                                                                                                                                                                                    | [TagProperty_STATUS[]](#TagProperty_STATUS)<br/><small>Optional</small>                                 |
 
-<a id="ManagementPolicySchema"></a>ManagementPolicySchema
----------------------------------------------------------
+ManagementPolicySchema{#ManagementPolicySchema}
+-----------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1540,8 +1540,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule[]](#ManagementPolicyRule)<br/><small>Required</small> |
 
-<a id="ManagementPolicySchema_STATUS"></a>ManagementPolicySchema_STATUS
------------------------------------------------------------------------
+ManagementPolicySchema_STATUS{#ManagementPolicySchema_STATUS}
+-------------------------------------------------------------
 
 The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts.
 
@@ -1551,8 +1551,8 @@ Used by: [StorageAccountsManagementPolicy_STATUS](#StorageAccountsManagementPoli
 |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | rules    | The Storage Account ManagementPolicies Rules. See more details in: https://docs.microsoft.com/en-us/azure/storage/common/storage-lifecycle-managment-concepts. | [ManagementPolicyRule_STATUS[]](#ManagementPolicyRule_STATUS)<br/><small>Optional</small> |
 
-<a id="NetworkRuleSet"></a>NetworkRuleSet
------------------------------------------
+NetworkRuleSet{#NetworkRuleSet}
+-------------------------------
 
 Network rule set
 
@@ -1566,8 +1566,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule[]](#ResourceAccessRule)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule[]](#VirtualNetworkRule)<br/><small>Optional</small>                   |
 
-<a id="NetworkRuleSet_STATUS"></a>NetworkRuleSet_STATUS
--------------------------------------------------------
+NetworkRuleSet_STATUS{#NetworkRuleSet_STATUS}
+---------------------------------------------
 
 Network rule set
 
@@ -1581,8 +1581,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | resourceAccessRules | Sets the resource access rules                                                                                          | [ResourceAccessRule_STATUS[]](#ResourceAccessRule_STATUS)<br/><small>Optional</small>                   |
 | virtualNetworkRules | Sets the virtual network rules                                                                                          | [VirtualNetworkRule_STATUS[]](#VirtualNetworkRule_STATUS)<br/><small>Optional</small>                   |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 The Private Endpoint Connection resource.
 
@@ -1592,8 +1592,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="ProtocolSettings"></a>ProtocolSettings
----------------------------------------------
+ProtocolSettings{#ProtocolSettings}
+-----------------------------------
 
 Protocol settings for file service
 
@@ -1603,8 +1603,8 @@ Used by: [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec).
 |----------|--------------------------|-------------------------------------------------------|
 | smb      | Setting for SMB protocol | [SmbSetting](#SmbSetting)<br/><small>Optional</small> |
 
-<a id="ProtocolSettings_STATUS"></a>ProtocolSettings_STATUS
------------------------------------------------------------
+ProtocolSettings_STATUS{#ProtocolSettings_STATUS}
+-------------------------------------------------
 
 Protocol settings for file service
 
@@ -1614,8 +1614,8 @@ Used by: [StorageAccountsFileService_STATUS](#StorageAccountsFileService_STATUS)
 |----------|--------------------------|---------------------------------------------------------------------|
 | smb      | Setting for SMB protocol | [SmbSetting_STATUS](#SmbSetting_STATUS)<br/><small>Optional</small> |
 
-<a id="RestorePolicyProperties"></a>RestorePolicyProperties
------------------------------------------------------------
+RestorePolicyProperties{#RestorePolicyProperties}
+-------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1626,8 +1626,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | days     | how long this blob can be restored. It should be great than zero and less than DeleteRetentionPolicy.days. | int<br/><small>Optional</small>  |
 | enabled  | Blob restore is enabled if set to true.                                                                    | bool<br/><small>Required</small> |
 
-<a id="RestorePolicyProperties_STATUS"></a>RestorePolicyProperties_STATUS
--------------------------------------------------------------------------
+RestorePolicyProperties_STATUS{#RestorePolicyProperties_STATUS}
+---------------------------------------------------------------
 
 The blob service properties for blob restore policy
 
@@ -1640,8 +1640,8 @@ Used by: [StorageAccountsBlobService_STATUS](#StorageAccountsBlobService_STATUS)
 | lastEnabledTime | Deprecated in favor of minRestoreTime property.                                                            | string<br/><small>Optional</small> |
 | minRestoreTime  | Returns the minimum date and time that the restore can be started.                                         | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference"></a>RoutingPreference
------------------------------------------------
+RoutingPreference{#RoutingPreference}
+-------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1653,8 +1653,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice](#RoutingPreference_RoutingChoice)<br/><small>Optional</small> |
 
-<a id="RoutingPreference_STATUS"></a>RoutingPreference_STATUS
--------------------------------------------------------------
+RoutingPreference_STATUS{#RoutingPreference_STATUS}
+---------------------------------------------------
 
 Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing
 
@@ -1666,8 +1666,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | publishMicrosoftEndpoints | A boolean flag which indicates whether microsoft routing storage endpoints are to be published | bool<br/><small>Optional</small>                                                                              |
 | routingChoice             | Routing Choice defines the kind of network routing opted by the user.                          | [RoutingPreference_RoutingChoice_STATUS](#RoutingPreference_RoutingChoice_STATUS)<br/><small>Optional</small> |
 
-<a id="SasPolicy"></a>SasPolicy
--------------------------------
+SasPolicy{#SasPolicy}
+---------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1678,8 +1678,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction](#SasPolicy_ExpirationAction)<br/><small>Required</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Required</small>                                                    |
 
-<a id="SasPolicy_STATUS"></a>SasPolicy_STATUS
----------------------------------------------
+SasPolicy_STATUS{#SasPolicy_STATUS}
+-----------------------------------
 
 SasPolicy assigned to the storage account.
 
@@ -1690,8 +1690,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | expirationAction    | The SAS expiration action. Can only be Log. | [SasPolicy_ExpirationAction_STATUS](#SasPolicy_ExpirationAction_STATUS)<br/><small>Optional</small> |
 | sasExpirationPeriod | The SAS expiration period, DD.HH:MM:SS.     | string<br/><small>Optional</small>                                                                  |
 
-<a id="SignedIdentifier"></a>SignedIdentifier
----------------------------------------------
+SignedIdentifier{#SignedIdentifier}
+-----------------------------------
 
 Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesShare_Spec).
 
@@ -1700,8 +1700,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | accessPolicy | Access policy                                     | [AccessPolicy](#AccessPolicy)<br/><small>Optional</small>                                                                                                  |
 | reference    | An unique identifier of the stored access policy. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="SignedIdentifier_STATUS"></a>SignedIdentifier_STATUS
------------------------------------------------------------
+SignedIdentifier_STATUS{#SignedIdentifier_STATUS}
+-------------------------------------------------
 
 Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesShare_STATUS).
 
@@ -1710,8 +1710,8 @@ Used by: [StorageAccountsFileServicesShare_STATUS](#StorageAccountsFileServicesS
 | accessPolicy | Access policy                                     | [AccessPolicy_STATUS](#AccessPolicy_STATUS)<br/><small>Optional</small> |
 | id           | An unique identifier of the stored access policy. | string<br/><small>Optional</small>                                      |
 
-<a id="Sku"></a>Sku
--------------------
+Sku{#Sku}
+---------
 
 The SKU of the storage account.
 
@@ -1722,8 +1722,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName](#SkuName)<br/><small>Required</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier](#Tier)<br/><small>Optional</small>       |
 
-<a id="Sku_STATUS"></a>Sku_STATUS
----------------------------------
+Sku_STATUS{#Sku_STATUS}
+-----------------------
 
 The SKU of the storage account.
 
@@ -1734,8 +1734,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS), [StorageAccountsBlobSe
 | name     | The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType. | [SkuName_STATUS](#SkuName_STATUS)<br/><small>Optional</small> |
 | tier     | The SKU tier. This is based on the SKU name.                                                                                    | [Tier_STATUS](#Tier_STATUS)<br/><small>Optional</small>       |
 
-<a id="StorageAccount_Kind_Spec"></a>StorageAccount_Kind_Spec
--------------------------------------------------------------
+StorageAccount_Kind_Spec{#StorageAccount_Kind_Spec}
+---------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1747,8 +1747,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccount_Kind_STATUS"></a>StorageAccount_Kind_STATUS
------------------------------------------------------------------
+StorageAccount_Kind_STATUS{#StorageAccount_Kind_STATUS}
+-------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1760,8 +1760,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Storage"          |             |
 | "StorageV2"        |             |
 
-<a id="StorageAccountOperatorSpec"></a>StorageAccountOperatorSpec
------------------------------------------------------------------
+StorageAccountOperatorSpec{#StorageAccountOperatorSpec}
+-------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1774,8 +1774,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secrets              | configures where to place Azure generated secrets.                                            | [StorageAccountOperatorSecrets](#StorageAccountOperatorSecrets)<br/><small>Optional</small>                                                                         |
 
-<a id="StorageAccountProperties_AccessTier_STATUS"></a>StorageAccountProperties_AccessTier_STATUS
--------------------------------------------------------------------------------------------------
+StorageAccountProperties_AccessTier_STATUS{#StorageAccountProperties_AccessTier_STATUS}
+---------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1785,8 +1785,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Hot"     |             |
 | "Premium" |             |
 
-<a id="StorageAccountProperties_AllowedCopyScope_STATUS"></a>StorageAccountProperties_AllowedCopyScope_STATUS
--------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_AllowedCopyScope_STATUS{#StorageAccountProperties_AllowedCopyScope_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1795,8 +1795,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "AAD"         |             |
 | "PrivateLink" |             |
 
-<a id="StorageAccountProperties_DnsEndpointType_STATUS"></a>StorageAccountProperties_DnsEndpointType_STATUS
------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_DnsEndpointType_STATUS{#StorageAccountProperties_DnsEndpointType_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1805,8 +1805,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "AzureDnsZone" |             |
 | "Standard"     |             |
 
-<a id="StorageAccountProperties_LargeFileSharesState_STATUS"></a>StorageAccountProperties_LargeFileSharesState_STATUS
----------------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_LargeFileSharesState_STATUS{#StorageAccountProperties_LargeFileSharesState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1815,8 +1815,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountProperties_MinimumTlsVersion_STATUS"></a>StorageAccountProperties_MinimumTlsVersion_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_MinimumTlsVersion_STATUS{#StorageAccountProperties_MinimumTlsVersion_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1826,8 +1826,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountProperties_ProvisioningState_STATUS"></a>StorageAccountProperties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_ProvisioningState_STATUS{#StorageAccountProperties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1837,8 +1837,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "ResolvingDNS" |             |
 | "Succeeded"    |             |
 
-<a id="StorageAccountProperties_PublicNetworkAccess_STATUS"></a>StorageAccountProperties_PublicNetworkAccess_STATUS
--------------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_PublicNetworkAccess_STATUS{#StorageAccountProperties_PublicNetworkAccess_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1847,8 +1847,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountProperties_StatusOfPrimary_STATUS"></a>StorageAccountProperties_StatusOfPrimary_STATUS
------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfPrimary_STATUS{#StorageAccountProperties_StatusOfPrimary_STATUS}
+-------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1857,8 +1857,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountProperties_StatusOfSecondary_STATUS"></a>StorageAccountProperties_StatusOfSecondary_STATUS
----------------------------------------------------------------------------------------------------------------
+StorageAccountProperties_StatusOfSecondary_STATUS{#StorageAccountProperties_StatusOfSecondary_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 
@@ -1867,8 +1867,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | "available"   |             |
 | "unavailable" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_AccessTier"></a>StorageAccountPropertiesCreateParameters_AccessTier
--------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_AccessTier{#StorageAccountPropertiesCreateParameters_AccessTier}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1878,8 +1878,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Hot"     |             |
 | "Premium" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_AllowedCopyScope"></a>StorageAccountPropertiesCreateParameters_AllowedCopyScope
--------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_AllowedCopyScope{#StorageAccountPropertiesCreateParameters_AllowedCopyScope}
+---------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1888,8 +1888,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "AAD"         |             |
 | "PrivateLink" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_DnsEndpointType"></a>StorageAccountPropertiesCreateParameters_DnsEndpointType
------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_DnsEndpointType{#StorageAccountPropertiesCreateParameters_DnsEndpointType}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1898,8 +1898,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "AzureDnsZone" |             |
 | "Standard"     |             |
 
-<a id="StorageAccountPropertiesCreateParameters_LargeFileSharesState"></a>StorageAccountPropertiesCreateParameters_LargeFileSharesState
----------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_LargeFileSharesState{#StorageAccountPropertiesCreateParameters_LargeFileSharesState}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1908,8 +1908,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountPropertiesCreateParameters_MinimumTlsVersion"></a>StorageAccountPropertiesCreateParameters_MinimumTlsVersion
----------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_MinimumTlsVersion{#StorageAccountPropertiesCreateParameters_MinimumTlsVersion}
+-----------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1919,8 +1919,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "TLS1_1" |             |
 | "TLS1_2" |             |
 
-<a id="StorageAccountPropertiesCreateParameters_PublicNetworkAccess"></a>StorageAccountPropertiesCreateParameters_PublicNetworkAccess
--------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountPropertiesCreateParameters_PublicNetworkAccess{#StorageAccountPropertiesCreateParameters_PublicNetworkAccess}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 
@@ -1929,8 +1929,8 @@ Used by: [StorageAccount_Spec](#StorageAccount_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="StorageAccountsBlobServiceOperatorSpec"></a>StorageAccountsBlobServiceOperatorSpec
------------------------------------------------------------------------------------------
+StorageAccountsBlobServiceOperatorSpec{#StorageAccountsBlobServiceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1941,8 +1941,8 @@ Used by: [StorageAccountsBlobService_Spec](#StorageAccountsBlobService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsBlobServicesContainerOperatorSpec"></a>StorageAccountsBlobServicesContainerOperatorSpec
--------------------------------------------------------------------------------------------------------------
+StorageAccountsBlobServicesContainerOperatorSpec{#StorageAccountsBlobServicesContainerOperatorSpec}
+---------------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1953,8 +1953,8 @@ Used by: [StorageAccountsBlobServicesContainer_Spec](#StorageAccountsBlobService
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServiceOperatorSpec"></a>StorageAccountsFileServiceOperatorSpec
------------------------------------------------------------------------------------------
+StorageAccountsFileServiceOperatorSpec{#StorageAccountsFileServiceOperatorSpec}
+-------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1965,8 +1965,8 @@ Used by: [StorageAccountsFileService_Spec](#StorageAccountsFileService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsFileServicesShareOperatorSpec"></a>StorageAccountsFileServicesShareOperatorSpec
------------------------------------------------------------------------------------------------------
+StorageAccountsFileServicesShareOperatorSpec{#StorageAccountsFileServicesShareOperatorSpec}
+-------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -1977,8 +1977,8 @@ Used by: [StorageAccountsFileServicesShare_Spec](#StorageAccountsFileServicesSha
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountSkuConversionStatus_STATUS"></a>StorageAccountSkuConversionStatus_STATUS
----------------------------------------------------------------------------------------------
+StorageAccountSkuConversionStatus_STATUS{#StorageAccountSkuConversionStatus_STATUS}
+-----------------------------------------------------------------------------------
 
 This defines the sku conversion status object for asynchronous sku conversions.
 
@@ -1991,8 +1991,8 @@ Used by: [StorageAccount_STATUS](#StorageAccount_STATUS).
 | startTime           | This property represents the sku conversion start time.                                                  | string<br/><small>Optional</small>                                                                                                                        |
 | targetSkuName       | This property represents the target sku name to which the account sku is being converted asynchronously. | [SkuName_STATUS](#SkuName_STATUS)<br/><small>Optional</small>                                                                                             |
 
-<a id="StorageAccountsManagementPolicyOperatorSpec"></a>StorageAccountsManagementPolicyOperatorSpec
----------------------------------------------------------------------------------------------------
+StorageAccountsManagementPolicyOperatorSpec{#StorageAccountsManagementPolicyOperatorSpec}
+-----------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2003,8 +2003,8 @@ Used by: [StorageAccountsManagementPolicy_Spec](#StorageAccountsManagementPolicy
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServiceOperatorSpec"></a>StorageAccountsQueueServiceOperatorSpec
--------------------------------------------------------------------------------------------
+StorageAccountsQueueServiceOperatorSpec{#StorageAccountsQueueServiceOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2015,8 +2015,8 @@ Used by: [StorageAccountsQueueService_Spec](#StorageAccountsQueueService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsQueueServicesQueueOperatorSpec"></a>StorageAccountsQueueServicesQueueOperatorSpec
--------------------------------------------------------------------------------------------------------
+StorageAccountsQueueServicesQueueOperatorSpec{#StorageAccountsQueueServicesQueueOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2027,8 +2027,8 @@ Used by: [StorageAccountsQueueServicesQueue_Spec](#StorageAccountsQueueServicesQ
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServiceOperatorSpec"></a>StorageAccountsTableServiceOperatorSpec
--------------------------------------------------------------------------------------------
+StorageAccountsTableServiceOperatorSpec{#StorageAccountsTableServiceOperatorSpec}
+---------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2039,8 +2039,8 @@ Used by: [StorageAccountsTableService_Spec](#StorageAccountsTableService_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="StorageAccountsTableServicesTableOperatorSpec"></a>StorageAccountsTableServicesTableOperatorSpec
--------------------------------------------------------------------------------------------------------
+StorageAccountsTableServicesTableOperatorSpec{#StorageAccountsTableServicesTableOperatorSpec}
+---------------------------------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -2051,8 +2051,8 @@ Used by: [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesT
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="TableSignedIdentifier"></a>TableSignedIdentifier
--------------------------------------------------------
+TableSignedIdentifier{#TableSignedIdentifier}
+---------------------------------------------
 
 Object to set Table Access Policy.
 
@@ -2063,8 +2063,8 @@ Used by: [StorageAccountsTableServicesTable_Spec](#StorageAccountsTableServicesT
 | accessPolicy | Access policy                                          | [TableAccessPolicy](#TableAccessPolicy)<br/><small>Optional</small>                                                                                        |
 | reference    | unique-64-character-value of the stored access policy. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 
-<a id="TableSignedIdentifier_STATUS"></a>TableSignedIdentifier_STATUS
----------------------------------------------------------------------
+TableSignedIdentifier_STATUS{#TableSignedIdentifier_STATUS}
+-----------------------------------------------------------
 
 Object to set Table Access Policy.
 
@@ -2075,8 +2075,8 @@ Used by: [StorageAccountsTableServicesTable_STATUS](#StorageAccountsTableService
 | accessPolicy | Access policy                                          | [TableAccessPolicy_STATUS](#TableAccessPolicy_STATUS)<br/><small>Optional</small> |
 | id           | unique-64-character-value of the stored access policy. | string<br/><small>Optional</small>                                                |
 
-<a id="AccessPolicy"></a>AccessPolicy
--------------------------------------
+AccessPolicy{#AccessPolicy}
+---------------------------
 
 Used by: [SignedIdentifier](#SignedIdentifier).
 
@@ -2086,8 +2086,8 @@ Used by: [SignedIdentifier](#SignedIdentifier).
 | permission | List of abbreviated permissions. | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy  | string<br/><small>Optional</small> |
 
-<a id="AccessPolicy_STATUS"></a>AccessPolicy_STATUS
----------------------------------------------------
+AccessPolicy_STATUS{#AccessPolicy_STATUS}
+-----------------------------------------
 
 Used by: [SignedIdentifier_STATUS](#SignedIdentifier_STATUS).
 
@@ -2097,8 +2097,8 @@ Used by: [SignedIdentifier_STATUS](#SignedIdentifier_STATUS).
 | permission | List of abbreviated permissions. | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy  | string<br/><small>Optional</small> |
 
-<a id="AccountImmutabilityPolicyProperties"></a>AccountImmutabilityPolicyProperties
------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties{#AccountImmutabilityPolicyProperties}
+-------------------------------------------------------------------------
 
 This defines account-level immutability policy properties.
 
@@ -2110,8 +2110,8 @@ Used by: [ImmutableStorageAccount](#ImmutableStorageAccount).
 | immutabilityPeriodSinceCreationInDays | The immutability period for the blobs in the container since the policy creation, in days.                                                                                                                                                                                                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                     |
 | state                                 | The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted. | [AccountImmutabilityPolicyProperties_State](#AccountImmutabilityPolicyProperties_State)<br/><small>Optional</small> |
 
-<a id="AccountImmutabilityPolicyProperties_STATUS"></a>AccountImmutabilityPolicyProperties_STATUS
--------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_STATUS{#AccountImmutabilityPolicyProperties_STATUS}
+---------------------------------------------------------------------------------------
 
 This defines account-level immutability policy properties.
 
@@ -2123,8 +2123,8 @@ Used by: [ImmutableStorageAccount_STATUS](#ImmutableStorageAccount_STATUS).
 | immutabilityPeriodSinceCreationInDays | The immutability period for the blobs in the container since the policy creation, in days.                                                                                                                                                                                                                                                                                                                                                                                                                                | int<br/><small>Optional</small>                                                                                                   |
 | state                                 | The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted. | [AccountImmutabilityPolicyProperties_State_STATUS](#AccountImmutabilityPolicyProperties_State_STATUS)<br/><small>Optional</small> |
 
-<a id="ActiveDirectoryProperties"></a>ActiveDirectoryProperties
----------------------------------------------------------------
+ActiveDirectoryProperties{#ActiveDirectoryProperties}
+-----------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -2141,8 +2141,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Optional</small>                                                                          |
 | samAccountName    | Specifies the Active Directory SAMAccountName for Azure Storage.          | string<br/><small>Optional</small>                                                                          |
 
-<a id="ActiveDirectoryProperties_STATUS"></a>ActiveDirectoryProperties_STATUS
------------------------------------------------------------------------------
+ActiveDirectoryProperties_STATUS{#ActiveDirectoryProperties_STATUS}
+-------------------------------------------------------------------
 
 Settings properties for Active Directory (AD).
 
@@ -2159,8 +2159,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | netBiosDomainName | Specifies the NetBIOS domain name.                                        | string<br/><small>Optional</small>                                                                                        |
 | samAccountName    | Specifies the Active Directory SAMAccountName for Azure Storage.          | string<br/><small>Optional</small>                                                                                        |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission
--------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -2171,8 +2171,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "StorageFileDataSmbShareElevatedContributor" |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS"></a>AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS
----------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS{#AzureFilesIdentityBasedAuthentication_DefaultSharePermission_STATUS}
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -2183,8 +2183,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "StorageFileDataSmbShareElevatedContributor" |             |
 | "StorageFileDataSmbShareReader"              |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions
----------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions}
+-----------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthentication).
 
@@ -2195,8 +2195,8 @@ Used by: [AzureFilesIdentityBasedAuthentication](#AzureFilesIdentityBasedAuthent
 | "AD"      |             |
 | "None"    |             |
 
-<a id="AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS"></a>AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS
------------------------------------------------------------------------------------------------------------------------------------------------------
+AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS{#AzureFilesIdentityBasedAuthentication_DirectoryServiceOptions_STATUS}
+-------------------------------------------------------------------------------------------------------------------------------------------
 
 Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBasedAuthentication_STATUS).
 
@@ -2207,8 +2207,8 @@ Used by: [AzureFilesIdentityBasedAuthentication_STATUS](#AzureFilesIdentityBased
 | "AD"      |             |
 | "None"    |             |
 
-<a id="BlobRestoreParameters_STATUS"></a>BlobRestoreParameters_STATUS
----------------------------------------------------------------------
+BlobRestoreParameters_STATUS{#BlobRestoreParameters_STATUS}
+-----------------------------------------------------------
 
 Blob restore parameters
 
@@ -2219,8 +2219,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | blobRanges    | Blob ranges to restore.             | [BlobRestoreRange_STATUS[]](#BlobRestoreRange_STATUS)<br/><small>Optional</small> |
 | timeToRestore | Restore blob to the specified time. | string<br/><small>Optional</small>                                                |
 
-<a id="BlobRestoreStatus_Status_STATUS"></a>BlobRestoreStatus_Status_STATUS
----------------------------------------------------------------------------
+BlobRestoreStatus_Status_STATUS{#BlobRestoreStatus_Status_STATUS}
+-----------------------------------------------------------------
 
 Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 
@@ -2230,8 +2230,8 @@ Used by: [BlobRestoreStatus_STATUS](#BlobRestoreStatus_STATUS).
 | "Failed"     |             |
 | "InProgress" |             |
 
-<a id="CorsRule"></a>CorsRule
------------------------------
+CorsRule{#CorsRule}
+-------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -2245,8 +2245,8 @@ Used by: [CorsRules](#CorsRules).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Required</small>                                              |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Required</small>                                                   |
 
-<a id="CorsRule_STATUS"></a>CorsRule_STATUS
--------------------------------------------
+CorsRule_STATUS{#CorsRule_STATUS}
+---------------------------------
 
 Specifies a CORS rule for the Blob service.
 
@@ -2260,8 +2260,8 @@ Used by: [CorsRules_STATUS](#CorsRules_STATUS).
 | exposedHeaders  | Required if CorsRule element is present. A list of response headers to expose to CORS clients.                               | string[]<br/><small>Optional</small>                                                            |
 | maxAgeInSeconds | Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.    | int<br/><small>Optional</small>                                                                 |
 
-<a id="Encryption_KeySource"></a>Encryption_KeySource
------------------------------------------------------
+Encryption_KeySource{#Encryption_KeySource}
+-------------------------------------------
 
 Used by: [Encryption](#Encryption).
 
@@ -2270,8 +2270,8 @@ Used by: [Encryption](#Encryption).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="Encryption_KeySource_STATUS"></a>Encryption_KeySource_STATUS
--------------------------------------------------------------------
+Encryption_KeySource_STATUS{#Encryption_KeySource_STATUS}
+---------------------------------------------------------
 
 Used by: [Encryption_STATUS](#Encryption_STATUS).
 
@@ -2280,8 +2280,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | "Microsoft.Keyvault" |             |
 | "Microsoft.Storage"  |             |
 
-<a id="EncryptionIdentity"></a>EncryptionIdentity
--------------------------------------------------
+EncryptionIdentity{#EncryptionIdentity}
+---------------------------------------
 
 Encryption identity for the storage account.
 
@@ -2292,8 +2292,8 @@ Used by: [Encryption](#Encryption).
 | federatedIdentityClientId     | ClientId of the multi-tenant application to be used in conjunction with the user-assigned identity for cross-tenant customer-managed-keys server-side encryption on the storage account. | string<br/><small>Optional</small>                                                                                                                         |
 | userAssignedIdentityReference | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.                                                                    | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="EncryptionIdentity_STATUS"></a>EncryptionIdentity_STATUS
----------------------------------------------------------------
+EncryptionIdentity_STATUS{#EncryptionIdentity_STATUS}
+-----------------------------------------------------
 
 Encryption identity for the storage account.
 
@@ -2304,8 +2304,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | federatedIdentityClientId | ClientId of the multi-tenant application to be used in conjunction with the user-assigned identity for cross-tenant customer-managed-keys server-side encryption on the storage account. | string<br/><small>Optional</small> |
 | userAssignedIdentity      | Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.                                                                    | string<br/><small>Optional</small> |
 
-<a id="EncryptionServices"></a>EncryptionServices
--------------------------------------------------
+EncryptionServices{#EncryptionServices}
+---------------------------------------
 
 A list of services that support encryption.
 
@@ -2318,8 +2318,8 @@ Used by: [Encryption](#Encryption).
 | queue    | The encryption function of the queue storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService](#EncryptionService)<br/><small>Optional</small> |
 
-<a id="EncryptionServices_STATUS"></a>EncryptionServices_STATUS
----------------------------------------------------------------
+EncryptionServices_STATUS{#EncryptionServices_STATUS}
+-----------------------------------------------------
 
 A list of services that support encryption.
 
@@ -2332,8 +2332,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | queue    | The encryption function of the queue storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 | table    | The encryption function of the table storage service. | [EncryptionService_STATUS](#EncryptionService_STATUS)<br/><small>Optional</small> |
 
-<a id="ExtendedLocationType"></a>ExtendedLocationType
------------------------------------------------------
+ExtendedLocationType{#ExtendedLocationType}
+-------------------------------------------
 
 The type of extendedLocation.
 
@@ -2343,8 +2343,8 @@ Used by: [ExtendedLocation](#ExtendedLocation).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="ExtendedLocationType_STATUS"></a>ExtendedLocationType_STATUS
--------------------------------------------------------------------
+ExtendedLocationType_STATUS{#ExtendedLocationType_STATUS}
+---------------------------------------------------------
 
 The type of extendedLocation.
 
@@ -2354,8 +2354,8 @@ Used by: [ExtendedLocation_STATUS](#ExtendedLocation_STATUS).
 |------------|-------------|
 | "EdgeZone" |             |
 
-<a id="GeoReplicationStats_PostFailoverRedundancy_STATUS"></a>GeoReplicationStats_PostFailoverRedundancy_STATUS
----------------------------------------------------------------------------------------------------------------
+GeoReplicationStats_PostFailoverRedundancy_STATUS{#GeoReplicationStats_PostFailoverRedundancy_STATUS}
+-----------------------------------------------------------------------------------------------------
 
 Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 
@@ -2364,8 +2364,8 @@ Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 | "Standard_LRS" |             |
 | "Standard_ZRS" |             |
 
-<a id="GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS"></a>GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS
------------------------------------------------------------------------------------------------------------------------------
+GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS{#GeoReplicationStats_PostPlannedFailoverRedundancy_STATUS}
+-------------------------------------------------------------------------------------------------------------------
 
 Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 
@@ -2376,8 +2376,8 @@ Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 | "Standard_RAGRS"  |             |
 | "Standard_RAGZRS" |             |
 
-<a id="GeoReplicationStats_Status_STATUS"></a>GeoReplicationStats_Status_STATUS
--------------------------------------------------------------------------------
+GeoReplicationStats_Status_STATUS{#GeoReplicationStats_Status_STATUS}
+---------------------------------------------------------------------
 
 Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 
@@ -2387,8 +2387,8 @@ Used by: [GeoReplicationStats_STATUS](#GeoReplicationStats_STATUS).
 | "Live"        |             |
 | "Unavailable" |             |
 
-<a id="Identity_Type"></a>Identity_Type
----------------------------------------
+Identity_Type{#Identity_Type}
+-----------------------------
 
 Used by: [Identity](#Identity).
 
@@ -2399,8 +2399,8 @@ Used by: [Identity](#Identity).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="Identity_Type_STATUS"></a>Identity_Type_STATUS
------------------------------------------------------
+Identity_Type_STATUS{#Identity_Type_STATUS}
+-------------------------------------------
 
 Used by: [Identity_STATUS](#Identity_STATUS).
 
@@ -2411,8 +2411,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | "SystemAssigned,UserAssigned" |             |
 | "UserAssigned"                |             |
 
-<a id="ImmutabilityPolicyProperty_State_STATUS"></a>ImmutabilityPolicyProperty_State_STATUS
--------------------------------------------------------------------------------------------
+ImmutabilityPolicyProperty_State_STATUS{#ImmutabilityPolicyProperty_State_STATUS}
+---------------------------------------------------------------------------------
 
 Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STATUS).
 
@@ -2421,8 +2421,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ImmutableStorageWithVersioning_MigrationState_STATUS"></a>ImmutableStorageWithVersioning_MigrationState_STATUS
----------------------------------------------------------------------------------------------------------------------
+ImmutableStorageWithVersioning_MigrationState_STATUS{#ImmutableStorageWithVersioning_MigrationState_STATUS}
+-----------------------------------------------------------------------------------------------------------
 
 Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning_STATUS).
 
@@ -2431,8 +2431,8 @@ Used by: [ImmutableStorageWithVersioning_STATUS](#ImmutableStorageWithVersioning
 | "Completed"  |             |
 | "InProgress" |             |
 
-<a id="IPRule"></a>IPRule
--------------------------
+IPRule{#IPRule}
+---------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -2443,8 +2443,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action](#IPRule_Action)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Required</small>                          |
 
-<a id="IPRule_STATUS"></a>IPRule_STATUS
----------------------------------------
+IPRule_STATUS{#IPRule_STATUS}
+-----------------------------
 
 IP rule with specific IP or IP range in CIDR format.
 
@@ -2455,8 +2455,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | action   | The action of IP ACL rule.                                                 | [IPRule_Action_STATUS](#IPRule_Action_STATUS)<br/><small>Optional</small> |
 | value    | Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed. | string<br/><small>Optional</small>                                        |
 
-<a id="KeyVaultProperties"></a>KeyVaultProperties
--------------------------------------------------
+KeyVaultProperties{#KeyVaultProperties}
+---------------------------------------
 
 Properties of key vault.
 
@@ -2468,8 +2468,8 @@ Used by: [Encryption](#Encryption).
 | keyvaulturi | The Uri of KeyVault.         | string<br/><small>Optional</small> |
 | keyversion  | The version of KeyVault key. | string<br/><small>Optional</small> |
 
-<a id="KeyVaultProperties_STATUS"></a>KeyVaultProperties_STATUS
----------------------------------------------------------------
+KeyVaultProperties_STATUS{#KeyVaultProperties_STATUS}
+-----------------------------------------------------
 
 Properties of key vault.
 
@@ -2484,8 +2484,8 @@ Used by: [Encryption_STATUS](#Encryption_STATUS).
 | keyversion                             | The version of KeyVault key.                                                                                                             | string<br/><small>Optional</small> |
 | lastKeyRotationTimestamp               | Timestamp of last rotation of the Key Vault Key.                                                                                         | string<br/><small>Optional</small> |
 
-<a id="LastAccessTimeTrackingPolicy_Name"></a>LastAccessTimeTrackingPolicy_Name
--------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name{#LastAccessTimeTrackingPolicy_Name}
+---------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 
@@ -2493,8 +2493,8 @@ Used by: [LastAccessTimeTrackingPolicy](#LastAccessTimeTrackingPolicy).
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="LastAccessTimeTrackingPolicy_Name_STATUS"></a>LastAccessTimeTrackingPolicy_Name_STATUS
----------------------------------------------------------------------------------------------
+LastAccessTimeTrackingPolicy_Name_STATUS{#LastAccessTimeTrackingPolicy_Name_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STATUS).
 
@@ -2502,8 +2502,8 @@ Used by: [LastAccessTimeTrackingPolicy_STATUS](#LastAccessTimeTrackingPolicy_STA
 |----------------------|-------------|
 | "AccessTimeTracking" |             |
 
-<a id="ManagementPolicyRule"></a>ManagementPolicyRule
------------------------------------------------------
+ManagementPolicyRule{#ManagementPolicyRule}
+-------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -2516,8 +2516,8 @@ Used by: [ManagementPolicySchema](#ManagementPolicySchema).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Required</small>                                                    |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type](#ManagementPolicyRule_Type)<br/><small>Required</small>   |
 
-<a id="ManagementPolicyRule_STATUS"></a>ManagementPolicyRule_STATUS
--------------------------------------------------------------------
+ManagementPolicyRule_STATUS{#ManagementPolicyRule_STATUS}
+---------------------------------------------------------
 
 An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.
 
@@ -2530,8 +2530,8 @@ Used by: [ManagementPolicySchema_STATUS](#ManagementPolicySchema_STATUS).
 | name       | A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy. | string<br/><small>Optional</small>                                                                  |
 | type       | The valid value is Lifecycle                                                                                                         | [ManagementPolicyRule_Type_STATUS](#ManagementPolicyRule_Type_STATUS)<br/><small>Optional</small>   |
 
-<a id="NetworkRuleSet_Bypass_STATUS"></a>NetworkRuleSet_Bypass_STATUS
----------------------------------------------------------------------
+NetworkRuleSet_Bypass_STATUS{#NetworkRuleSet_Bypass_STATUS}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -2542,8 +2542,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Metrics"       |             |
 | "None"          |             |
 
-<a id="NetworkRuleSet_DefaultAction"></a>NetworkRuleSet_DefaultAction
----------------------------------------------------------------------
+NetworkRuleSet_DefaultAction{#NetworkRuleSet_DefaultAction}
+-----------------------------------------------------------
 
 Used by: [NetworkRuleSet](#NetworkRuleSet).
 
@@ -2552,8 +2552,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="NetworkRuleSet_DefaultAction_STATUS"></a>NetworkRuleSet_DefaultAction_STATUS
------------------------------------------------------------------------------------
+NetworkRuleSet_DefaultAction_STATUS{#NetworkRuleSet_DefaultAction_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 
@@ -2562,8 +2562,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | "Allow" |             |
 | "Deny"  |             |
 
-<a id="ProtectedAppendWritesHistory_STATUS"></a>ProtectedAppendWritesHistory_STATUS
------------------------------------------------------------------------------------
+ProtectedAppendWritesHistory_STATUS{#ProtectedAppendWritesHistory_STATUS}
+-------------------------------------------------------------------------
 
 Protected append writes history setting for the blob container with Legal holds.
 
@@ -2574,8 +2574,8 @@ Used by: [LegalHoldProperties_STATUS](#LegalHoldProperties_STATUS).
 | allowProtectedAppendWritesAll | When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining legal hold protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. | bool<br/><small>Optional</small>   |
 | timestamp                     | Returns the date and time the tag was added.                                                                                                                                                                        | string<br/><small>Optional</small> |
 
-<a id="ResourceAccessRule"></a>ResourceAccessRule
--------------------------------------------------
+ResourceAccessRule{#ResourceAccessRule}
+---------------------------------------
 
 Resource Access Rule.
 
@@ -2586,8 +2586,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | resourceReference | Resource Id | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | tenantId          | Tenant Id   | string<br/><small>Optional</small>                                                                                                                         |
 
-<a id="ResourceAccessRule_STATUS"></a>ResourceAccessRule_STATUS
----------------------------------------------------------------
+ResourceAccessRule_STATUS{#ResourceAccessRule_STATUS}
+-----------------------------------------------------
 
 Resource Access Rule.
 
@@ -2598,8 +2598,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | resourceId | Resource Id | string<br/><small>Optional</small> |
 | tenantId   | Tenant Id   | string<br/><small>Optional</small> |
 
-<a id="RoutingPreference_RoutingChoice"></a>RoutingPreference_RoutingChoice
----------------------------------------------------------------------------
+RoutingPreference_RoutingChoice{#RoutingPreference_RoutingChoice}
+-----------------------------------------------------------------
 
 Used by: [RoutingPreference](#RoutingPreference).
 
@@ -2608,8 +2608,8 @@ Used by: [RoutingPreference](#RoutingPreference).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="RoutingPreference_RoutingChoice_STATUS"></a>RoutingPreference_RoutingChoice_STATUS
------------------------------------------------------------------------------------------
+RoutingPreference_RoutingChoice_STATUS{#RoutingPreference_RoutingChoice_STATUS}
+-------------------------------------------------------------------------------
 
 Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 
@@ -2618,8 +2618,8 @@ Used by: [RoutingPreference_STATUS](#RoutingPreference_STATUS).
 | "InternetRouting"  |             |
 | "MicrosoftRouting" |             |
 
-<a id="SasPolicy_ExpirationAction"></a>SasPolicy_ExpirationAction
------------------------------------------------------------------
+SasPolicy_ExpirationAction{#SasPolicy_ExpirationAction}
+-------------------------------------------------------
 
 Used by: [SasPolicy](#SasPolicy).
 
@@ -2627,8 +2627,8 @@ Used by: [SasPolicy](#SasPolicy).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SasPolicy_ExpirationAction_STATUS"></a>SasPolicy_ExpirationAction_STATUS
--------------------------------------------------------------------------------
+SasPolicy_ExpirationAction_STATUS{#SasPolicy_ExpirationAction_STATUS}
+---------------------------------------------------------------------
 
 Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 
@@ -2636,8 +2636,8 @@ Used by: [SasPolicy_STATUS](#SasPolicy_STATUS).
 |-------|-------------|
 | "Log" |             |
 
-<a id="SkuName"></a>SkuName
----------------------------
+SkuName{#SkuName}
+-----------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -2654,8 +2654,8 @@ Used by: [Sku](#Sku).
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="SkuName_STATUS"></a>SkuName_STATUS
------------------------------------------
+SkuName_STATUS{#SkuName_STATUS}
+-------------------------------
 
 The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.
 
@@ -2672,8 +2672,8 @@ Used by: [Sku_STATUS](#Sku_STATUS), and [StorageAccountSkuConversionStatus_STATU
 | "Standard_RAGZRS" |             |
 | "Standard_ZRS"    |             |
 
-<a id="SmbSetting"></a>SmbSetting
----------------------------------
+SmbSetting{#SmbSetting}
+-----------------------
 
 Setting for SMB protocol
 
@@ -2687,8 +2687,8 @@ Used by: [ProtocolSettings](#ProtocolSettings).
 | multichannel             | Multichannel setting. Applies to Premium FileStorage only.                                                                                           | [Multichannel](#Multichannel)<br/><small>Optional</small> |
 | versions                 | SMB protocol versions supported by server. Valid values are SMB2.1, SMB3.0, SMB3.1.1. Should be passed as a string with delimiter ';'.               | string<br/><small>Optional</small>                        |
 
-<a id="SmbSetting_STATUS"></a>SmbSetting_STATUS
------------------------------------------------
+SmbSetting_STATUS{#SmbSetting_STATUS}
+-------------------------------------
 
 Setting for SMB protocol
 
@@ -2702,8 +2702,8 @@ Used by: [ProtocolSettings_STATUS](#ProtocolSettings_STATUS).
 | multichannel             | Multichannel setting. Applies to Premium FileStorage only.                                                                                           | [Multichannel_STATUS](#Multichannel_STATUS)<br/><small>Optional</small> |
 | versions                 | SMB protocol versions supported by server. Valid values are SMB2.1, SMB3.0, SMB3.1.1. Should be passed as a string with delimiter ';'.               | string<br/><small>Optional</small>                                      |
 
-<a id="StorageAccountInternetEndpoints_STATUS"></a>StorageAccountInternetEndpoints_STATUS
------------------------------------------------------------------------------------------
+StorageAccountInternetEndpoints_STATUS{#StorageAccountInternetEndpoints_STATUS}
+-------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, file, web or dfs object via a internet routing endpoint.
 
@@ -2716,8 +2716,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | file     | Gets the file endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.  | string<br/><small>Optional</small> |
 
-<a id="StorageAccountMicrosoftEndpoints_STATUS"></a>StorageAccountMicrosoftEndpoints_STATUS
--------------------------------------------------------------------------------------------
+StorageAccountMicrosoftEndpoints_STATUS{#StorageAccountMicrosoftEndpoints_STATUS}
+---------------------------------------------------------------------------------
 
 The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object via a microsoft routing endpoint.
 
@@ -2732,8 +2732,8 @@ Used by: [Endpoints_STATUS](#Endpoints_STATUS).
 | table    | Gets the table endpoint. | string<br/><small>Optional</small> |
 | web      | Gets the web endpoint.   | string<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorConfigMaps"></a>StorageAccountOperatorConfigMaps
------------------------------------------------------------------------------
+StorageAccountOperatorConfigMaps{#StorageAccountOperatorConfigMaps}
+-------------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -2746,8 +2746,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint config map should be placed. If omitted, no config map will be created. | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint config map should be placed. If omitted, no config map will be created.   | [genruntime.ConfigMapDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ConfigMapDestination)<br/><small>Optional</small> |
 
-<a id="StorageAccountOperatorSecrets"></a>StorageAccountOperatorSecrets
------------------------------------------------------------------------
+StorageAccountOperatorSecrets{#StorageAccountOperatorSecrets}
+-------------------------------------------------------------
 
 Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 
@@ -2762,8 +2762,8 @@ Used by: [StorageAccountOperatorSpec](#StorageAccountOperatorSpec).
 | tableEndpoint | indicates where the TableEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure. | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 | webEndpoint   | indicates where the WebEndpoint secret should be placed. If omitted, the secret will not be retrieved from Azure.   | [genruntime.SecretDestination](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#SecretDestination)<br/><small>Optional</small> |
 
-<a id="StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS"></a>StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS{#StorageAccountSkuConversionStatus_SkuConversionStatus_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [StorageAccountSkuConversionStatus_STATUS](#StorageAccountSkuConversionStatus_STATUS).
 
@@ -2773,8 +2773,8 @@ Used by: [StorageAccountSkuConversionStatus_STATUS](#StorageAccountSkuConversion
 | "InProgress" |             |
 | "Succeeded"  |             |
 
-<a id="TableAccessPolicy"></a>TableAccessPolicy
------------------------------------------------
+TableAccessPolicy{#TableAccessPolicy}
+-------------------------------------
 
 Table Access Policy Properties Object.
 
@@ -2786,8 +2786,8 @@ Used by: [TableSignedIdentifier](#TableSignedIdentifier).
 | permission | Required. List of abbreviated permissions. Supported permission values include 'r','a','u','d' | string<br/><small>Required</small> |
 | startTime  | Start time of the access policy                                                                | string<br/><small>Optional</small> |
 
-<a id="TableAccessPolicy_STATUS"></a>TableAccessPolicy_STATUS
--------------------------------------------------------------
+TableAccessPolicy_STATUS{#TableAccessPolicy_STATUS}
+---------------------------------------------------
 
 Table Access Policy Properties Object.
 
@@ -2799,8 +2799,8 @@ Used by: [TableSignedIdentifier_STATUS](#TableSignedIdentifier_STATUS).
 | permission | Required. List of abbreviated permissions. Supported permission values include 'r','a','u','d' | string<br/><small>Optional</small> |
 | startTime  | Start time of the access policy                                                                | string<br/><small>Optional</small> |
 
-<a id="TagProperty_STATUS"></a>TagProperty_STATUS
--------------------------------------------------
+TagProperty_STATUS{#TagProperty_STATUS}
+---------------------------------------
 
 A tag of the LegalHold of a blob container.
 
@@ -2814,8 +2814,8 @@ Used by: [LegalHoldProperties_STATUS](#LegalHoldProperties_STATUS).
 | timestamp        | Returns the date and time the tag was added.                                | string<br/><small>Optional</small> |
 | upn              | Returns the User Principal Name of the user who added the tag.              | string<br/><small>Optional</small> |
 
-<a id="Tier"></a>Tier
----------------------
+Tier{#Tier}
+-----------
 
 The SKU tier. This is based on the SKU name.
 
@@ -2826,8 +2826,8 @@ Used by: [Sku](#Sku).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="Tier_STATUS"></a>Tier_STATUS
------------------------------------
+Tier_STATUS{#Tier_STATUS}
+-------------------------
 
 The SKU tier. This is based on the SKU name.
 
@@ -2838,8 +2838,8 @@ Used by: [Sku_STATUS](#Sku_STATUS).
 | "Premium"  |             |
 | "Standard" |             |
 
-<a id="UpdateHistoryProperty_STATUS"></a>UpdateHistoryProperty_STATUS
----------------------------------------------------------------------
+UpdateHistoryProperty_STATUS{#UpdateHistoryProperty_STATUS}
+-----------------------------------------------------------
 
 An update history of the ImmutabilityPolicy of a blob container.
 
@@ -2856,8 +2856,8 @@ Used by: [ImmutabilityPolicyProperties_STATUS](#ImmutabilityPolicyProperties_STA
 | update                                | The ImmutabilityPolicy update type of a blob container, possible values include: put, lock and extend.                                                                                                                                                                                                                                                                                                                                                                         | [UpdateHistoryProperty_Update_STATUS](#UpdateHistoryProperty_Update_STATUS)<br/><small>Optional</small> |
 | upn                                   | Returns the User Principal Name of the user who updated the ImmutabilityPolicy.                                                                                                                                                                                                                                                                                                                                                                                                | string<br/><small>Optional</small>                                                                      |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 UserAssignedIdentity for the resource.
 
@@ -2868,8 +2868,8 @@ Used by: [Identity_STATUS](#Identity_STATUS).
 | clientId    | The client ID of the identity.    | string<br/><small>Optional</small> |
 | principalId | The principal ID of the identity. | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -2879,8 +2879,8 @@ Used by: [Identity](#Identity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualNetworkRule"></a>VirtualNetworkRule
--------------------------------------------------
+VirtualNetworkRule{#VirtualNetworkRule}
+---------------------------------------
 
 Virtual Network rule.
 
@@ -2892,8 +2892,8 @@ Used by: [NetworkRuleSet](#NetworkRuleSet).
 | reference | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Required</small> |
 | state     | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State](#VirtualNetworkRule_State)<br/><small>Optional</small>                                                                          |
 
-<a id="VirtualNetworkRule_STATUS"></a>VirtualNetworkRule_STATUS
----------------------------------------------------------------
+VirtualNetworkRule_STATUS{#VirtualNetworkRule_STATUS}
+-----------------------------------------------------
 
 Virtual Network rule.
 
@@ -2905,8 +2905,8 @@ Used by: [NetworkRuleSet_STATUS](#NetworkRuleSet_STATUS).
 | id       | Resource ID of a subnet, for example: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{groupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}. | string<br/><small>Optional</small>                                                                |
 | state    | Gets the state of virtual network rule.                                                                                                                                                                                                                                       | [VirtualNetworkRule_State_STATUS](#VirtualNetworkRule_State_STATUS)<br/><small>Optional</small>   |
 
-<a id="AccountImmutabilityPolicyProperties_State"></a>AccountImmutabilityPolicyProperties_State
------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_State{#AccountImmutabilityPolicyProperties_State}
+-------------------------------------------------------------------------------------
 
 Used by: [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyProperties).
 
@@ -2916,8 +2916,8 @@ Used by: [AccountImmutabilityPolicyProperties](#AccountImmutabilityPolicyPropert
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="AccountImmutabilityPolicyProperties_State_STATUS"></a>AccountImmutabilityPolicyProperties_State_STATUS
--------------------------------------------------------------------------------------------------------------
+AccountImmutabilityPolicyProperties_State_STATUS{#AccountImmutabilityPolicyProperties_State_STATUS}
+---------------------------------------------------------------------------------------------------
 
 Used by: [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicyProperties_STATUS).
 
@@ -2927,8 +2927,8 @@ Used by: [AccountImmutabilityPolicyProperties_STATUS](#AccountImmutabilityPolicy
 | "Locked"   |             |
 | "Unlocked" |             |
 
-<a id="ActiveDirectoryProperties_AccountType"></a>ActiveDirectoryProperties_AccountType
----------------------------------------------------------------------------------------
+ActiveDirectoryProperties_AccountType{#ActiveDirectoryProperties_AccountType}
+-----------------------------------------------------------------------------
 
 Used by: [ActiveDirectoryProperties](#ActiveDirectoryProperties).
 
@@ -2937,8 +2937,8 @@ Used by: [ActiveDirectoryProperties](#ActiveDirectoryProperties).
 | "Computer" |             |
 | "User"     |             |
 
-<a id="ActiveDirectoryProperties_AccountType_STATUS"></a>ActiveDirectoryProperties_AccountType_STATUS
------------------------------------------------------------------------------------------------------
+ActiveDirectoryProperties_AccountType_STATUS{#ActiveDirectoryProperties_AccountType_STATUS}
+-------------------------------------------------------------------------------------------
 
 Used by: [ActiveDirectoryProperties_STATUS](#ActiveDirectoryProperties_STATUS).
 
@@ -2947,8 +2947,8 @@ Used by: [ActiveDirectoryProperties_STATUS](#ActiveDirectoryProperties_STATUS).
 | "Computer" |             |
 | "User"     |             |
 
-<a id="BlobRestoreRange_STATUS"></a>BlobRestoreRange_STATUS
------------------------------------------------------------
+BlobRestoreRange_STATUS{#BlobRestoreRange_STATUS}
+-------------------------------------------------
 
 Blob range
 
@@ -2959,8 +2959,8 @@ Used by: [BlobRestoreParameters_STATUS](#BlobRestoreParameters_STATUS).
 | endRange   | Blob end range. This is exclusive. Empty means account end.     | string<br/><small>Optional</small> |
 | startRange | Blob start range. This is inclusive. Empty means account start. | string<br/><small>Optional</small> |
 
-<a id="CorsRule_AllowedMethods"></a>CorsRule_AllowedMethods
------------------------------------------------------------
+CorsRule_AllowedMethods{#CorsRule_AllowedMethods}
+-------------------------------------------------
 
 Used by: [CorsRule](#CorsRule).
 
@@ -2977,8 +2977,8 @@ Used by: [CorsRule](#CorsRule).
 | "PUT"     |             |
 | "TRACE"   |             |
 
-<a id="CorsRule_AllowedMethods_STATUS"></a>CorsRule_AllowedMethods_STATUS
--------------------------------------------------------------------------
+CorsRule_AllowedMethods_STATUS{#CorsRule_AllowedMethods_STATUS}
+---------------------------------------------------------------
 
 Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 
@@ -2995,8 +2995,8 @@ Used by: [CorsRule_STATUS](#CorsRule_STATUS).
 | "PUT"     |             |
 | "TRACE"   |             |
 
-<a id="EncryptionService"></a>EncryptionService
------------------------------------------------
+EncryptionService{#EncryptionService}
+-------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -3007,8 +3007,8 @@ Used by: [EncryptionServices](#EncryptionServices), [EncryptionServices](#Encryp
 | enabled  | A boolean indicating whether or not the service encrypts the data as it is stored. Encryption at rest is enabled by default today and cannot be disabled.                                                | bool<br/><small>Optional</small>                                                    |
 | keyType  | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used. | [EncryptionService_KeyType](#EncryptionService_KeyType)<br/><small>Optional</small> |
 
-<a id="EncryptionService_STATUS"></a>EncryptionService_STATUS
--------------------------------------------------------------
+EncryptionService_STATUS{#EncryptionService_STATUS}
+---------------------------------------------------
 
 A service that allows server-side encryption to be used.
 
@@ -3020,8 +3020,8 @@ Used by: [EncryptionServices_STATUS](#EncryptionServices_STATUS), [EncryptionSer
 | keyType         | Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used. | [EncryptionService_KeyType_STATUS](#EncryptionService_KeyType_STATUS)<br/><small>Optional</small> |
 | lastEnabledTime | Gets a rough estimate of the date/time when the encryption was last enabled by the user. Data is encrypted at rest by default today and cannot be disabled.                                              | string<br/><small>Optional</small>                                                                |
 
-<a id="IPRule_Action"></a>IPRule_Action
----------------------------------------
+IPRule_Action{#IPRule_Action}
+-----------------------------
 
 Used by: [IPRule](#IPRule).
 
@@ -3029,8 +3029,8 @@ Used by: [IPRule](#IPRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="IPRule_Action_STATUS"></a>IPRule_Action_STATUS
------------------------------------------------------
+IPRule_Action_STATUS{#IPRule_Action_STATUS}
+-------------------------------------------
 
 Used by: [IPRule_STATUS](#IPRule_STATUS).
 
@@ -3038,8 +3038,8 @@ Used by: [IPRule_STATUS](#IPRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="ManagementPolicyDefinition"></a>ManagementPolicyDefinition
------------------------------------------------------------------
+ManagementPolicyDefinition{#ManagementPolicyDefinition}
+-------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -3050,8 +3050,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 | actions  | An object that defines the action set. | [ManagementPolicyAction](#ManagementPolicyAction)<br/><small>Required</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter](#ManagementPolicyFilter)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyDefinition_STATUS"></a>ManagementPolicyDefinition_STATUS
--------------------------------------------------------------------------------
+ManagementPolicyDefinition_STATUS{#ManagementPolicyDefinition_STATUS}
+---------------------------------------------------------------------
 
 An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.
 
@@ -3062,8 +3062,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 | actions  | An object that defines the action set. | [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS)<br/><small>Optional</small> |
 | filters  | An object that defines the filter set. | [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyRule_Type"></a>ManagementPolicyRule_Type
----------------------------------------------------------------
+ManagementPolicyRule_Type{#ManagementPolicyRule_Type}
+-----------------------------------------------------
 
 Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 
@@ -3071,8 +3071,8 @@ Used by: [ManagementPolicyRule](#ManagementPolicyRule).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="ManagementPolicyRule_Type_STATUS"></a>ManagementPolicyRule_Type_STATUS
------------------------------------------------------------------------------
+ManagementPolicyRule_Type_STATUS{#ManagementPolicyRule_Type_STATUS}
+-------------------------------------------------------------------
 
 Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 
@@ -3080,8 +3080,8 @@ Used by: [ManagementPolicyRule_STATUS](#ManagementPolicyRule_STATUS).
 |-------------|-------------|
 | "Lifecycle" |             |
 
-<a id="Multichannel"></a>Multichannel
--------------------------------------
+Multichannel{#Multichannel}
+---------------------------
 
 Multichannel setting. Applies to Premium FileStorage only.
 
@@ -3091,8 +3091,8 @@ Used by: [SmbSetting](#SmbSetting).
 |----------|-------------------------------------------|----------------------------------|
 | enabled  | Indicates whether multichannel is enabled | bool<br/><small>Optional</small> |
 
-<a id="Multichannel_STATUS"></a>Multichannel_STATUS
----------------------------------------------------
+Multichannel_STATUS{#Multichannel_STATUS}
+-----------------------------------------
 
 Multichannel setting. Applies to Premium FileStorage only.
 
@@ -3102,8 +3102,8 @@ Used by: [SmbSetting_STATUS](#SmbSetting_STATUS).
 |----------|-------------------------------------------|----------------------------------|
 | enabled  | Indicates whether multichannel is enabled | bool<br/><small>Optional</small> |
 
-<a id="UpdateHistoryProperty_Update_STATUS"></a>UpdateHistoryProperty_Update_STATUS
------------------------------------------------------------------------------------
+UpdateHistoryProperty_Update_STATUS{#UpdateHistoryProperty_Update_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 
@@ -3113,8 +3113,8 @@ Used by: [UpdateHistoryProperty_STATUS](#UpdateHistoryProperty_STATUS).
 | "lock"   |             |
 | "put"    |             |
 
-<a id="VirtualNetworkRule_Action"></a>VirtualNetworkRule_Action
----------------------------------------------------------------
+VirtualNetworkRule_Action{#VirtualNetworkRule_Action}
+-----------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -3122,8 +3122,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_Action_STATUS"></a>VirtualNetworkRule_Action_STATUS
------------------------------------------------------------------------------
+VirtualNetworkRule_Action_STATUS{#VirtualNetworkRule_Action_STATUS}
+-------------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -3131,8 +3131,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 |---------|-------------|
 | "Allow" |             |
 
-<a id="VirtualNetworkRule_State"></a>VirtualNetworkRule_State
--------------------------------------------------------------
+VirtualNetworkRule_State{#VirtualNetworkRule_State}
+---------------------------------------------------
 
 Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 
@@ -3144,8 +3144,8 @@ Used by: [VirtualNetworkRule](#VirtualNetworkRule).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="VirtualNetworkRule_State_STATUS"></a>VirtualNetworkRule_State_STATUS
----------------------------------------------------------------------------
+VirtualNetworkRule_State_STATUS{#VirtualNetworkRule_State_STATUS}
+-----------------------------------------------------------------
 
 Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 
@@ -3157,8 +3157,8 @@ Used by: [VirtualNetworkRule_STATUS](#VirtualNetworkRule_STATUS).
 | "Provisioning"         |             |
 | "Succeeded"            |             |
 
-<a id="EncryptionService_KeyType"></a>EncryptionService_KeyType
----------------------------------------------------------------
+EncryptionService_KeyType{#EncryptionService_KeyType}
+-----------------------------------------------------
 
 Used by: [EncryptionService](#EncryptionService).
 
@@ -3167,8 +3167,8 @@ Used by: [EncryptionService](#EncryptionService).
 | "Account" |             |
 | "Service" |             |
 
-<a id="EncryptionService_KeyType_STATUS"></a>EncryptionService_KeyType_STATUS
------------------------------------------------------------------------------
+EncryptionService_KeyType_STATUS{#EncryptionService_KeyType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 
@@ -3177,8 +3177,8 @@ Used by: [EncryptionService_STATUS](#EncryptionService_STATUS).
 | "Account" |             |
 | "Service" |             |
 
-<a id="ManagementPolicyAction"></a>ManagementPolicyAction
----------------------------------------------------------
+ManagementPolicyAction{#ManagementPolicyAction}
+-----------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -3190,8 +3190,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot](#ManagementPolicySnapShot)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion](#ManagementPolicyVersion)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyAction_STATUS"></a>ManagementPolicyAction_STATUS
------------------------------------------------------------------------
+ManagementPolicyAction_STATUS{#ManagementPolicyAction_STATUS}
+-------------------------------------------------------------
 
 Actions are applied to the filtered blobs when the execution condition is met.
 
@@ -3203,8 +3203,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | snapshot | The management policy action for snapshot  | [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS)<br/><small>Optional</small> |
 | version  | The management policy action for version   | [ManagementPolicyVersion_STATUS](#ManagementPolicyVersion_STATUS)<br/><small>Optional</small>   |
 
-<a id="ManagementPolicyFilter"></a>ManagementPolicyFilter
----------------------------------------------------------
+ManagementPolicyFilter{#ManagementPolicyFilter}
+-----------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -3216,8 +3216,8 @@ Used by: [ManagementPolicyDefinition](#ManagementPolicyDefinition).
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Required</small>                  |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                  |
 
-<a id="ManagementPolicyFilter_STATUS"></a>ManagementPolicyFilter_STATUS
------------------------------------------------------------------------
+ManagementPolicyFilter_STATUS{#ManagementPolicyFilter_STATUS}
+-------------------------------------------------------------
 
 Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.
 
@@ -3229,8 +3229,8 @@ Used by: [ManagementPolicyDefinition_STATUS](#ManagementPolicyDefinition_STATUS)
 | blobTypes      | An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob. | string[]<br/><small>Optional</small>                                |
 | prefixMatch    | An array of strings for prefixes to be match.                                                                                                      | string[]<br/><small>Optional</small>                                |
 
-<a id="ManagementPolicyBaseBlob"></a>ManagementPolicyBaseBlob
--------------------------------------------------------------
+ManagementPolicyBaseBlob{#ManagementPolicyBaseBlob}
+---------------------------------------------------
 
 Management policy action for base blob.
 
@@ -3245,8 +3245,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool                  | The function to tier blobs to cool storage.                                                                                                           | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 | tierToHot                   | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts                                      | [DateAfterModification](#DateAfterModification)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyBaseBlob_STATUS"></a>ManagementPolicyBaseBlob_STATUS
----------------------------------------------------------------------------
+ManagementPolicyBaseBlob_STATUS{#ManagementPolicyBaseBlob_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for base blob.
 
@@ -3261,8 +3261,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool                  | The function to tier blobs to cool storage.                                                                                                           | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 | tierToHot                   | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts                                      | [DateAfterModification_STATUS](#DateAfterModification_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot"></a>ManagementPolicySnapShot
--------------------------------------------------------------
+ManagementPolicySnapShot{#ManagementPolicySnapShot}
+---------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -3276,8 +3276,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool    | The function to tier blob snapshot to cool storage.                                                              | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicySnapShot_STATUS"></a>ManagementPolicySnapShot_STATUS
----------------------------------------------------------------------------
+ManagementPolicySnapShot_STATUS{#ManagementPolicySnapShot_STATUS}
+-----------------------------------------------------------------
 
 Management policy action for snapshot.
 
@@ -3291,8 +3291,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool    | The function to tier blob snapshot to cool storage.                                                              | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion"></a>ManagementPolicyVersion
------------------------------------------------------------
+ManagementPolicyVersion{#ManagementPolicyVersion}
+-------------------------------------------------
 
 Management policy action for blob version.
 
@@ -3306,8 +3306,8 @@ Used by: [ManagementPolicyAction](#ManagementPolicyAction).
 | tierToCool    | The function to tier blob version to cool storage.                                                               | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation](#DateAfterCreation)<br/><small>Optional</small> |
 
-<a id="ManagementPolicyVersion_STATUS"></a>ManagementPolicyVersion_STATUS
--------------------------------------------------------------------------
+ManagementPolicyVersion_STATUS{#ManagementPolicyVersion_STATUS}
+---------------------------------------------------------------
 
 Management policy action for blob version.
 
@@ -3321,8 +3321,8 @@ Used by: [ManagementPolicyAction_STATUS](#ManagementPolicyAction_STATUS).
 | tierToCool    | The function to tier blob version to cool storage.                                                               | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 | tierToHot     | The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts | [DateAfterCreation_STATUS](#DateAfterCreation_STATUS)<br/><small>Optional</small> |
 
-<a id="TagFilter"></a>TagFilter
--------------------------------
+TagFilter{#TagFilter}
+---------------------
 
 Blob index tag based filtering for blob objects
 
@@ -3334,8 +3334,8 @@ Used by: [ManagementPolicyFilter](#ManagementPolicyFilter).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Required</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Required</small> |
 
-<a id="TagFilter_STATUS"></a>TagFilter_STATUS
----------------------------------------------
+TagFilter_STATUS{#TagFilter_STATUS}
+-----------------------------------
 
 Blob index tag based filtering for blob objects
 
@@ -3347,8 +3347,8 @@ Used by: [ManagementPolicyFilter_STATUS](#ManagementPolicyFilter_STATUS).
 | op       | This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported | string<br/><small>Optional</small> |
 | value    | This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters                                       | string<br/><small>Optional</small> |
 
-<a id="DateAfterCreation"></a>DateAfterCreation
------------------------------------------------
+DateAfterCreation{#DateAfterCreation}
+-------------------------------------
 
 Object to define snapshot and version action conditions.
 
@@ -3359,8 +3359,8 @@ Used by: [ManagementPolicySnapShot](#ManagementPolicySnapShot), [ManagementPolic
 | daysAfterCreationGreaterThan       | Value indicating the age in days after creation                                                                                                                                                                                                                                                 | int<br/><small>Required</small> |
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterCreationGreaterThan to be set for snapshots and blob version based actions. The blob will be archived if both the conditions are satisfied. | int<br/><small>Optional</small> |
 
-<a id="DateAfterCreation_STATUS"></a>DateAfterCreation_STATUS
--------------------------------------------------------------
+DateAfterCreation_STATUS{#DateAfterCreation_STATUS}
+---------------------------------------------------
 
 Object to define snapshot and version action conditions.
 
@@ -3371,8 +3371,8 @@ Used by: [ManagementPolicySnapShot_STATUS](#ManagementPolicySnapShot_STATUS), [M
 | daysAfterCreationGreaterThan       | Value indicating the age in days after creation                                                                                                                                                                                                                                                 | float64<br/><small>Optional</small> |
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterCreationGreaterThan to be set for snapshots and blob version based actions. The blob will be archived if both the conditions are satisfied. | float64<br/><small>Optional</small> |
 
-<a id="DateAfterModification"></a>DateAfterModification
--------------------------------------------------------
+DateAfterModification{#DateAfterModification}
+---------------------------------------------
 
 Object to define the base blob action conditions. Properties daysAfterModificationGreaterThan, daysAfterLastAccessTimeGreaterThan and daysAfterCreationGreaterThan are mutually exclusive. The daysAfterLastTierChangeGreaterThan property is only applicable for tierToArchive actions which requires daysAfterModificationGreaterThan to be set, also it cannot be used in conjunction with daysAfterLastAccessTimeGreaterThan or daysAfterCreationGreaterThan.
 
@@ -3385,8 +3385,8 @@ Used by: [ManagementPolicyBaseBlob](#ManagementPolicyBaseBlob), [ManagementPolic
 | daysAfterLastTierChangeGreaterThan | Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterModificationGreaterThan to be set for baseBlobs based actions. The blob will be archived if both the conditions are satisfied. | int<br/><small>Optional</small> |
 | daysAfterModificationGreaterThan   | Value indicating the age in days after last modification                                                                                                                                                                                                                           | int<br/><small>Optional</small> |
 
-<a id="DateAfterModification_STATUS"></a>DateAfterModification_STATUS
----------------------------------------------------------------------
+DateAfterModification_STATUS{#DateAfterModification_STATUS}
+-----------------------------------------------------------
 
 Object to define the base blob action conditions. Properties daysAfterModificationGreaterThan, daysAfterLastAccessTimeGreaterThan and daysAfterCreationGreaterThan are mutually exclusive. The daysAfterLastTierChangeGreaterThan property is only applicable for tierToArchive actions which requires daysAfterModificationGreaterThan to be set, also it cannot be used in conjunction with daysAfterLastAccessTimeGreaterThan or daysAfterCreationGreaterThan.
 

--- a/docs/hugo/content/reference/subscription/v1api20211001.md
+++ b/docs/hugo/content/reference/subscription/v1api20211001.md
@@ -5,8 +5,8 @@ title: subscription.azure.com/v1api20211001
 linktitle: v1api20211001
 ------------------------
 
-<a id="Alias"></a>Alias
------------------------
+Alias{#Alias}
+-------------
 
 Generator information: - Generated from: /subscription/resource-manager/Microsoft.Subscription/stable/2021-10-01/subscriptions.json - ARM URI: /providers/Microsoft.Subscription/aliases/{aliasName}
 
@@ -19,7 +19,7 @@ Used by: [AliasList](#AliasList).
 | spec                                                                                    |             | [Alias_Spec](#Alias_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Alias_STATUS](#Alias_STATUS)<br/><small>Optional</small> |
 
-### <a id="Alias_Spec"></a>Alias_Spec
+### Alias_Spec {#Alias_Spec}
 
 | Property     | Description                                                                                                                     | Type                                                                                |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
@@ -27,7 +27,7 @@ Used by: [AliasList](#AliasList).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure | [AliasOperatorSpec](#AliasOperatorSpec)<br/><small>Optional</small>                 |
 | properties   | Put alias request properties.                                                                                                   | [PutAliasRequestProperties](#PutAliasRequestProperties)<br/><small>Optional</small> |
 
-### <a id="Alias_STATUS"></a>Alias_STATUS
+### Alias_STATUS{#Alias_STATUS}
 
 | Property   | Description                                                            | Type                                                                                                                                                    |
 |------------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,8 +38,8 @@ Used by: [AliasList](#AliasList).
 | systemData | Metadata pertaining to creation and last modification of the resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type, Microsoft.Subscription/aliases.                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AliasList"></a>AliasList
--------------------------------
+AliasList{#AliasList}
+---------------------
 
 Generator information: - Generated from: /subscription/resource-manager/Microsoft.Subscription/stable/2021-10-01/subscriptions.json - ARM URI: /providers/Microsoft.Subscription/aliases/{aliasName}
 
@@ -49,15 +49,15 @@ Generator information: - Generated from: /subscription/resource-manager/Microsof
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                               |
 | items                                                                               |             | [Alias[]](#Alias)<br/><small>Optional</small> |
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-10-01" |             |
 
-<a id="Alias_Spec"></a>Alias_Spec
----------------------------------
+Alias_Spec{#Alias_Spec}
+-----------------------
 
 Used by: [Alias](#Alias).
 
@@ -67,8 +67,8 @@ Used by: [Alias](#Alias).
 | operatorSpec | The specification for configuring operator behavior. This field is interpreted by the operator and not passed directly to Azure | [AliasOperatorSpec](#AliasOperatorSpec)<br/><small>Optional</small>                 |
 | properties   | Put alias request properties.                                                                                                   | [PutAliasRequestProperties](#PutAliasRequestProperties)<br/><small>Optional</small> |
 
-<a id="Alias_STATUS"></a>Alias_STATUS
--------------------------------------
+Alias_STATUS{#Alias_STATUS}
+---------------------------
 
 Used by: [Alias](#Alias).
 
@@ -81,8 +81,8 @@ Used by: [Alias](#Alias).
 | systemData | Metadata pertaining to creation and last modification of the resource. | [SystemData_STATUS](#SystemData_STATUS)<br/><small>Optional</small>                                                                                     |
 | type       | Resource type, Microsoft.Subscription/aliases.                         | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AliasOperatorSpec"></a>AliasOperatorSpec
------------------------------------------------
+AliasOperatorSpec{#AliasOperatorSpec}
+-------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -93,8 +93,8 @@ Used by: [Alias_Spec](#Alias_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="PutAliasRequestProperties"></a>PutAliasRequestProperties
----------------------------------------------------------------
+PutAliasRequestProperties{#PutAliasRequestProperties}
+-----------------------------------------------------
 
 Put subscription properties.
 
@@ -109,8 +109,8 @@ Used by: [Alias_Spec](#Alias_Spec).
 | subscriptionId       | This parameter can be used to create alias for existing subscription Id        | string<br/><small>Optional</small>                                                                      |
 | workload             | The workload type of the subscription. It can be either Production or DevTest. | [Workload](#Workload)<br/><small>Optional</small>                                                       |
 
-<a id="SubscriptionAliasResponseProperties_STATUS"></a>SubscriptionAliasResponseProperties_STATUS
--------------------------------------------------------------------------------------------------
+SubscriptionAliasResponseProperties_STATUS{#SubscriptionAliasResponseProperties_STATUS}
+---------------------------------------------------------------------------------------
 
 Put subscription creation result properties.
 
@@ -131,8 +131,8 @@ Used by: [Alias_STATUS](#Alias_STATUS).
 | tags                 | Tags for the subscription                                                      | map[string]string<br/><small>Optional</small>                                                                                                             |
 | workload             | The workload type of the subscription. It can be either Production or DevTest. | [Workload_STATUS](#Workload_STATUS)<br/><small>Optional</small>                                                                                           |
 
-<a id="SystemData_STATUS"></a>SystemData_STATUS
------------------------------------------------
+SystemData_STATUS{#SystemData_STATUS}
+-------------------------------------
 
 Metadata pertaining to creation and last modification of the resource.
 
@@ -147,8 +147,8 @@ Used by: [Alias_STATUS](#Alias_STATUS).
 | lastModifiedBy     | The identity that last modified the resource.         | string<br/><small>Optional</small>                                                                        |
 | lastModifiedByType | The type of identity that last modified the resource. | [SystemData_LastModifiedByType_STATUS](#SystemData_LastModifiedByType_STATUS)<br/><small>Optional</small> |
 
-<a id="AcceptOwnershipState_STATUS"></a>AcceptOwnershipState_STATUS
--------------------------------------------------------------------
+AcceptOwnershipState_STATUS{#AcceptOwnershipState_STATUS}
+---------------------------------------------------------
 
 The accept ownership state of the resource.
 
@@ -160,8 +160,8 @@ Used by: [SubscriptionAliasResponseProperties_STATUS](#SubscriptionAliasResponse
 | "Expired"   |             |
 | "Pending"   |             |
 
-<a id="PutAliasRequestAdditionalProperties"></a>PutAliasRequestAdditionalProperties
------------------------------------------------------------------------------------
+PutAliasRequestAdditionalProperties{#PutAliasRequestAdditionalProperties}
+-------------------------------------------------------------------------
 
 Put subscription additional properties.
 
@@ -174,8 +174,8 @@ Used by: [PutAliasRequestProperties](#PutAliasRequestProperties).
 | subscriptionTenantId | Tenant Id of the subscription             | string<br/><small>Optional</small>            |
 | tags                 | Tags for the subscription                 | map[string]string<br/><small>Optional</small> |
 
-<a id="SubscriptionAliasResponseProperties_ProvisioningState_STATUS"></a>SubscriptionAliasResponseProperties_ProvisioningState_STATUS
--------------------------------------------------------------------------------------------------------------------------------------
+SubscriptionAliasResponseProperties_ProvisioningState_STATUS{#SubscriptionAliasResponseProperties_ProvisioningState_STATUS}
+---------------------------------------------------------------------------------------------------------------------------
 
 Used by: [SubscriptionAliasResponseProperties_STATUS](#SubscriptionAliasResponseProperties_STATUS).
 
@@ -185,7 +185,19 @@ Used by: [SubscriptionAliasResponseProperties_STATUS](#SubscriptionAliasResponse
 | "Failed"    |             |
 | "Succeeded" |             |
 
-<a id="SystemData_CreatedByType_STATUS"></a>SystemData_CreatedByType_STATUS
+SystemData_CreatedByType_STATUS{#SystemData_CreatedByType_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SystemData_STATUS](#SystemData_STATUS).
+
+| Value             | Description |
+|-------------------|-------------|
+| "Application"     |             |
+| "Key"             |             |
+| "ManagedIdentity" |             |
+| "User"            |             |
+
+SystemData_LastModifiedByType_STATUS{#SystemData_LastModifiedByType_STATUS}
 ---------------------------------------------------------------------------
 
 Used by: [SystemData_STATUS](#SystemData_STATUS).
@@ -197,20 +209,8 @@ Used by: [SystemData_STATUS](#SystemData_STATUS).
 | "ManagedIdentity" |             |
 | "User"            |             |
 
-<a id="SystemData_LastModifiedByType_STATUS"></a>SystemData_LastModifiedByType_STATUS
--------------------------------------------------------------------------------------
-
-Used by: [SystemData_STATUS](#SystemData_STATUS).
-
-| Value             | Description |
-|-------------------|-------------|
-| "Application"     |             |
-| "Key"             |             |
-| "ManagedIdentity" |             |
-| "User"            |             |
-
-<a id="Workload"></a>Workload
------------------------------
+Workload{#Workload}
+-------------------
 
 The workload type of the subscription. It can be either Production or DevTest.
 
@@ -221,8 +221,8 @@ Used by: [PutAliasRequestProperties](#PutAliasRequestProperties).
 | "DevTest"    |             |
 | "Production" |             |
 
-<a id="Workload_STATUS"></a>Workload_STATUS
--------------------------------------------
+Workload_STATUS{#Workload_STATUS}
+---------------------------------
 
 The workload type of the subscription. It can be either Production or DevTest.
 

--- a/docs/hugo/content/reference/synapse/v1api20210601.md
+++ b/docs/hugo/content/reference/synapse/v1api20210601.md
@@ -5,15 +5,15 @@ title: synapse.azure.com/v1api20210601
 linktitle: v1api20210601
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2021-06-01" |             |
 
-<a id="Workspace"></a>Workspace
--------------------------------
+Workspace{#Workspace}
+---------------------
 
 Generator information: - Generated from: /synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/workspace.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Synapse/workspaces/{workspaceName}
 
@@ -26,7 +26,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | spec                                                                                    |             | [Workspace_Spec](#Workspace_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Workspace_STATUS](#Workspace_STATUS)<br/><small>Optional</small> |
 
-### <a id="Workspace_Spec"></a>Workspace_Spec
+### Workspace_Spec {#Workspace_Spec}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -51,7 +51,7 @@ Used by: [WorkspaceList](#WorkspaceList).
 | virtualNetworkProfile            | Virtual Network profile                                                                                                                                                                                                                                                                                                                | [VirtualNetworkProfile](#VirtualNetworkProfile)<br/><small>Optional</small>                                                                                          |
 | workspaceRepositoryConfiguration | Git integration settings                                                                                                                                                                                                                                                                                                               | [WorkspaceRepositoryConfiguration](#WorkspaceRepositoryConfiguration)<br/><small>Optional</small>                                                                    |
 
-### <a id="Workspace_STATUS"></a>Workspace_STATUS
+### Workspace_STATUS{#Workspace_STATUS}
 
 | Property                         | Description                                                                                                                                                                                                                                                                                                                            | Type                                                                                                                                                    |
 |----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -83,8 +83,8 @@ Used by: [WorkspaceList](#WorkspaceList).
 | workspaceRepositoryConfiguration | Git integration settings                                                                                                                                                                                                                                                                                                               | [WorkspaceRepositoryConfiguration_STATUS](#WorkspaceRepositoryConfiguration_STATUS)<br/><small>Optional</small>                                         |
 | workspaceUID                     | The workspace unique identifier                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspaceList"></a>WorkspaceList
----------------------------------------
+WorkspaceList{#WorkspaceList}
+-----------------------------
 
 Generator information: - Generated from: /synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/workspace.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Synapse/workspaces/{workspaceName}
 
@@ -94,8 +94,8 @@ Generator information: - Generated from: /synapse/resource-manager/Microsoft.Syn
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                       |
 | items                                                                               |             | [Workspace[]](#Workspace)<br/><small>Optional</small> |
 
-<a id="WorkspacesBigDataPool"></a>WorkspacesBigDataPool
--------------------------------------------------------
+WorkspacesBigDataPool{#WorkspacesBigDataPool}
+---------------------------------------------
 
 Generator information: - Generated from: /synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/bigDataPool.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/{bigDataPoolName}
 
@@ -108,7 +108,7 @@ Used by: [WorkspacesBigDataPoolList](#WorkspacesBigDataPoolList).
 | spec                                                                                    |             | [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS)<br/><small>Optional</small> |
 
-### <a id="WorkspacesBigDataPool_Spec"></a>WorkspacesBigDataPool_Spec
+### WorkspacesBigDataPool_Spec {#WorkspacesBigDataPool_Spec}
 
 | Property                    | Description                                                                                                                                                                                                                                                                            | Type                                                                                                                                                                 |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -135,7 +135,7 @@ Used by: [WorkspacesBigDataPoolList](#WorkspacesBigDataPoolList).
 | sparkVersion                | The Apache Spark version.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-### <a id="WorkspacesBigDataPool_STATUS"></a>WorkspacesBigDataPool_STATUS
+### WorkspacesBigDataPool_STATUS{#WorkspacesBigDataPool_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                               | Type                                                                                                                                                    |
 |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -165,8 +165,8 @@ Used by: [WorkspacesBigDataPoolList](#WorkspacesBigDataPoolList).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesBigDataPoolList"></a>WorkspacesBigDataPoolList
----------------------------------------------------------------
+WorkspacesBigDataPoolList{#WorkspacesBigDataPoolList}
+-----------------------------------------------------
 
 Generator information: - Generated from: /synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/bigDataPool.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/{bigDataPoolName}
 
@@ -176,8 +176,8 @@ Generator information: - Generated from: /synapse/resource-manager/Microsoft.Syn
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                               |
 | items                                                                               |             | [WorkspacesBigDataPool[]](#WorkspacesBigDataPool)<br/><small>Optional</small> |
 
-<a id="Workspace_Spec"></a>Workspace_Spec
------------------------------------------
+Workspace_Spec{#Workspace_Spec}
+-------------------------------
 
 Used by: [Workspace](#Workspace).
 
@@ -204,8 +204,8 @@ Used by: [Workspace](#Workspace).
 | virtualNetworkProfile            | Virtual Network profile                                                                                                                                                                                                                                                                                                                | [VirtualNetworkProfile](#VirtualNetworkProfile)<br/><small>Optional</small>                                                                                          |
 | workspaceRepositoryConfiguration | Git integration settings                                                                                                                                                                                                                                                                                                               | [WorkspaceRepositoryConfiguration](#WorkspaceRepositoryConfiguration)<br/><small>Optional</small>                                                                    |
 
-<a id="Workspace_STATUS"></a>Workspace_STATUS
----------------------------------------------
+Workspace_STATUS{#Workspace_STATUS}
+-----------------------------------
 
 A workspace
 
@@ -241,8 +241,8 @@ Used by: [Workspace](#Workspace).
 | workspaceRepositoryConfiguration | Git integration settings                                                                                                                                                                                                                                                                                                               | [WorkspaceRepositoryConfiguration_STATUS](#WorkspaceRepositoryConfiguration_STATUS)<br/><small>Optional</small>                                         |
 | workspaceUID                     | The workspace unique identifier                                                                                                                                                                                                                                                                                                        | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="WorkspacesBigDataPool_Spec"></a>WorkspacesBigDataPool_Spec
------------------------------------------------------------------
+WorkspacesBigDataPool_Spec{#WorkspacesBigDataPool_Spec}
+-------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool](#WorkspacesBigDataPool).
 
@@ -271,8 +271,8 @@ Used by: [WorkspacesBigDataPool](#WorkspacesBigDataPool).
 | sparkVersion                | The Apache Spark version.                                                                                                                                                                                                                                                              | string<br/><small>Optional</small>                                                                                                                                   |
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                         | map[string]string<br/><small>Optional</small>                                                                                                                        |
 
-<a id="WorkspacesBigDataPool_STATUS"></a>WorkspacesBigDataPool_STATUS
----------------------------------------------------------------------
+WorkspacesBigDataPool_STATUS{#WorkspacesBigDataPool_STATUS}
+-----------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool](#WorkspacesBigDataPool).
 
@@ -304,8 +304,8 @@ Used by: [WorkspacesBigDataPool](#WorkspacesBigDataPool).
 | tags                        | Resource tags.                                                                                                                                                                                                                                                                                                            | map[string]string<br/><small>Optional</small>                                                                                                           |
 | type                        | The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"                                                                                                                                                                                                                 | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="AutoPauseProperties"></a>AutoPauseProperties
----------------------------------------------------
+AutoPauseProperties{#AutoPauseProperties}
+-----------------------------------------
 
 Auto-pausing properties of a Big Data pool powered by Apache Spark
 
@@ -316,8 +316,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | delayInMinutes | Number of minutes of idle time before the Big Data pool is automatically paused. | int<br/><small>Optional</small>  |
 | enabled        | Whether auto-pausing is enabled for the Big Data pool.                           | bool<br/><small>Optional</small> |
 
-<a id="AutoPauseProperties_STATUS"></a>AutoPauseProperties_STATUS
------------------------------------------------------------------
+AutoPauseProperties_STATUS{#AutoPauseProperties_STATUS}
+-------------------------------------------------------
 
 Auto-pausing properties of a Big Data pool powered by Apache Spark
 
@@ -328,8 +328,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | delayInMinutes | Number of minutes of idle time before the Big Data pool is automatically paused. | int<br/><small>Optional</small>  |
 | enabled        | Whether auto-pausing is enabled for the Big Data pool.                           | bool<br/><small>Optional</small> |
 
-<a id="AutoScaleProperties"></a>AutoScaleProperties
----------------------------------------------------
+AutoScaleProperties{#AutoScaleProperties}
+-----------------------------------------
 
 Auto-scaling properties of a Big Data pool powered by Apache Spark
 
@@ -341,8 +341,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | maxNodeCount | The maximum number of nodes the Big Data pool can support.  | int<br/><small>Optional</small>  |
 | minNodeCount | The minimum number of nodes the Big Data pool can support.  | int<br/><small>Optional</small>  |
 
-<a id="AutoScaleProperties_STATUS"></a>AutoScaleProperties_STATUS
------------------------------------------------------------------
+AutoScaleProperties_STATUS{#AutoScaleProperties_STATUS}
+-------------------------------------------------------
 
 Auto-scaling properties of a Big Data pool powered by Apache Spark
 
@@ -354,8 +354,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | maxNodeCount | The maximum number of nodes the Big Data pool can support.  | int<br/><small>Optional</small>  |
 | minNodeCount | The minimum number of nodes the Big Data pool can support.  | int<br/><small>Optional</small>  |
 
-<a id="BigDataPoolResourceProperties_NodeSize"></a>BigDataPoolResourceProperties_NodeSize
------------------------------------------------------------------------------------------
+BigDataPoolResourceProperties_NodeSize{#BigDataPoolResourceProperties_NodeSize}
+-------------------------------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 
@@ -369,8 +369,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | "XXLarge"  |             |
 | "XXXLarge" |             |
 
-<a id="BigDataPoolResourceProperties_NodeSize_STATUS"></a>BigDataPoolResourceProperties_NodeSize_STATUS
--------------------------------------------------------------------------------------------------------
+BigDataPoolResourceProperties_NodeSize_STATUS{#BigDataPoolResourceProperties_NodeSize_STATUS}
+---------------------------------------------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 
@@ -384,8 +384,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | "XXLarge"  |             |
 | "XXXLarge" |             |
 
-<a id="BigDataPoolResourceProperties_NodeSizeFamily"></a>BigDataPoolResourceProperties_NodeSizeFamily
------------------------------------------------------------------------------------------------------
+BigDataPoolResourceProperties_NodeSizeFamily{#BigDataPoolResourceProperties_NodeSizeFamily}
+-------------------------------------------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 
@@ -396,8 +396,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | "MemoryOptimized"         |             |
 | "None"                    |             |
 
-<a id="BigDataPoolResourceProperties_NodeSizeFamily_STATUS"></a>BigDataPoolResourceProperties_NodeSizeFamily_STATUS
--------------------------------------------------------------------------------------------------------------------
+BigDataPoolResourceProperties_NodeSizeFamily_STATUS{#BigDataPoolResourceProperties_NodeSizeFamily_STATUS}
+---------------------------------------------------------------------------------------------------------
 
 Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 
@@ -408,8 +408,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | "MemoryOptimized"         |             |
 | "None"                    |             |
 
-<a id="CspWorkspaceAdminProperties"></a>CspWorkspaceAdminProperties
--------------------------------------------------------------------
+CspWorkspaceAdminProperties{#CspWorkspaceAdminProperties}
+---------------------------------------------------------
 
 Initial workspace AAD admin properties for a CSP subscription
 
@@ -419,8 +419,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |-------------------------------|------------------------------------------|------------------------------------|
 | initialWorkspaceAdminObjectId | AAD object ID of initial workspace admin | string<br/><small>Optional</small> |
 
-<a id="CspWorkspaceAdminProperties_STATUS"></a>CspWorkspaceAdminProperties_STATUS
----------------------------------------------------------------------------------
+CspWorkspaceAdminProperties_STATUS{#CspWorkspaceAdminProperties_STATUS}
+-----------------------------------------------------------------------
 
 Initial workspace AAD admin properties for a CSP subscription
 
@@ -430,8 +430,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |-------------------------------|------------------------------------------|------------------------------------|
 | initialWorkspaceAdminObjectId | AAD object ID of initial workspace admin | string<br/><small>Optional</small> |
 
-<a id="DataLakeStorageAccountDetails"></a>DataLakeStorageAccountDetails
------------------------------------------------------------------------
+DataLakeStorageAccountDetails{#DataLakeStorageAccountDetails}
+-------------------------------------------------------------
 
 Details of the data lake storage account associated with the workspace
 
@@ -445,8 +445,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | filesystem                   | Filesystem name                                                | string<br/><small>Optional</small>                                                                                                                           |
 | resourceReference            | ARM resource Id of this storage account                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small>   |
 
-<a id="DataLakeStorageAccountDetails_STATUS"></a>DataLakeStorageAccountDetails_STATUS
--------------------------------------------------------------------------------------
+DataLakeStorageAccountDetails_STATUS{#DataLakeStorageAccountDetails_STATUS}
+---------------------------------------------------------------------------
 
 Details of the data lake storage account associated with the workspace
 
@@ -459,8 +459,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | filesystem                   | Filesystem name                                                | string<br/><small>Optional</small> |
 | resourceId                   | ARM resource Id of this storage account                        | string<br/><small>Optional</small> |
 
-<a id="DynamicExecutorAllocation"></a>DynamicExecutorAllocation
----------------------------------------------------------------
+DynamicExecutorAllocation{#DynamicExecutorAllocation}
+-----------------------------------------------------
 
 Dynamic Executor Allocation Properties
 
@@ -472,8 +472,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | maxExecutors | The maximum number of executors alloted                          | int<br/><small>Optional</small>  |
 | minExecutors | The minimum number of executors alloted                          | int<br/><small>Optional</small>  |
 
-<a id="DynamicExecutorAllocation_STATUS"></a>DynamicExecutorAllocation_STATUS
------------------------------------------------------------------------------
+DynamicExecutorAllocation_STATUS{#DynamicExecutorAllocation_STATUS}
+-------------------------------------------------------------------
 
 Dynamic Executor Allocation Properties
 
@@ -485,8 +485,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | maxExecutors | The maximum number of executors alloted                          | int<br/><small>Optional</small>  |
 | minExecutors | The minimum number of executors alloted                          | int<br/><small>Optional</small>  |
 
-<a id="EncryptionDetails"></a>EncryptionDetails
------------------------------------------------
+EncryptionDetails{#EncryptionDetails}
+-------------------------------------
 
 Details of the encryption associated with the workspace
 
@@ -496,8 +496,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |----------|------------------------------|-------------------------------------------------------------------------------------|
 | cmk      | Customer Managed Key Details | [CustomerManagedKeyDetails](#CustomerManagedKeyDetails)<br/><small>Optional</small> |
 
-<a id="EncryptionDetails_STATUS"></a>EncryptionDetails_STATUS
--------------------------------------------------------------
+EncryptionDetails_STATUS{#EncryptionDetails_STATUS}
+---------------------------------------------------
 
 Details of the encryption associated with the workspace
 
@@ -508,8 +508,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | cmk                     | Customer Managed Key Details | [CustomerManagedKeyDetails_STATUS](#CustomerManagedKeyDetails_STATUS)<br/><small>Optional</small> |
 | doubleEncryptionEnabled | Double Encryption enabled    | bool<br/><small>Optional</small>                                                                  |
 
-<a id="LibraryInfo"></a>LibraryInfo
------------------------------------
+LibraryInfo{#LibraryInfo}
+-------------------------
 
 Library/package information of a Big Data pool powered by Apache Spark
 
@@ -522,8 +522,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | path          | Storage blob path of library. | string<br/><small>Optional</small> |
 | type          | Type of the library.          | string<br/><small>Optional</small> |
 
-<a id="LibraryInfo_STATUS"></a>LibraryInfo_STATUS
--------------------------------------------------
+LibraryInfo_STATUS{#LibraryInfo_STATUS}
+---------------------------------------
 
 Library/package information of a Big Data pool powered by Apache Spark
 
@@ -539,8 +539,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | type               | Type of the library.                        | string<br/><small>Optional</small> |
 | uploadedTimestamp  | The last update time of the library.        | string<br/><small>Optional</small> |
 
-<a id="LibraryRequirements"></a>LibraryRequirements
----------------------------------------------------
+LibraryRequirements{#LibraryRequirements}
+-----------------------------------------
 
 Library requirements for a Big Data pool powered by Apache Spark
 
@@ -551,8 +551,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | content  | The library requirements.                      | string<br/><small>Optional</small> |
 | filename | The filename of the library requirements file. | string<br/><small>Optional</small> |
 
-<a id="LibraryRequirements_STATUS"></a>LibraryRequirements_STATUS
------------------------------------------------------------------
+LibraryRequirements_STATUS{#LibraryRequirements_STATUS}
+-------------------------------------------------------
 
 Library requirements for a Big Data pool powered by Apache Spark
 
@@ -564,8 +564,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | filename | The filename of the library requirements file.         | string<br/><small>Optional</small> |
 | time     | The last update time of the library requirements file. | string<br/><small>Optional</small> |
 
-<a id="ManagedIdentity"></a>ManagedIdentity
--------------------------------------------
+ManagedIdentity{#ManagedIdentity}
+---------------------------------
 
 The workspace managed identity
 
@@ -576,8 +576,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | type                   | The type of managed identity for the workspace | [ManagedIdentity_Type](#ManagedIdentity_Type)<br/><small>Optional</small>                 |
 | userAssignedIdentities | The user assigned managed identities.          | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedIdentity_STATUS"></a>ManagedIdentity_STATUS
----------------------------------------------------------
+ManagedIdentity_STATUS{#ManagedIdentity_STATUS}
+-----------------------------------------------
 
 The workspace managed identity
 
@@ -590,8 +590,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | type                   | The type of managed identity for the workspace     | [ManagedIdentity_Type_STATUS](#ManagedIdentity_Type_STATUS)<br/><small>Optional</small>                          |
 | userAssignedIdentities | The user assigned managed identities.              | [map[string]UserAssignedManagedIdentity_STATUS](#UserAssignedManagedIdentity_STATUS)<br/><small>Optional</small> |
 
-<a id="ManagedVirtualNetworkSettings"></a>ManagedVirtualNetworkSettings
------------------------------------------------------------------------
+ManagedVirtualNetworkSettings{#ManagedVirtualNetworkSettings}
+-------------------------------------------------------------
 
 Managed Virtual Network Settings
 
@@ -603,8 +603,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | linkedAccessCheckOnTargetResource | Linked Access Check On Target Resource | bool<br/><small>Optional</small>     |
 | preventDataExfiltration           | Prevent Data Exfiltration              | bool<br/><small>Optional</small>     |
 
-<a id="ManagedVirtualNetworkSettings_STATUS"></a>ManagedVirtualNetworkSettings_STATUS
--------------------------------------------------------------------------------------
+ManagedVirtualNetworkSettings_STATUS{#ManagedVirtualNetworkSettings_STATUS}
+---------------------------------------------------------------------------
 
 Managed Virtual Network Settings
 
@@ -616,8 +616,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | linkedAccessCheckOnTargetResource | Linked Access Check On Target Resource | bool<br/><small>Optional</small>     |
 | preventDataExfiltration           | Prevent Data Exfiltration              | bool<br/><small>Optional</small>     |
 
-<a id="PrivateEndpointConnection_STATUS"></a>PrivateEndpointConnection_STATUS
------------------------------------------------------------------------------
+PrivateEndpointConnection_STATUS{#PrivateEndpointConnection_STATUS}
+-------------------------------------------------------------------
 
 A private endpoint connection
 
@@ -627,8 +627,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | id       | Fully qualified resource ID for the resource. Ex - /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;{resourceProviderNamespace}/&ZeroWidthSpace;{resourceType}/&ZeroWidthSpace;{resourceName} | string<br/><small>Optional</small> |
 
-<a id="PurviewConfiguration"></a>PurviewConfiguration
------------------------------------------------------
+PurviewConfiguration{#PurviewConfiguration}
+-------------------------------------------
 
 Purview Configuration
 
@@ -638,8 +638,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |--------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | purviewResourceReference | Purview Resource ID | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="PurviewConfiguration_STATUS"></a>PurviewConfiguration_STATUS
--------------------------------------------------------------------
+PurviewConfiguration_STATUS{#PurviewConfiguration_STATUS}
+---------------------------------------------------------
 
 Purview Configuration
 
@@ -649,8 +649,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |-------------------|---------------------|------------------------------------|
 | purviewResourceId | Purview Resource ID | string<br/><small>Optional</small> |
 
-<a id="SparkConfigProperties"></a>SparkConfigProperties
--------------------------------------------------------
+SparkConfigProperties{#SparkConfigProperties}
+---------------------------------------------
 
 SparkConfig Properties for a Big Data pool powered by Apache Spark
 
@@ -662,8 +662,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | content           | The spark config properties.                      | string<br/><small>Optional</small>                                                                              |
 | filename          | The filename of the spark config properties file. | string<br/><small>Optional</small>                                                                              |
 
-<a id="SparkConfigProperties_STATUS"></a>SparkConfigProperties_STATUS
----------------------------------------------------------------------
+SparkConfigProperties_STATUS{#SparkConfigProperties_STATUS}
+-----------------------------------------------------------
 
 SparkConfig Properties for a Big Data pool powered by Apache Spark
 
@@ -676,8 +676,8 @@ Used by: [WorkspacesBigDataPool_STATUS](#WorkspacesBigDataPool_STATUS).
 | filename          | The filename of the spark config properties file.         | string<br/><small>Optional</small>                                                                                            |
 | time              | The last update time of the spark config properties file. | string<br/><small>Optional</small>                                                                                            |
 
-<a id="VirtualNetworkProfile"></a>VirtualNetworkProfile
--------------------------------------------------------
+VirtualNetworkProfile{#VirtualNetworkProfile}
+---------------------------------------------
 
 Virtual Network Profile
 
@@ -687,8 +687,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 |-----------------|------------------------------------------|------------------------------------|
 | computeSubnetId | Subnet ID used for computes in workspace | string<br/><small>Optional</small> |
 
-<a id="VirtualNetworkProfile_STATUS"></a>VirtualNetworkProfile_STATUS
----------------------------------------------------------------------
+VirtualNetworkProfile_STATUS{#VirtualNetworkProfile_STATUS}
+-----------------------------------------------------------
 
 Virtual Network Profile
 
@@ -698,8 +698,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 |-----------------|------------------------------------------|------------------------------------|
 | computeSubnetId | Subnet ID used for computes in workspace | string<br/><small>Optional</small> |
 
-<a id="WorkspaceOperatorSpec"></a>WorkspaceOperatorSpec
--------------------------------------------------------
+WorkspaceOperatorSpec{#WorkspaceOperatorSpec}
+---------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -710,8 +710,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="WorkspaceProperties_PublicNetworkAccess"></a>WorkspaceProperties_PublicNetworkAccess
--------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess{#WorkspaceProperties_PublicNetworkAccess}
+---------------------------------------------------------------------------------
 
 Used by: [Workspace_Spec](#Workspace_Spec).
 
@@ -720,8 +720,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspaceProperties_PublicNetworkAccess_STATUS"></a>WorkspaceProperties_PublicNetworkAccess_STATUS
----------------------------------------------------------------------------------------------------------
+WorkspaceProperties_PublicNetworkAccess_STATUS{#WorkspaceProperties_PublicNetworkAccess_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [Workspace_STATUS](#Workspace_STATUS).
 
@@ -730,8 +730,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | "Disabled" |             |
 | "Enabled"  |             |
 
-<a id="WorkspaceRepositoryConfiguration"></a>WorkspaceRepositoryConfiguration
------------------------------------------------------------------------------
+WorkspaceRepositoryConfiguration{#WorkspaceRepositoryConfiguration}
+-------------------------------------------------------------------
 
 Git integration settings
 
@@ -749,8 +749,8 @@ Used by: [Workspace_Spec](#Workspace_Spec).
 | tenantId            | The VSTS tenant ID                                                                                             | string<br/><small>Optional</small> |
 | type                | Type of workspace repositoryID configuration. Example WorkspaceVSTSConfiguration, WorkspaceGitHubConfiguration | string<br/><small>Optional</small> |
 
-<a id="WorkspaceRepositoryConfiguration_STATUS"></a>WorkspaceRepositoryConfiguration_STATUS
--------------------------------------------------------------------------------------------
+WorkspaceRepositoryConfiguration_STATUS{#WorkspaceRepositoryConfiguration_STATUS}
+---------------------------------------------------------------------------------
 
 Git integration settings
 
@@ -768,8 +768,8 @@ Used by: [Workspace_STATUS](#Workspace_STATUS).
 | tenantId            | The VSTS tenant ID                                                                                             | string<br/><small>Optional</small> |
 | type                | Type of workspace repositoryID configuration. Example WorkspaceVSTSConfiguration, WorkspaceGitHubConfiguration | string<br/><small>Optional</small> |
 
-<a id="WorkspacesBigDataPoolOperatorSpec"></a>WorkspacesBigDataPoolOperatorSpec
--------------------------------------------------------------------------------
+WorkspacesBigDataPoolOperatorSpec{#WorkspacesBigDataPoolOperatorSpec}
+---------------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -780,8 +780,8 @@ Used by: [WorkspacesBigDataPool_Spec](#WorkspacesBigDataPool_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="CustomerManagedKeyDetails"></a>CustomerManagedKeyDetails
----------------------------------------------------------------
+CustomerManagedKeyDetails{#CustomerManagedKeyDetails}
+-----------------------------------------------------
 
 Details of the customer managed key associated with the workspace
 
@@ -792,8 +792,8 @@ Used by: [EncryptionDetails](#EncryptionDetails).
 | kekIdentity | Key encryption key              | [KekIdentityProperties](#KekIdentityProperties)<br/><small>Optional</small> |
 | key         | The key object of the workspace | [WorkspaceKeyDetails](#WorkspaceKeyDetails)<br/><small>Optional</small>     |
 
-<a id="CustomerManagedKeyDetails_STATUS"></a>CustomerManagedKeyDetails_STATUS
------------------------------------------------------------------------------
+CustomerManagedKeyDetails_STATUS{#CustomerManagedKeyDetails_STATUS}
+-------------------------------------------------------------------
 
 Details of the customer managed key associated with the workspace
 
@@ -805,8 +805,8 @@ Used by: [EncryptionDetails_STATUS](#EncryptionDetails_STATUS).
 | key         | The key object of the workspace                  | [WorkspaceKeyDetails_STATUS](#WorkspaceKeyDetails_STATUS)<br/><small>Optional</small>     |
 | status      | The customer managed key status on the workspace | string<br/><small>Optional</small>                                                        |
 
-<a id="ManagedIdentity_Type"></a>ManagedIdentity_Type
------------------------------------------------------
+ManagedIdentity_Type{#ManagedIdentity_Type}
+-------------------------------------------
 
 Used by: [ManagedIdentity](#ManagedIdentity).
 
@@ -816,8 +816,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 | "SystemAssigned"              |             |
 | "SystemAssigned,UserAssigned" |             |
 
-<a id="ManagedIdentity_Type_STATUS"></a>ManagedIdentity_Type_STATUS
--------------------------------------------------------------------
+ManagedIdentity_Type_STATUS{#ManagedIdentity_Type_STATUS}
+---------------------------------------------------------
 
 Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 
@@ -827,8 +827,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | "SystemAssigned"              |             |
 | "SystemAssigned,UserAssigned" |             |
 
-<a id="SparkConfigProperties_ConfigurationType"></a>SparkConfigProperties_ConfigurationType
--------------------------------------------------------------------------------------------
+SparkConfigProperties_ConfigurationType{#SparkConfigProperties_ConfigurationType}
+---------------------------------------------------------------------------------
 
 Used by: [SparkConfigProperties](#SparkConfigProperties).
 
@@ -837,8 +837,8 @@ Used by: [SparkConfigProperties](#SparkConfigProperties).
 | "Artifact" |             |
 | "File"     |             |
 
-<a id="SparkConfigProperties_ConfigurationType_STATUS"></a>SparkConfigProperties_ConfigurationType_STATUS
----------------------------------------------------------------------------------------------------------
+SparkConfigProperties_ConfigurationType_STATUS{#SparkConfigProperties_ConfigurationType_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [SparkConfigProperties_STATUS](#SparkConfigProperties_STATUS).
 
@@ -847,8 +847,8 @@ Used by: [SparkConfigProperties_STATUS](#SparkConfigProperties_STATUS).
 | "Artifact" |             |
 | "File"     |             |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -858,8 +858,8 @@ Used by: [ManagedIdentity](#ManagedIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="UserAssignedManagedIdentity_STATUS"></a>UserAssignedManagedIdentity_STATUS
----------------------------------------------------------------------------------
+UserAssignedManagedIdentity_STATUS{#UserAssignedManagedIdentity_STATUS}
+-----------------------------------------------------------------------
 
 User Assigned Managed Identity
 
@@ -870,8 +870,8 @@ Used by: [ManagedIdentity_STATUS](#ManagedIdentity_STATUS).
 | clientId    | The client ID.    | string<br/><small>Optional</small> |
 | principalId | The principal ID. | string<br/><small>Optional</small> |
 
-<a id="KekIdentityProperties"></a>KekIdentityProperties
--------------------------------------------------------
+KekIdentityProperties{#KekIdentityProperties}
+---------------------------------------------
 
 Key encryption key properties
 
@@ -882,8 +882,8 @@ Used by: [CustomerManagedKeyDetails](#CustomerManagedKeyDetails).
 | userAssignedIdentityReference | User assigned identity resource Id                                | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | useSystemAssignedIdentity     | Boolean specifying whether to use system assigned identity or not | v1.JSON<br/><small>Optional</small>                                                                                                                        |
 
-<a id="KekIdentityProperties_STATUS"></a>KekIdentityProperties_STATUS
----------------------------------------------------------------------
+KekIdentityProperties_STATUS{#KekIdentityProperties_STATUS}
+-----------------------------------------------------------
 
 Key encryption key properties
 
@@ -894,8 +894,8 @@ Used by: [CustomerManagedKeyDetails_STATUS](#CustomerManagedKeyDetails_STATUS).
 | userAssignedIdentity      | User assigned identity resource Id                                | string<br/><small>Optional</small>  |
 | useSystemAssignedIdentity | Boolean specifying whether to use system assigned identity or not | v1.JSON<br/><small>Optional</small> |
 
-<a id="WorkspaceKeyDetails"></a>WorkspaceKeyDetails
----------------------------------------------------
+WorkspaceKeyDetails{#WorkspaceKeyDetails}
+-----------------------------------------
 
 Details of the customer managed key associated with the workspace
 
@@ -906,8 +906,8 @@ Used by: [CustomerManagedKeyDetails](#CustomerManagedKeyDetails).
 | keyVaultUrl | Workspace Key sub-resource key vault url | string<br/><small>Optional</small> |
 | name        | Workspace Key sub-resource name          | string<br/><small>Optional</small> |
 
-<a id="WorkspaceKeyDetails_STATUS"></a>WorkspaceKeyDetails_STATUS
------------------------------------------------------------------
+WorkspaceKeyDetails_STATUS{#WorkspaceKeyDetails_STATUS}
+-------------------------------------------------------
 
 Details of the customer managed key associated with the workspace
 

--- a/docs/hugo/content/reference/web/v1api20220301.md
+++ b/docs/hugo/content/reference/web/v1api20220301.md
@@ -5,15 +5,15 @@ title: web.azure.com/v1api20220301
 linktitle: v1api20220301
 ------------------------
 
-<a id="APIVersion"></a>APIVersion
----------------------------------
+APIVersion{#APIVersion}
+-----------------------
 
 | Value        | Description |
 |--------------|-------------|
 | "2022-03-01" |             |
 
-<a id="ServerFarm"></a>ServerFarm
----------------------------------
+ServerFarm{#ServerFarm}
+-----------------------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/AppServicePlans.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/serverfarms/{name}
 
@@ -26,7 +26,7 @@ Used by: [ServerFarmList](#ServerFarmList).
 | spec                                                                                    |             | [ServerFarm_Spec](#ServerFarm_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [ServerFarm_STATUS](#ServerFarm_STATUS)<br/><small>Optional</small> |
 
-### <a id="ServerFarm_Spec"></a>ServerFarm_Spec
+### ServerFarm_Spec {#ServerFarm_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                 |
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -54,7 +54,7 @@ Used by: [ServerFarmList](#ServerFarmList).
 | workerTierName            | Target worker tier assigned to the App Service plan.                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | zoneRedundant             | If <code>true</code>, this App Service Plan will perform availability zone balancing. If <code>false</code>, this App Service Plan will not perform availability zone balancing.                                                                                                             | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="ServerFarm_STATUS"></a>ServerFarm_STATUS
+### ServerFarm_STATUS{#ServerFarm_STATUS}
 
 | Property                  | Description                                                                                                                                                                                      | Type                                                                                                                                                    |
 |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -91,8 +91,8 @@ Used by: [ServerFarmList](#ServerFarmList).
 | workerTierName            | Target worker tier assigned to the App Service plan.                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant             | If <code>true</code>, this App Service Plan will perform availability zone balancing. If <code>false</code>, this App Service Plan will not perform availability zone balancing.                 | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="ServerFarmList"></a>ServerFarmList
------------------------------------------
+ServerFarmList{#ServerFarmList}
+-------------------------------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/AppServicePlans.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/serverfarms/{name}
 
@@ -102,8 +102,8 @@ Generator information: - Generated from: /web/resource-manager/Microsoft.Web/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                         |
 | items                                                                               |             | [ServerFarm[]](#ServerFarm)<br/><small>Optional</small> |
 
-<a id="Site"></a>Site
----------------------
+Site{#Site}
+-----------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/sites/{name}
 
@@ -116,7 +116,7 @@ Used by: [SiteList](#SiteList).
 | spec                                                                                    |             | [Site_Spec](#Site_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [Site_STATUS](#Site_STATUS)<br/><small>Optional</small> |
 
-### <a id="Site_Spec"></a>Site_Spec
+### Site_Spec {#Site_Spec}
 
 | Property                      | Description                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                 |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -156,7 +156,7 @@ Used by: [SiteList](#SiteList).
 | vnetImagePullEnabled          | To enable pulling image over Virtual Network                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 | vnetRouteAllEnabled           | Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied.                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 
-### <a id="Site_STATUS"></a>Site_STATUS
+### Site_STATUS{#Site_STATUS}
 
 | Property                    | Description                                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                    |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -215,8 +215,8 @@ Used by: [SiteList](#SiteList).
 | vnetImagePullEnabled        | To enable pulling image over Virtual Network                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                        |
 | vnetRouteAllEnabled         | Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied.                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SiteList"></a>SiteList
------------------------------
+SiteList{#SiteList}
+-------------------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/sites/{name}
 
@@ -226,8 +226,8 @@ Generator information: - Generated from: /web/resource-manager/Microsoft.Web/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                             |
 | items                                                                               |             | [Site[]](#Site)<br/><small>Optional</small> |
 
-<a id="SitesSourcecontrol"></a>SitesSourcecontrol
--------------------------------------------------
+SitesSourcecontrol{#SitesSourcecontrol}
+---------------------------------------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/sites/{name}/sourcecontrols/web
 
@@ -240,7 +240,7 @@ Used by: [SitesSourcecontrolList](#SitesSourcecontrolList).
 | spec                                                                                    |             | [SitesSourcecontrol_Spec](#SitesSourcecontrol_Spec)<br/><small>Optional</small>     |
 | status                                                                                  |             | [SitesSourcecontrol_STATUS](#SitesSourcecontrol_STATUS)<br/><small>Optional</small> |
 
-### <a id="SitesSourcecontrol_Spec"></a>SitesSourcecontrol_Spec
+### SitesSourcecontrol_Spec {#SitesSourcecontrol_Spec}
 
 | Property                  | Description                                                                                                                                                                                                                                                                   | Type                                                                                                                                                                 |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -255,7 +255,7 @@ Used by: [SitesSourcecontrolList](#SitesSourcecontrolList).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a web.azure.com/Site resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | repoUrl                   | Repository or source control URL.                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 
-### <a id="SitesSourcecontrol_STATUS"></a>SitesSourcecontrol_STATUS
+### SitesSourcecontrol_STATUS{#SitesSourcecontrol_STATUS}
 
 | Property                  | Description                                                                                                                                                      | Type                                                                                                                                                    |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -272,8 +272,8 @@ Used by: [SitesSourcecontrolList](#SitesSourcecontrolList).
 | repoUrl                   | Repository or source control URL.                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="SitesSourcecontrolList"></a>SitesSourcecontrolList
----------------------------------------------------------
+SitesSourcecontrolList{#SitesSourcecontrolList}
+-----------------------------------------------
 
 Generator information: - Generated from: /web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json - ARM URI: /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Web/sites/{name}/sourcecontrols/web
 
@@ -283,8 +283,8 @@ Generator information: - Generated from: /web/resource-manager/Microsoft.Web/sta
 | [metav1.ListMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta) |             |                                                                         |
 | items                                                                               |             | [SitesSourcecontrol[]](#SitesSourcecontrol)<br/><small>Optional</small> |
 
-<a id="ServerFarm_Spec"></a>ServerFarm_Spec
--------------------------------------------
+ServerFarm_Spec{#ServerFarm_Spec}
+---------------------------------
 
 Used by: [ServerFarm](#ServerFarm).
 
@@ -314,8 +314,8 @@ Used by: [ServerFarm](#ServerFarm).
 | workerTierName            | Target worker tier assigned to the App Service plan.                                                                                                                                                                                                                                         | string<br/><small>Optional</small>                                                                                                                                   |
 | zoneRedundant             | If <code>true</code>, this App Service Plan will perform availability zone balancing. If <code>false</code>, this App Service Plan will not perform availability zone balancing.                                                                                                             | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="ServerFarm_STATUS"></a>ServerFarm_STATUS
------------------------------------------------
+ServerFarm_STATUS{#ServerFarm_STATUS}
+-------------------------------------
 
 Used by: [ServerFarm](#ServerFarm).
 
@@ -354,8 +354,8 @@ Used by: [ServerFarm](#ServerFarm).
 | workerTierName            | Target worker tier assigned to the App Service plan.                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                      |
 | zoneRedundant             | If <code>true</code>, this App Service Plan will perform availability zone balancing. If <code>false</code>, this App Service Plan will not perform availability zone balancing.                 | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="Site_Spec"></a>Site_Spec
--------------------------------
+Site_Spec{#Site_Spec}
+---------------------
 
 Used by: [Site](#Site).
 
@@ -397,8 +397,8 @@ Used by: [Site](#Site).
 | vnetImagePullEnabled          | To enable pulling image over Virtual Network                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 | vnetRouteAllEnabled           | Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied.                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                                     |
 
-<a id="Site_STATUS"></a>Site_STATUS
------------------------------------
+Site_STATUS{#Site_STATUS}
+-------------------------
 
 A web app, a mobile app backend, or an API app.
 
@@ -461,8 +461,8 @@ Used by: [Site](#Site).
 | vnetImagePullEnabled        | To enable pulling image over Virtual Network                                                                                                                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                        |
 | vnetRouteAllEnabled         | Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied.                                                                                                                                                                                                                                     | bool<br/><small>Optional</small>                                                                                                                        |
 
-<a id="SitesSourcecontrol_Spec"></a>SitesSourcecontrol_Spec
------------------------------------------------------------
+SitesSourcecontrol_Spec{#SitesSourcecontrol_Spec}
+-------------------------------------------------
 
 Used by: [SitesSourcecontrol](#SitesSourcecontrol).
 
@@ -479,8 +479,8 @@ Used by: [SitesSourcecontrol](#SitesSourcecontrol).
 | owner                     | The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a reference to a web.azure.com/Site resource | [genruntime.KnownResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#KnownResourceReference)<br/><small>Required</small> |
 | repoUrl                   | Repository or source control URL.                                                                                                                                                                                                                                             | string<br/><small>Optional</small>                                                                                                                                   |
 
-<a id="SitesSourcecontrol_STATUS"></a>SitesSourcecontrol_STATUS
----------------------------------------------------------------
+SitesSourcecontrol_STATUS{#SitesSourcecontrol_STATUS}
+-----------------------------------------------------
 
 Used by: [SitesSourcecontrol](#SitesSourcecontrol).
 
@@ -499,8 +499,8 @@ Used by: [SitesSourcecontrol](#SitesSourcecontrol).
 | repoUrl                   | Repository or source control URL.                                                                                                                                | string<br/><small>Optional</small>                                                                                                                      |
 | type                      | Resource type.                                                                                                                                                   | string<br/><small>Optional</small>                                                                                                                      |
 
-<a id="CloningInfo"></a>CloningInfo
------------------------------------
+CloningInfo{#CloningInfo}
+-------------------------
 
 Information needed for cloning operation.
 
@@ -520,8 +520,8 @@ Used by: [Site_Spec](#Site_Spec).
 | trafficManagerProfileName      | Name of Traffic Manager profile to create. This is only needed if Traffic Manager profile does not already exist.                                                                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>                                                                                                                         |
 | trafficManagerProfileReference | ARM resource ID of the Traffic Manager profile to use, if it exists. Traffic Manager resource ID is of the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficManagerProfiles/{profileName}.                                                                                                                                                                                        | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="CloningInfo_STATUS"></a>CloningInfo_STATUS
--------------------------------------------------
+CloningInfo_STATUS{#CloningInfo_STATUS}
+---------------------------------------
 
 Information needed for cloning operation.
 
@@ -541,8 +541,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | trafficManagerProfileId   | ARM resource ID of the Traffic Manager profile to use, if it exists. Traffic Manager resource ID is of the form /&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.Network/trafficManagerProfiles/{profileName}.                                                                                                                                                                                        | string<br/><small>Optional</small>            |
 | trafficManagerProfileName | Name of Traffic Manager profile to create. This is only needed if Traffic Manager profile does not already exist.                                                                                                                                                                                                                                                                                                                                                                                                                  | string<br/><small>Optional</small>            |
 
-<a id="ExtendedLocation"></a>ExtendedLocation
----------------------------------------------
+ExtendedLocation{#ExtendedLocation}
+-----------------------------------
 
 Extended Location.
 
@@ -552,8 +552,8 @@ Used by: [ServerFarm_Spec](#ServerFarm_Spec), and [Site_Spec](#Site_Spec).
 |----------|----------------------------|------------------------------------|
 | name     | Name of extended location. | string<br/><small>Optional</small> |
 
-<a id="ExtendedLocation_STATUS"></a>ExtendedLocation_STATUS
------------------------------------------------------------
+ExtendedLocation_STATUS{#ExtendedLocation_STATUS}
+-------------------------------------------------
 
 Extended Location.
 
@@ -564,8 +564,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS), and [Site_STATUS](#Site_STATUS
 | name     | Name of extended location. | string<br/><small>Optional</small> |
 | type     | Type of extended location. | string<br/><small>Optional</small> |
 
-<a id="GitHubActionConfiguration"></a>GitHubActionConfiguration
----------------------------------------------------------------
+GitHubActionConfiguration{#GitHubActionConfiguration}
+-----------------------------------------------------
 
 The GitHub action configuration.
 
@@ -578,8 +578,8 @@ Used by: [SitesSourcecontrol_Spec](#SitesSourcecontrol_Spec).
 | generateWorkflowFile   | Workflow option to determine whether the workflow file should be generated and written to the repository. | bool<br/><small>Optional</small>                                                                      |
 | isLinux                | This will help determine the workflow configuration to select.                                            | bool<br/><small>Optional</small>                                                                      |
 
-<a id="GitHubActionConfiguration_STATUS"></a>GitHubActionConfiguration_STATUS
------------------------------------------------------------------------------
+GitHubActionConfiguration_STATUS{#GitHubActionConfiguration_STATUS}
+-------------------------------------------------------------------
 
 The GitHub action configuration.
 
@@ -592,8 +592,8 @@ Used by: [SitesSourcecontrol_STATUS](#SitesSourcecontrol_STATUS).
 | generateWorkflowFile   | Workflow option to determine whether the workflow file should be generated and written to the repository. | bool<br/><small>Optional</small>                                                                                    |
 | isLinux                | This will help determine the workflow configuration to select.                                            | bool<br/><small>Optional</small>                                                                                    |
 
-<a id="HostingEnvironmentProfile"></a>HostingEnvironmentProfile
----------------------------------------------------------------
+HostingEnvironmentProfile{#HostingEnvironmentProfile}
+-----------------------------------------------------
 
 Specification for an App Service Environment to use for this resource.
 
@@ -603,8 +603,8 @@ Used by: [ServerFarm_Spec](#ServerFarm_Spec), and [Site_Spec](#Site_Spec).
 |-----------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID of the App Service Environment. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="HostingEnvironmentProfile_STATUS"></a>HostingEnvironmentProfile_STATUS
------------------------------------------------------------------------------
+HostingEnvironmentProfile_STATUS{#HostingEnvironmentProfile_STATUS}
+-------------------------------------------------------------------
 
 Specification for an App Service Environment to use for this resource.
 
@@ -616,8 +616,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS), and [Site_STATUS](#Site_STATUS
 | name     | Name of the App Service Environment.          | string<br/><small>Optional</small> |
 | type     | Resource type of the App Service Environment. | string<br/><small>Optional</small> |
 
-<a id="HostNameSslState"></a>HostNameSslState
----------------------------------------------
+HostNameSslState{#HostNameSslState}
+-----------------------------------
 
 SSL-enabled hostname.
 
@@ -632,8 +632,8 @@ Used by: [Site_Spec](#Site_Spec).
 | toUpdate   | Set to <code>true</code> to update existing hostname.                   | bool<br/><small>Optional</small>                                                    |
 | virtualIP  | Virtual IP address assigned to the hostname if IP based SSL is enabled. | string<br/><small>Optional</small>                                                  |
 
-<a id="HostNameSslState_STATUS"></a>HostNameSslState_STATUS
------------------------------------------------------------
+HostNameSslState_STATUS{#HostNameSslState_STATUS}
+-------------------------------------------------
 
 SSL-enabled hostname.
 
@@ -648,8 +648,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | toUpdate   | Set to <code>true</code> to update existing hostname.                   | bool<br/><small>Optional</small>                                                                  |
 | virtualIP  | Virtual IP address assigned to the hostname if IP based SSL is enabled. | string<br/><small>Optional</small>                                                                |
 
-<a id="KubeEnvironmentProfile"></a>KubeEnvironmentProfile
----------------------------------------------------------
+KubeEnvironmentProfile{#KubeEnvironmentProfile}
+-----------------------------------------------
 
 Specification for a Kubernetes Environment to use for this resource.
 
@@ -659,8 +659,8 @@ Used by: [ServerFarm_Spec](#ServerFarm_Spec).
 |-----------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | Resource ID of the Kubernetes Environment. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="KubeEnvironmentProfile_STATUS"></a>KubeEnvironmentProfile_STATUS
------------------------------------------------------------------------
+KubeEnvironmentProfile_STATUS{#KubeEnvironmentProfile_STATUS}
+-------------------------------------------------------------
 
 Specification for a Kubernetes Environment to use for this resource.
 
@@ -672,8 +672,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 | name     | Name of the Kubernetes Environment.          | string<br/><small>Optional</small> |
 | type     | Resource type of the Kubernetes Environment. | string<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity"></a>ManagedServiceIdentity
----------------------------------------------------------
+ManagedServiceIdentity{#ManagedServiceIdentity}
+-----------------------------------------------
 
 Managed service identity.
 
@@ -684,8 +684,8 @@ Used by: [Site_Spec](#Site_Spec).
 | type                   | Type of managed service identity.                                                                                                                                                                                                                                                                                                                                                                  | [ManagedServiceIdentity_Type](#ManagedServiceIdentity_Type)<br/><small>Optional</small>   |
 | userAssignedIdentities | The list of user assigned identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName} | [UserAssignedIdentityDetails[]](#UserAssignedIdentityDetails)<br/><small>Optional</small> |
 
-<a id="ManagedServiceIdentity_STATUS"></a>ManagedServiceIdentity_STATUS
------------------------------------------------------------------------
+ManagedServiceIdentity_STATUS{#ManagedServiceIdentity_STATUS}
+-------------------------------------------------------------
 
 Managed service identity.
 
@@ -698,8 +698,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | type                   | Type of managed service identity.                                                                                                                                                                                                                                                                                                                                                                  | [ManagedServiceIdentity_Type_STATUS](#ManagedServiceIdentity_Type_STATUS)<br/><small>Optional</small> |
 | userAssignedIdentities | The list of user assigned identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/&ZeroWidthSpace;subscriptions/&ZeroWidthSpace;{subscriptionId}/&ZeroWidthSpace;resourceGroups/&ZeroWidthSpace;{resourceGroupName}/&ZeroWidthSpace;providers/&ZeroWidthSpace;Microsoft.ManagedIdentity/userAssignedIdentities/{identityName} | [map[string]UserAssignedIdentity_STATUS](#UserAssignedIdentity_STATUS)<br/><small>Optional</small>    |
 
-<a id="Serverfarm_Properties_ProvisioningState_STATUS"></a>Serverfarm_Properties_ProvisioningState_STATUS
----------------------------------------------------------------------------------------------------------
+Serverfarm_Properties_ProvisioningState_STATUS{#Serverfarm_Properties_ProvisioningState_STATUS}
+-----------------------------------------------------------------------------------------------
 
 Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 
@@ -711,8 +711,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 | "InProgress" |             |
 | "Succeeded"  |             |
 
-<a id="Serverfarm_Properties_Status_STATUS"></a>Serverfarm_Properties_Status_STATUS
------------------------------------------------------------------------------------
+Serverfarm_Properties_Status_STATUS{#Serverfarm_Properties_Status_STATUS}
+-------------------------------------------------------------------------
 
 Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 
@@ -722,8 +722,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 | "Pending"  |             |
 | "Ready"    |             |
 
-<a id="ServerFarmOperatorSpec"></a>ServerFarmOperatorSpec
----------------------------------------------------------
+ServerFarmOperatorSpec{#ServerFarmOperatorSpec}
+-----------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -734,8 +734,8 @@ Used by: [ServerFarm_Spec](#ServerFarm_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="Site_Properties_AvailabilityState_STATUS"></a>Site_Properties_AvailabilityState_STATUS
----------------------------------------------------------------------------------------------
+Site_Properties_AvailabilityState_STATUS{#Site_Properties_AvailabilityState_STATUS}
+-----------------------------------------------------------------------------------
 
 Used by: [Site_STATUS](#Site_STATUS).
 
@@ -745,8 +745,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | "Limited"              |             |
 | "Normal"               |             |
 
-<a id="Site_Properties_ClientCertMode_Spec"></a>Site_Properties_ClientCertMode_Spec
------------------------------------------------------------------------------------
+Site_Properties_ClientCertMode_Spec{#Site_Properties_ClientCertMode_Spec}
+-------------------------------------------------------------------------
 
 Used by: [Site_Spec](#Site_Spec).
 
@@ -756,8 +756,8 @@ Used by: [Site_Spec](#Site_Spec).
 | "OptionalInteractiveUser" |             |
 | "Required"                |             |
 
-<a id="Site_Properties_ClientCertMode_STATUS"></a>Site_Properties_ClientCertMode_STATUS
----------------------------------------------------------------------------------------
+Site_Properties_ClientCertMode_STATUS{#Site_Properties_ClientCertMode_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [Site_STATUS](#Site_STATUS).
 
@@ -767,8 +767,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | "OptionalInteractiveUser" |             |
 | "Required"                |             |
 
-<a id="Site_Properties_RedundancyMode_Spec"></a>Site_Properties_RedundancyMode_Spec
------------------------------------------------------------------------------------
+Site_Properties_RedundancyMode_Spec{#Site_Properties_RedundancyMode_Spec}
+-------------------------------------------------------------------------
 
 Used by: [Site_Spec](#Site_Spec).
 
@@ -780,8 +780,8 @@ Used by: [Site_Spec](#Site_Spec).
 | "Manual"       |             |
 | "None"         |             |
 
-<a id="Site_Properties_RedundancyMode_STATUS"></a>Site_Properties_RedundancyMode_STATUS
----------------------------------------------------------------------------------------
+Site_Properties_RedundancyMode_STATUS{#Site_Properties_RedundancyMode_STATUS}
+-----------------------------------------------------------------------------
 
 Used by: [Site_STATUS](#Site_STATUS).
 
@@ -793,8 +793,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | "Manual"       |             |
 | "None"         |             |
 
-<a id="Site_Properties_UsageState_STATUS"></a>Site_Properties_UsageState_STATUS
--------------------------------------------------------------------------------
+Site_Properties_UsageState_STATUS{#Site_Properties_UsageState_STATUS}
+---------------------------------------------------------------------
 
 Used by: [Site_STATUS](#Site_STATUS).
 
@@ -803,8 +803,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | "Exceeded" |             |
 | "Normal"   |             |
 
-<a id="SiteConfig"></a>SiteConfig
----------------------------------
+SiteConfig{#SiteConfig}
+-----------------------
 
 Configuration of an App Service app.
 
@@ -879,8 +879,8 @@ Used by: [Site_Spec](#Site_Spec).
 | windowsFxVersion                       | Xenon App Framework and version                                                                                                                                                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                            |
 | xManagedServiceIdentityId              | Explicit Managed Service Identity Id                                                                                                                                                                                                                                                                                                                                                                                                                                                     | int<br/><small>Optional</small>                                                               |
 
-<a id="SiteConfig_STATUS"></a>SiteConfig_STATUS
------------------------------------------------
+SiteConfig_STATUS{#SiteConfig_STATUS}
+-------------------------------------
 
 Configuration of an App Service app.
 
@@ -956,8 +956,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | windowsFxVersion                       | Xenon App Framework and version                                                                                                                                                                                                                                                                                                                                                                                                                                                          | string<br/><small>Optional</small>                                                                          |
 | xManagedServiceIdentityId              | Explicit Managed Service Identity Id                                                                                                                                                                                                                                                                                                                                                                                                                                                     | int<br/><small>Optional</small>                                                                             |
 
-<a id="SiteOperatorSpec"></a>SiteOperatorSpec
----------------------------------------------
+SiteOperatorSpec{#SiteOperatorSpec}
+-----------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -968,8 +968,8 @@ Used by: [Site_Spec](#Site_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SitesSourcecontrolOperatorSpec"></a>SitesSourcecontrolOperatorSpec
--------------------------------------------------------------------------
+SitesSourcecontrolOperatorSpec{#SitesSourcecontrolOperatorSpec}
+---------------------------------------------------------------
 
 Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
 
@@ -980,8 +980,8 @@ Used by: [SitesSourcecontrol_Spec](#SitesSourcecontrol_Spec).
 | configMapExpressions | configures where to place operator written dynamic ConfigMaps (created with CEL expressions). | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 | secretExpressions    | configures where to place operator written dynamic secrets (created with CEL expressions).    | [core.DestinationExpression[]](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime/core#DestinationExpression)<br/><small>Optional</small> |
 
-<a id="SkuDescription"></a>SkuDescription
------------------------------------------
+SkuDescription{#SkuDescription}
+-------------------------------
 
 Description of a SKU for a scalable resource.
 
@@ -998,8 +998,8 @@ Used by: [ServerFarm_Spec](#ServerFarm_Spec).
 | skuCapacity  | Min, max, and default scale values of the SKU.             | [SkuCapacity](#SkuCapacity)<br/><small>Optional</small> |
 | tier         | Service tier of the resource SKU.                          | string<br/><small>Optional</small>                      |
 
-<a id="SkuDescription_STATUS"></a>SkuDescription_STATUS
--------------------------------------------------------
+SkuDescription_STATUS{#SkuDescription_STATUS}
+---------------------------------------------
 
 Description of a SKU for a scalable resource.
 
@@ -1016,8 +1016,8 @@ Used by: [ServerFarm_STATUS](#ServerFarm_STATUS).
 | skuCapacity  | Min, max, and default scale values of the SKU.             | [SkuCapacity_STATUS](#SkuCapacity_STATUS)<br/><small>Optional</small> |
 | tier         | Service tier of the resource SKU.                          | string<br/><small>Optional</small>                                    |
 
-<a id="SlotSwapStatus_STATUS"></a>SlotSwapStatus_STATUS
--------------------------------------------------------
+SlotSwapStatus_STATUS{#SlotSwapStatus_STATUS}
+---------------------------------------------
 
 The status of the last successful slot swap operation.
 
@@ -1029,8 +1029,8 @@ Used by: [Site_STATUS](#Site_STATUS).
 | sourceSlotName      | The source slot of the last swap operation.       | string<br/><small>Optional</small> |
 | timestampUtc        | The time the last successful slot swap completed. | string<br/><small>Optional</small> |
 
-<a id="ApiDefinitionInfo"></a>ApiDefinitionInfo
------------------------------------------------
+ApiDefinitionInfo{#ApiDefinitionInfo}
+-------------------------------------
 
 Information about the formal API definition for the app.
 
@@ -1040,8 +1040,8 @@ Used by: [SiteConfig](#SiteConfig).
 |----------|--------------------------------|------------------------------------|
 | url      | The URL of the API definition. | string<br/><small>Optional</small> |
 
-<a id="ApiDefinitionInfo_STATUS"></a>ApiDefinitionInfo_STATUS
--------------------------------------------------------------
+ApiDefinitionInfo_STATUS{#ApiDefinitionInfo_STATUS}
+---------------------------------------------------
 
 Information about the formal API definition for the app.
 
@@ -1051,8 +1051,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 |----------|--------------------------------|------------------------------------|
 | url      | The URL of the API definition. | string<br/><small>Optional</small> |
 
-<a id="ApiManagementConfig"></a>ApiManagementConfig
----------------------------------------------------
+ApiManagementConfig{#ApiManagementConfig}
+-----------------------------------------
 
 Azure API management (APIM) configuration linked to the app.
 
@@ -1062,8 +1062,8 @@ Used by: [SiteConfig](#SiteConfig).
 |-----------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference | APIM-Api Identifier. | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="ApiManagementConfig_STATUS"></a>ApiManagementConfig_STATUS
------------------------------------------------------------------
+ApiManagementConfig_STATUS{#ApiManagementConfig_STATUS}
+-------------------------------------------------------
 
 Azure API management (APIM) configuration linked to the app.
 
@@ -1073,8 +1073,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 |----------|----------------------|------------------------------------|
 | id       | APIM-Api Identifier. | string<br/><small>Optional</small> |
 
-<a id="AutoHealRules"></a>AutoHealRules
----------------------------------------
+AutoHealRules{#AutoHealRules}
+-----------------------------
 
 Rules that can be defined for auto-heal.
 
@@ -1085,8 +1085,8 @@ Used by: [SiteConfig](#SiteConfig).
 | actions  | Actions to be executed when a rule is triggered.                | [AutoHealActions](#AutoHealActions)<br/><small>Optional</small>   |
 | triggers | Conditions that describe when to execute the auto-heal actions. | [AutoHealTriggers](#AutoHealTriggers)<br/><small>Optional</small> |
 
-<a id="AutoHealRules_STATUS"></a>AutoHealRules_STATUS
------------------------------------------------------
+AutoHealRules_STATUS{#AutoHealRules_STATUS}
+-------------------------------------------
 
 Rules that can be defined for auto-heal.
 
@@ -1097,8 +1097,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | actions  | Actions to be executed when a rule is triggered.                | [AutoHealActions_STATUS](#AutoHealActions_STATUS)<br/><small>Optional</small>   |
 | triggers | Conditions that describe when to execute the auto-heal actions. | [AutoHealTriggers_STATUS](#AutoHealTriggers_STATUS)<br/><small>Optional</small> |
 
-<a id="AzureStorageInfoValue"></a>AzureStorageInfoValue
--------------------------------------------------------
+AzureStorageInfoValue{#AzureStorageInfoValue}
+---------------------------------------------
 
 Azure Files or Blob Storage access information value for dictionary storage.
 
@@ -1112,8 +1112,8 @@ Used by: [SiteConfig](#SiteConfig).
 | shareName   | Name of the file share (container name, for Blob storage).       | string<br/><small>Optional</small>                                                                                                                     |
 | type        | Type of storage.                                                 | [AzureStorageInfoValue_Type](#AzureStorageInfoValue_Type)<br/><small>Optional</small>                                                                  |
 
-<a id="AzureStorageInfoValue_STATUS"></a>AzureStorageInfoValue_STATUS
----------------------------------------------------------------------
+AzureStorageInfoValue_STATUS{#AzureStorageInfoValue_STATUS}
+-----------------------------------------------------------
 
 Azure Files or Blob Storage access information value for dictionary storage.
 
@@ -1127,8 +1127,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | state       | State of the storage account.                                    | [AzureStorageInfoValue_State_STATUS](#AzureStorageInfoValue_State_STATUS)<br/><small>Optional</small> |
 | type        | Type of storage.                                                 | [AzureStorageInfoValue_Type_STATUS](#AzureStorageInfoValue_Type_STATUS)<br/><small>Optional</small>   |
 
-<a id="Capability"></a>Capability
----------------------------------
+Capability{#Capability}
+-----------------------
 
 Describes the capabilities/features allowed for a specific SKU.
 
@@ -1140,8 +1140,8 @@ Used by: [SkuDescription](#SkuDescription).
 | reason   | Reason of the SKU capability. | string<br/><small>Optional</small> |
 | value    | Value of the SKU capability.  | string<br/><small>Optional</small> |
 
-<a id="Capability_STATUS"></a>Capability_STATUS
------------------------------------------------
+Capability_STATUS{#Capability_STATUS}
+-------------------------------------
 
 Describes the capabilities/features allowed for a specific SKU.
 
@@ -1153,8 +1153,8 @@ Used by: [SkuDescription_STATUS](#SkuDescription_STATUS).
 | reason   | Reason of the SKU capability. | string<br/><small>Optional</small> |
 | value    | Value of the SKU capability.  | string<br/><small>Optional</small> |
 
-<a id="ConnStringInfo"></a>ConnStringInfo
------------------------------------------
+ConnStringInfo{#ConnStringInfo}
+-------------------------------
 
 Database connection string information.
 
@@ -1166,8 +1166,8 @@ Used by: [SiteConfig](#SiteConfig).
 | name             | Name of connection string. | string<br/><small>Optional</small>                                      |
 | type             | Type of database.          | [ConnStringInfo_Type](#ConnStringInfo_Type)<br/><small>Optional</small> |
 
-<a id="ConnStringInfo_STATUS"></a>ConnStringInfo_STATUS
--------------------------------------------------------
+ConnStringInfo_STATUS{#ConnStringInfo_STATUS}
+---------------------------------------------
 
 Database connection string information.
 
@@ -1179,8 +1179,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | name             | Name of connection string. | string<br/><small>Optional</small>                                                    |
 | type             | Type of database.          | [ConnStringInfo_Type_STATUS](#ConnStringInfo_Type_STATUS)<br/><small>Optional</small> |
 
-<a id="CorsSettings"></a>CorsSettings
--------------------------------------
+CorsSettings{#CorsSettings}
+---------------------------
 
 Cross-Origin Resource Sharing (CORS) settings for the app.
 
@@ -1191,8 +1191,8 @@ Used by: [SiteConfig](#SiteConfig).
 | allowedOrigins     | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all.                       | string[]<br/><small>Optional</small> |
 | supportCredentials | Gets or sets whether CORS requests with credentials are allowed. See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Requests_with_credentials for more details. | bool<br/><small>Optional</small>     |
 
-<a id="CorsSettings_STATUS"></a>CorsSettings_STATUS
----------------------------------------------------
+CorsSettings_STATUS{#CorsSettings_STATUS}
+-----------------------------------------
 
 Cross-Origin Resource Sharing (CORS) settings for the app.
 
@@ -1203,8 +1203,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | allowedOrigins     | Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all.                       | string[]<br/><small>Optional</small> |
 | supportCredentials | Gets or sets whether CORS requests with credentials are allowed. See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Requests_with_credentials for more details. | bool<br/><small>Optional</small>     |
 
-<a id="Experiments"></a>Experiments
------------------------------------
+Experiments{#Experiments}
+-------------------------
 
 Routing rules in production experiments.
 
@@ -1214,8 +1214,8 @@ Used by: [SiteConfig](#SiteConfig).
 |-------------|------------------------|---------------------------------------------------------|
 | rampUpRules | List of ramp-up rules. | [RampUpRule[]](#RampUpRule)<br/><small>Optional</small> |
 
-<a id="Experiments_STATUS"></a>Experiments_STATUS
--------------------------------------------------
+Experiments_STATUS{#Experiments_STATUS}
+---------------------------------------
 
 Routing rules in production experiments.
 
@@ -1225,8 +1225,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 |-------------|------------------------|-----------------------------------------------------------------------|
 | rampUpRules | List of ramp-up rules. | [RampUpRule_STATUS[]](#RampUpRule_STATUS)<br/><small>Optional</small> |
 
-<a id="GitHubActionCodeConfiguration"></a>GitHubActionCodeConfiguration
------------------------------------------------------------------------
+GitHubActionCodeConfiguration{#GitHubActionCodeConfiguration}
+-------------------------------------------------------------
 
 The GitHub action code configuration.
 
@@ -1237,8 +1237,8 @@ Used by: [GitHubActionConfiguration](#GitHubActionConfiguration).
 | runtimeStack   | Runtime stack is used to determine the workflow file content for code base apps.     | string<br/><small>Optional</small> |
 | runtimeVersion | Runtime version is used to determine what build version to set in the workflow file. | string<br/><small>Optional</small> |
 
-<a id="GitHubActionCodeConfiguration_STATUS"></a>GitHubActionCodeConfiguration_STATUS
--------------------------------------------------------------------------------------
+GitHubActionCodeConfiguration_STATUS{#GitHubActionCodeConfiguration_STATUS}
+---------------------------------------------------------------------------
 
 The GitHub action code configuration.
 
@@ -1249,8 +1249,8 @@ Used by: [GitHubActionConfiguration_STATUS](#GitHubActionConfiguration_STATUS).
 | runtimeStack   | Runtime stack is used to determine the workflow file content for code base apps.     | string<br/><small>Optional</small> |
 | runtimeVersion | Runtime version is used to determine what build version to set in the workflow file. | string<br/><small>Optional</small> |
 
-<a id="GitHubActionContainerConfiguration"></a>GitHubActionContainerConfiguration
----------------------------------------------------------------------------------
+GitHubActionContainerConfiguration{#GitHubActionContainerConfiguration}
+-----------------------------------------------------------------------
 
 The GitHub action container configuration.
 
@@ -1263,8 +1263,8 @@ Used by: [GitHubActionConfiguration](#GitHubActionConfiguration).
 | serverUrl | The server URL for the container registry where the build will be hosted. | string<br/><small>Optional</small>                                                                                                                     |
 | username  | The username used to upload the image to the container registry.          | string<br/><small>Optional</small>                                                                                                                     |
 
-<a id="GitHubActionContainerConfiguration_STATUS"></a>GitHubActionContainerConfiguration_STATUS
------------------------------------------------------------------------------------------------
+GitHubActionContainerConfiguration_STATUS{#GitHubActionContainerConfiguration_STATUS}
+-------------------------------------------------------------------------------------
 
 The GitHub action container configuration.
 
@@ -1276,8 +1276,8 @@ Used by: [GitHubActionConfiguration_STATUS](#GitHubActionConfiguration_STATUS).
 | serverUrl | The server URL for the container registry where the build will be hosted. | string<br/><small>Optional</small> |
 | username  | The username used to upload the image to the container registry.          | string<br/><small>Optional</small> |
 
-<a id="HandlerMapping"></a>HandlerMapping
------------------------------------------
+HandlerMapping{#HandlerMapping}
+-------------------------------
 
 The IIS handler mappings used to define which handler processes HTTP requests with certain extension. For example, it is used to configure php-cgi.exe process to handle all HTTP requests with *.php extension.
 
@@ -1289,8 +1289,8 @@ Used by: [SiteConfig](#SiteConfig).
 | extension       | Requests with this extension will be handled using the specified FastCGI application. | string<br/><small>Optional</small> |
 | scriptProcessor | The absolute path to the FastCGI application.                                         | string<br/><small>Optional</small> |
 
-<a id="HandlerMapping_STATUS"></a>HandlerMapping_STATUS
--------------------------------------------------------
+HandlerMapping_STATUS{#HandlerMapping_STATUS}
+---------------------------------------------
 
 The IIS handler mappings used to define which handler processes HTTP requests with certain extension. For example, it is used to configure php-cgi.exe process to handle all HTTP requests with *.php extension.
 
@@ -1302,8 +1302,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | extension       | Requests with this extension will be handled using the specified FastCGI application. | string<br/><small>Optional</small> |
 | scriptProcessor | The absolute path to the FastCGI application.                                         | string<br/><small>Optional</small> |
 
-<a id="HostNameSslState_HostType"></a>HostNameSslState_HostType
----------------------------------------------------------------
+HostNameSslState_HostType{#HostNameSslState_HostType}
+-----------------------------------------------------
 
 Used by: [HostNameSslState](#HostNameSslState).
 
@@ -1312,8 +1312,8 @@ Used by: [HostNameSslState](#HostNameSslState).
 | "Repository" |             |
 | "Standard"   |             |
 
-<a id="HostNameSslState_HostType_STATUS"></a>HostNameSslState_HostType_STATUS
------------------------------------------------------------------------------
+HostNameSslState_HostType_STATUS{#HostNameSslState_HostType_STATUS}
+-------------------------------------------------------------------
 
 Used by: [HostNameSslState_STATUS](#HostNameSslState_STATUS).
 
@@ -1322,8 +1322,8 @@ Used by: [HostNameSslState_STATUS](#HostNameSslState_STATUS).
 | "Repository" |             |
 | "Standard"   |             |
 
-<a id="HostNameSslState_SslState"></a>HostNameSslState_SslState
----------------------------------------------------------------
+HostNameSslState_SslState{#HostNameSslState_SslState}
+-----------------------------------------------------
 
 Used by: [HostNameSslState](#HostNameSslState).
 
@@ -1333,8 +1333,8 @@ Used by: [HostNameSslState](#HostNameSslState).
 | "IpBasedEnabled" |             |
 | "SniEnabled"     |             |
 
-<a id="HostNameSslState_SslState_STATUS"></a>HostNameSslState_SslState_STATUS
------------------------------------------------------------------------------
+HostNameSslState_SslState_STATUS{#HostNameSslState_SslState_STATUS}
+-------------------------------------------------------------------
 
 Used by: [HostNameSslState_STATUS](#HostNameSslState_STATUS).
 
@@ -1344,8 +1344,8 @@ Used by: [HostNameSslState_STATUS](#HostNameSslState_STATUS).
 | "IpBasedEnabled" |             |
 | "SniEnabled"     |             |
 
-<a id="IpSecurityRestriction"></a>IpSecurityRestriction
--------------------------------------------------------
+IpSecurityRestriction{#IpSecurityRestriction}
+---------------------------------------------
 
 IP security restriction on an app.
 
@@ -1365,8 +1365,8 @@ Used by: [SiteConfig](#SiteConfig), and [SiteConfig](#SiteConfig).
 | vnetSubnetResourceReference | Virtual network resource id                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 | vnetTrafficTag              | (internal) Vnet traffic tag                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | int<br/><small>Optional</small>                                                                                                                            |
 
-<a id="IpSecurityRestriction_STATUS"></a>IpSecurityRestriction_STATUS
----------------------------------------------------------------------
+IpSecurityRestriction_STATUS{#IpSecurityRestriction_STATUS}
+-----------------------------------------------------------
 
 IP security restriction on an app.
 
@@ -1386,8 +1386,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS), and [SiteConfig_STATUS](#SiteC
 | vnetSubnetResourceId | Virtual network resource id                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | string<br/><small>Optional</small>                                                                |
 | vnetTrafficTag       | (internal) Vnet traffic tag                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | int<br/><small>Optional</small>                                                                   |
 
-<a id="ManagedServiceIdentity_Type"></a>ManagedServiceIdentity_Type
--------------------------------------------------------------------
+ManagedServiceIdentity_Type{#ManagedServiceIdentity_Type}
+---------------------------------------------------------
 
 Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 
@@ -1398,8 +1398,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="ManagedServiceIdentity_Type_STATUS"></a>ManagedServiceIdentity_Type_STATUS
----------------------------------------------------------------------------------
+ManagedServiceIdentity_Type_STATUS{#ManagedServiceIdentity_Type_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 
@@ -1410,8 +1410,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | "SystemAssigned, UserAssigned" |             |
 | "UserAssigned"                 |             |
 
-<a id="NameValuePair"></a>NameValuePair
----------------------------------------
+NameValuePair{#NameValuePair}
+-----------------------------
 
 Name value pair.
 
@@ -1422,8 +1422,8 @@ Used by: [SiteConfig](#SiteConfig).
 | name     | Pair name.  | string<br/><small>Optional</small> |
 | value    | Pair value. | string<br/><small>Optional</small> |
 
-<a id="NameValuePair_STATUS"></a>NameValuePair_STATUS
------------------------------------------------------
+NameValuePair_STATUS{#NameValuePair_STATUS}
+-------------------------------------------
 
 Name value pair.
 
@@ -1434,8 +1434,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | name     | Pair name.  | string<br/><small>Optional</small> |
 | value    | Pair value. | string<br/><small>Optional</small> |
 
-<a id="PushSettings"></a>PushSettings
--------------------------------------
+PushSettings{#PushSettings}
+---------------------------
 
 Push settings for the App.
 
@@ -1449,8 +1449,8 @@ Used by: [SiteConfig](#SiteConfig).
 | tagsRequiringAuth | Gets or sets a JSON string containing a list of tags that require user authentication to be used in the push registration endpoint. Tags can consist of alphanumeric characters and the following: '_', '@', '#', '.', ':', '-'. Validation should be performed at the PushRequestHandler. | string<br/><small>Optional</small> |
 | tagWhitelistJson  | Gets or sets a JSON string containing a list of tags that are in the allowed list for use by the push registration endpoint.                                                                                                                                                               | string<br/><small>Optional</small> |
 
-<a id="PushSettings_STATUS"></a>PushSettings_STATUS
----------------------------------------------------
+PushSettings_STATUS{#PushSettings_STATUS}
+-----------------------------------------
 
 Push settings for the App.
 
@@ -1467,8 +1467,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | tagWhitelistJson  | Gets or sets a JSON string containing a list of tags that are in the allowed list for use by the push registration endpoint.                                                                                                                                                               | string<br/><small>Optional</small> |
 | type              | Resource type.                                                                                                                                                                                                                                                                             | string<br/><small>Optional</small> |
 
-<a id="SiteConfig_FtpsState"></a>SiteConfig_FtpsState
------------------------------------------------------
+SiteConfig_FtpsState{#SiteConfig_FtpsState}
+-------------------------------------------
 
 Used by: [SiteConfig](#SiteConfig).
 
@@ -1478,8 +1478,8 @@ Used by: [SiteConfig](#SiteConfig).
 | "Disabled"   |             |
 | "FtpsOnly"   |             |
 
-<a id="SiteConfig_FtpsState_STATUS"></a>SiteConfig_FtpsState_STATUS
--------------------------------------------------------------------
+SiteConfig_FtpsState_STATUS{#SiteConfig_FtpsState_STATUS}
+---------------------------------------------------------
 
 Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 
@@ -1489,8 +1489,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | "Disabled"   |             |
 | "FtpsOnly"   |             |
 
-<a id="SiteConfig_LoadBalancing"></a>SiteConfig_LoadBalancing
--------------------------------------------------------------
+SiteConfig_LoadBalancing{#SiteConfig_LoadBalancing}
+---------------------------------------------------
 
 Used by: [SiteConfig](#SiteConfig).
 
@@ -1503,8 +1503,8 @@ Used by: [SiteConfig](#SiteConfig).
 | "WeightedRoundRobin"   |             |
 | "WeightedTotalTraffic" |             |
 
-<a id="SiteConfig_LoadBalancing_STATUS"></a>SiteConfig_LoadBalancing_STATUS
----------------------------------------------------------------------------
+SiteConfig_LoadBalancing_STATUS{#SiteConfig_LoadBalancing_STATUS}
+-----------------------------------------------------------------
 
 Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 
@@ -1517,95 +1517,95 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | "WeightedRoundRobin"   |             |
 | "WeightedTotalTraffic" |             |
 
-<a id="SiteConfig_ManagedPipelineMode"></a>SiteConfig_ManagedPipelineMode
--------------------------------------------------------------------------
-
-Used by: [SiteConfig](#SiteConfig).
-
-| Value        | Description |
-|--------------|-------------|
-| "Classic"    |             |
-| "Integrated" |             |
-
-<a id="SiteConfig_ManagedPipelineMode_STATUS"></a>SiteConfig_ManagedPipelineMode_STATUS
----------------------------------------------------------------------------------------
-
-Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
-
-| Value        | Description |
-|--------------|-------------|
-| "Classic"    |             |
-| "Integrated" |             |
-
-<a id="SiteConfig_MinTlsVersion"></a>SiteConfig_MinTlsVersion
--------------------------------------------------------------
-
-Used by: [SiteConfig](#SiteConfig).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SiteConfig_MinTlsVersion_STATUS"></a>SiteConfig_MinTlsVersion_STATUS
----------------------------------------------------------------------------
-
-Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SiteConfig_ScmMinTlsVersion"></a>SiteConfig_ScmMinTlsVersion
--------------------------------------------------------------------
-
-Used by: [SiteConfig](#SiteConfig).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SiteConfig_ScmMinTlsVersion_STATUS"></a>SiteConfig_ScmMinTlsVersion_STATUS
----------------------------------------------------------------------------------
-
-Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
-
-| Value | Description |
-|-------|-------------|
-| "1.0" |             |
-| "1.1" |             |
-| "1.2" |             |
-
-<a id="SiteConfig_ScmType"></a>SiteConfig_ScmType
--------------------------------------------------
-
-Used by: [SiteConfig](#SiteConfig).
-
-| Value          | Description |
-|----------------|-------------|
-| "BitbucketGit" |             |
-| "BitbucketHg"  |             |
-| "CodePlexGit"  |             |
-| "CodePlexHg"   |             |
-| "Dropbox"      |             |
-| "ExternalGit"  |             |
-| "ExternalHg"   |             |
-| "GitHub"       |             |
-| "LocalGit"     |             |
-| "None"         |             |
-| "OneDrive"     |             |
-| "Tfs"          |             |
-| "VSO"          |             |
-| "VSTSRM"       |             |
-
-<a id="SiteConfig_ScmType_STATUS"></a>SiteConfig_ScmType_STATUS
+SiteConfig_ManagedPipelineMode{#SiteConfig_ManagedPipelineMode}
 ---------------------------------------------------------------
 
+Used by: [SiteConfig](#SiteConfig).
+
+| Value        | Description |
+|--------------|-------------|
+| "Classic"    |             |
+| "Integrated" |             |
+
+SiteConfig_ManagedPipelineMode_STATUS{#SiteConfig_ManagedPipelineMode_STATUS}
+-----------------------------------------------------------------------------
+
+Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
+
+| Value        | Description |
+|--------------|-------------|
+| "Classic"    |             |
+| "Integrated" |             |
+
+SiteConfig_MinTlsVersion{#SiteConfig_MinTlsVersion}
+---------------------------------------------------
+
+Used by: [SiteConfig](#SiteConfig).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SiteConfig_MinTlsVersion_STATUS{#SiteConfig_MinTlsVersion_STATUS}
+-----------------------------------------------------------------
+
+Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SiteConfig_ScmMinTlsVersion{#SiteConfig_ScmMinTlsVersion}
+---------------------------------------------------------
+
+Used by: [SiteConfig](#SiteConfig).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SiteConfig_ScmMinTlsVersion_STATUS{#SiteConfig_ScmMinTlsVersion_STATUS}
+-----------------------------------------------------------------------
+
+Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
+
+| Value | Description |
+|-------|-------------|
+| "1.0" |             |
+| "1.1" |             |
+| "1.2" |             |
+
+SiteConfig_ScmType{#SiteConfig_ScmType}
+---------------------------------------
+
+Used by: [SiteConfig](#SiteConfig).
+
+| Value          | Description |
+|----------------|-------------|
+| "BitbucketGit" |             |
+| "BitbucketHg"  |             |
+| "CodePlexGit"  |             |
+| "CodePlexHg"   |             |
+| "Dropbox"      |             |
+| "ExternalGit"  |             |
+| "ExternalHg"   |             |
+| "GitHub"       |             |
+| "LocalGit"     |             |
+| "None"         |             |
+| "OneDrive"     |             |
+| "Tfs"          |             |
+| "VSO"          |             |
+| "VSTSRM"       |             |
+
+SiteConfig_ScmType_STATUS{#SiteConfig_ScmType_STATUS}
+-----------------------------------------------------
+
 Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 
 | Value          | Description |
@@ -1625,8 +1625,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | "VSO"          |             |
 | "VSTSRM"       |             |
 
-<a id="SiteLimits"></a>SiteLimits
----------------------------------
+SiteLimits{#SiteLimits}
+-----------------------
 
 Metric limits set on an app.
 
@@ -1638,8 +1638,8 @@ Used by: [SiteConfig](#SiteConfig).
 | maxMemoryInMb    | Maximum allowed memory usage in MB.    | int<br/><small>Optional</small>     |
 | maxPercentageCpu | Maximum allowed CPU usage percentage.  | float64<br/><small>Optional</small> |
 
-<a id="SiteLimits_STATUS"></a>SiteLimits_STATUS
------------------------------------------------
+SiteLimits_STATUS{#SiteLimits_STATUS}
+-------------------------------------
 
 Metric limits set on an app.
 
@@ -1651,8 +1651,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | maxMemoryInMb    | Maximum allowed memory usage in MB.    | int<br/><small>Optional</small>     |
 | maxPercentageCpu | Maximum allowed CPU usage percentage.  | float64<br/><small>Optional</small> |
 
-<a id="SiteMachineKey_STATUS"></a>SiteMachineKey_STATUS
--------------------------------------------------------
+SiteMachineKey_STATUS{#SiteMachineKey_STATUS}
+---------------------------------------------
 
 MachineKey of an app.
 
@@ -1665,8 +1665,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | validation    | MachineKey validation.         | string<br/><small>Optional</small> |
 | validationKey | Validation key.                | string<br/><small>Optional</small> |
 
-<a id="SkuCapacity"></a>SkuCapacity
------------------------------------
+SkuCapacity{#SkuCapacity}
+-------------------------
 
 Description of the App Service plan scale options.
 
@@ -1680,8 +1680,8 @@ Used by: [SkuDescription](#SkuDescription).
 | minimum        | Minimum number of workers for this App Service plan SKU.         | int<br/><small>Optional</small>    |
 | scaleType      | Available scale configurations for an App Service plan.          | string<br/><small>Optional</small> |
 
-<a id="SkuCapacity_STATUS"></a>SkuCapacity_STATUS
--------------------------------------------------
+SkuCapacity_STATUS{#SkuCapacity_STATUS}
+---------------------------------------
 
 Description of the App Service plan scale options.
 
@@ -1695,8 +1695,8 @@ Used by: [SkuDescription_STATUS](#SkuDescription_STATUS).
 | minimum        | Minimum number of workers for this App Service plan SKU.         | int<br/><small>Optional</small>    |
 | scaleType      | Available scale configurations for an App Service plan.          | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentity_STATUS"></a>UserAssignedIdentity_STATUS
--------------------------------------------------------------------
+UserAssignedIdentity_STATUS{#UserAssignedIdentity_STATUS}
+---------------------------------------------------------
 
 User Assigned identity.
 
@@ -1707,8 +1707,8 @@ Used by: [ManagedServiceIdentity_STATUS](#ManagedServiceIdentity_STATUS).
 | clientId    | Client Id of user assigned identity    | string<br/><small>Optional</small> |
 | principalId | Principal Id of user assigned identity | string<br/><small>Optional</small> |
 
-<a id="UserAssignedIdentityDetails"></a>UserAssignedIdentityDetails
--------------------------------------------------------------------
+UserAssignedIdentityDetails{#UserAssignedIdentityDetails}
+---------------------------------------------------------
 
 Information about the user assigned identity for the resource
 
@@ -1718,8 +1718,8 @@ Used by: [ManagedServiceIdentity](#ManagedServiceIdentity).
 |-----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reference |             | [genruntime.ResourceReference](https://pkg.go.dev/github.com/Azure/azure-service-operator/v2/pkg/genruntime#ResourceReference)<br/><small>Optional</small> |
 
-<a id="VirtualApplication"></a>VirtualApplication
--------------------------------------------------
+VirtualApplication{#VirtualApplication}
+---------------------------------------
 
 Virtual application in an app.
 
@@ -1732,8 +1732,8 @@ Used by: [SiteConfig](#SiteConfig).
 | virtualDirectories | Virtual directories for virtual application.                               | [VirtualDirectory[]](#VirtualDirectory)<br/><small>Optional</small> |
 | virtualPath        | Virtual path.                                                              | string<br/><small>Optional</small>                                  |
 
-<a id="VirtualApplication_STATUS"></a>VirtualApplication_STATUS
----------------------------------------------------------------
+VirtualApplication_STATUS{#VirtualApplication_STATUS}
+-----------------------------------------------------
 
 Virtual application in an app.
 
@@ -1746,8 +1746,8 @@ Used by: [SiteConfig_STATUS](#SiteConfig_STATUS).
 | virtualDirectories | Virtual directories for virtual application.                               | [VirtualDirectory_STATUS[]](#VirtualDirectory_STATUS)<br/><small>Optional</small> |
 | virtualPath        | Virtual path.                                                              | string<br/><small>Optional</small>                                                |
 
-<a id="AutoHealActions"></a>AutoHealActions
--------------------------------------------
+AutoHealActions{#AutoHealActions}
+---------------------------------
 
 Actions which to take by the auto-heal module when a rule is triggered.
 
@@ -1759,8 +1759,8 @@ Used by: [AutoHealRules](#AutoHealRules).
 | customAction            | Custom action to be taken.                                     | [AutoHealCustomAction](#AutoHealCustomAction)<br/><small>Optional</small>             |
 | minProcessExecutionTime | Minimum time the process must execute before taking the action | string<br/><small>Optional</small>                                                    |
 
-<a id="AutoHealActions_STATUS"></a>AutoHealActions_STATUS
----------------------------------------------------------
+AutoHealActions_STATUS{#AutoHealActions_STATUS}
+-----------------------------------------------
 
 Actions which to take by the auto-heal module when a rule is triggered.
 
@@ -1772,8 +1772,8 @@ Used by: [AutoHealRules_STATUS](#AutoHealRules_STATUS).
 | customAction            | Custom action to be taken.                                     | [AutoHealCustomAction_STATUS](#AutoHealCustomAction_STATUS)<br/><small>Optional</small>             |
 | minProcessExecutionTime | Minimum time the process must execute before taking the action | string<br/><small>Optional</small>                                                                  |
 
-<a id="AutoHealTriggers"></a>AutoHealTriggers
----------------------------------------------
+AutoHealTriggers{#AutoHealTriggers}
+-----------------------------------
 
 Triggers for auto-heal.
 
@@ -1788,8 +1788,8 @@ Used by: [AutoHealRules](#AutoHealRules).
 | statusCodes          | A rule based on status codes.                         | [StatusCodesBasedTrigger[]](#StatusCodesBasedTrigger)<br/><small>Optional</small>           |
 | statusCodesRange     | A rule based on status codes ranges.                  | [StatusCodesRangeBasedTrigger[]](#StatusCodesRangeBasedTrigger)<br/><small>Optional</small> |
 
-<a id="AutoHealTriggers_STATUS"></a>AutoHealTriggers_STATUS
------------------------------------------------------------
+AutoHealTriggers_STATUS{#AutoHealTriggers_STATUS}
+-------------------------------------------------
 
 Triggers for auto-heal.
 
@@ -1804,8 +1804,8 @@ Used by: [AutoHealRules_STATUS](#AutoHealRules_STATUS).
 | statusCodes          | A rule based on status codes.                         | [StatusCodesBasedTrigger_STATUS[]](#StatusCodesBasedTrigger_STATUS)<br/><small>Optional</small>           |
 | statusCodesRange     | A rule based on status codes ranges.                  | [StatusCodesRangeBasedTrigger_STATUS[]](#StatusCodesRangeBasedTrigger_STATUS)<br/><small>Optional</small> |
 
-<a id="AzureStorageInfoValue_State_STATUS"></a>AzureStorageInfoValue_State_STATUS
----------------------------------------------------------------------------------
+AzureStorageInfoValue_State_STATUS{#AzureStorageInfoValue_State_STATUS}
+-----------------------------------------------------------------------
 
 Used by: [AzureStorageInfoValue_STATUS](#AzureStorageInfoValue_STATUS).
 
@@ -1816,8 +1816,8 @@ Used by: [AzureStorageInfoValue_STATUS](#AzureStorageInfoValue_STATUS).
 | "NotValidated"       |             |
 | "Ok"                 |             |
 
-<a id="AzureStorageInfoValue_Type"></a>AzureStorageInfoValue_Type
------------------------------------------------------------------
+AzureStorageInfoValue_Type{#AzureStorageInfoValue_Type}
+-------------------------------------------------------
 
 Used by: [AzureStorageInfoValue](#AzureStorageInfoValue).
 
@@ -1826,8 +1826,8 @@ Used by: [AzureStorageInfoValue](#AzureStorageInfoValue).
 | "AzureBlob"  |             |
 | "AzureFiles" |             |
 
-<a id="AzureStorageInfoValue_Type_STATUS"></a>AzureStorageInfoValue_Type_STATUS
--------------------------------------------------------------------------------
+AzureStorageInfoValue_Type_STATUS{#AzureStorageInfoValue_Type_STATUS}
+---------------------------------------------------------------------
 
 Used by: [AzureStorageInfoValue_STATUS](#AzureStorageInfoValue_STATUS).
 
@@ -1836,8 +1836,8 @@ Used by: [AzureStorageInfoValue_STATUS](#AzureStorageInfoValue_STATUS).
 | "AzureBlob"  |             |
 | "AzureFiles" |             |
 
-<a id="ConnStringInfo_Type"></a>ConnStringInfo_Type
----------------------------------------------------
+ConnStringInfo_Type{#ConnStringInfo_Type}
+-----------------------------------------
 
 Used by: [ConnStringInfo](#ConnStringInfo).
 
@@ -1855,8 +1855,8 @@ Used by: [ConnStringInfo](#ConnStringInfo).
 | "SQLServer"       |             |
 | "ServiceBus"      |             |
 
-<a id="ConnStringInfo_Type_STATUS"></a>ConnStringInfo_Type_STATUS
------------------------------------------------------------------
+ConnStringInfo_Type_STATUS{#ConnStringInfo_Type_STATUS}
+-------------------------------------------------------
 
 Used by: [ConnStringInfo_STATUS](#ConnStringInfo_STATUS).
 
@@ -1874,8 +1874,8 @@ Used by: [ConnStringInfo_STATUS](#ConnStringInfo_STATUS).
 | "SQLServer"       |             |
 | "ServiceBus"      |             |
 
-<a id="IpSecurityRestriction_Tag"></a>IpSecurityRestriction_Tag
----------------------------------------------------------------
+IpSecurityRestriction_Tag{#IpSecurityRestriction_Tag}
+-----------------------------------------------------
 
 Used by: [IpSecurityRestriction](#IpSecurityRestriction).
 
@@ -1885,8 +1885,8 @@ Used by: [IpSecurityRestriction](#IpSecurityRestriction).
 | "ServiceTag" |             |
 | "XffProxy"   |             |
 
-<a id="IpSecurityRestriction_Tag_STATUS"></a>IpSecurityRestriction_Tag_STATUS
------------------------------------------------------------------------------
+IpSecurityRestriction_Tag_STATUS{#IpSecurityRestriction_Tag_STATUS}
+-------------------------------------------------------------------
 
 Used by: [IpSecurityRestriction_STATUS](#IpSecurityRestriction_STATUS).
 
@@ -1896,8 +1896,8 @@ Used by: [IpSecurityRestriction_STATUS](#IpSecurityRestriction_STATUS).
 | "ServiceTag" |             |
 | "XffProxy"   |             |
 
-<a id="RampUpRule"></a>RampUpRule
----------------------------------
+RampUpRule{#RampUpRule}
+-----------------------
 
 Routing rules for ramp up testing. This rule allows to redirect static traffic % to a slot or to gradually change routing % based on performance.
 
@@ -1914,8 +1914,8 @@ Used by: [Experiments](#Experiments).
 | name                      | Name of the routing rule. The recommended name would be to point to the slot which will receive the traffic in the experiment.                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>  |
 | reroutePercentage         | Percentage of the traffic which will be redirected to <code>ActionHostName</code>.                                                                                                                                                                                                                                                                                                                                                | float64<br/><small>Optional</small> |
 
-<a id="RampUpRule_STATUS"></a>RampUpRule_STATUS
------------------------------------------------
+RampUpRule_STATUS{#RampUpRule_STATUS}
+-------------------------------------
 
 Routing rules for ramp up testing. This rule allows to redirect static traffic % to a slot or to gradually change routing % based on performance.
 
@@ -1932,8 +1932,8 @@ Used by: [Experiments_STATUS](#Experiments_STATUS).
 | name                      | Name of the routing rule. The recommended name would be to point to the slot which will receive the traffic in the experiment.                                                                                                                                                                                                                                                                                                    | string<br/><small>Optional</small>  |
 | reroutePercentage         | Percentage of the traffic which will be redirected to <code>ActionHostName</code>.                                                                                                                                                                                                                                                                                                                                                | float64<br/><small>Optional</small> |
 
-<a id="VirtualDirectory"></a>VirtualDirectory
----------------------------------------------
+VirtualDirectory{#VirtualDirectory}
+-----------------------------------
 
 Directory for virtual application.
 
@@ -1944,8 +1944,8 @@ Used by: [VirtualApplication](#VirtualApplication).
 | physicalPath | Physical path.               | string<br/><small>Optional</small> |
 | virtualPath  | Path to virtual application. | string<br/><small>Optional</small> |
 
-<a id="VirtualDirectory_STATUS"></a>VirtualDirectory_STATUS
------------------------------------------------------------
+VirtualDirectory_STATUS{#VirtualDirectory_STATUS}
+-------------------------------------------------
 
 Directory for virtual application.
 
@@ -1956,8 +1956,8 @@ Used by: [VirtualApplication_STATUS](#VirtualApplication_STATUS).
 | physicalPath | Physical path.               | string<br/><small>Optional</small> |
 | virtualPath  | Path to virtual application. | string<br/><small>Optional</small> |
 
-<a id="AutoHealActions_ActionType"></a>AutoHealActions_ActionType
------------------------------------------------------------------
+AutoHealActions_ActionType{#AutoHealActions_ActionType}
+-------------------------------------------------------
 
 Used by: [AutoHealActions](#AutoHealActions).
 
@@ -1967,8 +1967,8 @@ Used by: [AutoHealActions](#AutoHealActions).
 | "LogEvent"     |             |
 | "Recycle"      |             |
 
-<a id="AutoHealActions_ActionType_STATUS"></a>AutoHealActions_ActionType_STATUS
--------------------------------------------------------------------------------
+AutoHealActions_ActionType_STATUS{#AutoHealActions_ActionType_STATUS}
+---------------------------------------------------------------------
 
 Used by: [AutoHealActions_STATUS](#AutoHealActions_STATUS).
 
@@ -1978,8 +1978,8 @@ Used by: [AutoHealActions_STATUS](#AutoHealActions_STATUS).
 | "LogEvent"     |             |
 | "Recycle"      |             |
 
-<a id="AutoHealCustomAction"></a>AutoHealCustomAction
------------------------------------------------------
+AutoHealCustomAction{#AutoHealCustomAction}
+-------------------------------------------
 
 Custom action to be executed when an auto heal rule is triggered.
 
@@ -1990,8 +1990,8 @@ Used by: [AutoHealActions](#AutoHealActions).
 | exe        | Executable to be run.          | string<br/><small>Optional</small> |
 | parameters | Parameters for the executable. | string<br/><small>Optional</small> |
 
-<a id="AutoHealCustomAction_STATUS"></a>AutoHealCustomAction_STATUS
--------------------------------------------------------------------
+AutoHealCustomAction_STATUS{#AutoHealCustomAction_STATUS}
+---------------------------------------------------------
 
 Custom action to be executed when an auto heal rule is triggered.
 
@@ -2002,8 +2002,8 @@ Used by: [AutoHealActions_STATUS](#AutoHealActions_STATUS).
 | exe        | Executable to be run.          | string<br/><small>Optional</small> |
 | parameters | Parameters for the executable. | string<br/><small>Optional</small> |
 
-<a id="RequestsBasedTrigger"></a>RequestsBasedTrigger
------------------------------------------------------
+RequestsBasedTrigger{#RequestsBasedTrigger}
+-------------------------------------------
 
 Trigger based on total requests.
 
@@ -2014,8 +2014,8 @@ Used by: [AutoHealTriggers](#AutoHealTriggers).
 | count        | Request Count. | int<br/><small>Optional</small>    |
 | timeInterval | Time interval. | string<br/><small>Optional</small> |
 
-<a id="RequestsBasedTrigger_STATUS"></a>RequestsBasedTrigger_STATUS
--------------------------------------------------------------------
+RequestsBasedTrigger_STATUS{#RequestsBasedTrigger_STATUS}
+---------------------------------------------------------
 
 Trigger based on total requests.
 
@@ -2026,8 +2026,8 @@ Used by: [AutoHealTriggers_STATUS](#AutoHealTriggers_STATUS).
 | count        | Request Count. | int<br/><small>Optional</small>    |
 | timeInterval | Time interval. | string<br/><small>Optional</small> |
 
-<a id="SlowRequestsBasedTrigger"></a>SlowRequestsBasedTrigger
--------------------------------------------------------------
+SlowRequestsBasedTrigger{#SlowRequestsBasedTrigger}
+---------------------------------------------------
 
 Trigger based on request execution time.
 
@@ -2040,8 +2040,8 @@ Used by: [AutoHealTriggers](#AutoHealTriggers), and [AutoHealTriggers](#AutoHeal
 | timeInterval | Time interval. | string<br/><small>Optional</small> |
 | timeTaken    | Time taken.    | string<br/><small>Optional</small> |
 
-<a id="SlowRequestsBasedTrigger_STATUS"></a>SlowRequestsBasedTrigger_STATUS
----------------------------------------------------------------------------
+SlowRequestsBasedTrigger_STATUS{#SlowRequestsBasedTrigger_STATUS}
+-----------------------------------------------------------------
 
 Trigger based on request execution time.
 
@@ -2054,8 +2054,8 @@ Used by: [AutoHealTriggers_STATUS](#AutoHealTriggers_STATUS), and [AutoHealTrigg
 | timeInterval | Time interval. | string<br/><small>Optional</small> |
 | timeTaken    | Time taken.    | string<br/><small>Optional</small> |
 
-<a id="StatusCodesBasedTrigger"></a>StatusCodesBasedTrigger
------------------------------------------------------------
+StatusCodesBasedTrigger{#StatusCodesBasedTrigger}
+-------------------------------------------------
 
 Trigger based on status code.
 
@@ -2070,8 +2070,8 @@ Used by: [AutoHealTriggers](#AutoHealTriggers).
 | timeInterval | Time interval.      | string<br/><small>Optional</small> |
 | win32Status  | Win32 error code.   | int<br/><small>Optional</small>    |
 
-<a id="StatusCodesBasedTrigger_STATUS"></a>StatusCodesBasedTrigger_STATUS
--------------------------------------------------------------------------
+StatusCodesBasedTrigger_STATUS{#StatusCodesBasedTrigger_STATUS}
+---------------------------------------------------------------
 
 Trigger based on status code.
 
@@ -2086,8 +2086,8 @@ Used by: [AutoHealTriggers_STATUS](#AutoHealTriggers_STATUS).
 | timeInterval | Time interval.      | string<br/><small>Optional</small> |
 | win32Status  | Win32 error code.   | int<br/><small>Optional</small>    |
 
-<a id="StatusCodesRangeBasedTrigger"></a>StatusCodesRangeBasedTrigger
----------------------------------------------------------------------
+StatusCodesRangeBasedTrigger{#StatusCodesRangeBasedTrigger}
+-----------------------------------------------------------
 
 Trigger based on range of status codes.
 
@@ -2100,8 +2100,8 @@ Used by: [AutoHealTriggers](#AutoHealTriggers).
 | statusCodes  | HTTP status code. | string<br/><small>Optional</small> |
 | timeInterval | Time interval.    | string<br/><small>Optional</small> |
 
-<a id="StatusCodesRangeBasedTrigger_STATUS"></a>StatusCodesRangeBasedTrigger_STATUS
------------------------------------------------------------------------------------
+StatusCodesRangeBasedTrigger_STATUS{#StatusCodesRangeBasedTrigger_STATUS}
+-------------------------------------------------------------------------
 
 Trigger based on range of status codes.
 

--- a/docs/v2/api/template/crd.tmpl
+++ b/docs/v2/api/template/crd.tmpl
@@ -6,7 +6,7 @@ linktitle: {{ .Version }}
 
 {{ range .Declarations "ranked" }}
 
-## <a id="{{ .ID }}"></a>{{ .Name }}
+## {{ .Name }}{# {{- .ID -}}}
 
 {{ .Description | inlineLinks | unwrap | applyEdits -}}
 {{ template "usage" . }}
@@ -16,11 +16,11 @@ linktitle: {{ .Version }}
 {{ end }}
 
 {{ with . | asResource }}
-### <a id="{{ .Spec.Type.ID }}"></a>{{ .Spec.Type.ID }}
+### {{ .Spec.Type.ID }} {# {{- .Spec.Type.ID -}} }
 
 {{ template "properties" ( .Spec.Type.ID | lookupDeclaration | asPropertyContainer ) }}
 
-### <a id="{{ .Status.Type.ID }}"></a>{{ .Status.Type.ID }}
+### {{ .Status.Type.Name }}{# {{- .Status.Type.ID -}} }
 
 {{ template "properties" ( .Status.Type.ID | lookupDeclaration | asPropertyContainer ) }}
 


### PR DESCRIPTION
## What this PR does

Changes the syntax used for specifying anchors in the documentation from HTML to Markdown.

Using `<a>` style anchors worked in prior standalone testing, but not for pages rendered by Hugo.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/quQijRpxpy7UQ/giphy.gif?cid=790b7611wavris33dkcehq4klosmuthie3hncmow8jf901vw&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## Checklist

- [x] this PR contains documentation
